### PR TITLE
Adding name to ingress fro Asset-manager as its using seperate ingress to gouvuk-rails-app Helm chart  

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -643,7 +643,7 @@ applications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: asset-manager
       hosts:
-      - asset-manager.eks.integration.govuk.digital
+      - name: asset-manager.eks.integration.govuk.digital
     replicaCount: 1
     workerReplicaCount: 1
     nfsServer: assets.blue.integration.govuk-internal.digital


### PR DESCRIPTION
As Asset-manager is using its own Helm chart and not govuk-rails-app, the changes made to ingress dont affect it for now. 
Therefore adding name back to ingress host.
