### PR TITLE
Split up AWS Secrets Manager secrets for Publisher.

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: argocd-apps
 description: Installs ArgoCD applications into the cluster-services namespace
-version: 0.5.7
+version: 0.5.8

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -48,6 +48,11 @@ applications:
           secretKeyRef:
             name: signon-token-publisher-publishing-api
             key: bearer_token
+      - name: FACT_CHECK_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: publisher
+            key: FACT_CHECK_USERNAME
       - name: FACT_CHECK_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -41,12 +41,12 @@ applications:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: "signon-token-publisher-asset-manager"
+            name: signon-token-publisher-asset-manager
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: "signon-token-publisher-publishing-api"
+            name: signon-token-publisher-publishing-api
             key: bearer_token
       - name: FACT_CHECK_PASSWORD
         valueFrom:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -51,42 +51,42 @@ applications:
       - name: FACT_CHECK_USERNAME
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: publisher-fact-check-email-account
             key: FACT_CHECK_USERNAME
       - name: FACT_CHECK_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: publisher-fact-check-email-account
             key: FACT_CHECK_PASSWORD
       - name: GOVUK_NOTIFY_API_KEY
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: publisher-notify
             key: GOVUK_NOTIFY_API_KEY
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: authenticating-proxy-jwt-auth-secret
             key: JWT_AUTH_SECRET
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: publisher
-            key: LINK_CHECKER_API_BEARER_TOKEN
+            name: signon-token-publisher-link-checker-api
+            key: bearer_token
       - name: LINK_CHECKER_API_SECRET_TOKEN
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: publisher-link-checker-api-callback-token
             key: LINK_CHECKER_API_SECRET_TOKEN
       - name: MONGODB_URI
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: publisher-docdb
             key: MONGODB_URI
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
-            name: publisher
+            name: publisher-secret-key-base
             key: SECRET_KEY_BASE
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.test.govuk-internal.digital

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -53,31 +53,11 @@ applications:
           secretKeyRef:
             name: publisher
             key: FACT_CHECK_PASSWORD
-      - name: FACT_CHECK_REPLY_TO_ADDRESS
-        valueFrom:
-          secretKeyRef:
-            name: publisher
-            key: FACT_CHECK_REPLY_TO_ADDRESS
-      - name: FACT_CHECK_REPLY_TO_ID
-        valueFrom:
-          secretKeyRef:
-            name: publisher
-            key: FACT_CHECK_REPLY_TO_ID
-      - name: GA_UNIVERSAL_ID
-        valueFrom:
-          secretKeyRef:
-            name: publisher
-            key: GA_UNIVERSAL_ID
       - name: GOVUK_NOTIFY_API_KEY
         valueFrom:
           secretKeyRef:
             name: publisher
             key: GOVUK_NOTIFY_API_KEY
-      - name: GOVUK_NOTIFY_TEMPLATE_ID
-        valueFrom:
-          secretKeyRef:
-            name: publisher
-            key: GOVUK_NOTIFY_TEMPLATE_ID
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:
@@ -103,8 +83,6 @@ applications:
           secretKeyRef:
             name: publisher
             key: SECRET_KEY_BASE
-      - name: PORT
-        value: "3000"
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
       - name: EMAIL_GROUP_BUSINESS
@@ -212,6 +190,8 @@ applications:
         value: "1800"
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
+      - name: GA_UNIVERSAL_ID
+        value: UA-26179049-22
       - name: GOVUK_APP_NAME
         value: static
       - name: GOVUK_APP_TYPE

--- a/charts/govuk-apps-conf/Chart.yaml
+++ b/charts/govuk-apps-conf/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: govuk-apps-conf
 description: Shared ConfigMap for global (per-environment) settings for GOV.UK apps
 type: application
-version: 0.2.1
+version: 0.3.0

--- a/charts/govuk-apps-conf/externalsecrets-templates/README.md
+++ b/charts/govuk-apps-conf/externalsecrets-templates/README.md
@@ -1,0 +1,15 @@
+# ExternalSecrets templates
+
+Templates for use with [External Secrets
+Operator](https://external-secrets.io/guides-templating/) are kept here and
+read in [../templates/external-secrets/](../templates/external-secrets/) via
+Helm's
+[`.Files.Get`](https://helm.sh/docs/chart_template_guide/accessing_files/#basic-example).
+
+These templates are Go templates, but not Helm templates. They are interpreted
+by the External Secrets operator.
+
+Keeping the ExternalSecrets templates in separate files — rather than writing
+them inline inside the Helm templates — avoids nesting Go templates and the
+[hard-to-read escaping syntax](https://stackoverflow.com/q/47195593/) which
+that entails.

--- a/charts/govuk-apps-conf/externalsecrets-templates/mongo-conn-string.tpl
+++ b/charts/govuk-apps-conf/externalsecrets-templates/mongo-conn-string.tpl
@@ -1,0 +1,1 @@
+mongodb://{{ .username | toString }}:{{ .password | toString }}@{{ .host | toString }}/govuk_content_production

--- a/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: authenticating-proxy-jwt-auth-secret
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Secret key for encrypting/decrypting JWT authentication tokens for
+      authenticating-proxy. Shared between authenticating-proxy, which decodes
+      the tokens, and asset-manager, publisher, content-publisher and
+      collections-publisher.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: authenticating-proxy-jwt-auth-secret
+  dataFrom:
+    - key: govuk/authenticating-proxy/jwt-auth-secret

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/docdb.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publisher-docdb
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Credentials for Publisher to connect to DocumentDB (MongoDB).
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publisher-docdb
+    template:
+      data:
+        MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/govuk_content_production'
+  dataFrom:
+    - key: govuk/common/shared-documentdb

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/fact-check-email-account.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/fact-check-email-account.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publisher-fact-check-email-account
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Username and password for the factcheck Gmail account. See
+      https://github.com/alphagov/publisher/blob/main/docs/fact-checking.md
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publisher-fact-check-email-account
+  dataFrom:
+    - key: govuk/publisher/fact-check-email-account

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/link-checker-api-callback-token.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publisher-link-checker-api-callback-token
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Publisher uses this for verification of batch-completion webhook
+      (i.e. callback) requests from Link Checker API. See
+      https://github.com/alphagov/link-checker-api/blob/main/docs/api.md#verifying-the-webhook-request
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publisher-link-checker-api-callback-token
+  dataFrom:
+    - key: govuk/publisher/link-checker-api-callback-token

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/notify.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publisher-notify
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      The GOV.UK Notify API key belonging to Publisher.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publisher-notify
+  dataFrom:
+    - key: govuk/publisher/notify

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/rails-secret-key-base.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/rails-secret-key-base.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publisher-rails-secret-key-base
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Rails SECRET_KEY_BASE, primarily used for encrypting Rails session
+      cookies.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publisher-rails-secret-key-base
+  dataFrom:
+    - key: govuk/common/rails-secret-key-base

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -1,3 +1,3 @@
 govukEnvironment: test
-internalDomainSuffix: ""
+internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -1,3 +1,5 @@
 govukEnvironment: test
 internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital
+externalSecrets:
+  refreshInterval: 1h  # Be kind to etcd and don't set this too short.


### PR DESCRIPTION
Publisher secrets were being stored in a single AWS Secrets Manager secret. This was a temporary hack to get the app running quickly, but would prevent us from being able to rotate and manage the credentials contained in that all-in-one Secret.

Split the logical secrets up into separate Secrets Manager secrets so that we don't break auditability and automatability.

For now, we're putting the ExternalSecrets definitions in the govuk-apps-conf Helm chart, for want of a better place. This isn't ideal; they really belong in the apps' own Helm charts (behind an `if .Values.enableExternalSecrets`) but this won't be feasible until we refactor our shared `govuk-rails-app` Helm chart into per-app charts with library chart(s) - i.e. shift from inheritance to composition (as @bilbof eruditely put it).

Some of the ExternalSecrets definitions require the use of Go templates in order to generate (for example) database connection strings (see https://external-secrets.io/guides-templating/). The MongoDB connection string here is one example but there will be others.  These templates (which are Go templates but not Helm templates and are processed by the ExternalSecrets operator) are kept in separate files and included verbatim in the Helm templates in order to avoid horrible double-escaping like this:

```dont-try-this-at-home-kids
{{ "{{" }} .username | toString {{ "}}" }}:{{ "{{" }} .password | toString {{ "}}" }}@{{ "{{" }} .hostname | toString {{ "}}" }}
```
🤮🤮🤮

Also a bunch of minor fixes and cleanup; see commits for details.

#### Alternatives considered

Thought about passing the ExternalSecrets definitions into the shared chart as Helm values, but given that ExternalSecrets can contain (non-Helm) Go templates of their own, the number of levels of string templating and YAML embedding involved would be most unwise (see above - it'd be even worse than that 😱).

Generating the ExternalSecrets definitions in a Helm template in `govuk-rails-app` was another option. This would have avoided the very worst of the double-escaping but would have involved implementing a fair bit of logic inside a Helm template and defining a nontrivial structure for passing in the necessary information from values.yaml about how to construct the ExternalSecrets. Still a lot of unwarranted layers of templating and abstraction, i.e. complexity that doesn't seem worth it compared to the chosen approach above.

Also considered using a separate ConfigMap for templating the MongoDB connection string instead of using [ExternalSecrets Operator's templating](https://external-secrets.io/guides-templating/), but concluded that this only moves the templating problem rather than simplifying it, merely resulting in an extra level of indirection.

#### Rollout

I've created all the required Secrets Manager secrets in the test and integration accounts.

I haven't added the Publisher link-checker-api Signon bearer token to the Signon bootstrap config yet.