### PR TITLE
Allow auth-proxy Mongo client to resolve short hostnames for nodes.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -390,6 +390,9 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: draft-origin
       hosts:
       - name: draft-origin.eks.integration.govuk.digital
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.integration.govuk-internal.digital
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -393,6 +393,9 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: draft-origin
       hosts:
       - name: draft-origin.eks.test.govuk.digital
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - pink.test.govuk-internal.digital
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           - name: {{ .Release.Name }}-nginx-conf
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
       volumes:
       - name: {{ .Release.Name }}-nginx-conf
         configMap:

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -37,4 +37,8 @@ spec:
           {{- end }}
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -60,6 +60,10 @@ workerResources:
     cpu: 500m
     memory: 512Mi
 
+# dnsConfig is passed directly into the pod specs in the app and worker
+# deployment templates.
+dnsConfig: {}
+
 # extraEnv:
 #  - name: RETICULATE_SPLINES
 #    value: "true"


### PR DESCRIPTION
The router_backend MongoDB clusters are configured to return short hostnames (i.e. not FQDNs) when listing cluster nodes. This seems to be causing problems for the Mongo client in authenticating-proxy; it spews errors like this:

    MONGODB | Error checking router-backend-1:27017: SocketError: getaddrinfo: Name or service not known
    MONGODB | Error checking router-backend-3:27017: SocketError: getaddrinfo: Name or service not known