### PR TITLE
Disable service links (`*_SERVICE_*` env vars) on app pods.

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -86,6 +86,7 @@ spec:
           {{- with .Values.nginxExtraVolumeMounts }}
           {{ . | toYaml | trim | nindent 10 }}
           {{- end }}
+      enableServiceLinks: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -37,6 +37,7 @@ spec:
           {{- end }}
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
+      enableServiceLinks: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}


### PR DESCRIPTION
Disable [service links] (the automatically-set environment variables with names like `$service_SERVICE_{HOST,PORT}_*`) in the `govuk-rails-app` chart. We're not using them and they create a lot of clutter in the environment which can be a pain when debugging.

Maybe someday we could use them in Router and Plek, but that's unlikely to happen soon (and we already have too many service discovery mechanisms!)

#### Testing

* Ran `helm template . --set appImage.repository=foo --set workerEnabled=true` and inspected the output.
* Installed the chart (`helm install frontend-test ../govuk-rails-app --values <(helm template . --values values-integration.yaml |yq e '.|select(.metadata.name=="frontend").spec.source.helm.values')`), verified that pods come up healthy and the output of `kubectl exec frontend-test-d56c666c4-t4jbb -c frontend-test -- env` no longer contains dozens of unused `*_SERVICE_{HOST,PORT}` vars.

[service links]: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables