### PR TITLE
Add ExternalSecret for Publishing API RDS DB

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -186,7 +186,7 @@ applications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: publishing-api-database-url-ec2
+            name: publishing-api-postgres
             key: DATABASE_URL
 - name: signon
   helmValues:

--- a/charts/govuk-apps-conf/externalsecrets-templates/psql-conn-string.tpl
+++ b/charts/govuk-apps-conf/externalsecrets-templates/psql-conn-string.tpl
@@ -1,0 +1,1 @@
+postgresql://{{ .username | toString }}:{{ .password | toString }}@{{ .host | toString }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/postgres.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/postgres.yaml
@@ -1,19 +1,21 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
-  name: publishing-api-database-url-ec2
+  name: publishing-api-postgres
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
     a8r.io/description: >
-      Connection string for Publishing API DB hosted in EC2.
-      !!! IMPORTANT: This should only be used by the TEST AWS environment !!!
+      Connection string for Publishing API DB hosted in RDS
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    name: publishing-api-database-url-ec2
+    name: publishing-api-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/publishing_api_production'
   dataFrom:
-    - key: govuk/publishing-api/database-url
+    - key: govuk/publishing-api/postgres


### PR DESCRIPTION
Integration uses the RDS hosted database rather than the EC2 hosted postgres instance. I've manually added a Secret `govuk/publishing-api/postgres` to AWS SecretsManager for this ExternalSecret.

This should get the ArgoCD apps `govuk-apps-conf` and `publishing-api` (I hope) green.