### PR TITLE
Add label to git-dex-argocd external secret

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.5.0
+version: 0.6.0

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -6,6 +6,8 @@ kind: ExternalSecret
 metadata:
   name: govuk-dex-argocd
   namespace: "{{ .Values.clusterServicesNamespace }}"
+  labels:
+    app.kubernetes.io/part-of: argocd
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -14,9 +16,5 @@ spec:
   target:
     name: govuk-dex-argocd
     creationPolicy: Owner
-    template:
-      metadata:
-        labels:
-          app.kubernetes.io/part-of: argocd
   dataFrom:
   - key: govuk/dex/argocd


### PR DESCRIPTION
There is no need to use a template to add a label to git-dex-argocd,
labels and annotations are copied from external-secret to k8s-secret,
see [doc](https://external-secrets.io/api-externalsecret/)