### PR TITLE
Fix wrong syntax for passing list as Helm value in ArgoCD.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.3.3
+version: 0.3.4

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -69,7 +69,7 @@ applications:
     - name: replicaCount
       value: "1"
     - name: appMemcacheServers
-      value: ["frontend-memcached.integration.govuk-internal.digital:11211"]
+      value: "{frontend-memcached.integration.govuk-internal.digital:11211}"
 - name: static
   helm:
     parameters:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -67,7 +67,7 @@ applications:
     - name: replicaCount
       value: "1"
     - name: appMemcacheServers
-      value: ["frontend-memcached.test.govuk-internal.digital:11211"]
+      value: "{frontend-memcached.test.govuk-internal.digital:11211}"
 - name: static
   helm:
     parameters:


### PR DESCRIPTION
ArgoCD's `app.spec.source.helm.parameters.value` takes a string, equivalent to `helm --set $string`; it can't be arbitrary YAML. This means that to pass a list, we have to write [something that looks like a string representation of a Go struct literal](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set) rather than just passing the darned list as YAML like you'd expect. Yuck.

There's almost certainly a cleaner alternative, but this at least fixes the `argocd-apps` app for now. The cleaner way is probably to switch from `helm.parameters` to `helm.values` so that we get rid of the `name: x, value: y` antipattern and we can use YAML syntax so passing a list looks vaguely reasonable (albeit still serialised as a string).

Fixes breakage which I introduced in 8c3e001. Tests passed because we're only testing with the default `values.yaml` and it turns out the tests only lint but don't actually validate the output against resource definitions. Oops.

[Trello](https://trello.com/c/h6lGL53t/706)

Tested: this at least seems to work when I deploy it via Helm in the test cluster. I'm not entirely convinced that the `{foo,bar}` struct-literal-like thing is really being parsed in the way that I expected, but it produces close enough to the desired result in this case. We'll likely stop using `helm.parameters` anyway so I'm not too concerned about it.