### PR TITLE
Don't nest appPort and nginxPort values inside appImage and nginxImage.

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -20,13 +20,13 @@ spec:
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
             - name: http
-              containerPort: {{ .Values.appImage.appPort }}
+              containerPort: {{ .Values.appPort }}
           envFrom:
           - configMapRef:
               name: govuk-apps-env
           env:
             - name: PORT
-              value: "{{ .Values.appImage.appPort }}"
+              value: "{{ .Values.appPort }}"
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
@@ -60,7 +60,7 @@ spec:
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
             - name: http
-              containerPort: {{ .Values.nginxImage.nginxPort }}
+              containerPort: {{ .Values.nginxPort }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -26,11 +26,11 @@ data:
       keepalive_timeout  65;
 
       upstream {{ .Release.Name }} {
-        server 127.0.0.1:{{ .Values.appImage.appPort }};
+        server 127.0.0.1:{{ .Values.appPort }};
       }
 
       server {
-        listen {{ .Values.nginxImage.nginxPort }};
+        listen {{ .Values.nginxPort }};
 
         location / {
           proxy_set_header   Host $host;

--- a/charts/govuk-rails-app/templates/service.yaml
+++ b/charts/govuk-rails-app/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.nginxImage.nginxPort }}
+      targetPort: {{ .Values.nginxPort }}
   selector:
     app: {{ .Release.Name }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -30,7 +30,7 @@ dbMigrationEnabled: false
 appImage:
   repository: ""  # Dummy value, overridden in ArgoCD config.
   tag: latest
-  appPort: 3000
+appPort: 3000
 
 # appProbes defines liveness/readiness/startup probes for the app container.
 # See templates/deployment.yaml file for the default values.
@@ -42,7 +42,7 @@ nginxImage:
   repository: nginx
   pullPolicy: Always
   tag: stable
-  nginxPort: 8080
+nginxPort: 8080
 
 appResources:
   limits:


### PR DESCRIPTION
The port numbers are unrelated to the image spec.

There are no other references to `appImage` or `nginxImage` to update.

Tested: `helm template . --set appImage.repository=foo/bar`