### PR TITLE
Fix assets smart-answers

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -786,6 +786,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smart-answers
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    uploadAssets:
+      path: "/app/public/assets/smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -751,6 +751,8 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smart-answers
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
+    uploadAssets:
+      path: "/app/public/assets/smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -21,7 +21,7 @@ spec:
         - "bash"
         - "-c"
         - |
-          [ -d "/app/public/assets/{{ .Release.Name }}" ] && \
+          [ -d "{{ .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Release.Name) }}" ] && \
           apt-get update && \
           apt-get install -y awscli && \
           aws s3 sync /app/public/assets/{{ .Release.Name }} \


### PR DESCRIPTION
(34af6072d982d6a5c7fa619fd74ed639973d7d1b) Allow assets path to be specified in the k8s job

Not all apps store their assets in the path `/app/public/assets/<app_name>`, e.g. smart-answers. Therefore, we introduce an override to be able to explicitly pass in the full path where the assets reside.

(de3c2e8337a191ca80537bb0c639ec67b76263a7) Specify assets paths for smart-answers
smart-answers store its assets under `/app/public/assets/smartanswers` rather `/app/public/assets/smart-answers`, i.e. no dash between smart and answers. Therefore, we specify the full explicit path.