### PR TITLE
Adding securityContext to Asset-manager Worker

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -59,11 +59,6 @@ spec:
             failureThreshold: 2
             periodSeconds: 5
           {{- end }}
-        - name: {{ .Release.Name }}-clamav
-          image: "{{ .Values.clamImage.repository }}:{{ .Values.clamImage.tag }}"
-          ports:
-            - name: tcp
-              containerPort: {{ .Values.clamPort }}
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app.kubernetes.io/component: worker
         app: {{ .Release.Name }}-worker
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -38,6 +41,8 @@ spec:
           volumeMounts:
             - name: {{ .Release.Name }}-asset-uploads-efs
               mountPath: /var/apps/
+          securityContext:
+            allowPrivilegeEscalation: false
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
       {{- with .Values.dnsConfig }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -25,7 +25,7 @@ workerEnabled: true
 workerReplicaCount: 1
 
 appImage:
-  repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/asset-manager"  # Dummy value, overridden in ArgoCD config.
+  repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/asset-manager"
   tag: latest
 appPort: 3000
 
@@ -43,19 +43,13 @@ nginxPort: 8080
 nginxProxyConnectTimeout: 1s
 nginxProxyReadTimeout: 15s
 
-clamImage:
-  repository: clamav/clamav
-  pullPolicy: Always
-  tag: stable
-clamPort: 3310
-
 appResources:
   limits:
     cpu: 1
-    memory: 2Gi
+    memory: 1Gi
   requests:
     cpu: 500m
-    memory: 2Gi
+    memory: 1Gi
 
 workerResources:
   limits:
@@ -64,14 +58,6 @@ workerResources:
   requests:
     cpu: 500m
     memory: 2Gi
-
-clamResources:
-  limits:
-    cpu: 1
-    memory: 2Gi
-  requests:
-    cpu: 500m
-    memory: 1Gi
 
 # nfsServer is the address of the NFSv4 (or Amazon EFS) server where uploaded
 nfsServer: "nfs-server"


### PR DESCRIPTION
Enabled Seccomp on Worker deployment, which will be used to sandbox the privileges of a process, restricting the calls it is able to make from userspace into the kernel and using Docker default profile, which is sufficient for most cases.
Also added securityContext to worker container; allowPrivilegeEscalation - Controls whether a process can gain more privileges than its parent process, i have set this to false by default it is always set to true.

I will be testing once Seccomp is enabled, depending on the results i will further consider creating custom profile if needed.

Docker’s default Seccomp profile:
https://github.com/moby/moby/tree/master/profiles/seccomp

Further to this and testing i will consider adding;
  - securityContext: runAsUser, runAsGroup, fsGroup. Depending on current EFS user UID and GID
  - Adding to non worker deployment also.

https://trello.com/c/pRBFWfGx/688-asset-manager-replatforming