### PR TITLE
Allow concurrent smokey cron job

### DIFF
--- a/charts/smokey/templates/workflows/smokey-loop.yaml
+++ b/charts/smokey/templates/workflows/smokey-loop.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   schedule: "*/10 9-17 * * 1-5"
   timezone: Europe/London
-  concurrencyPolicy: Replace
+  concurrencyPolicy: Allow
   workflowSpec:
     arguments:
       parameters:


### PR DESCRIPTION
It is ok to allow concurrent smokey loop as on average a
feature/step will be then tested every 10 minutes.

Currently, some steps are not run because Smokey take longer than
10 minutes to run now.