### PR TITLE
Fix wrong Helm apiVersion on a couple of charts.

### DIFF
--- a/charts/cluster-secret-store/Chart.yaml
+++ b/charts/cluster-secret-store/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: cluster-secret-store
 description: A Helm chart for an external-secrets ClusterSecretStore, integrates with AWS SecretsManager
-version: 0.1.0
+version: 0.1.1

--- a/charts/ingress-class/Chart.yaml
+++ b/charts/ingress-class/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: ingress-class
-description: A Helm chart for a IngressClass resource, for use with AWS Load Balancer Controller
-version: 0.1.0
+description: A Helm chart for an IngressClass resource, for use with AWS Load Balancer Controller
+version: 0.1.1


### PR DESCRIPTION
Helm 3 is, frustratingly, `apiVersion: v2`. 🙃 `v3` hasn't happened yet.

[Trello](https://trello.com/c/h6lGL53t/706)