### PR TITLE
Fix integration values file for argocd-apps Helm chart

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.5
+version: 0.5.6

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -3,9 +3,14 @@ globalHelmValues:
   externalDomainSuffix: eks.integration.govuk.digital
 
 applications:
+- name: argo-workflows
+  chartPath: charts/argo-workflows
 - name: cluster-secrets
+  chartPath: charts/cluster-secrets
 - name: govuk-apps-conf
+  chartPath: charts/govuk-apps-conf
 - name: smokey
+  chartPath: charts/smokey
 - name: publisher
   ingressHostname: publisher.{{ .Values.globalHelmValues.externalDomainSuffix }}
   helmValues:
@@ -29,6 +34,167 @@ applications:
       replicas: 1
     worker:
       replicas: 1
+- name: signon-resources
+  chartPath: charts/signon-resources
+- name: publisher
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
+      tag: latest  # To be edited by automation (not yet implemented).
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: publisher
+      hosts:
+      - name: publisher.eks.integration.govuk.digital
+    replicaCount: 1
+    workerReplicaCount: 1
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher-eks
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher-eks
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: "signon-token-publisher-asset-manager"
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: "signon-token-publisher-publishing-api"
+            key: bearer_token
+      - name: FACT_CHECK_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_PASSWORD
+      - name: FACT_CHECK_REPLY_TO_ADDRESS
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_REPLY_TO_ADDRESS
+      - name: FACT_CHECK_REPLY_TO_ID
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_REPLY_TO_ID
+      - name: GA_UNIVERSAL_ID
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: GA_UNIVERSAL_ID
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: GOVUK_NOTIFY_TEMPLATE_ID
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: JWT_AUTH_SECRET
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: LINK_CHECKER_API_BEARER_TOKEN
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: MONGODB_URI
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: SECRET_KEY_BASE
+      - name: PORT
+        value: "3000"
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: EMAIL_GROUP_BUSINESS
+        value: mainstream-publisher-notifications-integration+eks@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_CITIZEN
+        value: mainstream-publisher-notifications-integration+eks@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_DEV
+        value: mainstream-publisher-notifications-integration+eks@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
+        value: mainstream-publisher-notifications-integration+eks@digital.cabinet-office.gov.uk
+      - name: FACT_CHECK_ADDRESS_FORMAT
+        value: factcheck+integration-{id}-eks@alphagov.co.uk
+      - name: FACT_CHECK_SUBJECT_PREFIX
+        value: integration
+      - name: FACT_CHECK_REPLY_TO_ADDRESS
+        value: govuk-fact-check-integration+eks@digital.cabinet-office.gov.uk
+      - name: FACT_CHECK_REPLY_TO_ID
+        value: govuk-fact-check-integration+eks@digital.cabinet-office.gov.uk
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 123e4567-e89b-12d3-a456-426614174000
+- name: signon
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon
+      tag: latest  # To be edited by automation (not yet implemented).
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: signon
+      hosts:
+      - name: signon.eks.integration.govuk.digital
+    replicaCount: 1
+    workerReplicaCount: 1
+    extraEnv:
+      - name: DEVISE_PEPPER
+        value: secret
+      - name: DEVISE_SECRET_KEY
+        value: secret
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PORT
+        value: "3000"
+      - name: GOVUK_CONTENT_SCHEMAS_PATH
+        value: /govuk-content-schemas
+      - name: DEFAULT_TTL
+        value: "1800"
+      - name: GOVUK_APP_NAME
+        value: signon
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: signon
+            key: database-url
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: RAILS_ENV
+        value: production
+      - name: GOVUK_APP_TYPE
+        value: rack
+      - name: SIGNON_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: signon-auth-token
+            key: token
 - name: router
   helmValues:
     image:
@@ -37,24 +203,91 @@ applications:
     replicaCount: 1
 - name: frontend
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
       tag: latest  # To be edited by automation (not yet implemented).
-    replicaCount: 4
-    appMemcacheServers:
-    - frontend-memcached.eks.integration.govuk-internal.digital
+    replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-publishing-api
+            key: bearer_token
+      - name: PORT
+        value: "3000"
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached.eks.integration.govuk-internal.digital
 - name: static
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PORT
+        value: "3000"
+      - name: RAILS_ENV
+        value: production
+      - name: DEFAULT_TTL
+        value: "1800"
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: GOVUK_APP_NAME
+        value: static
+      - name: GOVUK_APP_TYPE
+        value: rack
+      - name: GOVUK_APP_ROOT
+        value: /var/apps/static
 - name: content-store
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
-    appMongodbUri: mongodb://mongo-1.integration.govuk-internal.digital,mongo-2.integration.govuk-internal.digital,mongo-3.integration.govuk-internal.digital/content_store_production
-- name: argo-workflows
-- name: signon-resources
+    extraEnv:
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-store-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_secret
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: PORT
+        value: "3000"
+      - name: GOVUK_CONTENT_SCHEMAS_PATH
+        value: /govuk-content-schemas
+      - name: DEFAULT_TTL
+        value: "1800"
+      - name: MONGODB_URI
+        value: mongodb://mongo-1.integration.govuk-internal.digital,mongo-2.integration.govuk-internal.digital,mongo-3.integration.govuk-internal.digital/content_store_production
+      - name: GOVUK_APP_NAME
+        value: content-store
+- name: info-frontend
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/info-frontend
+      tag: latest  # To be edited by automation (not yet implemented).
+    replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
+      - name: GOVUK_APP_DOMAIN
+        value: www.gov.uk
+      - name: GOVUK_WEBSITE_ROOT
+        value: https://www.gov.uk
+      - name: GOVUK_APP_NAME
+        value: info-frontend


### PR DESCRIPTION
With the introduction of the default Helm chart in #72, we
modify the `integration-values.yaml` to take this into account