### PR TITLE
Require Basic auth on `www-origin` in test and integration environments.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -246,10 +246,16 @@ applications:
     nginxConfigMap:
       create: false
       name: router-nginx-conf
-      extraVolumeMounts:
-        - name: router-nginx-conf
-          mountPath: /usr/share/nginx/html/robots.txt
-          subPath: robots.txt
+    nginxExtraVolumeMounts:
+      - name: router-nginx-conf
+        mountPath: /usr/share/nginx/html/robots.txt
+        subPath: robots.txt
+      - name: router-nginx-htpasswd
+        mountPath: /etc/nginx/htpasswd
+    nginxExtraVolumes:
+      - name: router-nginx-htpasswd
+        secret:
+          secretName: router-nginx-htpasswd
     nginxImage:
       tag: stable-perl
     appProbes: &router-app-probes

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -237,6 +237,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    uploadAssets:
+      enabled: false
     ingress:
       enabled: true
       annotations:
@@ -334,6 +336,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    uploadAssets:
+      enabled: false
     appProbes: *router-app-probes
     appResources:
       limits:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -246,6 +246,21 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - name: www-origin.eks.test.govuk.digital
+    nginxConfigMap:
+      create: false
+      name: router-nginx-conf
+    nginxExtraVolumeMounts:
+      - name: router-nginx-conf
+        mountPath: /usr/share/nginx/html/robots.txt
+        subPath: robots.txt
+      - name: router-nginx-htpasswd
+        mountPath: /etc/nginx/htpasswd
+    nginxExtraVolumes:
+      - name: router-nginx-htpasswd
+        secret:
+          secretName: router-nginx-htpasswd
+    nginxImage:
+      tag: stable-perl
     appProbes: &router-app-probes
       startupProbe: &router-probe
         httpGet:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -240,6 +240,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    uploadAssets:
+      enabled: false
     ingress:
       enabled: true
       annotations:
@@ -337,6 +339,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    uploadAssets:
+      enabled: false
     appProbes: *router-app-probes
     appResources:
       limits:

--- a/charts/govuk-apps-conf/templates/external-secrets/router/nginx-htpasswd.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/router/nginx-htpasswd.yaml
@@ -1,0 +1,21 @@
+{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: router-nginx-htpasswd
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    a8r.io/description: >
+      htpasswd file containing Basic Auth usernames and password hashes for the
+      nginx in front of Router. Not used in production or staging.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: router-nginx-htpasswd
+  dataFrom:
+    - key: govuk/router/htpasswd
+{{- end }}

--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -39,6 +39,11 @@ data:
       server {
         listen 8080;
 
+        {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
+        auth_basic "Enter the GOV.UK username/password (not your personal username/password)";
+        auth_basic_user_file /etc/nginx/htpasswd/htpasswd;
+        {{- end }}
+
         location / {
           proxy_set_header   Host $http_host;
           proxy_set_header   X-Real-IP $remote_addr;

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -81,10 +81,8 @@ spec:
           - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
-          {{- with .Values.nginxConfigMap.extraVolumeMounts }}
-          {{- if not (empty .) }}
+          {{- with .Values.nginxExtraVolumeMounts }}
           {{ . | toYaml | trim | nindent 10 }}
-          {{- end }}
           {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:
@@ -94,3 +92,6 @@ spec:
       - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
         configMap:
           name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+      {{- with .Values.nginxExtraVolumes }}
+      {{ . | toYaml | trim | nindent 6 }}
+      {{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -45,7 +45,8 @@ nginxImage:
 nginxPort: 8080
 nginxConfigMap:
   create: true
-  extraVolumeMounts: []
+nginxExtraVolumeMounts: []
+nginxExtraVolumes: []
 
 appResources:
   limits:


### PR DESCRIPTION
- Add an ExternalSecret to fetch the htpasswd contents from AWS Secrets Manager.
- Allow passing in extra volumes for the nginx pod in the `govuk-rails-app` chart.
- Mount the `htpasswd` file using Secret and VolumeMount.

Plus some minor cleanup while I'm there:

- Rename `nginxConfigMap.extraVolumeMounts` to `nginxExtraVolumeMounts` (because it's not specific to configmaps).
- Add missing nginx Helm values in the test environment.
- Remove an unnecessary `if not (empty .)` inside a `with` block. (A `with` block with an empty argument is already a no-op.)

I've added AWS Secrets Manager secrets in both accounts.

https://trello.com/c/iausYhX2/848

#### Testing

Tested by overriding `targetRevision` to the PR branch in `app/argocd-apps` via `kubectl edit`, with a temporary commit to `charts/argocd-apps/values-test.yaml` to override `targetRevision` for the `govuk-apps-conf` and `router` apps. nginx serves `401 Authorization Required` without basic auth creds (and with wrong creds) and proxies the request when valid creds are supplied.