### PR TITLE
GOVUK default Rails application Helm chart.

### DIFF
--- a/charts/govuk-rails-app/Chart.yaml
+++ b/charts/govuk-rails-app/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: govuk-rails-app
+description: A Helm chart for GOV.UK Rails app
+type: application
+version: 0.1.0

--- a/charts/govuk-rails-app/templates/NOTES.txt
+++ b/charts/govuk-rails-app/templates/NOTES.txt
@@ -1,5 +1,9 @@
 1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
+{{- if .Values.ingress.enabled }}
+  export INGRESS_NAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "govuk-rails-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export FQDN=$(kubectl get ingress --namespace {{ .Release.Namespace }} $INGRESS_NAME -o jsonpath="{.spec.rules[0].host}")
+  echo "Visit $FQDN to use this GOV.UK Rails Application"
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "govuk-rails-app.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
@@ -9,7 +13,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "govuk-rails-app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "content-store.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "govuk-rails-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/charts/govuk-rails-app/templates/NOTES.txt
+++ b/charts/govuk-rails-app/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "govuk-rails-app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "govuk-rails-app.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "govuk-rails-app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "content-store.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/govuk-rails-app/templates/_helpers.tpl
+++ b/charts/govuk-rails-app/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "govuk-rails-app.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "govuk-rails-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Release.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "govuk-rails-app.chart" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "govuk-rails-app.labels" -}}
+helm.sh/chart: {{ include "govuk-rails-app.chart" . }}
+{{ include "govuk-rails-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "govuk-rails-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "govuk-rails-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "govuk-rails-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "govuk-rails-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.dbMigrationEnabled -}}
+{{/*
+k8s Jobs are immutable but Helm still tries to patch them when they change, so
+we suffix the name with the chart version and image tag to create a new one
+when the chart or the binary changes. This workaround doesn't work when moving
+a mutable tag (like "latest"), but we shouldn't be using those anyway.
+*/}}
+{{- $chartVersionNoDots := .Chart.Version | replace "." "-" }}
+{{- $jobName := print .Release.Name "-dbmigrate-" $chartVersionNoDots "-" .Values.appImage.tag }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+    argocd.argoproj.io/hook: PreSync
+spec:
+  template:
+    metadata:
+      name: {{ $jobName }}
+      labels:
+        {{- include "govuk-rails-app.labels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ $jobName }}
+        image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+        command: ["bundle"]
+        args: ["exec", "rails", "db:migrate"]
+        envFrom:
+          - configMapRef:
+              name: govuk-apps-env
+          - secretRef:
+              name: {{ .Release.Name }}
+        env:
+        {{- with .Values.appExtraEnv }}
+          {{- . | toYaml | trim | nindent 12 }}
+        {{- end }}
+        {{- with .Values.appResources }}
+        resources:
+          {{- . | toYaml | trim | nindent 12 }}
+        {{- end }}
+{{- end }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.appPort }}
+          envFrom:
+          - configMapRef:
+              name: govuk-apps-env
+          env:
+            - name: PORT
+              value: "{{ .Values.appPort }}"
+            - name: SECRET_KEY_BASE
+              value: "secret"  # TODO: fix when we know how to handle secrets
+          {{- with .Values.appExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          startupProbe: &app-probe  # TODO: check the app responds with any Host header
+            httpGet:
+              path: /healthcheck/live
+              port: http
+            failureThreshold: 10
+            periodSeconds: 3
+            timeoutSeconds: 5
+          livenessProbe:
+            <<: *app-probe
+            failureThreshold: 3
+            periodSeconds: 5
+          readinessProbe:
+            <<: *app-probe
+            httpGet:
+              path: /healthcheck/ready
+              port: http
+            failureThreshold: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 2000
+            runAsGroup: 3000
+        - name: {{ .Release.Name }}-nginx
+          image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginxPort }}
+          livenessProbe: &nginx-probe  # TODO: make this an HTTP probe
+            tcpSocket:
+              port: http
+            periodSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            <<: *nginx-probe
+            failureThreshold: 2
+          volumeMounts:
+          - name: {{ .Release.Name }}-nginx-conf
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+          - name: tmp
+            mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: {{ .Release.Name }}-nginx-conf
+        configMap:
+          name: {{ .Release.Name }}-nginx-conf

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -12,75 +12,66 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "govuk-rails-app.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
     spec:
-      securityContext:
-        runAsNonRoot: true
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}::{{ .Values.appImage.tag }}"
           ports:
             - name: http
-              containerPort: {{ .Values.appPort }}
+              containerPort: {{ .Values.appImage.appPort }}
           envFrom:
           - configMapRef:
               name: govuk-apps-env
+          - secretRef:
+              name: {{ .Release.Name }}
           env:
-            - name: PORT
-              value: "{{ .Values.appPort }}"
-            - name: SECRET_KEY_BASE
-              value: "secret"  # TODO: fix when we know how to handle secrets
           {{- with .Values.appExtraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with .Values.appResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          startupProbe: &app-probe  # TODO: check the app responds with any Host header
+          livenessProbe:
             httpGet:
               path: /healthcheck/live
               port: http
-            failureThreshold: 10
-            periodSeconds: 3
-            timeoutSeconds: 5
-          livenessProbe:
-            <<: *app-probe
-            failureThreshold: 3
+            initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
-            <<: *app-probe
             httpGet:
               path: /healthcheck/ready
               port: http
-            failureThreshold: 2
+            initialDelaySeconds: 30
             periodSeconds: 5
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 2000
-            runAsGroup: 3000
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
             - name: http
-              containerPort: {{ .Values.nginxPort }}
-          livenessProbe: &nginx-probe  # TODO: make this an HTTP probe
+              containerPort: {{ .Values.nginxImage.nginxPort }}
+          livenessProbe:
             tcpSocket:
               port: http
-            periodSeconds: 3
-            failureThreshold: 3
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+            successThreshold: 1
           readinessProbe:
-            <<: *nginx-probe
-            failureThreshold: 2
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
           - name: {{ .Release.Name }}-nginx-conf
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
-          - name: tmp
-            mountPath: /tmp
       volumes:
-      - name: tmp
-        emptyDir: {}
       - name: {{ .Release.Name }}-nginx-conf
         configMap:
           name: {{ .Release.Name }}-nginx-conf

--- a/charts/govuk-rails-app/templates/external-secret.yaml
+++ b/charts/govuk-rails-app/templates/external-secret.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Release.Name }}
+  # TODO: Use individual AWS secrets instead of lumping them all together,
+  # so that we can have automated rotation, proper audit trail, etc.
+  # TODO: Once the AWS secrets are split up, pass the names (dataFrom.key[]) of
+  # the AWS secrets into the chart as values in some appropriate way. The name
+  # of the temporary, combined secret is hardcoded for now because we don't
+  # want to bake it into the interface to the chart.
+  dataFrom:
+    - key: govuk/{{ .Release.Name }}
+{{ end }}

--- a/charts/govuk-rails-app/templates/ingress.yaml
+++ b/charts/govuk-rails-app/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := .Release.Name -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "web"
+  annotations:
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}-{{ .Release.Namespace }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  # TODO: Import GOVUK_APP_DOMAIN_EXTERNAL from global config map and apend to host name.
+    - host: {{ .Values.ingress.host | default (printf "%s-%s" .Values.ingress.name .Release.Namespace ) }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/charts/govuk-rails-app/templates/ingress.yaml
+++ b/charts/govuk-rails-app/templates/ingress.yaml
@@ -4,12 +4,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Values.ingress.name }}
+  name: {{ .Values.ingress.name | default .Release.Name }}
   labels:
     {{- include "govuk-rails-app.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "web"
+    app.kubernetes.io/component: web
   annotations:
-    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}-{{ .Release.Namespace }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.tls }}
@@ -23,15 +22,18 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-  # TODO: Import GOVUK_APP_DOMAIN_EXTERNAL from global config map and apend to host name.
-    - host: {{ .Values.ingress.host | default (printf "%s-%s" .Values.ingress.name .Release.Namespace ) }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
-            pathType: {{ .Values.ingress.pathType }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -2,10 +2,15 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-nginx-conf
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
 data:
   nginx.conf: |-
-    error_log  /tmp/error.log warn;
-    pid        /tmp/nginx.pid;
+    user nginx;
+
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
 
     events {
       worker_connections  1024;
@@ -21,11 +26,11 @@ data:
       keepalive_timeout  65;
 
       upstream {{ .Release.Name }} {
-        server 127.0.0.1:{{ .Values.appPort }};
+        server 127.0.0.1:{{ .Values.appImage.appPort }};
       }
 
       server {
-        listen {{ .Values.nginxPort }};
+        listen {{ .Values.nginxImage.nginxPort }};
 
         location / {
           proxy_set_header   Host $host;

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nginx-conf
+data:
+  nginx.conf: |-
+    error_log  /tmp/error.log warn;
+    pid        /tmp/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      upstream {{ .Release.Name }} {
+        server 127.0.0.1:{{ .Values.appPort }};
+      }
+
+      server {
+        listen {{ .Values.nginxPort }};
+
+        location / {
+          proxy_set_header   Host $host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_pass         http://{{ .Release.Name }};
+          proxy_redirect     off;
+        }
+      }
+    }

--- a/charts/govuk-rails-app/templates/service.yaml
+++ b/charts/govuk-rails-app/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+{{ if .Values.service.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.nginxPort }}
+  selector:
+    app: {{ .Release.Name }}

--- a/charts/govuk-rails-app/templates/service.yaml
+++ b/charts/govuk-rails-app/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.nginxPort }}
+      targetPort: {{ .Values.nginxImage.nginxPort }}
   selector:
     app: {{ .Release.Name }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.workerEnabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+    app: {{ .Release.Name }}-worker
+spec:
+  replicas: {{ .Values.workerReplicas }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-worker
+  template:
+    metadata:
+      labels:
+        {{- include "govuk-rails-app.labels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        app: {{ .Release.Name }}-worker
+    spec:
+      containers:
+        - name: app
+          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          command: ["bundle"]
+          args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
+          envFrom:
+            - configMapRef:
+                name: govuk-apps-env
+            - secretRef:
+                name: {{ .Release.Name }}
+          env:
+          {{- with .Values.workerExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workerResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          # TODO: consider implementing a liveness probe for Sidekiq
+          # e.g. https://github.com/arturictus/sidekiq_alive
+{{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -5,9 +5,13 @@ service:
   annotations: {}
   port: 80
 
+externalSecrets:
+  enabled: true
+  refreshInterval: 60m
+
 ingress:
   enabled: false
-  name: 
+  name:
   host: ""
   path: "/"
   pathType: Prefix
@@ -17,23 +21,33 @@ ingress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
+  hosts:
+  - host:
+    paths:
+    - path: /
+      pathType: Prefix
 
 replicaCount: 1
 
+# workerEnabled should be true if the app uses Sidekiq, false otherwise.
+workerEnabled: false
+workerReplicaCount: 1
+
+# dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
+dbMigrationEnabled: false
+
 appImage:
-  # TODO: point this at a public repo and override to the private repo in our CD config.
-  repository:
+  repository: ""  # Dummy value, overridden in ArgoCD config.
   tag: latest
+  appPort: 3000
 
 nginxImage:
-  repository: nginxinc/nginx-unprivileged
+  repository: nginx
   pullPolicy: Always
   tag: stable
+  nginxPort: 8080
 
-nginxPort: 8080
-appPort: 3000
-
-# resources:
+appResources: {}
 #   limits:
 #     cpu: 500m
 #     memory: 512Mi
@@ -41,6 +55,14 @@ appPort: 3000
 #     cpu: 500m
 #     memory: 512Mi
 
-# appExtraEnv:
+workerResources: {}
+#   limits:
+#     cpu: 500m
+#     memory: 512Mi
+#   requests:
+#     cpu: 500m
+#     memory: 512Mi
+
+# extraEnv:
 #  - name: RETICULATE_SPLINES
 #    value: "true"

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -1,0 +1,46 @@
+# Default/example values for a Rails application.
+
+service:
+  type: NodePort
+  annotations: {}
+  port: 80
+
+ingress:
+  enabled: false
+  name: 
+  host: ""
+  path: "/"
+  pathType: Prefix
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
+
+replicaCount: 1
+
+appImage:
+  # TODO: point this at a public repo and override to the private repo in our CD config.
+  repository:
+  tag: latest
+
+nginxImage:
+  repository: nginxinc/nginx-unprivileged
+  pullPolicy: Always
+  tag: stable
+
+nginxPort: 8080
+appPort: 3000
+
+# resources:
+#   limits:
+#     cpu: 500m
+#     memory: 512Mi
+#   requests:
+#     cpu: 500m
+#     memory: 512Mi
+
+# appExtraEnv:
+#  - name: RETICULATE_SPLINES
+#    value: "true"


### PR DESCRIPTION
Adding govuk-rails-app default chart, to be used to deploy new rails app which are somewhat similar.

Ingress, worker and db-migrations can be enabled via true/false value.

TODO as part future work:
- External secrets strategy is yet to be finalised. 

Documentation:
- Brief guide to be added once testing is completed.

Manual Testing:
helm install frontend . --namespace nadeem --set ingress.enabled=true --set ingress.name=frontend --set appImage.repository=172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend --set 'appExtraEnv[0].name=TEST_ENV' --set 'appExtraEnv[0].value=testvalue'

Trello card: https://trello.com/c/8hYNGIjG/659-write-up-a-starter-helm-chart-for-our-template