### PR TITLE
Adding Devise pepper and Devise secret for Signon

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -207,9 +207,15 @@ applications:
     workerReplicaCount: 1
     extraEnv:
       - name: DEVISE_PEPPER
-        value: secret
+        valueFrom:
+          secretKeyRef:
+            name: signon-devise-pepper
+            key: DEVISE_PEPPER
       - name: DEVISE_SECRET_KEY
-        value: secret
+        valueFrom:
+          secretKeyRef:
+            name: signon-devise-secret
+            key: DEVISE_SECRET_KEY
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/devisePepper.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/devisePepper.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: signon-devise-pepper
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Devise pepper authentication solution belonging to Signon.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: signon-devise-pepper
+  dataFrom:
+    - key: govuk/signon/devise-pepper

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/deviseSecret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/deviseSecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: signon-devise-secret
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      Devise secret authentication solution belonging to Signon.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: signon-devise-secret
+  dataFrom:
+    - key: govuk/signon/devise-secret


### PR DESCRIPTION
Manually added DEVISE PEPPER and DEVISE SECRET KEY to AWS secrets manager.

govuk/signon/devise-pepper
govuk/signon/devise-secret