### PR TITLE
Add OAUTH credentials for Grafana/Dex authentication

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.6.0
+version: 0.7.0

--- a/charts/cluster-secrets/templates/dex-grafana.yaml
+++ b/charts/cluster-secrets/templates/dex-grafana.yaml
@@ -1,0 +1,21 @@
+# This secret contains the OAUTH secret which allows Grafana to
+# authenticate with Dex (https://dexidp.io/), a federated
+# OpenID connect provider.
+{{- range .Values.dexGrafanaSecretsNamespaces}}
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-dex-grafana
+  namespace: "{{ . }}"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-dex-grafana
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/dex/grafana
+{{- end }}

--- a/charts/cluster-secrets/values.yaml
+++ b/charts/cluster-secrets/values.yaml
@@ -1,1 +1,2 @@
 clusterServicesNamespace: cluster-services
+dexGrafanaSecretsNamespaces: ["cluster-services", "monitoring"]


### PR DESCRIPTION
OAUTH credentials for Grafana to authenticate with Dex, a federated
OpenID Connect provider.


Since Dex is in `cluster-services` and Grafana in `monitoring`
namespace, there is a need to create 2 external secrets.
They will remain in sync as the source of truth is in AWS Secret
Manager.

Ref:
1. [trello card](https://trello.com/c/Snqwc4Ac/784-deploy-dex-idp-and-configure-github-backend)