### PR TITLE
Use one ExternalSecret for the Rails secret instead of O(n).

### DIFF
--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -86,7 +86,7 @@ applications:
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
-            name: publisher-rails-secret-key-base
+            name: rails-secret-key-base
             key: SECRET_KEY_BASE
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.test.govuk-internal.digital

--- a/charts/govuk-apps-conf/templates/external-secrets/rails-secret-key-base.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/rails-secret-key-base.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
-  name: publisher-rails-secret-key-base
+  name: rails-secret-key-base
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
@@ -14,6 +14,6 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    name: publisher-rails-secret-key-base
+    name: rails-secret-key-base
   dataFrom:
     - key: govuk/common/rails-secret-key-base


### PR DESCRIPTION
Automating generation and rotation of Rails `SECRET_KEY_BASE` isn't a must-have for phase 1 launch, so let's not preemptively create 55-odd boilerplate ExternalSecrets files just because we might someday split up the single AWS secret to which they refer.

This avoids adding a boilerplate file per app, makes no functional change (since they'd all be pointing to the same AWS secret anyway) and doesn't really make it any harder to split up Rails `SECRET_KEY_BASE` later if we decide we really want to.

See #86 for background.

https://trello.com/c/uFDQulJk/796