### PR TITLE
Add pod monitor for govuk-rails-app

### DIFF
--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -29,9 +29,6 @@ data:
       upstream {{ .Release.Name }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }
-      upstream metrics {
-        server 127.0.0.1:{{ .Values.metricsPort}};
-      }
 
       server {
         listen {{ .Values.nginxPort }};
@@ -54,12 +51,6 @@ data:
           add_header         Cache-Control max-age=31536000;
           proxy_intercept_errors on;
           proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
-        }
-        location /metrics {
-          proxy_set_header   Host $http_host;
-          proxy_set_header   X-Real-IP $remote_addr;
-          proxy_pass         http://metrics;
-          proxy_redirect     off;
         }
 
         # Endpoint that isn't cached, which is used to assert that an external

--- a/charts/govuk-rails-app/templates/podMonitor.yaml
+++ b/charts/govuk-rails-app/templates/podMonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+  name: {{ .Release.Name }}
+  namespace: monitoring
+spec:
+  endpoints:
+  - port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  namespaceSelector: 
+    matchNames: 
+    - apps
+  podMetricsEndpoints:
+  - targetPort: {{ .Values.metricsPort }}

--- a/charts/govuk-rails-app/templates/service.yaml
+++ b/charts/govuk-rails-app/templates/service.yaml
@@ -16,8 +16,5 @@ spec:
     - name: app
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
-    - name: metrics
-      port: {{ .Values.service.metrics }}
-      targetPort: {{ .Values.metricsPort }}
   selector:
     app: {{ .Release.Name }}


### PR DESCRIPTION
This is to add a podMonitor resource to allow for the app metrics to be scraped to prometheus.

Also removes the need for extra port in service and removes associated nginx config.