### PR TITLE
Fixup smokey govuk_app_domain env var

### DIFF
--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -22,7 +22,7 @@ spec:
         - name: ENVIRONMENT
           value: "{{ .Values.govukEnvironment }}"
         - name: GOVUK_APP_DOMAIN
-          value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+          value: "{{ (printf "eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
         - name: GOVUK_WEBSITE_ROOT
           value: "{{ (printf "https://www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
         - name: SIGNON_EMAIL


### PR DESCRIPTION
This is so smokey will send requests to the right
app domains.