### PR TITLE
Add manuals-frontend to the platform

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -713,3 +713,20 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+- name: manuals-frontend
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/manuals-frontend
+      tag: latest  # To be edited by automation (not yet implemented).
+    replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-manuals-frontend
+            key: bearer_token

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -692,3 +692,20 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+- name: manuals-frontend
+  helmValues:
+    appImage:
+      repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/manuals-frontend
+      tag: latest  # To be edited by automation (not yet implemented).
+    replicaCount: 1
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-manuals-frontend
+            key: bearer_token

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -141,7 +141,8 @@ spec:
                   "bearer_tokens": [
                     { "application_slug": "content-store" },
                     { "application_slug": "draft-content-store" },
-                    { "application_slug": "router-api" }
+                    { "application_slug": "router-api" },
+                    { "application_slug": "manuals-frontend" }
                   ]
                 },
                 "whitehall": {


### PR DESCRIPTION
Note that this frontend has a dependency on the publishing-api,
see [here](https://github.com/alphagov/manuals-frontend/search?q=PUBLISHING_API)

Ref:
1. [trello card](https://trello.com/c/dP4vi19p/835-package-manuals-frontend-for-migration)
2. [manuals-frontend dockerise pr](alphagov/manuals-frontend: Pull Request 1267)