### PR TITLE
Suffix migration job names with chart version and image tag.

### DIFF
--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.9.0
+version: 0.9.1

--- a/charts/publisher/templates/web/dbmigration-job.yaml
+++ b/charts/publisher/templates/web/dbmigration-job.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.dbMigrationEnabled -}}
-{{- $jobName := print .Release.Name "-dbmigrate" -}}
+{{/* Job objects are immutable but Helm still tries to patch them when they
+change, so we suffix the name with the chart version and image tag to create a
+new one when the chart or the binary changes. */}}
+{{- $jobName := print .Release.Name "-dbmigrate-" .Chart.Version "-" .Values.image.tag -}}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
This avoids the problem where `helm upgrade` or Argo sync fails because helm/Argo tries to patch the annotations/metadata on the existing (immutable) Job resource.

As a bonus, this makes it easier to see which version of an app a given migration job corresponds to.

It'll result in a few no-op job runs, but that's ok. We'll only be running migration jobs when the chart or the app image changes.

We don't need to worry about the possibility of concurrent migration jobs because Rails/ActiveRecord takes care of locking.

Considered moving the DB migration responsibility into Argo Workflow, but that'd be less portable and more complex so this approach is probably better.

Also considered whether we even want to be running these "migrations" (i.e. schema changes) automatically in the first place, but we really don't want to impose new, manual process on established developer workflow without good reason. So we're keeping the automatic migrations for the time being. It's [normal for Rails], apparently 😅

[normal for Rails]: https://www.bbc.co.uk/news/uk-england-norfolk-36082307

[Trello card](https://trello.com/c/h6lGL53t/706)