### PR TITLE
Use DocumentDB for Content Store db

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.7
+version: 0.5.8

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -249,7 +249,10 @@ applications:
       - name: DEFAULT_TTL
         value: "1800"
       - name: MONGODB_URI
-        value: mongodb://shared-documentdb.test.govuk-internal.digital/content_store_production
+        valueFrom:
+          secretKeyRef:
+            name: content-store-documentdb
+            key: uri
       - name: GOVUK_APP_NAME
         value: content-store
 - name: signon-resources

--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.7.0
+version: 0.7.1

--- a/charts/cluster-secrets/templates/shared-documentdb.yaml
+++ b/charts/cluster-secrets/templates/shared-documentdb.yaml
@@ -1,0 +1,16 @@
+# NOTE: This is a temporary home for this ExternalSecret. We'll be moving it
+# to the govuk-apps-conf chart soon, and later to the content store chart.
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: content-store-documentdb
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: content-store-documentdb
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/common/content-store-documentdb


### PR DESCRIPTION
The self-hosted mongo cluster in EC2 in the test account seems to be in a bad state. A quick fix here is to try and use the existing SharedDocumentDb cluster for content store.

I manually created the `govuk/common/content-store-documentdb` secret in the test AWS account's SM - we don't intend to migrate Content Store to DocumentDB as part of this migration - this is merely a quick fix for the test environment.