### PR TITLE
Update AWS SM secret for RabbitMQ

### DIFF
--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -15,4 +15,4 @@ spec:
   target:
     name: publishing-api-rabbitmq
   dataFrom:
-    - key: govuk/apps/publishing-api/rabbitmq
+    - key: govuk/common/rabbitmq-govuk


### PR DESCRIPTION
I chose the old RabbitMQ secret