### PR TITLE
Use Redis cluster from the EKS project; the ECS one is going away.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.2.2
+version: 0.2.3

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -19,7 +19,7 @@ applications:
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
-      value: "redis://redis.ecs.integration.govuk-internal.digital:6379"
+      value: "redis://shared-redis.eks.integration.govuk-internal.digital"
     - name: web.replicas
       value: "1"
     - name: worker.replicas
@@ -36,7 +36,7 @@ applications:
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
-      value: "redis://redis.ecs.integration.govuk-internal.digital:6379"
+      value: "redis://shared-redis.eks.integration.govuk-internal.digital"
     - name: web.replicas
       value: "1"
     - name: worker.replicas

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -19,7 +19,7 @@ applications:
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
-      value: "redis://redis.ecs.test.govuk-internal.digital:6379"
+      value: "redis://shared-redis.eks.test.govuk-internal.digital"
     - name: web.replicas
       value: "1"
     - name: worker.replicas
@@ -36,7 +36,7 @@ applications:
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
-      value: "redis://redis.ecs.test.govuk-internal.digital:6379"
+      value: "redis://shared-redis.eks.test.govuk-internal.digital"
     - name: web.replicas
       value: "1"
     - name: worker.replicas

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.8.2
+version: 0.8.3

--- a/charts/publisher/values.yaml
+++ b/charts/publisher/values.yaml
@@ -53,7 +53,7 @@ common:
     plekServicePublisherUri:
     plekServiceStaticUri:
     railsEnv: "production"
-    redisUrl: "redis://redis.ecs.test.govuk-internal.digital:6379"  # TODO: decide on Redis for EKS
+    redisUrl: "redis://redis"  # TODO: decide on Redis for EKS
 
 web:
   replicas: 1


### PR DESCRIPTION
This reflects the new DNS names for these Redis clusters from alphagov/govuk-infrastructure#483.

[Trello](https://trello.com/c/Rp2xjAYJ/674)