### PR TITLE
Add Nginx customizable proxy timeouts

### DIFF
--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -32,6 +32,8 @@ data:
 
       server {
         listen {{ .Values.nginxPort }};
+        proxy_connect_timeout {{ .Values.nginxProxyConnectTimeout }};
+        proxy_read_timeout    {{ .Values.nginxProxyReadTimeout }};
 
         location / {
           proxy_set_header   Host $http_host;

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -45,6 +45,8 @@ nginxImage:
   pullPolicy: Always
   tag: stable
 nginxPort: 8080
+nginxProxyConnectTimeout: 1s
+nginxProxyReadTimeout: 15s
 nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []


### PR DESCRIPTION
Currently, govuk in ec2 has customizable proxy timeouts.
This adds this feature to the EKS platform

Ref:
1. [trello card](https://trello.com/c/BTwxMSVt/864-nginx-request-timeouts)