### PR TITLE
Stop validating chart version number has incremented

### DIFF
--- a/ct.yml
+++ b/ct.yml
@@ -1,5 +1,6 @@
 remote: origin
 target-branch: main
 validate-maintainers: false
+check-version-increment: false
 chart-dirs:
   - charts


### PR DESCRIPTION
This deactivates a check for chart version increments.

We find the chart versioning isn't particularly useful
given we don't install Helm charts using Helm (ArgoCD
uses kubectl apply/replace and only uses Helm for templating).
We also had many git conflicts on the chart version,
which is the reason for this change.

Docs: https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md