### PR TITLE
Allow Argo Applications to create namespaces

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.2
+version: 0.1.3

--- a/charts/argo-services/templates/argocd/govuk-project.yaml
+++ b/charts/argo-services/templates/argocd/govuk-project.yaml
@@ -13,6 +13,11 @@ spec:
   sourceRepos:
   - '*'
 
+  # Deny all cluster-scoped resources from being created, except for Namespace
+  clusterResourceWhitelist:
+  - group: ''
+    kind: Namespace
+
   destinations:
   - namespace: "*"
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Applications will attempt to create the namespace into which they will deploy resources if the namespace does not exist.

Currently this only affects the apps namespace.