### PR TITLE
Enable Finder Frontend to send requests to EC2 Email Alert API

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -538,6 +538,12 @@ applications:
             key: SECRET_KEY_BASE
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-finder-frontend-email-alert-api
+            key: bearer_token
+
 - name: collections
   helmValues:
     appImage:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -537,6 +537,11 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-finder-frontend-email-alert-api
+            key: bearer_token
 - name: collections
   helmValues:
     appImage:

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -48,7 +48,7 @@ spec:
                   "permissions": []
                 },
                 "email-alert-api": {
-                  "name": "Email Alert API [EKS]",
+                  "name": "Email Alert API",
                   "secret_name": "signon-app-email-alert-api",
                   "description": "API to manage GOV.UK email subscriptions",
                   "home_uri": "https://email-alert-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -186,6 +186,14 @@ spec:
                   "bearer_tokens": [
                     { "application_slug": "link-checker-api" },
                     { "application_slug": "publishing-api" }
+                  ]
+                },
+                "finder-frontend": {
+                  "name": "Finder Frontend",
+                  "username": "finder-frontend",
+                  "email": "finder-frontend@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "email-alert-api" }
                   ]
                 }
               }


### PR DESCRIPTION
Finder frontend creates email subscriptions for users from their
search queries. In order to create subscriber_lists using
email-alert-api a bearer token is required.

Currently finder-frontend uses EC2 hosted email-alert-api so
we can use the existing Signon application.

Note that the redirect_url and home_url are irrelevant for api-only
applications.