### PR TITLE
Use assignment instead of helper templates in govuk-apps-conf.

### DIFF
--- a/charts/govuk-apps-conf/Chart.yaml
+++ b/charts/govuk-apps-conf/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: govuk-apps-conf
 description: Shared ConfigMap for global (per-environment) settings for GOV.UK apps
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/charts/govuk-apps-conf/templates/_helpers.tpl
+++ b/charts/govuk-apps-conf/templates/_helpers.tpl
@@ -49,13 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "govuk-apps-conf.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Construct the domain name suffixes for internal and external services.
-*/}}
-{{- define "govuk.internalDomainSuffix" -}}
-{{- printf "%s.%s" .Release.Namespace .Values.clusterDomain }}
-{{- end }}
-{{- define "govuk.externalDomainSuffix" -}}
-{{- printf "eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal }}
-{{- end }}

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{ $internalDomainSuffix := printf "%s.%s" .Release.Namespace .Values.clusterDomain }}
+{{ $externalDomainSuffix := printf "eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,20 +7,17 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
 data:
-  {{/*
-  TODO: probably omit namespace from these user-facing URLs in the default
-  namespace. Consider a helper template for the namespace suffix.
-  */}}
-  ASSET_HOST: https://www-origin-{{ .Release.Namespace }}.{{ template "govuk.externalDomainSuffix" . }}
-  GOVUK_APP_DOMAIN: {{ template "govuk.internalDomainSuffix" . }}
-  GOVUK_APP_DOMAIN_EXTERNAL: {{ template "govuk.externalDomainSuffix" . }}
-  GOVUK_ASSET_ROOT: https://assets-{{ .Release.Namespace }}.{{ template "govuk.externalDomainSuffix" . }}
+  {{- /* TODO: omit namespace from these user-facing URLs in the default namespace. */}}
+  ASSET_HOST: https://www-origin-{{ .Release.Namespace }}.{{ $externalDomainSuffix }}
+  GOVUK_APP_DOMAIN: {{ $internalDomainSuffix }}
+  GOVUK_APP_DOMAIN_EXTERNAL: {{ $externalDomainSuffix }}
+  GOVUK_ASSET_ROOT: https://assets-{{ .Release.Namespace }}.{{ $externalDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
-  GOVUK_WEBSITE_ROOT: https://www-origin-{{ .Release.Namespace }}.{{ template "govuk.externalDomainSuffix" . }}
-  PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.{{ template "govuk.internalDomainSuffix" . }}
-  PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin-{{ .Release.Namespace }}.{{ template "govuk.externalDomainSuffix" . }}
-  PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api-web.{{ template "govuk.internalDomainSuffix" . }}
-  PLEK_SERVICE_ROUTER_API_URI: http://router-api.{{ template "govuk.internalDomainSuffix" . }}
-  PLEK_SERVICE_SIGNON_URI: http://signon.{{ template "govuk.externalDomainSuffix" . }}
-  PLEK_SERVICE_STATIC_URI: http://static.{{ template "govuk.internalDomainSuffix" . }}
+  GOVUK_WEBSITE_ROOT: https://www-origin-{{ .Release.Namespace }}.{{ $externalDomainSuffix }}
+  PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.{{ $internalDomainSuffix }}
+  PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin-{{ .Release.Namespace }}.{{ $externalDomainSuffix }}
+  PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api-web.{{ $internalDomainSuffix }}
+  PLEK_SERVICE_ROUTER_API_URI: http://router-api.{{ $internalDomainSuffix }}
+  PLEK_SERVICE_SIGNON_URI: http://signon.{{ $externalDomainSuffix }}
+  PLEK_SERVICE_STATIC_URI: http://static.{{ $internalDomainSuffix }}
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}-eks


### PR DESCRIPTION
This is way cleaner and easier to understand. I don't know why I used helper templates here instead of just doing simple assignment locally 🤦 

[Trello card](https://trello.com/c/h6lGL53t/706)

Tested: `helm template .` produces same output as before (except that there's no longer a spurious blank line after `data:`).