### PR TITLE
Fix assets paths for Whitehall and remove an unnecessary domain suffix.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -533,6 +533,9 @@ applications:
   helmValues:
     dbMigrationEnabled: true
     workerEnabled: true
+    uploadAssets: &whitehall-upload-assets
+      path: "/app/public/assets/whitehall"
+      s3Directory: "whitehall"
     ingress:
       enabled: true
       annotations:
@@ -604,14 +607,14 @@ applications:
   repoName: whitehall
   helmValues:
     replicaCount: 1
-    extraEnv:
-      *whitehall-envs
+    uploadAssets: *whitehall-upload-assets
+    extraEnv: *whitehall-envs
 - name: draft-whitehall-frontend
   repoName: whitehall
   helmValues:
     replicaCount: 1
-    extraEnv:
-      *whitehall-envs
+    uploadAssets: *whitehall-upload-assets
+    extraEnv: *whitehall-envs
 - name: government-frontend
   helmValues:
     replicaCount: 1

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -305,7 +305,7 @@ applications:
       - name: BACKEND_URL_static
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
-        value: "http://whitehall-frontend.apps.svc.cluster.local"
+        value: "http://whitehall-frontend"
       - name: BACKEND_URL_account-api
         value: "http://account-api"
       - name: BACKEND_URL_feedback

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -564,6 +564,9 @@ applications:
       tag: f01a5161aa0d93b2efdd0775c61081695f12447a  # TODO: To be edited by automation (not yet implemented).
     dbMigrationEnabled: true
     workerEnabled: true
+    uploadAssets: &whitehall-upload-assets
+      path: "/app/public/assets/whitehall"
+      s3Directory: "whitehall"
     ingress:
       enabled: true
       annotations:
@@ -637,16 +640,16 @@ applications:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/whitehall
       tag: f01a5161aa0d93b2efdd0775c61081695f12447a  # TODO: To be edited by automation (not yet implemented).
     replicaCount: 1
-    extraEnv:
-      *whitehall-envs
+    uploadAssets: *whitehall-upload-assets
+    extraEnv: *whitehall-envs
 - name: draft-whitehall-frontend
   helmValues:
     appImage:
       repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/whitehall
       tag: f01a5161aa0d93b2efdd0775c61081695f12447a  # TODO: To be edited by automation (not yet implemented).
     replicaCount: 1
-    extraEnv:
-      *whitehall-envs
+    uploadAssets: *whitehall-upload-assets
+    extraEnv: *whitehall-envs
 - name: government-frontend
   helmValues:
     appImage:


### PR DESCRIPTION
The assets upload job was defaulting to nonexistent paths for the three Whitehall deployments. Since whitehall-admin, whitehall-frontend and draft-whitehall-frontend each run the same image (though not necessarily the same version) with a different `.Release.Name` and none of those names match the assets directory inside the image, we need to override it.

We still run the assets upload job independently for each of the three deployments because it's possible for them to be running different versions and therefore need to upload different assets files - even though the vast majority of the time it'll just be fruitlessly uploading the same thing three times.

Also clean up an unnecessary domain suffix while we're there.