### PR TITLE
Use www instead of www-origin as GOVUK_WEBSITE_ROOT.

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
-  GOVUK_WEBSITE_ROOT: https://www-origin.{{ .Values.externalDomainSuffix }}
+  GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_ACCOUNT_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}


### PR DESCRIPTION
This should make apps construct hrefs with the `www.eks.integration.govuk.digital` domain instead of `www-origin.eks.integration.govuk.digital`, which should fix several issues including surprising Basic Auth prompts on Signon and fonts not loading because of CORS issues.

[Trello](https://trello.com/c/9BPpFRBe/851)