### PR TITLE
Add ArgoCD and Argo Workflows OAUTH Dex secrets

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.3.0
+version: 0.4.0

--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -1,0 +1,17 @@
+# Note: This secret contains the OAUTH secret which allows Argo-Workflows to
+# authenticate with Dex (https://dexidp.io/), a federated
+# OpenID connect provider.
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-dex-argo-workflows
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-dex-argo-workflows
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/dex/argo-workflows

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -1,0 +1,21 @@
+# Note: This secret contains the OAUTH secret which allows ArgoCD to
+# authenticate with Dex (https://dexidp.io/), a federated
+# OpenID connect provider.
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-dex-argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-dex-argocd
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: argocd
+  dataFrom:
+  - key: govuk/dex/argocd


### PR DESCRIPTION
These OAUTH secrets will allow ArgoCD and Argo Workflows to use Dex as Single Sign On (SSO) provider.