### PR TITLE
Fix wrong value name for Router

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -197,7 +197,7 @@ applications:
             key: token
 - name: router
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -156,7 +156,7 @@ applications:
             key: token
 - name: router
   helmValues:
-    image:
+    appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -160,6 +160,15 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: www-origin
+      hosts:
+      - name: www-origin.eks.test.govuk.digital
+    extraEnv:
+      - name: foo  # XXX TODO: finish configuring Router
+        value: bar
 - name: frontend
   helmValues:
     appImage:


### PR DESCRIPTION
Also add back the ingress config for Router in the test environment. The integration values files needs some broader cleanup so leaving that for Monday.

Router's env vars are also missing - this is also still to do.