### PR TITLE
Add a PreSync job to the govuk-rails-app chart

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -113,6 +113,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publishing-api
       tag: latest  # To be edited by automation (not yet implemented).
     dbMigrationEnabled: true
+    uploadAssets:
+      enabled: false
     workerEnabled: true
     replicaCount: 1
     workerReplicaCount: 1
@@ -392,6 +394,8 @@ applications:
     dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
       searches:
         - blue.integration.govuk-internal.digital
+    uploadAssets:
+      enabled: false
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -114,6 +114,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publishing-api
       tag: latest  # To be edited by automation (not yet implemented).
     dbMigrationEnabled: true
+    uploadAssets:
+      enabled: false
     workerEnabled: true
     replicaCount: 1
     workerReplicaCount: 1
@@ -386,6 +388,8 @@ applications:
     dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
       searches:
         - pink.test.govuk-internal.digital
+    uploadAssets:
+      enabled: false
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.uploadAssets.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -21,3 +22,4 @@ spec:
           aws s3 sync /app/public/assets/{{ .Release.Name }} \
             s3://govuk-app-assets-{{ .Values.govukEnvironment }}/assets/{{ .Release.Name }}/
       restartPolicy: Never
+{{- end }}

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-uploadRailsAssets
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-uploadRailsAssets
+        image: "{{ required "Valid .Values.appImage.repository required!" .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
+        command:
+        - "bash"
+        - "-c"
+        - |
+          [ -d "/app/public/assets/{{ .Release.Name }}" ] && \
+          apt-get update && \
+          apt-get install -y awscli && \
+          aws s3 sync /app/public/assets/{{ .Release.Name }} \
+            s3://govuk-app-assets-{{ .Values.govukEnvironment }}/assets/{{ .Release.Name }}/
+      restartPolicy: Never

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -72,3 +72,5 @@ dnsConfig: {}
 #    value: "true"
 
 govukEnvironment: test
+uploadAssets:
+  enabled: true


### PR DESCRIPTION
This uploads Rails assets to S3, so that they can be served from there.