### PR TITLE
Adding govuk-rails-app to ArgoCD as the defaut chart.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.2
+version: 0.5.4

--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -15,7 +15,7 @@ spec:
   project: govuk
   source:
     repoURL: 'git@github.com/alphagov/govuk-helm-charts'
-    path: "{{ .chartPath | default (printf "charts/%s" .name) }}"
+    path: "{{ .chartPath | default (printf "charts/govuk-rails-app") }}"
     targetRevision: {{ .targetRevision | default "HEAD" }}
     helm:
       # Environment-specific Helm values. These take precedence over the app

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -4,32 +4,173 @@ globalHelmValues:
   externalDomainSuffix: eks.test.govuk.digital
 
 applications:
+- name: argo-workflows
+  chartPath: charts/argo-workflows
 - name: cluster-secrets
+  chartPath: charts/cluster-secrets
 - name: govuk-apps-conf
+  chartPath: charts/govuk-apps-conf
 - name: smokey
+  chartPath: charts/smokey
 - name: publisher
-  ingressHostname: publisher.{{ .Values.globalHelmValues.externalDomainSuffix }}
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
       tag: latest  # To be edited by automation (not yet implemented).
-    redisUrl: redis://shared-redis-govuk.eks.test.govuk-internal.digital
-    replicas: 1
-    worker:
-      replicas: 1
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: publisher
+      hosts:
+      - name: publisher.eks.test.govuk.digital
+    replicaCount: 1
+    workerReplicaCount: 1
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher-eks
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher-eks
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: "signon-token-publisher-asset-manager"
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: "signon-token-publisher-publishing-api"
+            key: bearer_token
+      - name: FACT_CHECK_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_PASSWORD
+      - name: FACT_CHECK_REPLY_TO_ADDRESS
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_REPLY_TO_ADDRESS
+      - name: FACT_CHECK_REPLY_TO_ID
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_REPLY_TO_ID
+      - name: GA_UNIVERSAL_ID
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: GA_UNIVERSAL_ID
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: GOVUK_NOTIFY_TEMPLATE_ID
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: JWT_AUTH_SECRET
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: LINK_CHECKER_API_BEARER_TOKEN
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: MONGODB_URI
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: SECRET_KEY_BASE
+      - name: PORT
+        value: "3000"
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
+      - name: EMAIL_GROUP_BUSINESS
+        value: mainstream-publisher-notifications-test@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_CITIZEN
+        value: mainstream-publisher-notifications-test@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_DEV
+        value: mainstream-publisher-notifications-test@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
+        value: mainstream-publisher-notifications-test@digital.cabinet-office.gov.uk
+      - name: FACT_CHECK_ADDRESS_FORMAT
+        value: factcheck+test-{id}@alphagov.co.uk
+      - name: FACT_CHECK_SUBJECT_PREFIX
+        value: test
+      - name: FACT_CHECK_REPLY_TO_ADDRESS
+        value: govuk-fact-check-test@digital.cabinet-office.gov.uk
+      - name: FACT_CHECK_REPLY_TO_ID
+        value: govuk-fact-check-test@digital.cabinet-office.gov.uk
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 123e4567-e89b-12d3-a456-426614174000
 - name: signon
   helmValues:
-    common:
-      image:
-        repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
-        tag: latest  # To be edited by automation (not yet implemented).
-      env:
-        redisUrl: redis://shared-redis-govuk.eks.test.govuk-internal.digital
-    web:
-      dbMigrationEnabled: true
-      replicas: 1
-    worker:
-      replicas: 1
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
+      tag: latest  # To be edited by automation (not yet implemented).
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: signon
+      hosts:
+      - name: signon.eks.test.govuk.digital
+    replicaCount: 1
+    workerReplicaCount: 1
+    extraEnv:
+      - name: DEVISE_PEPPER
+        value: secret
+      - name: DEVISE_SECRET_KEY
+        value: secret
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PORT
+        value: "3000"
+      - name: GOVUK_CONTENT_SCHEMAS_PATH
+        value: /govuk-content-schemas
+      - name: DEFAULT_TTL
+        value: "1800"
+      - name: GOVUK_APP_NAME
+        value: signon
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: signon
+            key: database-url
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
+      - name: RAILS_ENV
+        value: production
+      - name: GOVUK_APP_TYPE
+        value: rack
+      - name: SIGNON_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: signon-auth-token
+            key: token
 - name: router
   helmValues:
     image:
@@ -38,24 +179,78 @@ applications:
     replicaCount: 1
 - name: frontend
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
-    appMemcacheServers:
-    - frontend-memcached.eks.test.govuk-internal.digital
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-publishing-api
+            key: bearer_token
+      - name: PORT
+        value: "3000"
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached.eks.test.govuk-internal.digital
 - name: static
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PORT
+        value: "3000"
+      - name: RAILS_ENV
+        value: production
+      - name: DEFAULT_TTL
+        value: "1800"
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
+      - name: GOVUK_APP_NAME
+        value: static
+      - name: GOVUK_APP_TYPE
+        value: rack
+      - name: GOVUK_APP_ROOT
+        value: /var/apps/static
 - name: content-store
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
-    appMongodbUri: mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production
-- name: argo-workflows
+    extraEnv:
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-store-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_secret
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PORT
+        value: "3000"
+      - name: GOVUK_CONTENT_SCHEMAS_PATH
+        value: /govuk-content-schemas
+      - name: DEFAULT_TTL
+        value: "1800"
+      - name: MONGODB_URI
+        value: mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production
+      - name: GOVUK_APP_NAME
+        value: content-store
 - name: signon-resources
+  chartPath: charts/signon-resources

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -9,6 +9,6 @@ globalHelmValues:
   govukStack: blue  # TODO: eliminate the need for govukStack.
   externalDomainSuffix: ""
   # TODO: delete internalDomainSuffix once Plek handles empty GOVUK_APP_DOMAIN.
-  internalDomainSuffix: apps.svc.cluster.local.
+  internalDomainSuffix: apps.svc.cluster.local
 appsNamespace: apps
 applications: []

--- a/charts/govuk-rails-app/Chart.yaml
+++ b/charts/govuk-rails-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: govuk-rails-app
 description: A Helm chart for GOV.UK Rails app
 type: application
-version: 0.1.0
+version: 0.1.2

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -32,10 +32,8 @@ spec:
         envFrom:
           - configMapRef:
               name: govuk-apps-env
-          - secretRef:
-              name: {{ .Release.Name }}
         env:
-        {{- with .Values.appExtraEnv }}
+        {{- with .Values.extraEnv }}
           {{- . | toYaml | trim | nindent 12 }}
         {{- end }}
         {{- with .Values.appResources }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -17,17 +17,15 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}::{{ .Values.appImage.tag }}"
+          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
             - name: http
               containerPort: {{ .Values.appImage.appPort }}
           envFrom:
           - configMapRef:
               name: govuk-apps-env
-          - secretRef:
-              name: {{ .Release.Name }}
           env:
-          {{- with .Values.appExtraEnv }}
+          {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.appResources }}

--- a/charts/govuk-rails-app/templates/ingress.yaml
+++ b/charts/govuk-rails-app/templates/ingress.yaml
@@ -23,17 +23,15 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .name }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          - path: {{ default "/" .path }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -27,10 +27,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: govuk-apps-env
-            - secretRef:
-                name: {{ .Release.Name }}
           env:
-          {{- with .Values.workerExtraEnv }}
+          {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.workerResources }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -11,10 +11,6 @@ externalSecrets:
 
 ingress:
   enabled: false
-  name:
-  host: ""
-  path: "/"
-  pathType: Prefix
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
@@ -22,10 +18,9 @@ ingress:
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
   hosts:
-  - host:
-    paths:
-    - path: /
-      pathType: Prefix
+  - name:
+    path: /
+    pathType: Prefix
 
 replicaCount: 1
 


### PR DESCRIPTION
govuk-rails-app chart is now been set as the default chart in ArgoCD - This can be overwritten in:
values-{env}.yaml with 
`- chartPath {chart location}`

Updated govuk-rails-app to fix Ingress.

Things to do:
- Secrets 

https://trello.com/c/OL5uMIxV/786-update-helm-chart-repository-to-include-the-new-govuk-rails-app-in-argocd