### PR TITLE
Add secret description to annotation of k8s object

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.8.1
+version: 0.8.2

--- a/charts/cluster-secrets/templates/dex-alert-manager.yaml
+++ b/charts/cluster-secrets/templates/dex-alert-manager.yaml
@@ -1,6 +1,3 @@
-# This secret contains the OAUTH secret which allows the
-# ingress of Alert Manager to authenticate with Dex
-# (https://dexidp.io/), a federated OpenID connect provider.
 {{- range .Values.dexAlertManagerSecretsNamespaces}}
 ---
 apiVersion: external-secrets.io/v1alpha1
@@ -8,6 +5,11 @@ kind: ExternalSecret
 metadata:
   name: govuk-dex-alert-manager
   namespace: "{{ . }}"
+  annotations:
+    a8r.io/description: >
+      This secret contains the OAUTH secret which allows the
+      ingress of Alert Manager to authenticate with Dex
+      (https://dexidp.io/), a federated OpenID connect provider
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -1,11 +1,13 @@
-# This secret contains the OAUTH secret which allows Argo-Workflows to
-# authenticate with Dex (https://dexidp.io/), a federated
-# OpenID connect provider.
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argo-workflows
   namespace: "{{ .Values.clusterServicesNamespace }}"
+  annotations:
+    a8r.io/description: >
+      This secret contains the OAUTH secret which allows Argo-Workflows to
+      authenticate with Dex (https://dexidp.io/), a federated
+      OpenID connect provider
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -1,6 +1,3 @@
-# Note: This secret contains the OAUTH secret which allows ArgoCD to
-# authenticate with Dex (https://dexidp.io/), a federated
-# OpenID connect provider.
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
@@ -8,6 +5,11 @@ metadata:
   namespace: "{{ .Values.clusterServicesNamespace }}"
   labels:
     app.kubernetes.io/part-of: argocd
+  annotations:
+    a8r.io/description: >
+      This secret contains the OAUTH secret which allows ArgoCD to
+      authenticate with Dex (https://dexidp.io/), a federated
+      OpenID connect provider
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -1,10 +1,12 @@
-# Note: This secret is used to allow Dex (https://dexidp.io/), a federated
-# OpenID connect provider, to use GitHub as an identity provider
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-github
   namespace: "{{ .Values.clusterServicesNamespace }}"
+  annotations:
+    a8r.io/description: >
+      This secret is used to allow Dex (https://dexidp.io/), a federated
+      OpenID connect provider, to use GitHub as an identity provider
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-grafana.yaml
+++ b/charts/cluster-secrets/templates/dex-grafana.yaml
@@ -1,6 +1,3 @@
-# This secret contains the OAUTH secret which allows Grafana to
-# authenticate with Dex (https://dexidp.io/), a federated
-# OpenID connect provider.
 {{- range .Values.dexGrafanaSecretsNamespaces}}
 ---
 apiVersion: external-secrets.io/v1alpha1
@@ -8,6 +5,11 @@ kind: ExternalSecret
 metadata:
   name: govuk-dex-grafana
   namespace: "{{ . }}"
+  annotations:
+    a8r.io/description: >
+      This secret contains the OAUTH secret which allows Grafana to
+      authenticate with Dex (https://dexidp.io/), a federated
+      OpenID connect provider
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/dex-prometheus.yaml
+++ b/charts/cluster-secrets/templates/dex-prometheus.yaml
@@ -1,6 +1,3 @@
-# This secret contains the OAUTH secret which allows the
-# ingress of Prometheus to authenticate with Dex
-# (https://dexidp.io/), a federated OpenID connect provider.
 {{- range .Values.dexPrometheusSecretsNamespaces}}
 ---
 apiVersion: external-secrets.io/v1alpha1
@@ -8,6 +5,11 @@ kind: ExternalSecret
 metadata:
   name: govuk-dex-prometheus
   namespace: "{{ . }}"
+  annotations:
+    a8r.io/description: >
+      This secret contains the OAUTH secret which allows the
+      ingress of Prometheus to authenticate with Dex
+      (https://dexidp.io/), a federated OpenID connect provider
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/logit_host_external_secret.yaml
+++ b/charts/cluster-secrets/templates/logit_host_external_secret.yaml
@@ -2,6 +2,9 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: logit-host
+  annotations:
+    a8r.io/description: >
+      This secret contains necessary credentials to send logs to logit
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/charts/cluster-secrets/templates/slack-webhook-url.yaml
+++ b/charts/cluster-secrets/templates/slack-webhook-url.yaml
@@ -1,9 +1,10 @@
-# NOTE: This assumes that an AWS SecretsManager secret `govuk/slack-webhook-url`
-# exists with key `url`.
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: slack-webhook-url
+  annotations:
+    a8r.io/description: >
+      This secret contains the slack webhook to post on Slack
 spec:
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
The secret description are added as an annotation of the k8s externalsecrets object.

see pr #86 for further details.