### PR TITLE
Revert Puma for now.

### DIFF
--- a/charts/content-store/Chart.yaml
+++ b/charts/content-store/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: content-store
 description: A Helm chart for GOV.UK Content-Store
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/charts/content-store/templates/deployment.yaml
+++ b/charts/content-store/templates/deployment.yaml
@@ -20,8 +20,6 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
-          command: ["bundle"]
-          args: ["exec", "puma"]
           env:
             - name: DEFAULT_TTL
               value: "{{ .Values.appDefaultTtl }}"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.6.0
+version: 0.6.1

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
-          command: ["bundle"]
-          args: ["exec", "puma"]
           env:
             - name: ASSET_HOST
               value: "{{ .Values.appAssetHost | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.6.0
+version: 0.6.1

--- a/charts/publisher/templates/web/deployment.yaml
+++ b/charts/publisher/templates/web/deployment.yaml
@@ -25,8 +25,6 @@ spec:
       containers:
         - name: app
           image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
-          command: ["bundle"]
-          args: ["exec", "puma"]
           ports:
             - name: http
               containerPort: {{ .Values.web.port }}

--- a/charts/signon/Chart.yaml
+++ b/charts/signon/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon
 description: A Helm chart for GOV.UK Signon
 type: application
-version: 0.2.0
+version: 0.2.1

--- a/charts/signon/templates/deployment.yaml
+++ b/charts/signon/templates/deployment.yaml
@@ -20,8 +20,6 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
-          command: ["bundle"]
-          args: ["exec", "puma"]
           env:
             - name: ASSET_HOST
               value: "{{ .Values.appAssetHost | default (printf "https://www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"

--- a/charts/static/Chart.yaml
+++ b/charts/static/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/charts/static/templates/deployment.yaml
+++ b/charts/static/templates/deployment.yaml
@@ -20,8 +20,6 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
-          command: ["bundle"]
-          args: ["exec", "puma"]
           env:
             - name: GOVUK_APP_DOMAIN
               value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"


### PR DESCRIPTION
Puma isn't yet included in the Gemfile for some of these apps, so running `bundle exec puma` doesn't work in all cases.

Keep the `bundle exec sidekiq` command override because that one's OK.

This partially reverts 2b41ccb.

[Trello card](https://trello.com/c/irrbEFMV/668)