### PR TITLE
Have chart-releaser skip duplicate chart versions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.3.0
         env:
+          CR_SKIP_EXISTING: "true"
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
With `CR_SKIP_EXISTING=true`, chart-releaser will skip uploading a chart
tarball where one already exists with the same filename (i.e. same chart name
and chart version). This means the chart-releaser GitHub Action will no longer
fail when we make changes to a chart without updating the version number.

This is essentially a quick bodge to avoid having to automate incrementing the
chart version on merge-to-main for now.

### But why?

We really don't want to have to update chart versions for charts which we're
only deploying via ArgoCD (which doesn't care about version numbers). Having to
change the version number on every change causes merge conflicts and has proved
a frequent source of annoyance even in the absense of merge conflicts, even for
experienced users. This was a recurring theme in the feedback from the 2021-11
user testing.

There's no technical reason why we need to bother with version numbers for the
charts which we're installing with ArgoCD, since Argo just evaluates the chart
using `helm template` and compares the output; it doesn't care about chart
version numbers. We still need to care about version numbers for charts which
we're deploying using the Helm Terraform provider, though.

Unfortunately the chart-releaser GH Action doesn't support filtering on paths;
it just releases every charts that's changed under `charts_dir` and it uses the
Git history rather than the chart version to tell whether a chart has changed.

We could configure separate chart-releaser actions for the Terraform-deployed
charts, but that sounds like a maintenance pain.

Eventually we might want to have all of our charts published in the chart repo,
at which point we could automate bumping the version number.  We'd have to
forego Helm's conventional use of semver and just increment (say) the minor
version number. Doesn't seem worth it for now though.

https://trello.com/c/wCTPia2K/812