### PR TITLE
Fix env var value for email-alert-frontend

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -748,7 +748,7 @@ applications:
     replicaCount: 1
     extraEnv:
       - name: SUBSCRIPTION_MANAGEMENT_ENABLED
-        value: yes
+        value: "yes"
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: SECRET_KEY_BASE

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -713,7 +713,7 @@ applications:
     replicaCount: 1
     extraEnv:
       - name: SUBSCRIPTION_MANAGEMENT_ENABLED
-        value: yes
+        value: "yes"
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: SECRET_KEY_BASE


### PR DESCRIPTION
In #175, `yes` was used without quotes so was interpreted by yaml as
bool.