### PR TITLE
Add individual cluster secrets to correct namespaces

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.4.0
+version: 0.5.0

--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argo-workflows
+  namespace: "{{ .Values.clusterServicesNamespace }}"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argocd
+  namespace: "{{ .Values.clusterServicesNamespace }}"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -4,6 +4,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-github
+  namespace: "{{ .Values.clusterServicesNamespace }}"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/values.yaml
+++ b/charts/cluster-secrets/values.yaml
@@ -1,0 +1,1 @@
+clusterServicesNamespace: cluster-services


### PR DESCRIPTION
By default, the cluster-secrets helm chart is installed in the
`apps` namespace and the secrets are created there.

Some secrets, such has the govuk-dex-* ones, are actually destined to
`cluster-services` namespaces.

This PR fixes that defining in which namespace each individual secret
should be located if not in the default `apps` namespace.