### PR TITLE
Add info-frontend to the test cluster

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.4
+version: 0.5.5

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -254,3 +254,18 @@ applications:
         value: content-store
 - name: signon-resources
   chartPath: charts/signon-resources
+- name: info-frontend
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/info-frontend
+      tag: latest  # To be edited by automation (not yet implemented).
+    replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: GOVUK_APP_DOMAIN
+        value: www.gov.uk
+      - name: GOVUK_WEBSITE_ROOT
+        value: https://www.gov.uk
+      - name: GOVUK_APP_NAME
+        value: info-frontend


### PR DESCRIPTION
The info-frontend app deployed to my own namespace successfully using a standalone Helm chart. I am testing its deployment using the govuk-rails-app shared chart and ArgoCD.