### PR TITLE
Fix Router healthchecks.

### DIFF
--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -242,11 +242,30 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - name: www-origin.eks.test.govuk.digital
-    service:
-      port: 8000
+    appProbes: &router-app-probes
+      startupProbe: &router-probe
+        httpGet:
+          path: /healthcheck
+          port: 3001
+        failureThreshold: 10
+        periodSeconds: 1
+        timeoutSeconds: 1
+      livenessProbe:
+        <<: *router-probe
+        failureThreshold: 3
+        periodSeconds: 5
+      readinessProbe:
+        <<: *router-probe
+        httpGet:
+          path: /healthcheck
+          port: 3001
+        failureThreshold: 2
+        periodSeconds: 5
     extraEnv:
-      - name: ROUTER_PUBADDR  # TODO: remove once Dockerfile cleaned up.
-        value: ":8000"
+      - name: ROUTER_PUBADDR
+        value: ":3000"
+      - name: ROUTER_APIADDR
+        value: ":3001"
       - name: ROUTER_MONGO_URL
         value: &router_mongo_hosts "\
           router-backend-1.pink.test.govuk-internal.digital,\
@@ -268,11 +287,10 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
-    service:
-      port: 8000
+    appProbes: *router-app-probes
     extraEnv:
-      - name: ROUTER_PUBADDR  # TODO: remove once Dockerfile cleaned up.
-        value: ":8000"
+      - name: ROUTER_PUBADDR
+        value: ":3000"
       - name: ROUTER_MONGO_URL
         value: *router_mongo_hosts
       - name: ROUTER_MONGO_DB

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -32,18 +32,9 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /healthcheck/live
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /healthcheck/ready
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 5
+          {{- with .Values.appProbes }}
+          {{- . | toYaml | trim | nindent 10 }}
+          {{- end }}
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -32,6 +32,28 @@ appImage:
   tag: latest
   appPort: 3000
 
+# appProbes defines liveness/readiness/startup probes for the app container.
+# These default should suffice for most GOV.UK Rails apps.
+appProbes:
+  startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
+    httpGet:
+      path: /healthcheck/live
+      port: http
+    failureThreshold: 10
+    periodSeconds: 3
+    timeoutSeconds: 5
+  livenessProbe:
+    <<: *app-probe
+    failureThreshold: 3
+    periodSeconds: 5
+  readinessProbe:
+    <<: *app-probe
+    httpGet:
+      path: /healthcheck/ready
+      port: http
+    failureThreshold: 2
+    periodSeconds: 5
+
 nginxImage:
   repository: nginx
   pullPolicy: Always


### PR DESCRIPTION
- Allow overriding the defaults for liveness/readiness/startup probes in the govuk-rails-app chart.
- Override the probes for Router to use the right port and path.
- Improve the defaults for the rest of the apps while we're in there.