### PR TITLE
Set resource limits on pub-api

### DIFF
--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -117,6 +117,14 @@ applications:
     workerEnabled: true
     replicaCount: 1
     workerReplicaCount: 1
+    appResources:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
     extraEnv:
       - name: PORT
         value: "3000"


### PR DESCRIPTION
We're seeing Publishing API containers exit with code 137 so want to set a limit so we can provide that it truly is OOMing.