### PR TITLE
Set Host/X- headers at Router Nginx

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -39,6 +39,13 @@ data:
       server {
         listen 8080;
 
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+
         {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
         auth_basic "Enter the GOV.UK username/password (not your personal username/password)";
         auth_basic_user_file /etc/nginx/htpasswd/htpasswd;
@@ -90,7 +97,7 @@ data:
           absolute_redirect off;
           return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
         }
-        
+
         # DWP YouTube Channel Verification
         location = /dla-ending/google6db9c061ce178960.html {
           add_header Content-Type text/html;


### PR DESCRIPTION
These were ported over from the Router Nginx config used
in EC2: https://github.com/alphagov/govuk-puppet/blob/cc19f6f5fb90dc79591077c0a92bc9b719863cf7/modules/router/templates/router_include.conf.erb#L3-L8

The X-Forwarded-Host is particularly important. It is used by
Rails ActionDispatch to generate URLs, and overrides the Host
header. It is crucial that this is set to the original Host
i.e. www.gov.uk, otherwise URLs will be generated using internal
hosts such as frontend.apps.svc etc.