### PR TITLE
Use `sh` rather than `bash` for assets-upload-job.

### DIFF
--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -18,7 +18,7 @@ spec:
         # image. Better still: have the build process emit the assets and just
         # copy them to the serving bucket here, without involving the app image.
         command:
-        - "bash"
+        - "sh"
         - "-c"
         - |
           ASSETS_PATH="{{ .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Release.Name) }}"


### PR DESCRIPTION
This makes it compatible with a wider range of base images. For example, it makes it fail in a more helpful way when unintentionally run against Router, which is currently based on Alpine.

Tested: ran the modified command via `kubectl exec` and checked the success and failure (nonexistent directory) cases.

[Trello card](https://trello.com/c/ZR6s2YhF/839)