### PR TITLE
Set GOV.UK Website Root to Fastly domain

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -1,5 +1,6 @@
 globalHelmValues:
   govukEnvironment: integration
+  govukWebsiteRoot: https://www.integration.publishing.service.gov.uk
   externalDomainSuffix: eks.integration.govuk.digital
 
 applications:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -1,6 +1,7 @@
 globalHelmValues:
   govukEnvironment: test
   govukStack: pink  # TODO: eliminate the need for govukStack
+  govukWebsiteRoot: https://www.test.publishing.service.gov.uk
   externalDomainSuffix: eks.test.govuk.digital
 
 applications:

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
-  GOVUK_WEBSITE_ROOT: https://www-origin.{{ .Values.externalDomainSuffix }}
+  GOVUK_WEBSITE_ROOT: {{ .Values.govukWebsiteRoot }}
   PLEK_SERVICE_ACCOUNT_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}


### PR DESCRIPTION
Fastly bypasses authentication for requests from our VPC
which should resolve a number of smoke test failures caused
by requests from apps to apis served on the public website root
failing due to a lack of basic auth.

I've fixed a couple of these problems already by going app-by-app:
* https://github.com/alphagov/finder-frontend/pull/2738
* https://github.com/alphagov/publisher/pull/1552
and I think we should continue to do this.

This change is intended to catch any other instances of this issue
that we don't spot (though this change may hide them from us!).