### PR TITLE
Run smoke test on loop every 10 minutes

### DIFF
--- a/charts/smokey/templates/workflows/smokey-loop.yaml
+++ b/charts/smokey/templates/workflows/smokey-loop.yaml
@@ -3,7 +3,7 @@ kind: CronWorkflow
 metadata:
   name: smokey-loop
 spec:
-  schedule: "*/3 9-17 * * 1-5"
+  schedule: "*/10 9-17 * * 1-5"
   timezone: Europe/London
   concurrencyPolicy: Replace
   workflowSpec:


### PR DESCRIPTION
The smoke tests take longer than 3 minutes to complete and are
getting terminated before completing. Running every 10 minutes
should ensure we get the full results from a smoke test.