### PR TITLE
Add /__canary__ endpoint to all Nginx configurations

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -38,5 +38,14 @@ data:
           proxy_pass         http://{{ .Release.Name }};
           proxy_redirect     off;
         }
+
+        # Endpoint that isn't cached, which is used to assert that an external
+        # service can receive a response from GOV.UK origin on www hostname. It
+        # is intended for pingdom monitoring
+        location = /__canary__ {
+          default_type application/json;
+          add_header cache-control "max-age=0,no-store,no-cache";
+          return 200 '{"message": "Tweet tweet"}\n';
+        }
       }
     }

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -52,6 +52,15 @@ data:
           proxy_intercept_errors on;
           proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
         }
+
+        # Endpoint that isn't cached, which is used to assert that an external
+        # service can receive a response from GOV.UK origin on www hostname. It
+        # is intended for pingdom monitoring
+        location = /__canary__ {
+          default_type application/json;
+          add_header cache-control "max-age=0,no-store,no-cache";
+          return 200 '{"message": "Tweet tweet"}\n';
+        }
       }
     }
 {{- end }}


### PR DESCRIPTION
This is required for the assets subdomain (pingdom checks it)
and may be useful for other applications.