### PR TITLE
Fix smart-answers: env var should be string

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -788,7 +788,7 @@ applications:
     replicaCount: 1
     extraEnv:
       - name: EXPOSE_GOVSPEAK
-        value: 1
+        value: "1"
       - name: COMPANIES_HOUSE_API_KEY
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -753,7 +753,7 @@ applications:
     replicaCount: 1
     extraEnv:
       - name: EXPOSE_GOVSPEAK
-        value: 1
+        value: "1"
       - name: COMPANIES_HOUSE_API_KEY
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Fix the podspec (#188) of smart-answers by changing the numeric
env var to string. See [upstream issue](https://github.com/kubernetes/kubernetes/issues/82296)