### PR TITLE
Truncate image in job names

### DIFF
--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -6,7 +6,7 @@ when the chart or the binary changes. This workaround doesn't work when moving
 a mutable tag (like "latest"), but we shouldn't be using those anyway.
 */}}
 {{- $chartVersionNoDots := .Chart.Version | replace "." "-" }}
-{{- $jobName := print .Release.Name "-dbmigrate-" $chartVersionNoDots "-" .Values.appImage.tag }}
+{{- $jobName := print .Release.Name "-dbmigrate-" $chartVersionNoDots "-" (trunc 7 .Values.appImage.tag) }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Container names are limited to 64 chars.