### PR TITLE
Fix formatting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 
 Once Helm has been set up correctly, add the repo as follows:
 
-  helm repo add <alias> https://alphagov.github.io/govuk-helm-charts/
+    helm repo add govuk-helm-charts https://alphagov.github.io/govuk-helm-charts/
 
 If you had already added this repo earlier, run `helm repo update` to retrieve
 the latest versions of the packages.  You can then run `helm search repo


### PR DESCRIPTION
The example command for adding the Helm repo was getting mangled by Markdown. It's now copy-pasteable.