### PR TITLE
Add promote release step to postsync workflow

### DIFF
--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -27,11 +27,20 @@ spec:
               parameters:
                 - name: extra-args
                   value: "{{" and @app-{{workflow.parameters.application}}"}}"
-          # TODO: Promote releases
-          # - name: promote-release
-          #   templateRef:
-          #     name: promote-release
-          #     template: promote-release
+          - name: promote-release
+            depends: smoke-test.Succeeded
+            templateRef:
+              name: promote-release
+              template: update-image-tag
+            arguments:
+              parameters:
+                - name: imageTag
+                  value: "{{"{{workflow.parameters.commitSha}}"}}"
+                - name: environment
+                  value: "{{ .Values.nextEnvironment }}"
+                - name: application
+                  value: "{{"{{workflow.parameters.application}}"}}"
+
     - name: exit-handler
       steps:
       - - templateRef:

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: update-image-tag
+spec:
+  entrypoint: update-image-tag 
+  arguments:
+    parameters:
+      - name: imageTag
+      - name: environment
+      - name: application
+  templates:
+    - name: update-image-tag
+      inputs:
+        parameters:
+          - name: imageTag
+          - name: environment
+          - name: application
+        artifacts:
+          - name: govuk-helm-charts
+            path: /govuk-helm-charts
+            git:
+              repo: https://github.com/alphagov/govuk-helm-charts.git
+              depth: 1
+              usernameSecret:
+                name: govuk-ci-github-creds
+                key: token
+              passwordSecret:
+                name: govuk-ci-github-creds
+                key: email
+      script:
+        image: bitnami/minideb:latest
+        command: [/bin/bash]
+        env:
+          - name: GIT_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: govuk-ci-github-creds
+                key: email
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: govuk-ci-github-creds
+                key: token
+          - name: IMAGE_TAG
+            value: "{{"{{inputs.parameters.imageTag}}"}}"
+          - name: ENVIRONMENT
+            value: "{{"{{inputs.parameters.environment}}"}}"
+          - name: APPLICATION
+            value: "{{"{{inputs.parameters.application}}"}}"
+        source: |
+          {{- .Files.Get "scripts/update-image-tag.sh" | nindent 14 }}

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -7,6 +7,8 @@ applications:
 - name: argo-workflows
   chartPath: charts/argo-workflows
   postSyncWorkflowEnabled: "false"
+  helmValues:
+    nextEnvironment: staging
 - name: cluster-secrets
   chartPath: charts/cluster-secrets
   postSyncWorkflowEnabled: "false"

--- a/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
+++ b/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-ci-github-creds
+  annotations:
+    a8r.io/description: >
+       Personal access token for govuk-ci GitHub user 
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-ci-github-creds
+    creationPolicy: Owner
+  dataFrom:
+    - key: govuk/github/govuk-ci

--- a/scripts/update-image-tag.sh
+++ b/scripts/update-image-tag.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+apt-get update && apt-get install -y git
+
+git config --global user.email "${GIT_EMAIL}"
+git config --global user.name govuk-ci
+
+BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
+FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${APPLICATION}"
+
+cd "govuk-helm-charts" || exit 1
+
+LATEST_GIT_SHA=$(git rev-parse main)
+
+if [ "${LATEST_GIT_SHA}" == "${IMAGE_TAG}" ]; then
+  echo "Modifying Helm Charts repo..."
+
+  git checkout -b "${BRANCH}"
+
+  echo "${IMAGE_TAG}" >"{$FILE}"
+
+  git add "${FILE}"
+  git commit -m "Deploy ${APPLICATION}:${IMAGE_TAG} to ${ENVIRONMENT}"
+
+  git push -u origin "${BRANCH}"
+  gh api repos/alphagov/govuk-helm-charts/merges -f head="${BRANCH}" -f base=main
+  git push origin --delete "${BRANCH}"
+
+  echo "Done!"
+else
+  echo "Image tag not updated for ${ENVIRONMENT}: image tag not the latest commit on main."
+  exit 1
+fi


### PR DESCRIPTION
This adds a workflowTemplate to update the image tag value in the helm chart, which is used by the promote release step of the post-sync workflow.