### PR TITLE
Fixup signon app slugs

### DIFF
--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -23,7 +23,7 @@ spec:
           - name: APPLICATIONS
             value: |-
               {
-                "content-store-eks": {
+                "content-store": {
                   "name": "Content Store [EKS]",
                   "slug": "content-store",
                   "secret_name": "signon-app-content-store",
@@ -32,7 +32,7 @@ spec:
                   "redirect_uri": "https://content-store.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "draft-content-store-eks": {
+                "draft-content-store": {
                   "name": "Draft Content Store [EKS]",
                   "slug": "draft-content-store",
                   "secret_name": "signon-app-draft-content-store",
@@ -41,7 +41,7 @@ spec:
                   "redirect_uri": "https://draft-content-store.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "router-api-eks": {
+                "router-api": {
                   "name": "Router API [EKS]",
                   "slug": "router-api",
                   "secret_name": "signon-app-router-api",
@@ -50,7 +50,7 @@ spec:
                   "redirect_uri": "https://router-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "asset-manager-eks": {
+                "asset-manager": {
                   "name": "Asset Manager [EKS]",
                   "slug": "asset-manager",
                   "secret_name": "signon-app-asset-manager",
@@ -59,7 +59,7 @@ spec:
                   "redirect_uri": "https://asset-manager.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "authenticating-proxy-eks": {
+                "authenticating-proxy": {
                   "name": "Content Preview (aka Authenticating Proxy) [EKS]",
                   "slug": "authenticating-proxy",
                   "secret_name": "signon-app-authenticating-proxy",
@@ -68,7 +68,7 @@ spec:
                   "redirect_uri": "https://draft-origin.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "link-checker-api-eks": {
+                "link-checker-api": {
                   "name": "Link Checker API [EKS]",
                   "slug": "link-checker-api",
                   "secret_name": "signon-app-link-checker-api",
@@ -86,7 +86,7 @@ spec:
                   "redirect_uri": "https://publisher.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": ["view_all"]
                 },
-                "publishing-api-eks": {
+                "publishing-api": {
                   "name": "Publishing API [EKS]",
                   "slug": "publishing-api",
                   "secret_name": "signon-app-publishing-api",

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -25,7 +25,6 @@ spec:
               {
                 "content-store": {
                   "name": "Content Store [EKS]",
-                  "slug": "content-store",
                   "secret_name": "signon-app-content-store",
                   "description": "Central store for current live content on GOV.UK",
                   "home_uri": "https://content-store.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -34,7 +33,6 @@ spec:
                 },
                 "draft-content-store": {
                   "name": "Draft Content Store [EKS]",
-                  "slug": "draft-content-store",
                   "secret_name": "signon-app-draft-content-store",
                   "description": "Central store for draft content on GOV.UK",
                   "home_uri": "https://draft-content-store.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -43,7 +41,6 @@ spec:
                 },
                 "router-api": {
                   "name": "Router API [EKS]",
-                  "slug": "router-api",
                   "secret_name": "signon-app-router-api",
                   "description": "Manages the Router database",
                   "home_uri": "https://router-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -52,7 +49,6 @@ spec:
                 },
                 "asset-manager": {
                   "name": "Asset Manager [EKS]",
-                  "slug": "asset-manager",
                   "secret_name": "signon-app-asset-manager",
                   "description": "Manages assets",
                   "home_uri": "https://asset-manager.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -61,7 +57,6 @@ spec:
                 },
                 "authenticating-proxy": {
                   "name": "Content Preview (aka Authenticating Proxy) [EKS]",
-                  "slug": "authenticating-proxy",
                   "secret_name": "signon-app-authenticating-proxy",
                   "description": "Provides authenticated access to draft content on GOV.UK",
                   "home_uri": "https://draft-origin.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -70,7 +65,6 @@ spec:
                 },
                 "link-checker-api": {
                   "name": "Link Checker API [EKS]",
-                  "slug": "link-checker-api",
                   "secret_name": "signon-app-link-checker-api",
                   "description": "Checks links",
                   "home_uri": "https://link-checker-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -79,7 +73,6 @@ spec:
                 },
                 "publisher-eks": {
                   "name": "Publisher [EKS]",
-                  "slug": "publisher-eks",
                   "secret_name": "signon-app-publisher-eks",
                   "description": "Mainstream publishing application",
                   "home_uri": "https://publisher.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -88,7 +81,6 @@ spec:
                 },
                 "publishing-api": {
                   "name": "Publishing API [EKS]",
-                  "slug": "publishing-api",
                   "secret_name": "signon-app-publishing-api",
                   "description": "Central store for all publishing content on GOV.UK",
                   "home_uri": "https://publishing-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -97,7 +89,6 @@ spec:
                 },
                 "whitehall-eks": {
                   "name": "Whitehall [EKS]",
-                  "slug": "whitehall",
                   "secret_name": "signon-app-whitehall-eks",
                   "description": "Mainstream Whitehall application",
                   "home_uri": "https://whitehall-admin.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",


### PR DESCRIPTION
This should get the signon-resources job passing. It looks like the slugs were erroneously renamed.

We're currently still deciding how we'll migrate Signon Applications with minimal disruption to end users. For now we've decided to create a separate Application for the publishing apps (Whitehall Admin, Publisher) while we consider how we'll resolve this problem (probably we'll use env var overrides for the REDIRECT_URIs for Applications).

We'll come back to this after we've hit the frontend serving milestone.