### PR TITLE
Add DWP Youtube Verification

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -79,6 +79,12 @@ data:
         location = /robots.txt {
           root /usr/share/nginx/html;
         }
+
+        # DWP YouTube Channel Verification
+        location = /dla-ending/google6db9c061ce178960.html {
+          add_header Content-Type text/html;
+          return 200 '';
+        }
       }
     }
   robots.txt: |-


### PR DESCRIPTION
This change is to support DWP in the YouTube verification process.

https://trello.com/c/kMT4IgNn/845-dwp-youtube-channel-verification