### PR TITLE
Add PORT envvar to all app pods

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           - configMapRef:
               name: govuk-apps-env
           env:
+          - name: PORT
+            value: "{{ .Values.appImage.appPort }}"
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
We set the exposed containerPort to `.Values.appImage.appPort` so this ensures that we set the PORT envvar (used by our Rails apps pretty consistently) to the same value.

Currently both government-frontend and finder-frontend are failing their healthchecks as their [Dockerfiles] specify PORT=3090 so the apps are not running on the exposed port.

[Dockerfiles]: https://github.com/alphagov/government-frontend/blob/main/Dockerfile#L32