### PR TITLE
Allow multiple hostnames match for govuk-rails-app ingress

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -26,7 +26,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: publisher
       hosts:
-      - name: publisher.eks.integration.govuk.digital
+      - publisher.eks.integration.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv:
@@ -197,7 +197,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: signon
       hosts:
-      - name: signon.eks.integration.govuk.digital
+        - signon.eks.integration.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv:
@@ -238,7 +238,9 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
-      - name: www-origin.eks.integration.govuk.digital
+        - www-origin.eks.integration.govuk.digital
+      additionalAllowedHostnames:
+        - www.eks.integration.govuk.digital
     nginxConfigMap:
       create: false
       name: router-nginx-conf
@@ -393,7 +395,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: draft-origin
       hosts:
-      - name: draft-origin.eks.integration.govuk.digital
+        - draft-origin.eks.integration.govuk.digital
     dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
       searches:
         - blue.integration.govuk-internal.digital
@@ -549,7 +551,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: whitehall-admin
       hosts:
-      - name: whitehall-admin.eks.integration.govuk.digital
+        - whitehall-admin.eks.integration.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv: &whitehall-envs
@@ -643,7 +645,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: asset-manager
       hosts:
-      - name: asset-manager.eks.integration.govuk.digital
+        - asset-manager.eks.integration.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     nfsServer: assets.blue.integration.govuk-internal.digital

--- a/charts/argocd-apps/values-test.yaml
+++ b/charts/argocd-apps/values-test.yaml
@@ -28,7 +28,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: publisher
       hosts:
-      - name: publisher.eks.test.govuk.digital
+        - publisher.eks.test.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv:
@@ -213,7 +213,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: signon
       hosts:
-      - name: signon.eks.test.govuk.digital
+        - signon.eks.test.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv:
@@ -251,7 +251,9 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
-      - name: www-origin.eks.test.govuk.digital
+        - www-origin.eks.test.govuk.digital
+      additionalAllowedHostnames:
+        - www.eks.test.govuk.digital
     nginxConfigMap:
       create: false
       name: router-nginx-conf
@@ -409,7 +411,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: draft-origin
       hosts:
-      - name: draft-origin.eks.test.govuk.digital
+        - draft-origin.eks.test.govuk.digital
     dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
       searches:
         - pink.test.govuk-internal.digital
@@ -576,7 +578,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: whitehall-admin
       hosts:
-      - name: whitehall-admin.eks.test.govuk.digital
+        - whitehall-admin.eks.test.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv: &whitehall-envs
@@ -678,7 +680,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: asset-manager
       hosts:
-      - name: asset-manager.eks.test.govuk.digital
+        - asset-manager.eks.test.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     extraEnv:

--- a/charts/govuk-rails-app/templates/ingress.yaml
+++ b/charts/govuk-rails-app/templates/ingress.yaml
@@ -10,28 +10,27 @@ metadata:
     app.kubernetes.io/component: web
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    external-dns.alpha.kubernetes.io/ingress-hostname-source: annotation-only
+    external-dns.alpha.kubernetes.io/hostname: {{ join "," .Values.ingress.hosts }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.hosts }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
+        {{- range .Values.ingress.hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .name }}
-      http:
+    {{- range concat .Values.ingress.hosts .Values.ingress.additionalAllowedHostnames}}
+    - http:
         paths:
-          - path: {{ default "/" .path }}
-            pathType: {{ default "Prefix" .pathType }}
+          - path: "/"
+            pathType: "Prefix"
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+      host: {{ . }}
     {{- end }}
 {{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -15,9 +15,8 @@ ingress:
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
   hosts:
-  - name:
-    path: /
-    pathType: Prefix
+    - www.example.com
+  additionalAllowedHostnames: []
 
 replicaCount: 1
 


### PR DESCRIPTION
Add the ability to have multiple hostnames match for a given
app.

This is needed for the origin of GOV.UK where fastly will
use the `www.*` domain in the host header field rather than
the `www-origin.*` domain.

Some GOV.UK apps, such as whitehall, uses the host header to
construct a response.

The `ingress.hosts` is now a list which specifies the DNS
domain to be created as well as the tls cert to be attached.

Ref:
1. [trello card](https://trello.com/c/cQm9F4Bf/879-make-www-origin-ingress-ignore-the-host-header)
2. [tls cert](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/cert_discovery/#discover-via-ingress-tls)
3. [dns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/alb-ingress.md#ingress-examples)