### PR TITLE
Fixup: make ArgoCD labels annotations

### DIFF
--- a/charts/govuk-rails-app/Chart.yaml
+++ b/charts/govuk-rails-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: govuk-rails-app
 description: A Helm chart for GOV.UK Rails app
 type: application
-version: 0.1.3
+version: 0.1.4

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     {{- include "govuk-rails-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
+  annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-options: Replace=true
 spec:

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.9.4
+version: 0.9.5

--- a/charts/publisher/templates/web/dbmigration-job.yaml
+++ b/charts/publisher/templates/web/dbmigration-job.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     {{- include "publisher.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
+  annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-options: Replace=true
 spec:


### PR DESCRIPTION
These were incorrectly placed under labels rather than
annotations.
See docs: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/