### PR TITLE
Serve assets from the existing (EC2) assets service for now.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -1,6 +1,7 @@
 globalHelmValues:
   govukEnvironment: integration
   externalDomainSuffix: eks.integration.govuk.digital
+  publishingServiceDomainSuffix: integration.publishing.service.gov.uk
 
 applications:
 - name: argo-workflows

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -2,6 +2,7 @@ globalHelmValues:
   govukEnvironment: test
   govukStack: pink  # TODO: eliminate the need for govukStack
   externalDomainSuffix: eks.test.govuk.digital
+  publishingServiceDomainSuffix: test.publishing.service.gov.uk
 
 applications:
 - name: argo-workflows

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
   ASSET_HOST: https://www.{{ .Values.externalDomainSuffix }}
   GOVUK_APP_DOMAIN: {{ .Values.internalDomainSuffix }}
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
-  GOVUK_ASSET_ROOT: https://assets.{{ .Values.externalDomainSuffix }}
+  GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -1,6 +1,7 @@
 govukEnvironment: test
 internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital
+publishingServiceDomainSuffix: test.publishing.service.gov.uk
 ec2InternalDomainSuffix: govuk-internal.digital
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.


### PR DESCRIPTION
Since we're focusing on the www frontend for now and it'll be a while longer before we have Asset Manager fully functional in k8s, use the existing Asset Manager domain for serving assets.

"Assets" here means attachements in GOV.UK content (like PDFs and some images), not CSS/JS/images that are part of the GOV.UK apps.