### PR TITLE
Enable Collections to send requests to Email Alert API

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -560,6 +560,11 @@ applications:
             key: SECRET_KEY_BASE
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-email-alert-api
+            key: bearer_token
 - name: whitehall-admin
   helmValues:
     appImage:

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -115,6 +115,14 @@ spec:
           - name: API_USERS
             value: |-
               {
+                "collections": {
+                  "name": "Collections",
+                  "username": "collections",
+                  "email": "collections@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "email-alert-api" }
+                  ]
+                },
                 "content-store": {
                   "name": "Content Store",
                   "username": "content-store",


### PR DESCRIPTION
Collections requires a bearer token to send requests to the email-alert-api.