### PR TITLE
Use EC2-hosted APIs

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -13,10 +13,11 @@ data:
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_WEBSITE_ROOT: https://www-origin.{{ .Values.externalDomainSuffix }}
-  PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.{{ .Values.internalDomainSuffix }}
+  PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api.{{ .Values.internalDomainSuffix }}
-  PLEK_SERVICE_ROUTER_API_URI: http://router-api.{{ .Values.internalDomainSuffix }}
+  PLEK_SERVICE_ROUTER_API_URI: http://router-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_SEARCH_API_URI: http://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_SIGNON_URI: http://signon.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_STATIC_URI: http://static.{{ .Values.internalDomainSuffix }}
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}-eks

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -1,5 +1,6 @@
 govukEnvironment: test
 internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital
+ec2InternalDomainSuffix: govuk-internal.digital
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.


### PR DESCRIPTION
The frontend applications will send requests to Content Store, Search API, Router API (etc.) hosted in EC2, rather than instances of these services in Kubernetes.

This will make it easier for us to get frontend apps serving traffic sooner as we'll need a smaller subset of prod-ready helm charts.

This is needed to get smoke tests passing for applications that rely on Search API, since this service is not yet available at `http://search.apps` in-cluster.