### PR TITLE
Add hmrc-manuals-api to the EKS platform

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -912,3 +912,28 @@ applications:
         value: govuk-integration-search-ltr-endpoint
       - name: TENSORFLOW_SAGEMAKER_VARIANTS
         value: null  # value is empty
+- name: hmrc-manuals-api
+  helmValues:
+    uploadAssets:
+      enabled: false
+    replicaCount: 1
+    extraEnv:
+      - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
+        value: "1"
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-hmrc-manuals-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-hmrc-manuals-api
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-hmrc-manuals-api-publishing-api
+            key: bearer_token
+      - name: PUBLISH_TOPICS
+        value: "1"

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -945,3 +945,28 @@ applications:
         value: govuk-integration-search-ltr-endpoint
       - name: TENSORFLOW_SAGEMAKER_VARIANTS
         value: null  # value is empty
+- name: hmrc-manuals-api
+  helmValues:
+    uploadAssets:
+      enabled: false
+    replicaCount: 1
+    extraEnv:
+      - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
+        value: "1"
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-hmrc-manuals-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-hmrc-manuals-api
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-hmrc-manuals-api-publishing-api
+            key: bearer_token
+      - name: PUBLISH_TOPICS
+        value: "1"

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -118,6 +118,14 @@ spec:
                   "home_uri": "https://search-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "redirect_uri": "https://search-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": ["signin", "ltr_training", "manage_search_indices"]
+                },
+                "hmrc-manuals-api-eks": {
+                  "name": "HMRC Manuals API [EKS]",
+                  "secret_name": "signon-app-hmrc-manuals-api",
+                  "description": "API for allowing HMRC to publish redacted manuals to GOV.UK",
+                  "home_uri": "https://hmrc-manuals-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://hmrc-manuals-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": ["signin"]
                 }
               }
           - name: API_USERS
@@ -222,6 +230,14 @@ spec:
                   "name": "Search API",
                   "username": "search-api",
                   "email": "search-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "publishing-api" }
+                  ]
+                },
+                "hmrc-manuals-api-eks": {
+                  "name": "HMRC Manuals API",
+                  "username": "hmrc-manuals-api",
+                  "email": "hmrc-manuals-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "bearer_tokens": [
                     { "application_slug": "publishing-api" }
                   ]


### PR DESCRIPTION
add hmrc-manuals-api to the EKS platform.

Ref:
1. [trello card](https://trello.com/c/FD0nrcon/847-package-hmrc-manuals-api-for-migration)