### PR TITLE
refactor: use smartanswers rather than smart-answers in most places

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -311,7 +311,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://smart-answers"
+        value: "http://smartanswers"
       - name: BACKEND_URL_static
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
@@ -370,7 +370,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://draft-service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://draft-smart-answers"
+        value: "http://draft-smartanswers"
       - name: BACKEND_URL_static
         value: "http://draft-static"
       - name: BACKEND_URL_whitehall-frontend
@@ -790,32 +790,29 @@ applications:
           secretKeyRef:
             name: email-alert-auth
             key: token
-- name: smart-answers
+- name: smartanswers
   helmValues:
     appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smart-answers
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
-    uploadAssets:
-      path: "/app/public/assets/smartanswers"
-      s3Directory: "smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"
       - name: COMPANIES_HOUSE_API_KEY
         valueFrom:
           secretKeyRef:
-            name: smart-answers-companies-house
+            name: smartanswers-companies-house
             key: api_key
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smart-answers-link-checker-api
+            name: signon-token-smartanswers-link-checker-api
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smart-answers-publishing-api
+            name: signon-token-smartanswers-publishing-api
             key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:
@@ -825,10 +822,10 @@ applications:
       - name: ZENDESK_CLIENT_USERNAME
         valueFrom:
           secretKeyRef:
-            name: smart-answers-zendesk-client
+            name: smartanswers-zendesk-client
             key: username
       - name: ZENDESK_CLIENT_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: smart-answers-zendesk-client
+            name: smartanswers-zendesk-client
             key: password

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -314,7 +314,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://smart-answers"
+        value: "http://smartanswers"
       - name: BACKEND_URL_static
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
@@ -373,7 +373,7 @@ applications:
       - name: BACKEND_URL_service-manual-frontend
         value: "http://draft-service-manual-frontend"
       - name: BACKEND_URL_smartanswers
-        value: "http://draft-smart-answers"
+        value: "http://draft-smartanswers"
       - name: BACKEND_URL_static
         value: "http://draft-static"
       - name: BACKEND_URL_whitehall-frontend
@@ -764,22 +764,19 @@ applications:
           secretKeyRef:
             name: email-alert-auth
             key: token
-- name: smart-answers
+- name: smartanswers
   helmValues:
     appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smart-answers
       tag: latest  # To be edited by automation (not yet implemented).
     replicaCount: 1
-    uploadAssets:
-      path: "/app/public/assets/smartanswers"
-      s3Directory: "smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"
       - name: COMPANIES_HOUSE_API_KEY
         valueFrom:
           secretKeyRef:
-            name: smart-answers-companies-house
+            name: smartanswers-companies-house
             key: api_key
       - name: SECRET_KEY_BASE
         valueFrom:
@@ -789,20 +786,20 @@ applications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smart-answers-link-checker-api
+            name: signon-token-smartanswers-link-checker-api
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smart-answers-publishing-api
+            name: signon-token-smartanswers-publishing-api
             key: bearer_token
       - name: ZENDESK_CLIENT_USERNAME
         valueFrom:
           secretKeyRef:
-            name: smart-answers-zendesk-client
+            name: smartanswers-zendesk-client
             key: username
       - name: ZENDESK_CLIENT_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: smart-answers-zendesk-client
+            name: smartanswers-zendesk-client
             key: password

--- a/charts/govuk-apps-conf/templates/external-secrets/smartanswers/companies-house.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/smartanswers/companies-house.yaml
@@ -1,18 +1,18 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
-  name: smart-answers-zendesk-client
+  name: smartanswers-companies-house
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
     a8r.io/description: >
-       Username/Password used by Smart-answers to access Zendesk
+       API key used by Smart-answers to access Companies House API
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    name: smart-answers-zendesk-client
+    name: smartanswers-companies-house
   dataFrom:
-    - key: govuk/smart-answers/zendesk-client
+    - key: govuk/smartanswers/companies-house

--- a/charts/govuk-apps-conf/templates/external-secrets/smartanswers/zendesk-client.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/smartanswers/zendesk-client.yaml
@@ -1,18 +1,18 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
-  name: smart-answers-companies-house
+  name: smartanswers-zendesk-client
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
     a8r.io/description: >
-       API key used by Smart-answers to access Companies House API
+       Username/Password used by Smart-answers to access Zendesk
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    name: smart-answers-companies-house
+    name: smartanswers-zendesk-client
   dataFrom:
-    - key: govuk/smart-answers/companies-house
+    - key: govuk/smartanswers/zendesk-client

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -179,10 +179,10 @@ spec:
                     { "application_slug": "publishing-api" }
                   ]
                 },
-                "smart-answers": {
+                "smartanswers": {
                   "name": "Smart Answers",
-                  "username": "smart-anwsers",
-                  "email": "smart-answers@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "username": "smartanwsers",
+                  "email": "smartanswers@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "bearer_tokens": [
                     { "application_slug": "link-checker-api" },
                     { "application_slug": "publishing-api" }


### PR DESCRIPTION
smartanswers is the name used mostly everywhere for this app except for the GitHub repo name. This change reflects that.