### PR TITLE
Use a separate memcache for Frontend in EKS.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.3.7
+version: 0.3.8

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -69,7 +69,7 @@ applications:
     - name: replicaCount
       value: "1"
     - name: appMemcacheServers
-      value: "{frontend-memcached.integration.govuk-internal.digital:11211}"
+      value: "{frontend-memcached.eks.integration.govuk-internal.digital:11211}"
 - name: static
   helm:
     parameters:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -67,7 +67,7 @@ applications:
     - name: replicaCount
       value: "1"
     - name: appMemcacheServers
-      value: "{frontend-memcached.test.govuk-internal.digital:11211}"
+      value: "{frontend-memcached.eks.test.govuk-internal.digital:11211}"
 - name: static
   helm:
     parameters:


### PR DESCRIPTION
Using the same memcache as the old EC2 environment causes problems because Frontend puts objects in memcache which contain references to Rails assets, which are served from different locations in the two environments.

The new memcaches don't exist yet, but that's fine. It just falls back to generating the content if it can't reach the cache.