### PR TITLE
Fixup send-slack template format

### DIFF
--- a/charts/argo-services/cd-notifications-config.yaml
+++ b/charts/argo-services/cd-notifications-config.yaml
@@ -26,9 +26,9 @@ template.send-argo-events-webhook: |
       method: "POST"
       path: "/argocd"
 template.send-slack: |
-  webhook: |
-    slack_webhook: |
-      "body": |
+  webhook:
+    slack_webhook:
+      body: |
         {
           "attachments": [{
             "title": "{{.app.metadata.name}}",


### PR DESCRIPTION
To map to the format in https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/release-1.0/catalog/install.yaml and the other template in this file.

This should resolve the error we've been seeing in the logs for `deploy/argocd-notifications-controller`:

```
Failed to parse new settings: failed to unmarshal template send-slack: error unmarshaling JSON: json: cannot unmarshal string into Go struct field Notification.webhook of type services.WebhookNotifications
```

https://trello.com/c/iw709yOo/820-set-up-slack-notifications-for-integration-argocd