### PR TITLE
Run checks on push only, no longer on PR.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,8 @@
 name: linting
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Avoid duplicate checks. On PR, run only if the PR is from a forked repo.
-    if: >
-      github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name !=
-          github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The GitHub Slack bot doesn't play nice with skipped checks: it says things like "1/2 successful checks" when one of the checks is skipped, which makes it look like one of the checks is still pending, which gives the false impression that the PR isn't ready for review yet when it actually is. So let's just get rid of the checks on PR rather than making them conditional.

The (theoretical) disadvantage of this approach is that check won't run automatically on third-party PRs, but we've literally never had one of these in the entire history of this repo or its predecessor, alphagov/govuk-aws.

Previous approach was #39.