### PR TITLE
Use `pullPolicy: Always` for the mutably-tagged nginx image.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -258,8 +258,9 @@ applications:
       - name: router-nginx-htpasswd
         secret:
           secretName: router-nginx-htpasswd
-    nginxImage:
+    nginxImage: &router-nginx-image
       tag: stable-perl
+      pullPolicy: Always
     appProbes: &router-app-probes
       startupProbe: &router-probe
         httpGet:
@@ -338,6 +339,7 @@ applications:
     replicaCount: 1
     uploadAssets:
       enabled: false
+    nginxImage: *router-nginx-image
     appProbes: *router-app-probes
     appResources:
       limits:

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -261,8 +261,9 @@ applications:
       - name: router-nginx-htpasswd
         secret:
           secretName: router-nginx-htpasswd
-    nginxImage:
+    nginxImage: &router-nginx-image
       tag: stable-perl
+      pullPolicy: Always
     appProbes: &router-app-probes
       startupProbe: &router-probe
         httpGet:
@@ -341,6 +342,7 @@ applications:
     replicaCount: 1
     uploadAssets:
       enabled: false
+    nginxImage: *router-nginx-image
     appProbes: *router-app-probes
     appResources:
       limits:

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - name: {{ .Release.Name }}
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
@@ -58,6 +59,7 @@ spec:
           {{- end }}
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+          imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}
           ports:
             - name: http
               containerPort: {{ .Values.nginxPort }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -29,6 +29,7 @@ dbMigrationEnabled: false
 
 appImage:
   repository: ""  # Dummy value, overridden in ArgoCD config.
+  pullPolicy: Always
   tag: latest
 appPort: 3000
 


### PR DESCRIPTION
Once we have a mechanism for automatically updating pinned image tags, we'll be able to stop referring to mutable tags like `stable`. Until then, it's the lesser of evils.

The `pullPolicy: Always` got accidentally dropped in #179 when switching from `stable` to `stable-perl` to support the lowercasing-URLs config.

Also fix the `govuk-rails-app` chart so that it actually honours the `pullPolicy` values that are passed in 😅