### PR TITLE
Use www instead of www-origin for ASSET_HOST.

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   {{- /* TODO: omit namespace from these user-facing URLs in the default namespace. */}}
   {{- /* TODO: delete PLEK_SERVICE_*_URI once Plek can construct http:// internal URLs. */}}
-  ASSET_HOST: https://www-origin.{{ .Values.externalDomainSuffix }}
+  ASSET_HOST: https://www.{{ .Values.externalDomainSuffix }}
   GOVUK_APP_DOMAIN: {{ .Values.internalDomainSuffix }}
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}


### PR DESCRIPTION
Missed this in 3d958bb. See that commit for context.

[Trello](https://trello.com/c/9BPpFRBe/851)