### PR TITLE
Add existing GOV.UK Apps to ArgoCD

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.1.2
+version: 0.2.0

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -36,3 +36,47 @@ applications:
       value: "1"
     - name: worker.replicas
       value: "1"
+- name: router
+  helm:
+    parameters:
+    - name: govukEnvironment
+      value: "test"
+    - name: image.repository
+      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/router"
+    - name: image.tag
+      value: "latest" # Automatically updated
+    - name: replicaCount
+      value: "1"
+- name: frontend
+  helm:
+    parameters:
+    - name: govukEnvironment
+      value: "test"
+    - name: image.repository
+      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend"
+    - name: image.tag
+      value: "latest" # Automatically updated
+    - name: replicaCount
+      value: "1"
+- name: static
+  helm:
+    parameters:
+    - name: govukEnvironment
+      value: "test"
+    - name: image.repository
+      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/static"
+    - name: image.tag
+      value: "latest" # Automatically updated
+    - name: replicaCount
+      value: "1"
+- name: content-store
+  helm:
+    parameters:
+    - name: govukEnvironment
+      value: "test"
+    - name: image.repository
+      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store"
+    - name: image.tag
+      value: "latest" # Automatically updated
+    - name: replicaCount
+      value: "1"


### PR DESCRIPTION
Remaining existing GOV.UK Apps are added to ArgoCD:
1. frontend
2. static
3. content-store
4. router

In addition, we add the slack notification after the app is deployed by ArgoCD

Ref:
1. [trello card](https://trello.com/c/GqZuxOeR/699-create-argo-applications-for-remaining-apps)