### PR TITLE
Add the www hostname to the Router ingress.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -245,6 +245,7 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - name: www-origin.eks.integration.govuk.digital
+      - name: www-eks.integration.publishing.service.gov.uk
     nginxConfigMap:
       create: false
       name: router-nginx-conf


### PR DESCRIPTION
Fastly appears to forward the Host header by default and we had trouble trying to override it in VCL, so let's just try having the load balancer accept the www hostname in addition to the www-origin one.

On the existing EC2 stack, the load balancer forwards everything to Router regardless of the hostname.

[Trello](https://trello.com/c/9BPpFRBe/851)