### PR TITLE
Fix smart-answers plek entry (draft-)router

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -311,7 +311,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://smartanswers"
+        value: "http://smart-answers"
       - name: BACKEND_URL_static
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
@@ -370,7 +370,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://draft-service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://draft-smartanswers"
+        value: "http://draft-smart-answers"
       - name: BACKEND_URL_static
         value: "http://draft-static"
       - name: BACKEND_URL_whitehall-frontend

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -314,7 +314,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://smartanswers"
+        value: "http://smart-answers"
       - name: BACKEND_URL_static
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
@@ -373,7 +373,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://draft-service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://draft-smartanswers"
+        value: "http://draft-smart-answers"
       - name: BACKEND_URL_static
         value: "http://draft-static"
       - name: BACKEND_URL_whitehall-frontend


### PR DESCRIPTION
smart-answers app has been added to the platform in #188, the k8s service
name for it is `smart-answers` and therefore we need to fix the
 wrong plek entry for smart-answers