### PR TITLE
Avoid duplicate lint checks on first-party PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Avoid duplicate checks. On PR, run only if the PR is from a forked repo.
+    if: >
+      github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name !=
+          github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
#### Alternatives considered

* We could just remove `pull_requests` from the `on` predicate. That'd mean we don't run checks automatically on third-party PRs, which has pros and cons: better for security, bit inconvenient for accepting third-party contributions (but this happens so rarely that we're probably talking about a handful of minutes a year).
* There's also https://github.com/marketplace/actions/skip-duplicate-actions, but that looks like it could become complex to configure.

#### Tested

![Screenshot 2021-12-01 at 11 39 50](https://user-images.githubusercontent.com/1170635/144228251-45b32ee0-9b51-4a12-a0d4-fc8ccab2ad72.png)