### PR TITLE
Remove redundant ssl-policy annotations from Ingresses.

### DIFF
--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.2.1
+version: 0.3.1

--- a/charts/publisher/values.yaml
+++ b/charts/publisher/values.yaml
@@ -97,7 +97,6 @@ ingress:
     alb.ingress.kubernetes.io/load-balancer-name: publisher
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
-    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06  # No TLS 1.0 or 1.1.
 
 secretsPrefix: "govuk/"
 

--- a/charts/router/Chart.yaml
+++ b/charts/router/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: router
 description: A Helm chart for GOV.UK router
 type: application
-version: 0.3.1
+version: 0.4.1

--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -56,4 +56,3 @@ ingress:
     alb.ingress.kubernetes.io/load-balancer-name: www-origin
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
-    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06  # No TLS 1.0 or 1.1.


### PR DESCRIPTION
The TLS >= 1.2 policy is now configured as the default on the controller as of alphagov/govuk-infrastructure#451.

Tested: installed in namespace on the test cluster and ran an [audit of the TLS config](https://www.ssllabs.com/ssltest/analyze.html?d=www-origin-chris.eks.test.govuk.digital&s=34.240.19.213&latest) to verify that TLS 1.0 and 1.1 are still disabled.

Needs alphagov/govuk-infrastructure#451 to be merged first.

[Trello card](https://trello.com/c/kL8xAztY/637)