### PR TITLE
Replace DB migrate Jobs during Sync rather than upgrading in-place

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.4
+version: 0.5.5

--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -39,5 +39,6 @@ spec:
     - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
+    - ApplyOutOfSyncOnly=true
 ---
 {{ end }}

--- a/charts/govuk-rails-app/Chart.yaml
+++ b/charts/govuk-rails-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: govuk-rails-app
 description: A Helm chart for GOV.UK Rails app
 type: application
-version: 0.1.2
+version: 0.1.3

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- include "govuk-rails-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
     argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:
     metadata:

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.9.3
+version: 0.9.4

--- a/charts/publisher/templates/web/dbmigration-job.yaml
+++ b/charts/publisher/templates/web/dbmigration-job.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- include "publisher.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
     argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:
     metadata:


### PR DESCRIPTION
Jobs are immutable so our sync policy should use `kubectl replace` rather than `kubectl apply`. This is configured at the individual resource level only on DB migration jobs.

The motivation for this change is that DB migration jobs can fail or need to be re-run, and we'd like to ensure that we can re-sync those objects successfully.

Docs: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#replace-resource-instead-of-applying-changes