### PR TITLE
Fixup Publisher secret

### DIFF
--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.4.0
+version: 0.5.0

--- a/charts/publisher/values.yaml
+++ b/charts/publisher/values.yaml
@@ -12,7 +12,7 @@ common:
     tag: latest
 
   secrets:
-    externalSecretRef:
+    externalSecretRef: govuk/publisher
     externalSecretRefreshInterval: "60m"
     keys:
       - ASSET_MANAGER_BEARER_TOKEN


### PR DESCRIPTION
This sets the dataFrom key for publisher's external-secret
to the secret stored in secretsmanager (it's currently blank).