### PR TITLE
Add a simple `PrometheusRule` to check successful Frontend deployment

### DIFF
--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.3.1
+version: 0.4.0

--- a/charts/frontend/templates/prometheusrules.yaml
+++ b/charts/frontend/templates/prometheusrules.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: frontend.rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: frontend
+    rules:
+    - alert: FrontendNoPodsRunning
+      annotations:
+        description: "Frontend has no pods running in namespace {{ "{{" }} $labels.namespace }}"
+      expr: |-
+        count by (namespace)(kube_pod_container_status_running{container="frontend", namespace="{{ .Release.Namespace }}"}) < 1
+      for: 5m
+      labels:
+        severity: warning
+    # Note: this alert does not necessarily represent best practice
+    - alert: FrontendNotDeployedSuccessfully
+      annotations:
+        description: "Frontend has not deployed successfully in namespace {{ "{{" }} $labels.namespace }}"
+      expr: |-
+        (kube_deployment_status_condition{deployment="frontend", condition="ReplicaFailure", status="true", namespace="{{ .Release.Namespace }}"} == 
+        on(namespace) kube_deployment_status_condition{deployment="frontend", condition="Progressing", status="false"})==1
+      for: 5m
+      labels:
+        severity: warning


### PR DESCRIPTION
This PR adds a simple `Prometheus` rule to check that Frontend has been successfully deployed. It uses the [`kube_deployment_status_condition` deployment metric](https://github.com/kubernetes/kube-state-metrics/blob/master/docs/deployment-metrics.md) to check that, for each namespace Frontend is deployed into, the `frontend` deployment returns `true` for both being `Available` and `Progressing`.

Evaluating the status of a deployment within Kubernetes does not seem to be as trivial within Prometheus as one might expect. [According to the docs](https://kubernetes.io/docs/concepts/workloads/controllers/_print/#complete-deployment), a deployment which is `Available` means that the minimum number of replicas have been satisfied, as specified in a Deployment spec; it doesn't necessarily mean that the entire deployment is complete. A deployment which is `Progressing` means either that the deployment is creating pods etc and _is_ actually in progress, or that it has completed successfully, specifying the `Reason` as `NewReplicaSetAvailable`.

Unfortunately, `Reason` does not appear to be available within the `kube_deployment_status_condition` deployment metric and as such we can't use it to properly check whether a deployment was successful. For this reason, this commit is only checking for any deployments of Frontend where `Progressing` is false and `ReplicaFailure` is true.

It's also worth noting that the reason behind this rule is to check that Prometheus fires the alert when appropriate (when a deployment of frontend fails) and that this firing alert shows up in AlertManager; it isn't necessarily intended as a best-practice example of what a good `PrometheusRule` should look like.

Trello: https://trello.com/c/G90Aq8u8