### PR TITLE
Lint the per-environment values files for argocd-apps.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.3.4
+version: 0.3.5

--- a/charts/argocd-apps/ci/integration-values.yaml
+++ b/charts/argocd-apps/ci/integration-values.yaml
@@ -1,0 +1,1 @@
+../values-integration.yaml

--- a/charts/argocd-apps/ci/test-values.yaml
+++ b/charts/argocd-apps/ci/test-values.yaml
@@ -1,0 +1,1 @@
+../values-test.yaml

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -20,7 +20,7 @@ applications:
     - name: common.image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher"
     - name: common.image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
@@ -37,7 +37,7 @@ applications:
     - name: common.image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon"
     - name: common.image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
@@ -56,7 +56,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/router"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
 - name: frontend
@@ -65,7 +65,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
     - name: appMemcacheServers
@@ -78,7 +78,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/static"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
 - name: content-store
@@ -87,7 +87,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
     - name: appMongodbUri

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -20,7 +20,7 @@ applications:
     - name: common.image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher"
     - name: common.image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
@@ -37,7 +37,7 @@ applications:
     - name: common.image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon"
     - name: common.image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: web.dbMigrationEnabled
       value: "true"
     - name: common.env.redisUrl
@@ -54,7 +54,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/router"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
 - name: frontend
@@ -63,7 +63,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
     - name: appMemcacheServers
@@ -76,7 +76,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/static"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
 - name: content-store
@@ -85,7 +85,7 @@ applications:
     - name: image.repository
       value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store"
     - name: image.tag
-      value: "latest" # Automatically updated
+      value: "latest"  # Automatically updated
     - name: replicaCount
       value: "1"
     - name: appMongodbUri


### PR DESCRIPTION
`chart-testing` will test against all files matching the glob `ci/*-values.yaml` under the chart directory. Bizarrely, this doesn't appear to be configurable.

Sadly this still won't pick up errors like the one fixed in #45. This is because `helm lint` doesn't have a way to provide it the CRDs against which to validate the output. In order to catch issues like that, we'd need to do `ct lint-and-install`, which needs a cluster to install into. We might be able to use the test cluster for this, but that sounds complicated (not least from a security perspective) so I'm not going to look into that any time soon.

See https://github.com/helm/charts/blob/master/test/README.md#providing-custom-test-values