### PR TITLE
Add NFS server to Asset Manager

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -684,6 +684,7 @@ applications:
       - name: asset-manager.eks.integration.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
+    nfsServer: assets.blue.integration.govuk-internal.digital
     extraEnv:
       - name: ASSET_MANAGER_CLAMSCAN_PATH
         value: /usr/bin/clamscan  # TODO: Clamscan hasn't been tested yet, will update it to correct values after testing

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
         - name: {{ .Release.Name }}
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          volumeMounts:
+            - name: {{ .Release.Name }}-asset-uploads-efs
+              mountPath: /var/apps/
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
@@ -94,3 +97,7 @@ spec:
       - name: {{ .Release.Name }}-nginx-conf
         configMap:
           name: {{ .Release.Name }}-nginx-conf
+      - name: {{ .Release.Name }}-asset-uploads-efs
+        nfs: 
+          server: "{{ required "An NFS server is required!" .Values.nfsServer }}"
+          path: /

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -35,10 +35,18 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-asset-uploads-efs
+              mountPath: /var/apps/
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: {{ .Release.Name }}-asset-uploads-efs
+        nfs: 
+          server: "{{ required "An NFS server is required!" .Values.nfsServer }}"
+          path: /
 {{- end }}

--- a/charts/asset-manager/values-integration.yaml
+++ b/charts/asset-manager/values-integration.yaml
@@ -1,4 +1,4 @@
-# Values for Asset-manager Rails application.
+# Integration values for Asset-manager Rails application.
 
 service:
   type: NodePort
@@ -71,13 +71,12 @@ clamResources:
     cpu: 500m
     memory: 1Gi
 
-# nfsServer is the address of the NFSv4 (or Amazon EFS) server where uploaded
-nfsServer: ""
+nfsServer: assets.blue.integration.govuk-internal.digital
 
 # dnsConfig is passed directly into the pod specs in the app and worker
 # deployment templates.
 dnsConfig: {}
 
-# extraEnv:
+extraEnv:
 #  - name: RETICULATE_SPLINES
 #    value: "true"


### PR DESCRIPTION
## What

Adds NFS server to Asset Manager to enable upload and virus scanning of files before moving passing files to s3

## Reference

https://trello.com/c/pRBFWfGx/688-asset-manager-replatforming