### PR TITLE
Revert "Add the www hostname to the Router ingress."

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -245,7 +245,6 @@ applications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - name: www-origin.eks.integration.govuk.digital
-      - name: www-eks.integration.publishing.service.gov.uk
     nginxConfigMap:
       create: false
       name: router-nginx-conf


### PR DESCRIPTION
This approach isn't gonna fly because the LB controller expects to find a TLS cert for every hostname that's configured on the LB, which we definitely don't want here for the `www` hostname. We'll have to either figure out what was going wrong with setting the Host header in Fastly VCL or configure a default backend here so that we don't care about the Host header.

Reverts alphagov/govuk-helm-charts#222