### PR TITLE
Fix nginx proxy-to-S3 config for app assets.

### DIFF
--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -39,10 +39,17 @@ data:
           proxy_redirect     off;
         }
         location /assets {
-          proxy_set_header   Host $host;
-          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_set_header   Authorization "";
+          proxy_set_header   Connection "";
+          proxy_set_header   X-Real-IP $remote_addr;  # TODO: pass the actual end-client address
+          proxy_hide_header  x-amz-id-2;
+          proxy_hide_header  x-amz-meta-server-side-encryption;
+          proxy_hide_header  x-amz-request-id;
+          proxy_hide_header  x-amz-server-side-encryption;
+          proxy_hide_header  x-amz-version-id;
+          add_header         Cache-Control max-age=31536000;
+          proxy_intercept_errors on;
           proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
-          proxy_redirect     off;
         }
       }
     }


### PR DESCRIPTION
We were mistakenly overriding the `host` header on the outgoing request to the value of the host header from the incoming request, owing to a copy-pasto.

Also:

- Strip `x-amz-*` headers from the response.
- Strip the `Authorization` and `Connection` headers from the request; Amazon doesn't want our integration Basic Auth creds and we don't want the upstream client to be able to force keep-alive or closing of the downstream connection.
- Make static assets cacheable for a long time. The filenames contain a hash of the content, so this is what the Rails authors intended.
- Use our own error pages instead of proxying S3's.

https://trello.com/c/ZR6s2YhF/839

Tested: deployed temporarily to Integration by:

* overriding `spec.source.targetRevision` in `kubectl edit app -n cluster-services argocd-apps`
* pushing a temporary commit to this branch to override `targetRevision` for `govuk-rails-app` in `charts/argocd-apps/values-integration.yaml` (there's probably an easier way involving `argocd app set` but 🤷)
* uploading a one-off set of assets to S3 like so:

```sh
for app in collections finder-frontend frontend government-frontend info-frontend manuals-frontend static whitehall-frontend signon whitehall-admin publisher contacts-admin
do
  echo $app
  kubectl exec deploy/$app -itc $app -- \
  bash -c "apt-get update && \
    apt-get install -y awscli && \
    aws s3 sync /app/public/assets/$app \
      s3://govuk-app-assets-integration/assets/$app/ && \
    echo $app done"
done
```