### PR TITLE
Add Publishing API

### DIFF
--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -108,6 +108,79 @@ applications:
         value: govuk-fact-check-test@digital.cabinet-office.gov.uk
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 123e4567-e89b-12d3-a456-426614174000
+- name: publishing-api
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publishing-api
+      tag: latest  # To be edited by automation (not yet implemented).
+    dbMigrationEnabled: true
+    workerEnabled: true
+    replicaCount: 1
+    workerReplicaCount: 1
+    extraEnv:
+      - name: PORT
+        value: "3000"
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publishing-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publishing-api
+            key: oauth_secret
+      - name: CONTENT_STORE_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-content-store
+            key: bearer_token
+      - name: DRAFT_CONTENT_STORE_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-draft-content-store
+            key: bearer_token
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-router-api
+            key: bearer_token
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: RABBITMQ_HOSTS
+        value: rabbitmq.test.govuk-internal.digital
+      - name: RABBITMQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: publishing-api-rabbitmq
+            key: password
+      - name: RABBITMQ_USER
+        value: publishing_api
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.test.govuk-internal.digital
+      - name: EVENT_LOG_AWS_BUCKETNAME
+        value: govuk-publishing-api-event-log-test
+      - name: EVENT_LOG_AWS_ACCESS_ID
+        value: unset  # TODO: Set up Event Log S3 Bucket (not in terraform)
+      - name: EVENT_LOG_AWS_SECRET_KEY
+        value: unset  # TODO: Set up Event Log S3 Bucket (not in terraform)
+      - name: EVENT_LOG_AWS_USERNAME
+        value: govuk-publishing-api-event-log_user
+      - name: GOVUK_CONTENT_SCHEMAS_PATH
+        value: /govuk-content-schemas
+      - name: SENTRY_DSN
+        valueFrom:
+          secretKeyRef:
+            name: publishing-api-sentry-dsn
+            key: dsn
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: publishing-api-database-url-ec2
+            key: DATABASE_URL
 - name: signon
   helmValues:
     appImage:

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/ec2-database-url.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/ec2-database-url.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publishing-api-database-url-ec2
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Connection string for Publishing API DB hosted in EC2
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publishing-api-database-url-ec2
+  dataFrom:
+    - key: govuk/publishing-api/database-url

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publishing-api-rabbitmq
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      RabbitMQ credentials for publishing-api.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publishing-api-rabbitmq
+  dataFrom:
+    - key: govuk/apps/publishing-api/rabbitmq

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/sentry-dsn.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/sentry-dsn.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: publishing-api-sentry-dsn
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Client key for Sentry publishing-api project.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publishing-api-sentry-dsn
+  dataFrom:
+    - key: govuk/common/publishing-api-sentry-dsn

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -32,6 +32,15 @@ spec:
                   "redirect_uri": "https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
+                "draft-content-store": {
+                  "name": "Draft Content Store",
+                  "slug": "draft-content-store",
+                  "secret_name": "signon-app-draft-content-store",
+                  "description": "Central store for draft content on GOV.UK",
+                  "home_uri": "https://draft-content-store.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://draft-content-store.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": []
+                },
                 "router-api": {
                   "name": "Router API",
                   "slug": "router-api",
@@ -121,7 +130,9 @@ spec:
                   "username": "publishing-api",
                   "email": "publishing-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "bearer_tokens": [
-                    { "application_slug": "content-store" }
+                    { "application_slug": "content-store" },
+                    { "application_slug": "draft-content-store" },
+                    { "application_slug": "router-api" }
                   ]
                 },
                 "whitehall": {


### PR DESCRIPTION
Will use AWS MQ in the test environment (created at https://github.com/alphagov/govuk-infrastructure/pull/547).

https://trello.com/c/ZEn9p3Hk/810-migrate-publishing-api-to-eks