### PR TITLE
Fix name clashes on ALBs created by Ingresses.

### DIFF
--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.8.0
+version: 0.8.1

--- a/charts/publisher/templates/web/ingress.yaml
+++ b/charts/publisher/templates/web/ingress.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     {{- include "publisher.labels" . | nindent 4 }}
     app.kubernetes.io/component: "web"
-  {{- with .Values.web.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.web.ingress.name }}-{{ .Release.Namespace }}
+    {{- toYaml .Values.web.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.web.ingress.tls }}
   tls:

--- a/charts/publisher/templates/web/ingress.yaml
+++ b/charts/publisher/templates/web/ingress.yaml
@@ -23,7 +23,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.web.ingress.host | default (printf "publisher-%s.eks.%s.%s" .Release.Namespace .Values.common.govukEnvironment .Values.common.govukDomainExternal ) }}
+    - host: {{ .Values.web.ingress.host | default (printf "%s-%s.eks.%s.%s" .Values.web.ingress.name .Release.Namespace .Values.common.govukEnvironment .Values.common.govukDomainExternal ) }}
       http:
         paths:
           - path: {{ .Values.web.ingress.path }}

--- a/charts/publisher/values.yaml
+++ b/charts/publisher/values.yaml
@@ -81,7 +81,6 @@ web:
     annotations:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/load-balancer-name: publisher
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
       alb.ingress.kubernetes.io/ssl-redirect: "443"
       alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready

--- a/charts/router/Chart.yaml
+++ b/charts/router/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: router
 description: A Helm chart for GOV.UK router
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/router/templates/ingress.yaml
+++ b/charts/router/templates/ingress.yaml
@@ -7,10 +7,9 @@ metadata:
   name: {{ .Values.ingress.name }}
   labels:
     {{- include "router.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}-{{ .Release.Namespace }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/router/templates/ingress.yaml
+++ b/charts/router/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host | default (printf "www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
+    - host: {{ .Values.ingress.host | default (printf "%s-%s.eks.%s.%s" .Values.ingress.name .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
        paths:
          - path: {{ .Values.ingress.path }}

--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -53,6 +53,5 @@ ingress:
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/load-balancer-name: www-origin
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"

--- a/charts/signon/Chart.yaml
+++ b/charts/signon/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon
 description: A Helm chart for GOV.UK Signon
 type: application
-version: 0.2.3
+version: 0.2.4

--- a/charts/signon/templates/ingress.yaml
+++ b/charts/signon/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host | default (printf "signon-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
+    - host: {{ .Values.ingress.host | default (printf "%s-%s.eks.%s.%s" .Values.ingress.name .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
        paths:
          - path: {{ .Values.ingress.path }}

--- a/charts/signon/templates/ingress.yaml
+++ b/charts/signon/templates/ingress.yaml
@@ -5,10 +5,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}-{{ .Release.Namespace }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/signon/values.yaml
+++ b/charts/signon/values.yaml
@@ -25,7 +25,6 @@ ingress:
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/load-balancer-name: signon
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
 


### PR DESCRIPTION
By default, aws-lb-controller creates load balancers with random strings as names. We want to be able to look up the LB for a given Ingress easily and vice versa. We previously acheived this using fixed names, but these would clash when deploying the same apps into more than one namespace for testing.

Include the namespace in the ALB name so that the names are unique while also being human-friendly.

This doesn't cater for overriding the ALB name via Helm values, but I can't think of any valid reason for wanting to do that at this stage. We can easily add a value for it later if we need it.

Also substitute ingress.name in the hostname instead of hardcoding. This doesn't change the output for any of our current use cases; just makes things more flexible.

Tested: charts produce valid kube yaml and apps come up successfully on install.