### PR TITLE
Add ExternalSecret config for Dex GitHub

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.2.0
+version: 0.3.0

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -1,0 +1,16 @@
+# Note: This secret is used to allow Dex (https://dexidp.io/), a federated
+# OpenID connect provider, to use GitHub as an identity provider
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-dex-github
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-dex-github
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/dex/github


### PR DESCRIPTION
Add ExternalSecret config for Dex GitHub, which will retrieve the Dex Github secret from AWS Secret manager.
[Dex](https://dexidp.io/) is a federated OpenID connect provider which abstracts multiple identity providers, e.g. GitHub.

This secret will be used to configure Dex later to be used with GitHub as an identity provider.

Ref:
1. [trello card](https://trello.com/c/Snqwc4Ac/784-deploy-dex-idp-and-configure-github-backend)