### PR TITLE
add annotation to enable switching-on/off postsync workflow

### DIFF
--- a/charts/argo-services/cd-notifications-config.yaml
+++ b/charts/argo-services/cd-notifications-config.yaml
@@ -53,7 +53,7 @@ template.send-slack: |
 trigger.on-deployed: |
   - send: ["send-argo-events-webhook"]
     when: "app.status.operationState.phase in ['Succeeded'] and app.status.health.status
-      == 'Healthy'"
+      == 'Healthy' and app.metadata.annotations['postSyncWorkflowEnabled'] == 'true' "
 trigger.sync-operation-change: |
   - oncePer: "app.status.operationState.syncResult.revision"
     send: ["send-slack"]

--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     slackChannel: "{{ .slackChannel | default "govuk-deploy-alerts" }}"
     notifications.argoproj.io/subscribe.on-deployed.argo_events: ""
+    postSyncWorkflowEnabled: "{{ .postSyncWorkflowEnabled | default "true" }}"
 spec:
   project: govuk
   source:

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -6,10 +6,13 @@ globalHelmValues:
 applications:
 - name: argo-workflows
   chartPath: charts/argo-workflows
+  postSyncWorkflowEnabled: "false"
 - name: cluster-secrets
   chartPath: charts/cluster-secrets
+  postSyncWorkflowEnabled: "false"
 - name: govuk-apps-conf
   chartPath: charts/govuk-apps-conf
+  postSyncWorkflowEnabled: "false"
 - name: smokey
   chartPath: charts/smokey
 - name: publisher
@@ -488,6 +491,7 @@ applications:
         value: content-store
 - name: signon-resources
   chartPath: charts/signon-resources
+  postSyncWorkflowEnabled: "false"
 - name: info-frontend
   helmValues:
     replicaCount: 1

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -7,10 +7,13 @@ globalHelmValues:
 applications:
 - name: argo-workflows
   chartPath: charts/argo-workflows
+  postSyncWorkflowEnabled: "false"
 - name: cluster-secrets
   chartPath: charts/cluster-secrets
+  postSyncWorkflowEnabled: "false"
 - name: govuk-apps-conf
   chartPath: charts/govuk-apps-conf
+  postSyncWorkflowEnabled: "false"
 - name: smokey
   chartPath: charts/smokey
 - name: publisher
@@ -513,6 +516,7 @@ applications:
             key: MONGODB_URI
 - name: signon-resources
   chartPath: charts/signon-resources
+  postSyncWorkflowEnabled: "false"
   helmValues:
     image:
       tag: 0.0.14


### PR DESCRIPTION
Some apps do not need a postsync workflow since currently
the workflow does a smokey run and slack notification.

if the postSyncWorkflowEnabled annotation of an argo app is set
to false, no trigger is sent to argo events & workflow to trigger
a postsync workflow.