### PR TITLE
Remove Kubernetes Namespace from external domains

### DIFF
--- a/charts/govuk-apps-conf/Chart.yaml
+++ b/charts/govuk-apps-conf/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: govuk-apps-conf
 description: Shared ConfigMap for global (per-environment) settings for GOV.UK apps
 type: application
-version: 0.2.0
+version: 0.2.1

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -7,14 +7,14 @@ metadata:
 data:
   {{- /* TODO: omit namespace from these user-facing URLs in the default namespace. */}}
   {{- /* TODO: delete PLEK_SERVICE_*_URI once Plek can construct http:// internal URLs. */}}
-  ASSET_HOST: https://www-origin-{{ .Release.Namespace }}.{{ .Values.externalDomainSuffix }}
+  ASSET_HOST: https://www-origin.{{ .Values.externalDomainSuffix }}
   GOVUK_APP_DOMAIN: {{ .Values.internalDomainSuffix }}
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
-  GOVUK_ASSET_ROOT: https://assets-{{ .Release.Namespace }}.{{ .Values.externalDomainSuffix }}
+  GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
-  GOVUK_WEBSITE_ROOT: https://www-origin-{{ .Release.Namespace }}.{{ .Values.externalDomainSuffix }}
+  GOVUK_WEBSITE_ROOT: https://www-origin.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.{{ .Values.internalDomainSuffix }}
-  PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin-{{ .Release.Namespace }}.{{ .Values.externalDomainSuffix }}
+  PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api-web.{{ .Values.internalDomainSuffix }}
   PLEK_SERVICE_ROUTER_API_URI: http://router-api.{{ .Values.internalDomainSuffix }}
   PLEK_SERVICE_SIGNON_URI: http://signon.{{ .Values.externalDomainSuffix }}

--- a/charts/router/Chart.yaml
+++ b/charts/router/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: router
 description: A Helm chart for GOV.UK router
 type: application
-version: 0.4.3
+version: 0.4.4

--- a/charts/router/templates/NOTES.txt
+++ b/charts/router/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host | default (printf "www-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}{{ .path }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host | default (printf "www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal ) }}{{ .path }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "router.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/router/templates/deployment.yaml
+++ b/charts/router/templates/deployment.yaml
@@ -45,13 +45,13 @@ spec:
             - name: DEFAULT_TTL
               value: "{{ .Values.appDefaultTtl }}"
             - name: GOVUK_APP_DOMAIN_EXTERNAL
-              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukDomainExternal | default (printf "eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: GOVUK_APP_ROOT
               value: "{{ .Values.appGovukAppRoot }}"
             - name: GOVUK_ENVIRONMENT
               value: "{{ .Values.govukEnvironment }}"
             - name: GOVUK_WEBSITE_ROOT
-              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: ROUTER_APIADDR
               value: ":{{ .Values.appRouterApiAddr }}"
             - name: ROUTER_BACKEND_HEADER_TIMEOUT

--- a/charts/router/templates/ingress.yaml
+++ b/charts/router/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
   annotations:
-    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}-{{ .Release.Namespace }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.tls }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host | default (printf "%s-%s.eks.%s.%s" .Values.ingress.name .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
+    - host: {{ .Values.ingress.host | default (printf "%s.eks.%s.%s" .Values.ingress.name .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
        paths:
          - path: {{ .Values.ingress.path }}

--- a/charts/signon-resources/Chart.yaml
+++ b/charts/signon-resources/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon-resources
 description: A Helm chart for creating Signon resources such as bearer tokens
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -55,8 +55,8 @@ spec:
                   "slug": "publisher-eks",
                   "secret_name": "signon-app-publisher-eks",
                   "description": "Mainstream publishing application",
-                  "home_uri": "https://publisher-apps.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
-                  "redirect_uri": "https://publisher-apps.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "home_uri": "https://publisher.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://publisher.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": ["view_all"]
                 },
                 "publishing-api": {

--- a/charts/signon/Chart.yaml
+++ b/charts/signon/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: signon
 description: A Helm chart for GOV.UK Signon
 type: application
-version: 0.2.5
+version: 0.2.6

--- a/charts/signon/templates/deployment.yaml
+++ b/charts/signon/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
               containerPort: {{ .Values.appPort }}
           env:
             - name: ASSET_HOST
-              value: "{{ .Values.appAssetHost | default (printf "https://www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appAssetHost | default (printf "https://www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -35,17 +35,17 @@ spec:
             - name: GOVUK_APP_DOMAIN
               value: "{{ .Values.appGovukAppDomain | default (printf "%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
             - name: GOVUK_APP_DOMAIN_EXTERNAL
-              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukDomainExternal | default (printf "eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: GOVUK_APP_NAME
               value: "{{ .Values.appGovukAppName | default .Release.Name }}"
             - name: GOVUK_APP_TYPE
               value: "{{ .Values.appGovukAppType }}"
             - name: GOVUK_WEBSITE_ROOT
-              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: DEFAULT_TTL
               value: "{{ .Values.appDefaultTtl }}"
             - name: GOVUK_ASSET_ROOT
-              value: "{{ .Values.appGovukAssetRoot | default (printf "https://assets-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukAssetRoot | default (printf "https://assets.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: GOVUK_CONTENT_SCHEMAS_PATH
               value: "{{ .Values.appGovukContentSchemasPath }}"
             - name: GOVUK_ENVIRONMENT

--- a/charts/signon/templates/ingress.yaml
+++ b/charts/signon/templates/ingress.yaml
@@ -6,7 +6,7 @@ kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
   annotations:
-    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}-{{ .Release.Namespace }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.name }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.tls }}
@@ -20,7 +20,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host | default (printf "%s-%s.eks.%s.%s" .Values.ingress.name .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
+    - host: {{ .Values.ingress.host | default (printf "%s.eks.%s.%s" .Values.ingress.name .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
        paths:
          - path: {{ .Values.ingress.path }}

--- a/charts/smokey/Chart.yaml
+++ b/charts/smokey/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: smokey
 description: A Helm chart for GOV.UK Smokey
 type: application
-version: 0.1.3
+version: 0.1.4

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -24,7 +24,7 @@ spec:
         - name: GOVUK_APP_DOMAIN
           value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
         - name: GOVUK_WEBSITE_ROOT
-          value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+          value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
         - name: SIGNON_EMAIL
           value: "signon@alphagov.co.uk"
         - name: SIGNON_PASSWORD

--- a/charts/static/Chart.yaml
+++ b/charts/static/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.4.3
+version: 0.4.4

--- a/charts/static/templates/deployment.yaml
+++ b/charts/static/templates/deployment.yaml
@@ -22,17 +22,17 @@ spec:
               containerPort: {{ .Values.appPort }}
           env:
             - name: GOVUK_APP_DOMAIN
-              value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+              value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s" .Values.govukEnvironment .Values.clusterDomain) }}"
             - name: GOVUK_APP_DOMAIN_EXTERNAL
-              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: GOVUK_APP_NAME
               value: "{{ .Values.appGovukAppName | default .Release.Name }}"
             - name: GOVUK_WEBSITE_ROOT
-              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: DEFAULT_TTL
               value: "{{ .Values.appDefaultTtl }}"
             - name: GOVUK_ASSET_ROOT
-              value: "{{ .Values.appGovukAssetRoot | default (printf "https://assets.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+              value: "{{ .Values.appGovukAssetRoot | default (printf "https://assets.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
             - name: GOVUK_ENVIRONMENT
               value: "{{ .Values.govukEnvironment }}"
             - name: PORT


### PR DESCRIPTION
Recently we removed the `-apps` suffix from external app domains, i.e. signon-apps.eks.test.govuk.digital became
signon.eks.test.govuk.digital.

This finishes that journey off by removing the namespace from all other external domains. Namespaces can continue to be used in-cluster.