### PR TITLE
Revert "Attempt 2 at increasing frontend replica set size"

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.2.7
+version: 0.2.8

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -64,7 +64,7 @@ applications:
     - name: image.tag
       value: "latest" # Automatically updated
     - name: replicaCount
-      value: "3"
+      value: "1"
 - name: static
   helm:
     parameters:


### PR DESCRIPTION
This reverts commit b91085aaa2591bd6b114a95d5b5676839e1ca988 to restore
the replicaCount value to the state it held before the test exercise.

The chart value is still incremented, as I believe that can't be
decremented once set.