### PR TITLE
Fix step and templateRef names in postsync workflow

### DIFF
--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -30,7 +30,7 @@ spec:
           - name: promote-release
             depends: smoke-test.Succeeded
             templateRef:
-              name: promote-release
+              name: update-image-tag
               template: update-image-tag
             arguments:
               parameters:
@@ -43,16 +43,17 @@ spec:
 
     - name: exit-handler
       steps:
-      - - templateRef:
-            name: notify-slack
-            template: notify-slack
-          arguments:
-            parameters:
-              - name: slackChannel
-                # NOTE: Change to {{"{{workflow.parameters.slackChannel}}"}} to
-                # send to team slack channel.
-                value: "govuk-deploy-alerts"
-              - name: text
-                value: "\
-                  post-sync job ({{"{{workflow.name}}"}}) for <{{"{{workflow.parameters.argoUrl}}"}}|{{"{{workflow.parameters.application}}"}}> in {{ .Values.govukEnvironment }} {{"{{workflow.status}}"}} \
-                  (revision <{{"{{workflow.parameters.commitUrl}}"}}|{{"{{workflow.parameters.commitSha}}"}}>)."
+        - - name: notify-slack
+            templateRef:
+              name: notify-slack
+              template: notify-slack
+            arguments:
+              parameters:
+                - name: slackChannel
+                  # NOTE: Change to {{"{{workflow.parameters.slackChannel}}"}} to
+                  # send to team slack channel.
+                  value: "govuk-deploy-alerts"
+                - name: text
+                  value: "\
+                    post-sync job ({{"{{workflow.name}}"}}) for <{{"{{workflow.parameters.argoUrl}}"}}|{{"{{workflow.parameters.application}}"}}> in {{ .Values.govukEnvironment }} {{"{{workflow.status}}"}} \
+                    (revision <{{"{{workflow.parameters.commitUrl}}"}}|{{"{{workflow.parameters.commitSha}}"}}>)."


### PR DESCRIPTION
This updates name fields for the notify slack step, this is an expected field and prevents manual workflow updates without it. The name reference in the templateRef is updated to correctly reflect the name of the template being referenced.