### PR TITLE
Add specific nginx configuration for router

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -241,6 +241,15 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - name: www-origin.eks.integration.govuk.digital
+    nginxConfigMap:
+      create: false
+      name: router-nginx-conf
+      extraVolumeMounts:
+        - name: router-nginx-conf
+          mountPath: /usr/share/nginx/html/robots.txt
+          subPath: robots.txt
+    nginxImage:
+      tag: stable-perl
     appProbes: &router-app-probes
       startupProbe: &router-probe
         httpGet:

--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: router-nginx-conf
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  nginx.conf: |-
+    user nginx;
+
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      perl_set $uri_lowercase 'sub {
+        my $r = shift;
+        return lc($r->uri);
+      }';
+
+      upstream router {
+        server 127.0.0.1:3000;
+      }
+
+      server {
+        listen 8080;
+
+        location / {
+          proxy_set_header   Host $http_host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_pass         http://router;
+          proxy_redirect     off;
+        }
+        location /assets {
+          proxy_set_header   Authorization "";
+          proxy_set_header   Connection "";
+          proxy_set_header   X-Real-IP $remote_addr;  # TODO: pass the actual end-client address
+          proxy_hide_header  x-amz-id-2;
+          proxy_hide_header  x-amz-meta-server-side-encryption;
+          proxy_hide_header  x-amz-request-id;
+          proxy_hide_header  x-amz-server-side-encryption;
+          proxy_hide_header  x-amz-version-id;
+          add_header         Cache-Control max-age=31536000;
+          proxy_intercept_errors on;
+          proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
+        }
+        location = /__canary__ {
+          return 200 '{"message": "Tweet tweet"}';
+        }
+        location ~ ^\/[A-Z]+[A-Z\W\d]+$ {
+          rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
+        }
+        location = /robots.txt {
+          root /usr/share/nginx/html;
+        }
+      }
+    }
+  robots.txt: |-
+    {{- if eq .Values.govukEnvironment "staging" }}
+    User-agent: *
+    Disallow: /
+    {{- else }}
+    User-agent: *
+    Disallow: /*/print$
+    # Don't allow indexing of user needs pages
+    Disallow: /info/*
+    Sitemap: https://www.gov.uk/sitemap.xml
+
+    # https://ahrefs.com/robot/ crawls the site frequently
+    User-agent: AhrefsBot
+    Crawl-delay: 10
+
+    # https://www.deepcrawl.com/bot/ makes lots of requests. Ideally
+    # we'd slow it down rather than blocking it but it doesn't mention
+    # whether or not it supports crawl-delay.
+    User-agent: deepcrawl
+    Disallow: /
+
+    # Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
+    # (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
+    # The robot doesn't recognise its User-Agent string, see the MS support article:
+    # https://support.microsoft.com/en-us/help/3019711/the-sharepoint-server-crawler-ignores-directives-in-robots-txt
+    User-agent: MS Search 6.0 Robot
+    Disallow: /
+
+    # Google's crawler was sending requests for each variation of query param for the sectors page of licence-finder
+    # resulting in millions of requests a day.
+    User-agent: Googlebot
+    Disallow: /licence-finder/*
+    {{- end }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -78,14 +78,19 @@ spec:
             failureThreshold: 3
             successThreshold: 1
           volumeMounts:
-          - name: {{ .Release.Name }}-nginx-conf
+          - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+          {{- with .Values.nginxConfigMap.extraVolumeMounts }}
+          {{- if not (empty .) }}
+          {{ . | toYaml | trim | nindent 10 }}
+          {{- end }}
+          {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ .Release.Name }}-nginx-conf
+      - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
         configMap:
-          name: {{ .Release.Name }}-nginx-conf
+          name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginxConfigMap.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53,3 +54,4 @@ data:
         }
       }
     }
+{{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -43,6 +43,9 @@ nginxImage:
   pullPolicy: Always
   tag: stable
 nginxPort: 8080
+nginxConfigMap:
+  create: true
+  extraVolumeMounts: []
 
 appResources:
   limits:


### PR DESCRIPTION
Trello cards:
https://trello.com/c/Lkb8N313/381-epic-nginx-and-varnish-changes-needed
https://trello.com/c/jRmN4yoh/805-robotstxt-page

This adds a separate nginx config specifically for router. This is needed to implement a lot of functionality that nginx and varnish currently provide in the old EC2-based environments. This also allows for specifying individual nginx config files for other applications in the future.
