### PR TITLE
Remove long-obsolete `search` backend from Router.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -309,8 +309,6 @@ applications:
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify
         value: "https://licensify.integration.publishing.service.gov.uk"
-      - name: BACKEND_URL_search
-        value: "http://search"
       - name: BACKEND_URL_search-api
         value: "http://search-api"
 - name: draft-router
@@ -368,8 +366,6 @@ applications:
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify
         value: "https://licensify.integration.publishing.service.gov.uk"
-      - name: BACKEND_URL_search
-        value: "http://search"
       - name: BACKEND_URL_search-api
         value: "http://search-api"
 - name: authenticating-proxy

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -312,8 +312,6 @@ applications:
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify  # There is no Licensify in test.
         value: "https://licensify.integration.publishing.service.gov.uk"
-      - name: BACKEND_URL_search
-        value: "http://search"
       - name: BACKEND_URL_search-api
         value: "http://search-api"
 - name: draft-router
@@ -371,8 +369,6 @@ applications:
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify  # There is no Licensify in test.
         value: "https://licensify.integration.publishing.service.gov.uk"
-      - name: BACKEND_URL_search
-        value: "http://search"
       - name: BACKEND_URL_search-api
         value: "http://search-api"
 - name: authenticating-proxy


### PR DESCRIPTION
I didn't spot in 77d4dc7 that the `search` backend is disused. It points to a Carrenza VIP which no longer exists (double-checked in staging and in prod).

The `search-api` backend is still in use and remains in the config.