### PR TITLE
Make apps log to stdout

### DIFF
--- a/charts/content-store/Chart.yaml
+++ b/charts/content-store/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: content-store
 description: A Helm chart for GOV.UK Content-Store
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/charts/content-store/templates/deployment.yaml
+++ b/charts/content-store/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: "{{ .Values.appPort }}"
             - name: RAILS_ENV
               value: "{{ .Values.appRailsEnv }}"
+            - name: RAILS_LOG_TO_STDOUT
+              value: "true"
             - name: SECRET_KEY_BASE
               value: "secret" #TODO: fix when we know how to handle secrets
           {{- with .Values.appExtraEnv }}

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.7.0
+version: 0.7.1

--- a/charts/publisher/templates/common/configmap.yaml
+++ b/charts/publisher/templates/common/configmap.yaml
@@ -29,4 +29,5 @@ data:
   PLEK_SERVICE_STATIC_URI: "{{ .Values.common.env.plekServiceStaticUri | default (printf "http://static.%s.%s" .Release.Namespace .Values.common.govukDomainInternal) }}"
   PORT: "{{ .Values.web.port }}"
   RAILS_ENV: "{{ .Values.common.env.railsEnv  }}"
+  RAILS_LOG_TO_STDOUT: "true"
   REDIS_URL: "{{ .Values.common.env.redisUrl }}"    # TODO: decide on Redis for EKS

--- a/charts/signon/Chart.yaml
+++ b/charts/signon/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon
 description: A Helm chart for GOV.UK Signon
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/signon/templates/deployment.yaml
+++ b/charts/signon/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: "{{ .Values.appPort }}"
             - name: RAILS_ENV
               value: "{{ .Values.appRailsEnv }}"
+            - name: RAILS_LOG_TO_STDOUT
+              value: "true"
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/charts/static/Chart.yaml
+++ b/charts/static/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/charts/static/templates/deployment.yaml
+++ b/charts/static/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: "{{ .Values.appPort }}"
             - name: RAILS_ENV
               value: "{{ .Values.appRailsEnv }}"
+            - name: RAILS_LOG_TO_STDOUT
+              value: "true"
             - name: REDIS_URL
               value: "{{ .Values.appRedisUrl | default (printf "redis://redis.ecs.%s.%s:6379" .Values.govukEnvironment .Values.govukDomainExternal) }}" #TODO: use EKS Redis cluster
             - name: GOVUK_APP_ROOT


### PR DESCRIPTION
This PR updates the Helm charts for content-store, publisher, signon and static to log to stdout via the use of the environment variable `RAILS_LOG_TO_STDOUT`.