### PR TITLE
Use /healthcheck/live for readiness probe

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           readinessProbe:
             <<: *app-probe
             httpGet:
-              path: /healthcheck/live
+              path: /healthcheck/live  # TODO: fix readiness check so that we can use it here.
               port: http
             failureThreshold: 2
             periodSeconds: 5

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           readinessProbe:
             <<: *app-probe
             httpGet:
-              path: /healthcheck/ready
+              path: /healthcheck/live
               port: http
             failureThreshold: 2
             periodSeconds: 5


### PR DESCRIPTION
Readiness probes should tell us whether a pod is ready to serve requests, and should not check their dependencies.

[GOV RFC 141](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-141-application-healthchecks.md) incorrectly states:

> If an app can't talk to a backing service it relies on, then it probably can't be trusted to handle any requests.

This is untrue since an application should be expected to degrade gracefully, and an external dependency may not be required for all request paths. For example, Finder Frontend can serve the `/search` homepage without the Search API being reachable, and can serve all requests if the memcached instance is down, and will degrade gracefully if Content Store is unavailable.

The /healthcheck/ready endpoints check the connectivity to and the health of dependencies such as caches, databases, APIs, and external services.

This is inappropriate for a readiness probe in Kubernetes, which should only check whether the app is ready to receive traffic, (i.e. is Puma/Unicorn ready).

As an example, should memcached or content-store go down, this would cause a cascading failure as some frontend apps would fail their healthchecks.

Instead the status checks should be exported as Prometheus metrics, which will enable us to debug issues, but not prevent the app from degrading gracefully (as some apps do) or serving requests which don't require the external depencency (some apps have these).

This change will also make it easier to debug in Kubernetes, since we'll be able to get our apps running and not have the pods killed and restarted while we're debugging.