### PR TITLE
Use DocumentDB for Content Store db

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.6
+version: 0.5.7

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -249,7 +249,7 @@ applications:
       - name: DEFAULT_TTL
         value: "1800"
       - name: MONGODB_URI
-        value: mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production
+        value: mongodb://shared-documentdb.test.govuk-internal.digital/content_store_production
       - name: GOVUK_APP_NAME
         value: content-store
 - name: signon-resources


### PR DESCRIPTION
The self-hosted mongo cluster in EC2 in the test
account seems to be in a bad state. A quick fix here
is to try and use the existing SharedDocumentDb cluster
for content store.