### PR TITLE
Adding AWS access key and AWS secret key for Asset-manager

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -663,3 +663,17 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+      - name: AWS_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: asset-manager-aws-access-key
+            key: AWS_ACCESS_KEY
+      - name: AWS_SECRET_KEY
+        valueFrom:
+          secretKeyRef:
+            name: asset-manager-aws-secret-key
+            key: AWS_SECRET_KEY
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-assets-integration-test

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-access-key.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-access-key.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: asset-manager-aws-access-key
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      AWS access key to access AWS Asset-manager S3 bucket.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: asset-manager-aws-access-key
+  dataFrom:
+    - key: govuk/asset-manager/aws-access-key

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-secret-key.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-secret-key.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: asset-manager-aws-secret-key
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Secret key to access AWS Asset-manager S3 bucket.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: asset-manager-aws-secret-key
+  dataFrom:
+    - key: govuk/asset-manager/aws-secret-key


### PR DESCRIPTION
Adding AWS access key and AWS secret key to access govuk-assets-integration-test AWS S3 bucket.

https://trello.com/c/pRBFWfGx/688-asset-manager-replatforming