### PR TITLE
Retry failed post-sync workflows on transient error

### DIFF
--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   entrypoint: handle-sync-event
   onExit: exit-handler
+  retryStrategy:
+    limit: "3"
+    expression: "asInt(lastRetry.exitCode) > 1"
   arguments:
     parameters:
       - name: application


### PR DESCRIPTION
We've seen smokey is a little flakey and can fail when the Java proxy it uses for Selenium tests (BrowserMob) fails to start. It's unclear why this proxy is needed.

We can go further and specify a transient error pattern, but I think we should avoid this since we want to use the argo workflows component for more than just smoke testing. E.g. https://github.com/argoproj/argo-workflows/blob/master/util/errors/errors.go#L37

Not 100% sure that the retryStrategy will work on the WorkflowTemplate rather than the whole Workflow (docs aren't super useful https://argoproj.github.io/argo-workflows/retries/).