### PR TITLE
Fix hmrc-manuals-api

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -632,7 +632,6 @@ applications:
   chartPath: charts/asset-manager
   helmValues:
     workerEnabled: true
-    nginxProxyReadTimeout: 60s
     ingress:
       enabled: true
       annotations:
@@ -915,6 +914,7 @@ applications:
         value: null  # value is empty
 - name: hmrc-manuals-api
   helmValues:
+    nginxProxyReadTimeout: 300s
     uploadAssets:
       enabled: false
     replicaCount: 1
@@ -934,7 +934,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-hmrc-manuals-api-publishing-api
+            name: signon-token-hmrc-manuals-api-eks-publishing-api
             key: bearer_token
       - name: PUBLISH_TOPICS
         value: "1"

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -948,6 +948,7 @@ applications:
         value: null  # value is empty
 - name: hmrc-manuals-api
   helmValues:
+    nginxProxyReadTimeout: 300s
     uploadAssets:
       enabled: false
     replicaCount: 1
@@ -967,7 +968,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-hmrc-manuals-api-publishing-api
+            name: signon-token-hmrc-manuals-api-eks-publishing-api
             key: bearer_token
       - name: PUBLISH_TOPICS
         value: "1"


### PR DESCRIPTION
fixes:
1. correct name for signon token to authenticate with
   publishing-api
2. add the nginx proxy timeout