### PR TITLE
Exclude test-only ec2-database-url ExternalSecret in other envs.

### DIFF
--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/test-ec2-database-url.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/test-ec2-database-url.yaml
@@ -1,3 +1,5 @@
+{{- /* TODO: remove this file once the test account is gone or fixed up. */ -}}
+{{- if (eq .Values.govukEnvironment "test") -}}
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
@@ -17,3 +19,4 @@ spec:
     name: publishing-api-database-url-ec2
   dataFrom:
     - key: govuk/publishing-api/database-url
+{{- end -}}


### PR DESCRIPTION
This was making govuk-apps-conf look unhealthy in the ArgoCD UI.

Tested: `helm template .` and `helm template . --set govukEnvironment=integration`