### PR TITLE
Continuously deploy the govuk-apps-conf chart.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.3.2
+version: 0.3.3

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -2,6 +2,11 @@ govukEnvironment: integration
 
 applications:
 - name: cluster-secrets
+- name: govuk-apps-conf
+  helm:
+    parameters:
+    - name: govukEnvironment
+      value: integration
 - name: smokey
   helm:
     parameters:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -2,6 +2,11 @@ govukEnvironment: test
 
 applications:
 - name: cluster-secrets
+- name: govuk-apps-conf
+  helm:
+    parameters:
+    - name: govukEnvironment
+      value: test
 - name: smokey
   helm:
     parameters:


### PR DESCRIPTION
For now, this chart contains a shared configmap which represents config
items common to all (or most) of the GOV.UK apps.

See #23.

[Trello](https://trello.com/c/h6lGL53t/706)