### PR TITLE
Update GitHub Workflow Helm Chart Releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,7 +20,13 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.3.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Following the example [here](https://github.com/marketplace/actions/helm-chart-releaser?version=v1.3.0),
the GitHub workflow to add helm charts to the helm repository is
updated.

We add the permissions for this workflow to write to the repo,
this is because at org level, the new default is `read` only,
see [rfc](https://docs.google.com/document/d/1IFz7E4DcWJ09giNB38fxfccU6fdW4TrQi722zztmSxs/edit#)