### PR TITLE
Improve post-sync workflow name

### DIFF
--- a/charts/argo-services/templates/events/sync_notification_sensor.yaml
+++ b/charts/argo-services/templates/events/sync_notification_sensor.yaml
@@ -39,12 +39,17 @@ spec:
             src:
               dependencyName: sync-notification
               dataKey: body.slackChannel
+          - dest: metadata.generateName
+            src:
+              dependencyName: sync-notification
+              dataKey: body.application
+            operation: prepend
         source:
           resource:
             apiVersion: argoproj.io/v1alpha1
             kind: Workflow
             metadata:
-              generateName: post-sync-
+              generateName: -post-sync-
               namespace: {{ .Values.workflowsNamespace }}
             spec:
               arguments:


### PR DESCRIPTION
Currently, all post-sync workflows are named
`post-sync-<random-string>` which makes it hard to
decipher which post-sync is associated to which
application.

Now, we prepend the application name to the post-sync name.