### PR TITLE
Adding whitehall-admin whitehall-frontend and draft-whitehall-frontend

### DIFF
--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -295,3 +295,100 @@ applications:
         value: secret  # TODO: set SECRET_KEY_BASE and make it a secret
       - name: GOVUK_APP_NAME
         value: collections
+- name: whitehall-admin
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/whitehall
+      tag: f01a5161aa0d93b2efdd0775c61081695f12447a  # TODO: To be edited by automation (not yet implemented).
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: whitehall-admin
+      hosts:
+      - name: whitehall-admin.eks.test.govuk.digital
+    replicaCount: 1
+    workerReplicaCount: 1
+    extraEnv: &whitehall-envs
+      - name: GOVUK_APP_NAME
+        value: whitehall
+      - name: GOVUK_APP_TYPE
+        value: rack
+      - name: NODE_ENV
+        value: production
+      - name: RACK_ENV
+        value: production
+      - name: RAILS_ENV
+        value: production
+      - name: GDS_SSO_OAUTH_ID
+        value: eiGhei3oop2seGh4Phee8eikuphai9coh5moJ2ohTh8soghohdohquashaor0joh
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-whitehall-eks
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-asset-manager
+            key: bearer_token
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-publishing-api
+            key: bearer_token
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 759acac6-da53-4a19-b591-b7538c7c39de
+      - name: GOVUK_STATSD_PREFIX
+        value: whitehall
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached.eks.test.govuk-internal.digital
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: whitehall-mysql
+            key: DATABASE_URL
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+- name: whitehall-frontend
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/whitehall
+      tag: f01a5161aa0d93b2efdd0775c61081695f12447a  # TODO: To be edited by automation (not yet implemented).
+    replicaCount: 1
+    extraEnv:
+      *whitehall-envs
+- name: draft-whitehall-frontend
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/whitehall
+      tag: f01a5161aa0d93b2efdd0775c61081695f12447a  # TODO: To be edited by automation (not yet implemented).
+    replicaCount: 1
+    extraEnv:
+      *whitehall-envs

--- a/charts/govuk-apps-conf/externalsecrets-templates/mysql-conn-string.tpl
+++ b/charts/govuk-apps-conf/externalsecrets-templates/mysql-conn-string.tpl
@@ -1,0 +1,1 @@
+mysql2://{{ .username | toString }}:{{ .password | toString }}@{{ .host | toString }}

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/link-checker-api-callback-token.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: whitehall-link-checker-api-callback-token
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Whitehall uses this for verification of batch-completion webhook
+      (i.e. callback) requests from Link Checker API. See
+      https://github.com/alphagov/link-checker-api/blob/main/docs/api.md#verifying-the-webhook-request
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: whitehall-link-checker-api-callback-token
+  dataFrom:
+    - key: govuk/whitehall/link-checker-api-callback-token

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/mysql.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/mysql.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: whitehall-mysql
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Credentials for Whitehall to connect to MYSQL.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: whitehall-mysql
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/whitehall_production'
+  dataFrom:
+    - key: govuk/common/shared-mysql-primary

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/notify.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: whitehall-notify
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      The GOV.UK Notify API key belonging to Whitehall.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: whitehall-notify
+  dataFrom:
+    - key: govuk/whitehall/notify

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -77,7 +77,17 @@ spec:
                   "redirect_uri": "https://publishing-api.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": ["view_all"]
                 }
+                "whitehall": {
+                  "name": "Whitehall",
+                  "slug": "whitehall",
+                  "secret_name": "signon-app-whitehall-eks",
+                  "description": "Mainstream Whitehall application",
+                  "home_uri": "https://whitehall-admin.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://whitehall-admin.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": []
+                }
               }
+
           - name: API_USERS
             value: |-
               {
@@ -113,6 +123,16 @@ spec:
                   "email": "publishing-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "bearer_tokens": [
                     { "application_slug": "content-store" }
+                  ]
+                },
+                "whitehall": {
+                  "name": "Whitehall",
+                  "username": "whitehall",
+                  "email": "whitehall@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "publishing-api" },
+                    { "application_slug": "link-checker-api" },
+                    { "application_slug": "asset-manager" }
                   ]
                 }
               }


### PR DESCRIPTION
This Change is a work in progress.

From the initial looks on EC2 hosting Whitehall, all three contain the same ENV values,
therefore i am using YAML anchor,

Ultimately ENV values may differ, i will then update the chart.

Env values which i have skipped for now:
- GOVUK_CSP_REPORT_ONLY
- GOVUK_CSP_REPORT_URI
- GOVUK_DATA_SYNC_PERIOD

I have excluded a couple of secrets which i will add later.
secrets skipped:
- EMAIL_ALERT_API_BEARER_TOKEN
- RUMMAGER_BEARER_TOKEN

https://trello.com/c/lIyh6zBn/753-work-out-which-apps-can-be-merged-using-govuk-rails-app-helm-chart