### PR TITLE
Use ArgoCD finalizers in test and staging envs only.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.3.12
+version: 0.3.13

--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -3,10 +3,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .name }}
+  {{- if has $.Values.govukEnvironment (list "test" "integration") }}
   finalizers:
-  # TODO: Disable this finalizer in production –
-  # deleting this Application will delete its resources (pods etc.)
   - resources-finalizer.argocd.argoproj.io
+  {{- end }}
   annotations:
     slackChannel: "{{ .slackChannel | default "govuk-deploy-alerts" }}"
     notifications.argoproj.io/subscribe.on-deployed.argo_events: ""

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -1,2 +1,2 @@
-govukEnvironment:
+govukEnvironment: ""
 applications: []


### PR DESCRIPTION
In prod (and probably staging, just for prod-fidelity) we don't want Argo to delete an application's resources on deletion of its Argo app resource. In production it's more likely that Argo apps would be deleted temporarily or accidentally than with the intent of removing all trace of the application.

[Trello](https://trello.com/c/h6lGL53t/706)