### PR TITLE
Remove Argo PreSync hooks for dbmigrate jobs.

### DIFF
--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -15,7 +15,6 @@ metadata:
     {{- include "govuk-rails-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
   annotations:
-    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:

--- a/charts/publisher/templates/web/dbmigration-job.yaml
+++ b/charts/publisher/templates/web/dbmigration-job.yaml
@@ -15,7 +15,6 @@ metadata:
     {{- include "publisher.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
   annotations:
-    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:


### PR DESCRIPTION
These were causing deadlock when rolling out changes to Publisher.

We don't think we need them anyway because Rails DB migrations should be back- and forward-compatible by one version anyway as good practice.