### PR TITLE
Add job to upload error pages to S3 and serve 404 error pages from S3

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -108,6 +108,19 @@ data:
           proxy_read_timeout 50s;
           proxy_pass http://router;
         }
+
+        # Error pages
+        error_page 404 /404.html;
+
+        charset utf-8;
+
+        location /404.html {
+          # Set Cache-Control headers on 404 pages since we overide those set by apps.
+          # So that we dont fall through to the default provided by the CDN.
+          add_header Cache-Control "public, max-age=30" always;
+          proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com/error_pages/404.html;
+          internal;
+        }
       }
     }
   robots.txt: |-

--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Release.Name "static" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: static-error-page-upload
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: static-error-page-upload
+          image: amazon/aws-cli:2.4.25
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              export ERROR_PAGES=(400 401 403 404 405 406 410 422 429 500 502 503 504) && \
+              mkdir /error_pages && \
+              for page in "${ERROR_PAGES[@]}"; do \
+                echo "${page}"
+                curl "http://static/templates/${page}.html.erb" > /error_pages/${page}.html; \
+              done; \
+              aws s3 sync "/error_pages/" "s3://govuk-app-assets-{{ .Values.govukEnvironment }}/error_pages/"
+      restartPolicy: Never
+{{- end }}

--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -12,16 +12,18 @@ spec:
     spec:
       containers:
         - name: static-error-page-upload
+          # TODO: find a way to keep this up-to-date
           image: amazon/aws-cli:2.4.25
           command:
             - "/bin/sh"
             - "-c"
             - |
+              set -eu && \
               export ERROR_PAGES=(400 401 403 404 405 406 410 422 429 500 502 503 504) && \
               mkdir /error_pages && \
               for page in "${ERROR_PAGES[@]}"; do \
                 echo "${page}"
-                curl "http://static/templates/${page}.html.erb" > /error_pages/${page}.html; \
+                curl --fail "http://static/templates/${page}.html.erb" > /error_pages/${page}.html; \
               done; \
               aws s3 sync "/error_pages/" "s3://govuk-app-assets-{{ .Values.govukEnvironment }}/error_pages/"
       restartPolicy: Never


### PR DESCRIPTION
This adds a job that uploads rendered error pages from static to S3 whenever static is deployed. It also gets nginx in front of router to start serving 404 error pages from S3.

Trello card: https://trello.com/c/SaGBEzbI/775-return-static-error-pages-from-origin