### PR TITLE
Add GitHub Actions linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: linting
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1.1
+        with:
+          version: 3.*
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.*
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yml

--- a/charts/content-store/Chart.yaml
+++ b/charts/content-store/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: content-store
 description: A Helm chart for GOV.UK Content-Store
 type: application
-version: 0.3.0
-appVersion: "1.16.0"
+version: 0.3.1

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.3.0
-appVersion: "1.16.0"
+version: 0.3.1

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.16.0"

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -3,4 +3,3 @@ name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
 version: 0.2.1
-appVersion: "1.16.0"

--- a/charts/router/Chart.yaml
+++ b/charts/router/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: router
 description: A Helm chart for GOV.UK router
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.16.0"

--- a/charts/router/Chart.yaml
+++ b/charts/router/Chart.yaml
@@ -3,4 +3,3 @@ name: router
 description: A Helm chart for GOV.UK router
 type: application
 version: 0.3.1
-appVersion: "1.16.0"

--- a/charts/static/Chart.yaml
+++ b/charts/static/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.3.0
-appVersion: "1.16.0"
+version: 0.3.1

--- a/ct.yml
+++ b/ct.yml
@@ -1,0 +1,5 @@
+remote: origin
+target-branch: main
+validate-maintainers: false
+chart-dirs:
+  - charts


### PR DESCRIPTION
In addition, we bumped the versions of router and publisher because 
the helm chart releaser is failing since the chart was updated in #1 but 
the chart version was not updated. I.e the chart releaser cannot overwrite
an existing chart.

We decided to remove appVersion from the Chart.yaml