### PR TITLE
Add default Argo Workflow TTL config

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argocd-workflows
 description: Configure Argo workflows
-version: 0.0.1
+version: 0.1.1

--- a/charts/argo-workflows/workflow-controller-configmap.yaml
+++ b/charts/argo-workflows/workflow-controller-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  # Global default values that apply to all Argo workflows except overridden at the workflow-level
+  workflowDefaults: |
+    spec:
+      activeDeadlineSeconds: 7200
+      ttlStrategy:
+        secondsAfterSuccess: 432000
+      podGC:
+        strategy: OnPodCompletion
+
+  persistence: |
+    archive: true


### PR DESCRIPTION
We need to change the default Argo Workflow TTL so
that resources are not wasted storing Argo workflow
artifacts "indefinitely".

Ref:
1. [trello card](https://trello.com/c/N9ER3ukt/755-cleanup-completed-jobs)