### PR TITLE
Use $http_host for Nginx Host header

### DIFF
--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -33,7 +33,7 @@ data:
         listen {{ .Values.nginxPort }};
 
         location / {
-          proxy_set_header   Host $host;
+          proxy_set_header   Host $http_host;
           proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://{{ .Release.Name }};
           proxy_redirect     off;


### PR DESCRIPTION
host and http_host are subtly different
see https://stackoverflow.com/a/67226842

We use http_host in EC2 so this is an attempt
to preserve some prior behaviour.

Rails apps generate urls using the HOST header
so we want to ensure that the HOST is set to
the original host provided at the edge, not
the internal backend host used by Router.