### PR TITLE
Minor tweaks to the asset-s3-upload job.

### DIFF
--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -7,6 +7,7 @@ metadata:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
+  backoffLimit: 2  # Retry once, in case of network error.
   template:
     spec:
       containers:

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-upload-rails-assets
+  name: {{ .Release.Name }}-upload-assets
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-      - name: {{ .Release.Name }}-upload-rails-assets
+      - name: {{ .Release.Name }}-upload-assets
         image: "{{ required "Valid .Values.appImage.repository required!" .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
         command:
         - "bash"

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -13,6 +13,10 @@ spec:
       containers:
       - name: {{ .Release.Name }}-upload-assets
         image: "{{ required "Valid .Values.appImage.repository required!" .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
+        # TODO: remove this horrible hack of installing awscli inside the
+        # container by building it (or a smaller equivalent) into the base
+        # image. Better still: have the build process emit the assets and just
+        # copy them to the serving bucket here, without involving the app image.
         command:
         - "bash"
         - "-c"


### PR DESCRIPTION
* [Remove "rails" from the asset upload job name.](https://github.com/alphagov/govuk-helm-charts/commit/42c8d530d78bf52f282eb4f41a0386094a1c7d77)
* [Retry app asset upload jobs once in case of network failure.](https://github.com/alphagov/govuk-helm-charts/commit/4d78a58c883b03a2c0c293b8ae4add044ec9c845)
* [Add a TODO for removing the install-awscli-at-runtime bodge.](https://github.com/alphagov/govuk-helm-charts/commit/b1fb280316d869d996e3e8271611c1590461136f)

https://trello.com/c/ZR6s2YhF/839