### PR TITLE
fix smokey

### DIFF
--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -17,14 +17,23 @@ spec:
         command:
           - "bundle"
           - "exec"
-          - "cucumber --profile={{ .Values.govukEnvironment }} --strict-undefined --tags='@replatforming' --tags='not @notreplatforming and not @not{{ .Values.govukEnvironment }}{{"{{ inputs.parameters.extra-args }}"}}'"
+          - "cucumber --profile=${ENVIRONMENT} --strict-undefined --tags='@replatforming' --tags='not @notreplatforming and not @not${ENVIRONMENT}{{"{{ inputs.parameters.extra-args }}"}}'"
         env:
         - name: ENVIRONMENT
-          value: "{{ .Values.govukEnvironment }}"
+          valueFrom:
+            configMapKeyRef:
+              name: govuk-apps-env
+              key: GOVUK_ENVIRONMENT
         - name: GOVUK_APP_DOMAIN
-          value: "{{ (printf "eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
+          valueFrom:
+            configMapKeyRef:
+              name: govuk-apps-env
+              key: GOVUK_APP_DOMAIN
         - name: GOVUK_WEBSITE_ROOT
-          value: "{{ (printf "https://www-origin.eks.%s.%s" .Values.govukEnvironment .Values.govukDomainExternal) }}"
+          valueFrom:
+            configMapKeyRef:
+              name: govuk-apps-env
+              key: GOVUK_WEBSITE_ROOT
         - name: SIGNON_EMAIL
           value: "signon@alphagov.co.uk"
         - name: SIGNON_PASSWORD

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -1,8 +1,3 @@
-govukEnvironment: test
-govukDomainExternal: govuk.digital
-govukDomainInternal: govuk-internal.digital
-clusterDomain: svc.cluster.local
-
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey
   tag: latest


### PR DESCRIPTION
some env values from smokey were outdated with the implementation of fastly for GOV.UK EKS integration.

To avoid setting common variables in Smokey again, they are now taken from the common confimap `govuk-apps-env`.