### PR TITLE
Create Signon Resources on cluster turnup

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.0
+version: 0.5.1

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -57,3 +57,4 @@ applications:
     replicaCount: 1
     appMongodbUri: mongodb://mongo-1.integration.govuk-internal.digital,mongo-2.integration.govuk-internal.digital,mongo-3.integration.govuk-internal.digital/content_store_production
 - name: argo-workflows
+- name: signon-resources

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -58,3 +58,4 @@ applications:
     replicaCount: 1
     appMongodbUri: mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production
 - name: argo-workflows
+- name: signon-resources

--- a/charts/content-store/Chart.yaml
+++ b/charts/content-store/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: content-store
 description: A Helm chart for GOV.UK Content-Store
 type: application
-version: 0.5.0
+version: 0.5.1

--- a/charts/content-store/templates/deployment.yaml
+++ b/charts/content-store/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               value: "{{ .Values.appPort }}"
             - name: SECRET_KEY_BASE
               value: "secret"  # TODO: fix when we know how to handle secrets
-          {{- with .Values.appExtraEnv }}
+          {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/content-store/values.yaml
+++ b/charts/content-store/values.yaml
@@ -31,6 +31,23 @@ appGovukContentSchemasPath: "/govuk-content-schemas"
 appDefaultTtl: "1800"
 appMongodbUri: "mongodb://mongo/content-store"
 
+extraEnv:
+  - name: ROUTER_API_BEARER_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: signon-token-content-store-router-api
+        key: bearer_token
+  - name: GDS_SSO_OAUTH_ID
+    valueFrom:
+      secretKeyRef:
+        name: signon-app-content-store
+        key: oauth_id
+  - name: GDS_SSO_OAUTH_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: signon-app-content-store
+        key: oauth_secret
+
 # appExtraEnv:
 #   - name: RETICULATE_SPLINES
 #     value: "true"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.7.2
+version: 0.7.3

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               value: "{{ .Values.appPort }}"
             - name: SECRET_KEY_BASE
               value: "secret"  # TODO: fix when we know how to handle secrets
-          {{- with .Values.appExtraEnv }}
+          {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -22,6 +22,13 @@ appPort: 3000
 
 appMemcacheServers: []
 
+extraEnv:
+  - name: PUBLISHING_API_BEARER_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: signon-token-frontend-publishing-api
+        key: bearer_token
+
 # resources:
 #   limits:
 #     cpu: 500m

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.9.2
+version: 0.9.3

--- a/charts/publisher/values.yaml
+++ b/charts/publisher/values.yaml
@@ -28,7 +28,82 @@ replicas: 1
 workerReplicas: 1
 port: 3000
 dbMigrationEnabled: true
-extraEnv: []
+extraEnv:
+  - name: GDS_SSO_OAUTH_ID
+    valueFrom:
+      secretKeyRef:
+        name: signon-app-publisher-eks
+        key: oauth_id
+  - name: GDS_SSO_OAUTH_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: signon-app-publisher-eks
+        key: oauth_secret
+  - name: ASSET_MANAGER_BEARER_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: "signon-token-publisher-asset-manager"
+        key: bearer_token
+  - name: PUBLISHING_API_BEARER_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: "signon-token-publisher-publishing-api"
+        key: bearer_token
+  - name: FACT_CHECK_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: FACT_CHECK_PASSWORD
+  - name: FACT_CHECK_REPLY_TO_ADDRESS
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: FACT_CHECK_REPLY_TO_ADDRESS
+  - name: FACT_CHECK_REPLY_TO_ID
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: FACT_CHECK_REPLY_TO_ID
+  - name: GA_UNIVERSAL_ID
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: GA_UNIVERSAL_ID
+  - name: GOVUK_NOTIFY_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: GOVUK_NOTIFY_API_KEY
+  - name: GOVUK_NOTIFY_TEMPLATE_ID
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: GOVUK_NOTIFY_TEMPLATE_ID
+  - name: JWT_AUTH_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: JWT_AUTH_SECRET
+  - name: LINK_CHECKER_API_BEARER_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: LINK_CHECKER_API_BEARER_TOKEN
+  - name: LINK_CHECKER_API_SECRET_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: LINK_CHECKER_API_SECRET_TOKEN
+  - name: MONGODB_URI
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: MONGODB_URI
+  - name: SECRET_KEY_BASE
+    valueFrom:
+      secretKeyRef:
+        name: publisher
+        key: SECRET_KEY_BASE
 # - name: RETICULATE_SPLINES
 #   value: true
 

--- a/charts/signon-resources/Chart.yaml
+++ b/charts/signon-resources/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: signon-resources
+description: A Helm chart for creating Signon resources such as bearer tokens
+type: application
+version: 0.1.0

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -1,0 +1,112 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "bootstrap-signon-resources-{{ randNumeric 8 }}"
+spec:
+  template:
+    metadata:
+      name: bootstrap-signon-resources
+    spec:
+      restartPolicy: Never
+      serviceAccountName: signon-secrets-bootstrapper
+      containers:
+      - name: bootstrap-signon-resources
+        image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
+        command: ["bundle"]
+        args: ["exec", "rake", "bootstrap:signon"]
+        env:
+          - name: SIGNON_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: signon-auth-token
+                key: token
+          - name: APPLICATIONS
+            value: |-
+              {
+                "content-store": {
+                  "name": "Content Store",
+                  "slug": "content-store",
+                  "secret_name": "signon-app-content-store",
+                  "description": "Central store for current live content on GOV.UK",
+                  "home_uri": "https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": []
+                },
+                "router-api": {
+                  "name": "Router API",
+                  "slug": "router-api",
+                  "secret_name": "signon-app-router-api",
+                  "description": "Manages the Router database",
+                  "home_uri": "https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": []
+                },
+                "asset-manager": {
+                  "name": "Asset Manager",
+                  "slug": "asset-manager",
+                  "secret_name": "signon-app-asset-manager",
+                  "description": "Manages assets",
+                  "home_uri": "https://asset-manager.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://asset-manager.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": []
+                },
+                "publisher-eks": {
+                  "name": "Publisher [EKS]",
+                  "slug": "publisher-eks",
+                  "secret_name": "signon-app-publisher-eks",
+                  "description": "Mainstream publishing application",
+                  "home_uri": "https://publisher-apps.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://publisher-apps.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": ["view_all"]
+                },
+                "publishing-api": {
+                  "name": "Publishing API",
+                  "slug": "publishing-api",
+                  "secret_name": "signon-app-publishing-api",
+                  "description": "Central store for all publishing content on GOV.UK",
+                  "home_uri": "https://publishing-api.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://publishing-api.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": ["view_all"]
+                }
+              }
+          - name: API_USERS
+            value: |-
+              {
+                "content-store": {
+                  "name": "Content Store",
+                  "username": "content-store",
+                  "email": "content-store@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "router-api" }
+                  ]
+                },
+                "frontend": {
+                  "name": "Frontend",
+                  "username": "frontend",
+                  "email": "frontend@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "publishing-api" }
+                  ]
+                },
+                "publisher": {
+                  "name": "Publisher",
+                  "username": "publisher",
+                  "email": "publisher@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "publishing-api" },
+                    { "application_slug": "asset-manager" }
+                  ]
+                },
+                "publishing-api": {
+                  "name": "Publishing API",
+                  "username": "publishing-api",
+                  "email": "publishing-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "content-store" }
+                  ]
+                }
+              }
+          - name: SIGNON_API_ENDPOINT
+            value: http://signon.apps.{{.Values.clusterDomain}}/api/v1
+          - name: GOVUK_PUBLISHING_DOMAIN
+            value: {{.Values.govukEnvironment}}.{{.Values.govukPublishingDomain}}

--- a/charts/signon-resources/templates/signon-secrets-role.yaml
+++ b/charts/signon-resources/templates/signon-secrets-role.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signon-secrets-bootstrapper
+  namespace: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: apps
+  name: signon-secret-manager
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["secrets"]
+  verbs: ["get","create","patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: signon-secret-manager-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: signon-secret-manager
+subjects:
+  - kind: ServiceAccount
+    name: signon-secrets-bootstrapper

--- a/charts/signon-resources/values.yaml
+++ b/charts/signon-resources/values.yaml
@@ -1,0 +1,11 @@
+common:
+  image:
+    # TODO: Replace with ECR once image CI is set up
+    repository: govuk/signon-bootstrap
+    tag: 0.0.11
+
+govukEnvironment: test
+govukDomainExternal: govuk.digital
+clusterDomain: svc.cluster.local
+
+govukPublishingDomain: publishing.service.gov.uk

--- a/charts/signon/Chart.yaml
+++ b/charts/signon/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon
 description: A Helm chart for GOV.UK Signon
 type: application
-version: 0.2.4
+version: 0.2.5

--- a/charts/signon/templates/deployment.yaml
+++ b/charts/signon/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
@@ -64,7 +64,10 @@ spec:
             - name: SECRET_KEY_BASE
               value: "secret" #TODO: fix when we know how to handle secrets
             - name: SIGNON_ADMIN_PASSWORD
-              value: "secret"
+              valueFrom:
+                secretKeyRef:
+                  name: signon-auth-token
+                  key: token
           {{- with .Values.appExtraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}

--- a/charts/signon/values.yaml
+++ b/charts/signon/values.yaml
@@ -3,7 +3,7 @@ govukDomainExternal: govuk.digital
 govukDomainInternal: govuk-internal.digital
 clusterDomain: svc.cluster.local
 
-appImage:
+image:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
   tag: latest
 

--- a/doc/bootstrapping-steps.md
+++ b/doc/bootstrapping-steps.md
@@ -1,0 +1,10 @@
+# Bootstrapping steps
+
+Once you have applied the `cluster-services` Terraform project, you should
+run the following commands against the cluster.
+
+1. Manually store the Signon API token as a secret.
+  
+  ```shell
+  kubectl -n apps create secret generic signon-auth-token --from-literal=token=$(openssl rand -base64 40)
+  ```


### PR DESCRIPTION
Signon Resources (Applications, ApiUsers, Authorisations) will be created automatically during cluster turnup.

Changes:

- Adds a Signon Resources Helm chart (contains a job that creates the Signon Resources by calling the Rake task implemented in https://github.com/alphagov/govuk-infrastructure/pull/499 which in turn calls the Signon API and the Kubernetes API to create the Secrets required by other charts)
- Updates other charts to use the Secrets generated by the Signon Resources chart

Since the Helm chart design is being considered elsewhere, please consider the (inconsistent) way we set secrets/env vars across charts as only temporary. 

Trello: https://trello.com/c/fUXJ6X1U/725-create-signon-resources-when-signon-is-deployed