### PR TITLE
Change method to clone repo in update-image-tag workflow

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 apt-get update && apt-get install -y git curl
 
@@ -20,9 +21,8 @@ cd "govuk-helm-charts" || exit 1
 
 LATEST_GIT_SHA=$(git rev-parse main)
 
-if [ "${LATEST_GIT_SHA}" == "${IMAGE_TAG}" ]; then
-  echo "Modifying Helm Charts repo..."
-
+# Relies on the assumption the IMAGE_TAG is a commit SHA
+if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
   git checkout -b "${BRANCH}"
 
   echo "${IMAGE_TAG}" > "{$FILE}"

--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 apt-get update && apt-get install -y git
 
-REPO="https://${GIT_NAME}:${GITHUB_TOKEN}@github.com/alphagov/govuk-helm-charts.git"
 BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${APPLICATION}"
 
 git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
 git config --global user.name "${GIT_NAME}"
 
-git clone --depth 1 --branch main "${REPO}"
+gh auth setup-git
+gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
+
 cd "govuk-helm-charts" || exit 1
 
 LATEST_GIT_SHA=$(git rev-parse main)

--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 apt-get update && apt-get install -y git
 
-git config --global user.email "${GIT_EMAIL}"
-git config --global user.name govuk-ci
-
+GIT_NAME=govuk-ci
+REPO="https://${GIT_NAME}:${GITHUB_TOKEN}@github.com/alphagov/govuk-helm-charts.git"
 BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${APPLICATION}"
 
+git config --global user.email "${GIT_EMAIL}"
+git config --global user.name "${GIT_NAME}"
+
+git clone --depth 1 --branch main "${REPO}"
 cd "govuk-helm-charts" || exit 1
 
 LATEST_GIT_SHA=$(git rev-parse main)
@@ -16,7 +19,7 @@ if [ "${LATEST_GIT_SHA}" == "${IMAGE_TAG}" ]; then
 
   git checkout -b "${BRANCH}"
 
-  echo "${IMAGE_TAG}" >"{$FILE}"
+  echo "${IMAGE_TAG}" > "{$FILE}"
 
   git add "${FILE}"
   git commit -m "Deploy ${APPLICATION}:${IMAGE_TAG} to ${ENVIRONMENT}"

--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-apt-get update && apt-get install -y git
+
+apt-get update && apt-get install -y git curl
+
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+apt-get update && apt-get install -y gh
 
 BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${APPLICATION}"

--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 apt-get update && apt-get install -y git
 
-GIT_NAME=govuk-ci
 REPO="https://${GIT_NAME}:${GITHUB_TOKEN}@github.com/alphagov/govuk-helm-charts.git"
 BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${APPLICATION}"
 
-git config --global user.email "${GIT_EMAIL}"
+git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
 git config --global user.name "${GIT_NAME}"
 
 git clone --depth 1 --branch main "${REPO}"

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -16,18 +16,6 @@ spec:
           - name: imageTag
           - name: environment
           - name: application
-        artifacts:
-          - name: govuk-helm-charts
-            path: /govuk-helm-charts
-            git:
-              repo: https://github.com/alphagov/govuk-helm-charts.git
-              depth: 1
-              usernameSecret:
-                name: govuk-ci-github-creds
-                key: token
-              passwordSecret:
-                name: govuk-ci-github-creds
-                key: email
       script:
         image: bitnami/minideb:latest
         command: [/bin/bash]

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -20,11 +20,11 @@ spec:
         image: bitnami/minideb:latest
         command: [/bin/bash]
         env:
-          - name: GIT_EMAIL
+          - name: GIT_NAME
             valueFrom:
               secretKeyRef:
                 name: govuk-ci-github-creds
-                key: email
+                key: username
           - name: GITHUB_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This changes retrieving the govuk-helm-charts repo from a argo workflow artefact input to using the git clone command in the script. This allows us to keep this script consistent with the GitHub Action script to update image tags in integrations. It allows for easier debugging of authentication issue.

This updates the secret reference to use the username, which was mistakenly set to the email address previously.