### PR TITLE
Fix request routing to Search API and Account API.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -306,8 +306,9 @@ applications:
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
         value: "http://whitehall-frontend"
+        # TODO: switch back to in-cluster account-api once it's fully working (similarly for draft).
       - name: BACKEND_URL_account-api
-        value: "http://account-api"
+        value: "https://account-api.integration.govuk-internal.digital"
       - name: BACKEND_URL_feedback
         value: "http://feedback"
       - name: BACKEND_URL_finder-frontend
@@ -317,9 +318,10 @@ applications:
       - name: BACKEND_URL_licencefinder
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify
-        value: "https://licensify.integration.publishing.service.gov.uk"
+        value: "https://licensify.integration.govuk-internal.digital"
+        # TODO: switch back to in-cluster search-api once it's fully working (similarly for draft).
       - name: BACKEND_URL_search-api
-        value: "http://search-api"
+        value: "https://search-api.integration.govuk-internal.digital"
 - name: draft-router
   repoName: router
   helmValues:
@@ -365,7 +367,7 @@ applications:
       - name: BACKEND_URL_whitehall-frontend
         value: "http://draft-whitehall-frontend"
       - name: BACKEND_URL_account-api
-        value: "http://account-api"
+        value: "https://account-api.integration.govuk-internal.digital"
       - name: BACKEND_URL_feedback
         value: "http://feedback"
       - name: BACKEND_URL_finder-frontend
@@ -375,9 +377,9 @@ applications:
       - name: BACKEND_URL_licencefinder
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify
-        value: "https://licensify.integration.publishing.service.gov.uk"
+        value: "https://licensify.integration.govuk-internal.digital"
       - name: BACKEND_URL_search-api
-        value: "http://search-api"
+        value: "https://search-api.integration.govuk-internal.digital"
 - name: authenticating-proxy
   helmValues:
     replicaCount: 1

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -14,14 +14,16 @@ data:
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
-  PLEK_SERVICE_ACCOUNT_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  # TODO: switch back to in-cluster Account API once it's fully working.
+  PLEK_SERVICE_ACCOUNT_API_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_EMAIL_ALERT_API_URI: https://email-alert-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_FRONTEND_URI: http://frontend.{{ .Values.internalDomainSuffix }}
   PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api.{{ .Values.internalDomainSuffix }}
   PLEK_SERVICE_ROUTER_API_URI: https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_SEARCH_URI: http://search-api.{{ .Values.internalDomainSuffix }}
+  # TODO: switch back to in-cluster Search API once it's fully working.
+  PLEK_SERVICE_SEARCH_URI: https://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_SIGNON_URI: http://signon.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_STATIC_URI: http://static.{{ .Values.internalDomainSuffix }}
   PLEK_SERVICE_WHITEHALL_FRONTEND_URI: http://whitehall-frontend.{{ .Values.internalDomainSuffix }}


### PR DESCRIPTION
We intend to use Search API and Account API in EC2 for now, while we're focusing on frontend (www) functionality. There were various configuration issues preventing these requests from being routed correctly.

- Configure Router to forward to EC2 search-api and account-api.
- Configure apps (via Plek) to use EC2 search-api.
- Use the internal load balancer addresses (`govuk-internal.digital`) where we can.
- It's `PLEK_SERVICE_ACCOUNT_API_URI`, not `PLEK_SERVICE_ACCOUNT_URI`, because the client code calls [`Plek.find("account-api")`][1].

Not making these changes in the test environment because the EC2 stuff in the test account is too broken for this to be meaningful there.

[1]: https://github.com/alphagov/gds-api-adapters/blob/599e216/lib/gds_api.rb#L34