### PR TITLE
Use YAML for Helm values instead of setting key/value params.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.3.13
+version: 0.4.0

--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -16,13 +16,14 @@ spec:
     repoURL: 'git@github.com/alphagov/govuk-helm-charts'
     path: "{{ .chartPath | default (printf "charts/%s" .name) }}"
     targetRevision: {{ .targetRevision | default "HEAD" }}
-    {{- with .helmValues }}
     helm:
       # Environment-specific Helm values. These take precedence over the app
       # chart's values.yaml.
       values: |
+        govukEnvironment: {{ $.Values.govukEnvironment }}
+        {{- with .helmValues }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- end }}
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: apps

--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.applications }}
+{{ range .Values.applications }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,17 +16,13 @@ spec:
     repoURL: 'git@github.com/alphagov/govuk-helm-charts'
     path: "{{ .chartPath | default (printf "charts/%s" .name) }}"
     targetRevision: {{ .targetRevision | default "HEAD" }}
-
-    # Helm overrides specific to environment
-    # Same as setting through values.yaml, but these take precedence.
-{{ if .helm }}
+    {{- with .helmValues }}
     helm:
-      {{ if .helm.parameters }}
-      parameters:
-        {{- .helm.parameters | toYaml | trim | nindent 6 }}
-      {{- end }}
-{{- end }}
-
+      # Environment-specific Helm values. These take precedence over the app
+      # chart's values.yaml.
+      values: |
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: apps
@@ -39,4 +35,4 @@ spec:
     - PrunePropagationPolicy=foreground
     - PruneLast=true
 ---
-{{- end }}
+{{ end }}

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -3,93 +3,67 @@ govukEnvironment: integration
 applications:
 - name: cluster-secrets
 - name: govuk-apps-conf
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: integration
+  helmValues:
+    govukEnvironment: integration
 - name: smokey
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: "integration"
+  helmValues:
+    govukEnvironment: integration
 - name: publisher
-  helm:
-    parameters:
-    - name: common.govukEnvironment
-      value: "integration"
-    - name: common.image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher"
-    - name: common.image.tag
-      value: "latest"  # Automatically updated
-    - name: web.dbMigrationEnabled
-      value: "true"
-    - name: common.env.redisUrl
-      value: "redis://shared-redis.eks.integration.govuk-internal.digital"
-    - name: web.replicas
-      value: "1"
-    - name: worker.replicas
-      value: "1"
+  helmValues:
+    common:
+      govukEnvironment: integration
+      image:
+        repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
+        tag: latest  # Automatically updated
+      env:
+        redisUrl: redis://shared-redis.eks.integration.govuk-internal.digital
+    web:
+      dbMigrationEnabled: true
+      replicas: 1
+    worker:
+      replicas: 1
 - name: signon
-  helm:
-    parameters:
-    - name: common.govukEnvironment
-      value: "integration"
-    - name: common.image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon"
-    - name: common.image.tag
-      value: "latest"  # Automatically updated
-    - name: web.dbMigrationEnabled
-      value: "true"
-    - name: common.env.redisUrl
-      value: "redis://shared-redis.eks.integration.govuk-internal.digital"
-    - name: web.replicas
-      value: "1"
-    - name: worker.replicas
-      value: "1"
+  helmValues:
+    common:
+      govukEnvironment: integration
+      image:
+        repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
+        tag: latest  # Automatically updated
+      env:
+        redisUrl: redis://shared-redis.eks.integration.govuk-internal.digital
+    web:
+      dbMigrationEnabled: true
+      replicas: 1
+    worker:
+      replicas: 1
 - name: router
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: "integration"
-    - name: govukStack
-      value: "blue"  # TODO: eliminate the need for govukStack
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/router"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
+  helmValues:
+    govukEnvironment: integration
+    govukStack: blue  # TODO: eliminate the need for govukStack
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
+      tag: latest  # Automatically updated
+    replicaCount: 1
 - name: frontend
-  helm:
-    parameters:
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
-    - name: appMemcacheServers
-      value: "{frontend-memcached.eks.integration.govuk-internal.digital:11211}"
+  helmValues:
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
+      tag: latest  # Automatically updated
+    replicaCount: 1
+    appMemcacheServers:
+    - frontend-memcached.eks.integration.govuk-internal.digital
 - name: static
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: "integration"
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/static"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
+  helmValues:
+    govukEnvironment: integration
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
+      tag: latest  # Automatically updated
+    replicaCount: 1
 - name: content-store
-  helm:
-    parameters:
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
-    - name: appMongodbUri
-      value: "mongodb://mongo-1.integration.govuk-internal.digital,mongo-2.integration.govuk-internal.digital,mongo-3.integration.govuk-internal.digital/content_store_production"
+  helmValues:
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
+      tag: latest  # Automatically updated
+    replicaCount: 1
+    appMongodbUri: mongodb://mongo-1.integration.govuk-internal.digital,mongo-2.integration.govuk-internal.digital,mongo-3.integration.govuk-internal.digital/content_store_production
 - name: argo-workflows

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -3,15 +3,10 @@ govukEnvironment: integration
 applications:
 - name: cluster-secrets
 - name: govuk-apps-conf
-  helmValues:
-    govukEnvironment: integration
 - name: smokey
-  helmValues:
-    govukEnvironment: integration
 - name: publisher
   helmValues:
     common:
-      govukEnvironment: integration
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
         tag: latest  # To be edited by automation (not yet implemented).
@@ -25,7 +20,6 @@ applications:
 - name: signon
   helmValues:
     common:
-      govukEnvironment: integration
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
         tag: latest  # To be edited by automation (not yet implemented).
@@ -38,7 +32,6 @@ applications:
       replicas: 1
 - name: router
   helmValues:
-    govukEnvironment: integration
     govukStack: blue  # TODO: eliminate the need for govukStack
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
@@ -54,7 +47,6 @@ applications:
     - frontend-memcached.eks.integration.govuk-internal.digital
 - name: static
   helmValues:
-    govukEnvironment: integration
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
       tag: latest  # To be edited by automation (not yet implemented).

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -14,7 +14,7 @@ applications:
       govukEnvironment: integration
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
-        tag: latest  # Automatically updated
+        tag: latest  # To be edited by automation (not yet implemented).
       env:
         redisUrl: redis://shared-redis.eks.integration.govuk-internal.digital
     web:
@@ -28,7 +28,7 @@ applications:
       govukEnvironment: integration
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
-        tag: latest  # Automatically updated
+        tag: latest  # To be edited by automation (not yet implemented).
       env:
         redisUrl: redis://shared-redis.eks.integration.govuk-internal.digital
     web:
@@ -42,13 +42,13 @@ applications:
     govukStack: blue  # TODO: eliminate the need for govukStack
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
 - name: frontend
   helmValues:
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
     appMemcacheServers:
     - frontend-memcached.eks.integration.govuk-internal.digital
@@ -57,13 +57,13 @@ applications:
     govukEnvironment: integration
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
 - name: content-store
   helmValues:
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
     appMongodbUri: mongodb://mongo-1.integration.govuk-internal.digital,mongo-2.integration.govuk-internal.digital,mongo-3.integration.govuk-internal.digital/content_store_production
 - name: argo-workflows

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -14,7 +14,7 @@ applications:
       govukEnvironment: test
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
-        tag: latest  # Automatically updated
+        tag: latest  # To be edited by automation (not yet implemented).
       env:
         redisUrl: redis://shared-redis.eks.test.govuk-internal.digital
     web:
@@ -28,7 +28,7 @@ applications:
       govukEnvironment: test
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
-        tag: latest  # Automatically updated
+        tag: latest  # To be edited by automation (not yet implemented).
       env:
         redisUrl: redis://shared-redis.eks.test.govuk-internal.digital
     web:
@@ -41,13 +41,13 @@ applications:
     govukEnvironment: test
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
 - name: frontend
   helmValues:
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
     appMemcacheServers:
     - frontend-memcached.eks.test.govuk-internal.digital
@@ -56,13 +56,13 @@ applications:
     govukEnvironment: test
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
 - name: content-store
   helmValues:
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
-      tag: latest  # Automatically updated
+      tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
     appMongodbUri: mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production
 - name: argo-workflows

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -3,15 +3,10 @@ govukEnvironment: test
 applications:
 - name: cluster-secrets
 - name: govuk-apps-conf
-  helmValues:
-    govukEnvironment: test
 - name: smokey
-  helmValues:
-    govukEnvironment: test
 - name: publisher
   helmValues:
     common:
-      govukEnvironment: test
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
         tag: latest  # To be edited by automation (not yet implemented).
@@ -25,7 +20,6 @@ applications:
 - name: signon
   helmValues:
     common:
-      govukEnvironment: test
       image:
         repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
         tag: latest  # To be edited by automation (not yet implemented).
@@ -38,7 +32,6 @@ applications:
       replicas: 1
 - name: router
   helmValues:
-    govukEnvironment: test
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
@@ -53,7 +46,6 @@ applications:
     - frontend-memcached.eks.test.govuk-internal.digital
 - name: static
   helmValues:
-    govukEnvironment: test
     image:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
       tag: latest  # To be edited by automation (not yet implemented).

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -3,91 +3,66 @@ govukEnvironment: test
 applications:
 - name: cluster-secrets
 - name: govuk-apps-conf
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: test
+  helmValues:
+    govukEnvironment: test
 - name: smokey
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: "test"
+  helmValues:
+    govukEnvironment: test
 - name: publisher
-  helm:
-    parameters:
-    - name: common.govukEnvironment
-      value: "test"
-    - name: common.image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher"
-    - name: common.image.tag
-      value: "latest"  # Automatically updated
-    - name: web.dbMigrationEnabled
-      value: "true"
-    - name: common.env.redisUrl
-      value: "redis://shared-redis.eks.test.govuk-internal.digital"
-    - name: web.replicas
-      value: "1"
-    - name: worker.replicas
-      value: "1"
+  helmValues:
+    common:
+      govukEnvironment: test
+      image:
+        repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
+        tag: latest  # Automatically updated
+      env:
+        redisUrl: redis://shared-redis.eks.test.govuk-internal.digital
+    web:
+      dbMigrationEnabled: true
+      replicas: 1
+    worker:
+      replicas: 1
 - name: signon
-  helm:
-    parameters:
-    - name: common.govukEnvironment
-      value: "test"
-    - name: common.image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon"
-    - name: common.image.tag
-      value: "latest"  # Automatically updated
-    - name: web.dbMigrationEnabled
-      value: "true"
-    - name: common.env.redisUrl
-      value: "redis://shared-redis.eks.test.govuk-internal.digital"
-    - name: web.replicas
-      value: "1"
-    - name: worker.replicas
-      value: "1"
+  helmValues:
+    common:
+      govukEnvironment: test
+      image:
+        repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
+        tag: latest  # Automatically updated
+      env:
+        redisUrl: redis://shared-redis.eks.test.govuk-internal.digital
+    web:
+      dbMigrationEnabled: true
+      replicas: 1
+    worker:
+      replicas: 1
 - name: router
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: "test"
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/router"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
+  helmValues:
+    govukEnvironment: test
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
+      tag: latest  # Automatically updated
+    replicaCount: 1
 - name: frontend
-  helm:
-    parameters:
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
-    - name: appMemcacheServers
-      value: "{frontend-memcached.eks.test.govuk-internal.digital:11211}"
+  helmValues:
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
+      tag: latest  # Automatically updated
+    replicaCount: 1
+    appMemcacheServers:
+    - frontend-memcached.eks.test.govuk-internal.digital
 - name: static
-  helm:
-    parameters:
-    - name: govukEnvironment
-      value: "test"
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/static"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
+  helmValues:
+    govukEnvironment: test
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
+      tag: latest  # Automatically updated
+    replicaCount: 1
 - name: content-store
-  helm:
-    parameters:
-    - name: image.repository
-      value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store"
-    - name: image.tag
-      value: "latest"  # Automatically updated
-    - name: replicaCount
-      value: "1"
-    - name: appMongodbUri
-      value: "mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production"
+  helmValues:
+    image:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
+      tag: latest  # Automatically updated
+    replicaCount: 1
+    appMongodbUri: mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production
 - name: argo-workflows


### PR DESCRIPTION
This means we have the same syntax when passing Helm values via Argo as when deploying using Helm directly, which makes testing easier as well as making the config more readable.

Also:
* Pass `govukEnvironment` into every app chart instead of repeating it for every app.
* Fix the confusing comments about `tag: latest`. The idea is that those lines will be edited by release automation (an Argo post-sync hook), but we haven't implemented that yet. This PR should make implementing that automation a bit easier since everything is now plain YAML instead of the clunky `{name: x, value: y}` format.

[Trello](https://trello.com/c/h6lGL53t/706)

Tested: tried it on the test cluster by editing app/argocd-apps to point at the branch (`kubectl edit app argocd-apps`). The Argo apps seem to work as expected.