### PR TITLE
Checkout Branch Only for GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout source code
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v1.1


### PR DESCRIPTION
Change the GitHub Actions CI to checkout out the branch
which triggered the action only rather than all history
for all branches and tags.

It is not possible to use the latest branch commit only
due to the way the `ct` tool [works](https://github.com/helm/chart-testing/blob/ba5aed29ec88e9fc187915f115890cb174999a3c/pkg/chart/chart.go#L703)

Ref:
1. [Checkout V2 Documentation](https://github.com/actions/checkout#checkout-v2)
2. [GitHub Actions Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts)