### PR TITLE
Strip out headers in error page request to S3

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -120,6 +120,14 @@ data:
           add_header Cache-Control "public, max-age=30" always;
           proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com/error_pages/404.html;
           internal;
+          proxy_set_header   Authorization "";
+          proxy_set_header   Connection "";
+          proxy_set_header   X-Real-IP $remote_addr;  # TODO: pass the actual end-client address
+          proxy_hide_header  x-amz-id-2;
+          proxy_hide_header  x-amz-meta-server-side-encryption;
+          proxy_hide_header  x-amz-request-id;
+          proxy_hide_header  x-amz-server-side-encryption;
+          proxy_hide_header  x-amz-version-id;
         }
       }
     }


### PR DESCRIPTION
This strips out some headers that S3 doesn't like when requesting error pages

Trello card: https://trello.com/c/SaGBEzbI/775-return-static-error-pages-from-origin