### PR TITLE
Allow overriding container probes

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -32,8 +32,27 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          {{- with .Values.appProbes }}
-          {{- . | toYaml | trim | nindent 10 }}
+          {{- if .Values.appProbes }}
+          {{- .Values.appProbes | toYaml | trim | nindent 10 }}
+          {{- else }}
+          startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
+            httpGet:
+              path: /healthcheck/live
+              port: http
+            failureThreshold: 10
+            periodSeconds: 3
+            timeoutSeconds: 5
+          livenessProbe:
+            <<: *app-probe
+            failureThreshold: 3
+            periodSeconds: 5
+          readinessProbe:
+            <<: *app-probe
+            httpGet:
+              path: /healthcheck/ready
+              port: http
+            failureThreshold: 2
+            periodSeconds: 5
           {{- end }}
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -33,26 +33,10 @@ appImage:
   appPort: 3000
 
 # appProbes defines liveness/readiness/startup probes for the app container.
-# These default should suffice for most GOV.UK Rails apps.
-appProbes:
-  startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
-    httpGet:
-      path: /healthcheck/live
-      port: http
-    failureThreshold: 10
-    periodSeconds: 3
-    timeoutSeconds: 5
-  livenessProbe:
-    <<: *app-probe
-    failureThreshold: 3
-    periodSeconds: 5
-  readinessProbe:
-    <<: *app-probe
-    httpGet:
-      path: /healthcheck/ready
-      port: http
-    failureThreshold: 2
-    periodSeconds: 5
+# See templates/deployment.yaml file for the default values.
+# When overriding these probes, you must override all three probes if you need
+# them - the whole block is replaced.
+appProbes: {}
 
 nginxImage:
   repository: nginx


### PR DESCRIPTION
When you provide two values.yaml files to helm template
the blocks are *merged* so that two blocks with the same
keys have the union of both sets of keys/values.

This meant that it wasn't possible to set a non-httpGet livenessProbe
as the httpGet block in the default liveness probe would always
be included in any livenessProbe.