### PR TITLE
Fixup signon-resources chart

### DIFF
--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: signon-secrets-bootstrapper
       containers:
       - name: bootstrap-signon-resources
-        image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["bundle"]
         args: ["exec", "rake", "bootstrap:signon"]
         env:

--- a/charts/signon-resources/values.yaml
+++ b/charts/signon-resources/values.yaml
@@ -1,7 +1,6 @@
-common:
-  image:
-    repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon-resources
-    tag: latest
+image:
+  repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/signon-resources
+  tag: latest
 
 govukEnvironment: test
 govukDomainExternal: govuk.digital


### PR DESCRIPTION
Removes the unrequired 'common' block.