### PR TITLE
Disallow all robots except in production.

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -70,35 +70,9 @@ data:
       }
     }
   robots.txt: |-
-    {{- if eq .Values.govukEnvironment "staging" }}
-    User-agent: *
-    Disallow: /
+    {{- if eq .Values.govukEnvironment "production" }}
+      {{- $.Files.Get "www-production-robots.txt" | nindent 4 }}
     {{- else }}
-    User-agent: *
-    Disallow: /*/print$
-    # Don't allow indexing of user needs pages
-    Disallow: /info/*
-    Sitemap: https://www.gov.uk/sitemap.xml
-
-    # https://ahrefs.com/robot/ crawls the site frequently
-    User-agent: AhrefsBot
-    Crawl-delay: 10
-
-    # https://www.deepcrawl.com/bot/ makes lots of requests. Ideally
-    # we'd slow it down rather than blocking it but it doesn't mention
-    # whether or not it supports crawl-delay.
-    User-agent: deepcrawl
-    Disallow: /
-
-    # Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
-    # (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
-    # The robot doesn't recognise its User-Agent string, see the MS support article:
-    # https://support.microsoft.com/en-us/help/3019711/the-sharepoint-server-crawler-ignores-directives-in-robots-txt
-    User-agent: MS Search 6.0 Robot
-    Disallow: /
-
-    # Google's crawler was sending requests for each variation of query param for the sectors page of licence-finder
-    # resulting in millions of requests a day.
-    User-agent: Googlebot
-    Disallow: /licence-finder/*
+      User-agent: *
+      Disallow: /
     {{- end }}

--- a/charts/govuk-apps-conf/www-production-robots.txt
+++ b/charts/govuk-apps-conf/www-production-robots.txt
@@ -1,0 +1,27 @@
+User-agent: *
+Disallow: /*/print$
+# Don't allow indexing of user needs pages
+Disallow: /info/*
+Sitemap: https://www.gov.uk/sitemap.xml
+
+# https://ahrefs.com/robot/ crawls the site frequently
+User-agent: AhrefsBot
+Crawl-delay: 10
+
+# https://www.deepcrawl.com/bot/ makes lots of requests. Ideally we'd slow it
+# down rather than blocking it but it doesn't mention whether or not it
+# supports crawl-delay.
+User-agent: deepcrawl
+Disallow: /
+
+# Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
+# (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
+# The robot doesn't recognise its User-Agent string, see the MS support article:
+# https://support.microsoft.com/en-us/help/3019711/the-sharepoint-server-crawler-ignores-directives-in-robots-txt
+User-agent: MS Search 6.0 Robot
+Disallow: /
+
+# Google's crawler was sending requests for each variation of query param for
+# the sectors page of licence-finder # resulting in millions of requests a day.
+User-agent: Googlebot
+Disallow: /licence-finder/*


### PR DESCRIPTION
Invert the conditional so that we serve the disallow-all robots.txt in all non-production environments. We wouldn't want crawlers to index a non-production site if it were to be accidentally made public.

Also move the prod robots.txt into a separate file to make it easier to read and maintain. Since the file doesn't vary by environment, include it verbatim using `$.Files.Get` to further simplify matters. 

Tested: inspected output of `helm template .` and `helm template . --set govukEnvironment=production`.