### PR TITLE
Add OAUTH for Prometheus and Alert Manager

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.7.1
+version: 0.8.1

--- a/charts/cluster-secrets/templates/dex-alert-manager.yaml
+++ b/charts/cluster-secrets/templates/dex-alert-manager.yaml
@@ -1,0 +1,21 @@
+# This secret contains the OAUTH secret which allows the
+# ingress of Alert Manager to authenticate with Dex
+# (https://dexidp.io/), a federated OpenID connect provider.
+{{- range .Values.dexAlertManagerSecretsNamespaces}}
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-dex-alert-manager
+  namespace: "{{ . }}"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-dex-alert-manager
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/dex/alert-manager
+{{- end }}

--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -1,4 +1,4 @@
-# Note: This secret contains the OAUTH secret which allows Argo-Workflows to
+# This secret contains the OAUTH secret which allows Argo-Workflows to
 # authenticate with Dex (https://dexidp.io/), a federated
 # OpenID connect provider.
 apiVersion: external-secrets.io/v1alpha1

--- a/charts/cluster-secrets/templates/dex-prometheus.yaml
+++ b/charts/cluster-secrets/templates/dex-prometheus.yaml
@@ -1,0 +1,21 @@
+# This secret contains the OAUTH secret which allows the
+# ingress of Prometheus to authenticate with Dex
+# (https://dexidp.io/), a federated OpenID connect provider.
+{{- range .Values.dexPrometheusSecretsNamespaces}}
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-dex-prometheus
+  namespace: "{{ . }}"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-dex-prometheus
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/dex/prometheus
+{{- end }}

--- a/charts/cluster-secrets/values.yaml
+++ b/charts/cluster-secrets/values.yaml
@@ -1,2 +1,4 @@
 clusterServicesNamespace: cluster-services
 dexGrafanaSecretsNamespaces: ["cluster-services", "monitoring"]
+dexPrometheusSecretsNamespaces: ["cluster-services", "monitoring"]
+dexAlertManagerSecretsNamespaces: ["cluster-services", "monitoring"]


### PR DESCRIPTION
Add OAUTH secret that the ingress of Prometheus and Alert-Manager will use to control access to these 2 apps which do not support in-built authentication.

Test:
1. https://prometheus.eks.integration.govuk.digital/
2. https://alertmanager.eks.integration.govuk.digital/

Ref:
1. [trello card](https://trello.com/c/XiOPhFt5/813-add-oidc-auth-to-prometheus-alertmanager-loadbalancers)