### PR TITLE
Fixup proxy_set_header for router Nginx / location

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -39,12 +39,11 @@ data:
       server {
         listen 8080;
 
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Server $host;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_redirect off;
+        proxy_set_header   Host $http_host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-Server $host;
+        proxy_set_header   X-Forwarded-Host $http_host;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 
         {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
         auth_basic "Enter the GOV.UK username/password (not your personal username/password)";
@@ -52,8 +51,6 @@ data:
         {{- end }}
 
         location / {
-          proxy_set_header   Host $http_host;
-          proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://router;
           proxy_redirect     off;
         }


### PR DESCRIPTION
As documented in http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
The proxy_set_header directives are inherited from the previous configuration level
if and only if there are no proxy_set_header directives defined on the current level.

This means that if any proxy_set_header are defined in the location
block then any headers set with proxy_set_header at the server
block level will be dropped.

This moves the proxy_set_header directives from the / location
block to the server block, to match the EC2 Router Nginx config,
which will ensure x-forwarded-host is set.

https://github.com/alphagov/govuk-puppet/blob/main/modules/router/templates/router_include.conf.erb#L6