### PR TITLE
Set govukStack correctly for the integration environment.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.2.3
+version: 0.2.4

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -46,6 +46,8 @@ applications:
     parameters:
     - name: govukEnvironment
       value: "integration"
+    - name: govukStack
+      value: "blue"  # TODO: eliminate the need for govukStack
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/router"
     - name: image.tag
@@ -79,6 +81,8 @@ applications:
     parameters:
     - name: govukEnvironment
       value: "integration"
+    - name: govukStack
+      value: "blue"  # TODO: eliminate the need for govukStack
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store"
     - name: image.tag

--- a/charts/static/Chart.yaml
+++ b/charts/static/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/static/values.yaml
+++ b/charts/static/values.yaml
@@ -1,7 +1,6 @@
 # Default values for static.
 
 govukEnvironment: test
-govukStack: pink
 govukDomainExternal: govuk.digital
 govukDomainInternal: govuk-internal.digital
 clusterDomain: svc.cluster.local


### PR DESCRIPTION
Also remove `govukStack` from static's values.yaml because it's unused there.

`govukStack` is a terrible wart, but we can't quite get rid of it just yet. We need to change the hostnames of MongoDB cluster nodes in the test account from `pink` to `blue` first, so until we get around to doing that it'll stick around, complicating up the Helm charts.

[Trello](https://trello.com/c/Rp2xjAYJ/674)