### PR TITLE
Keep PrometheusRule resources in same namespace as apps.

### DIFF
--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.6.1
+version: 0.6.2

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -110,6 +110,6 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
-      - name: {{ .Release.Name }}-nginx-conf 
+      - name: {{ .Release.Name }}-nginx-conf
         configMap:
           name: {{ .Release.Name }}-nginx-conf

--- a/charts/frontend/templates/prometheusrules.yaml
+++ b/charts/frontend/templates/prometheusrules.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: frontend.rules
-  namespace: monitoring
 spec:
   groups:
   - name: frontend

--- a/charts/frontend/templates/prometheusrules.yaml
+++ b/charts/frontend/templates/prometheusrules.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         description: "Frontend has not deployed successfully in namespace {{ "{{" }} $labels.namespace }}"
       expr: |-
-        (kube_deployment_status_condition{deployment="frontend", condition="ReplicaFailure", status="true", namespace="{{ .Release.Namespace }}"} == 
+        (kube_deployment_status_condition{deployment="frontend", condition="ReplicaFailure", status="true", namespace="{{ .Release.Namespace }}"} ==
         on(namespace) kube_deployment_status_condition{deployment="frontend", condition="Progressing", status="false"})==1
       for: 5m
       labels:

--- a/charts/signon/Chart.yaml
+++ b/charts/signon/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon
 description: A Helm chart for GOV.UK Signon
 type: application
-version: 0.2.2
+version: 0.2.3

--- a/charts/signon/templates/deployment.yaml
+++ b/charts/signon/templates/deployment.yaml
@@ -108,6 +108,6 @@ spec:
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
       volumes:
-      - name: {{ .Release.Name }}-nginx-conf 
+      - name: {{ .Release.Name }}-nginx-conf
         configMap:
           name: {{ .Release.Name }}-nginx-conf


### PR DESCRIPTION
We don't want the app Helm charts to create resources in global/shared namespaces unnecessarily, otherwise we prevent copies of apps from being deployed in other namespaces.

Also some trailing whitespace cleanup.