### PR TITLE
Remove test env var from configmap

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -12,7 +12,6 @@ data:
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
-  TEST_ENV_VAR_CM_CYCLE: "true"
   GOVUK_WEBSITE_ROOT: https://www-origin.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}


### PR DESCRIPTION
I verified that a newly added env var is not propagated through to all pods that use the configmap.