### PR TITLE
Bump argo-services chart version

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.3
+version: 0.1.4


### PR DESCRIPTION
needed to deploy new version of argo-services after #256 since
this chart is deployed via terraform rather than argo.