### PR TITLE
Fix assets smartanswers 2

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -788,6 +788,7 @@ applications:
     replicaCount: 1
     uploadAssets:
       path: "/app/public/assets/smartanswers"
+      s3Directory: "smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -753,6 +753,7 @@ applications:
     replicaCount: 1
     uploadAssets:
       path: "/app/public/assets/smartanswers"
+      s3Directory: "smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -21,10 +21,11 @@ spec:
         - "bash"
         - "-c"
         - |
-          [ -d "{{ .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Release.Name) }}" ] && \
+          ASSETS_PATH="{{ .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Release.Name) }}"
+          [ -d "${ASSETS_PATH}" ] && \
           apt-get update && \
           apt-get install -y awscli && \
-          aws s3 sync /app/public/assets/{{ .Release.Name }} \
-            s3://govuk-app-assets-{{ .Values.govukEnvironment }}/assets/{{ .Release.Name }}/
+          aws s3 sync ${ASSETS_PATH} \
+            s3://govuk-app-assets-{{ .Values.govukEnvironment }}/assets/{{ .Values.uploadAssets.s3Directory | default .Release.Name }}/
       restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
(65535f8fbfaec07b04ead118d365427a5e7fd400) Fix https://github.com/alphagov/govuk-helm-charts/pull/194 explicit/full assets_path
In https://github.com/alphagov/govuk-helm-charts/pull/194, the full assets_paths feature was introduced but the changes where not propagated in whole bash. This PR fixes that.

In addition, the `s3Directory` parameter is introduced to specify the directory under `s3://govuk-app-assets-{{ .Values.govukEnvironment }}/assets/` where assets are stored.

(0a73bc2b452a89cc962b9321232c0ae7e8ea0f3f) specify new assets s3 directory for smart-answers
