### PR TITLE
Point frontend (Milestone 1) apps at backends/APIs in EC2.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -33,12 +33,12 @@ applications:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
-            name: signon-app-publisher-eks
+            name: signon-app-publisher
             key: oauth_id
       - name: GDS_SSO_OAUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: signon-app-publisher-eks
+            name: signon-app-publisher
             key: oauth_secret
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
@@ -439,7 +439,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-frontend-publishing-api
+            name: signon-token-frontend-publishing-api-ec2
             key: bearer_token
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
@@ -465,7 +465,7 @@ applications:
       - name: ROUTER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-content-store-router-api
+            name: signon-token-content-store-router-api-ec2
             key: bearer_token
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -517,7 +517,7 @@ applications:
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-finder-frontend-email-alert-api
+            name: signon-token-finder-frontend-email-alert-api-ec2
             key: bearer_token
 
 - name: collections
@@ -534,7 +534,7 @@ applications:
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-collections-email-alert-api
+            name: signon-token-collections-email-alert-api-ec2
             key: bearer_token
 - name: whitehall-admin
   repoName: whitehall
@@ -558,17 +558,17 @@ applications:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
-            name: signon-app-whitehall-eks
+            name: signon-app-whitehall
             key: oauth_id
       - name: GDS_SSO_OAUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: signon-app-whitehall-eks
+            name: signon-app-whitehall
             key: oauth_secret
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-whitehall-asset-manager
+            name: signon-token-whitehall-asset-manager-ec2
             key: bearer_token
       - name: GOVUK_NOTIFY_API_KEY
         valueFrom:
@@ -583,7 +583,7 @@ applications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-whitehall-link-checker-api
+            name: signon-token-whitehall-link-checker-api-ec2
             key: bearer_token
       - name: LINK_CHECKER_API_SECRET_TOKEN
         valueFrom:
@@ -593,7 +593,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-whitehall-publishing-api
+            name: signon-token-whitehall-publishing-api-ec2
             key: bearer_token
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 759acac6-da53-4a19-b591-b7538c7c39de
@@ -718,7 +718,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-manuals-frontend-publishing-api
+            name: signon-token-manuals-frontend-publishing-api-ec2
             key: bearer_token
 - name: email-alert-frontend
   helmValues:
@@ -736,17 +736,17 @@ applications:
       - name: ACCOUNT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-email-alert-frontend-account-api
+            name: signon-token-email-alert-frontend-account-api-ec2
             key: bearer_token
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-email-alert-frontend-email-alert-api
+            name: signon-token-email-alert-frontend-email-alert-api-ec2
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-email-alert-frontend-publishing-api
+            name: signon-token-email-alert-frontend-publishing-api-ec2
             key: bearer_token
       - name: EMAIL_ALERT_AUTH_TOKEN
         valueFrom:
@@ -768,12 +768,12 @@ applications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-link-checker-api
+            name: signon-token-smartanswers-link-checker-api-ec2
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-publishing-api
+            name: signon-token-smartanswers-publishing-api-ec2
             key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:
@@ -810,17 +810,17 @@ applications:
       - name: SUPPORT_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-feedback-support
+            name: signon-token-feedback-support-ec2
             key: bearer_token
       - name: SUPPORT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-feedback-support-api
+            name: signon-token-feedback-support-api-ec2
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-feedback-publishing-api
+            name: signon-token-feedback-publishing-api-ec2
             key: bearer_token
       - name: ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY
         valueFrom:
@@ -861,12 +861,12 @@ applications:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
-            name: signon-app-search-api-eks
+            name: signon-app-search-api
             key: oauth_id
       - name: GDS_SSO_OAUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: signon-app-search-api-eks
+            name: signon-app-search-api
             key: oauth_secret
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:
@@ -906,7 +906,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-search-api-eks-publishing-api
+            name: signon-token-search-api-publishing-api
             key: bearer_token
       - name: RABBITMQ_HOSTS
         value: rabbitmq.integration.govuk-internal.digital
@@ -948,7 +948,7 @@ applications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-hmrc-manuals-api-eks-publishing-api
+            name: signon-token-hmrc-manuals-api-publishing-api
             key: bearer_token
       - name: PUBLISH_TOPICS
         value: "1"

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -16,11 +16,13 @@ data:
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
   # TODO: switch back to in-cluster Account API once it's fully working.
   PLEK_SERVICE_ACCOUNT_API_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_ASSET_MANAGER_URI: https://asset-manager.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_EMAIL_ALERT_API_URI: https://email-alert-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_FRONTEND_URI: http://frontend.{{ .Values.internalDomainSuffix }}
-  PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api.{{ .Values.internalDomainSuffix }}
+  PLEK_SERVICE_LINK_CHECKER_API_URI: https://link-checker-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_PUBLISHING_API_URI: https://publishing-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_ROUTER_API_URI: https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   # TODO: switch back to in-cluster Search API once it's fully working.
   PLEK_SERVICE_SEARCH_URI: https://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -67,13 +67,13 @@ spec:
           - name: APPLICATIONS
             value: |-
               {
-                "account-api": {
-                  "name": "Account API [EKS]",
-                  "secret_name": "signon-app-account-api",
+                "account-api-ec2": {
+                  "name": "Account API",
+                  "secret_name": "signon-app-account-api-ec2",
                   "description": "API to manage GOV.UK Accounts feature",
-                  "home_uri": "https://account-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
-                  "redirect_uri": "https://account-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
-                  "permissions": ["internal_app","update_protected_attributes","internal_app"]
+                  "home_uri": "https://account-api.{{ .Values.publishingServiceDomainSuffix }}",
+                  "redirect_uri": "https://account-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
+                  "permissions": ["internal_app", "update_protected_attributes"]
                 },
                 "content-store": {
                   "name": "Content Store [EKS]",
@@ -91,20 +91,28 @@ spec:
                   "redirect_uri": "https://draft-content-store.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "email-alert-api": {
+                "email-alert-api-ec2": {
                   "name": "Email Alert API",
-                  "secret_name": "signon-app-email-alert-api",
+                  "secret_name": "signon-app-email-alert-api-ec2",
                   "description": "API to manage GOV.UK email subscriptions",
                   "home_uri": "https://email-alert-api.{{ .Values.publishingServiceDomainSuffix }}",
                   "redirect_uri": "https://email-alert-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
-                  "permissions": ["internal_app","status_updates"]
+                  "permissions": ["internal_app", "status_updates"]
                 },
-                "router-api": {
+                "router-api-ec2": {
                   "name": "Router API",
-                  "secret_name": "signon-app-router-api",
+                  "secret_name": "signon-app-router-api-ec2",
                   "description": "Manages the Router database",
                   "home_uri": "https://router-api.{{ .Values.publishingServiceDomainSuffix }}",
                   "redirect_uri": "https://router-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
+                  "permissions": []
+                },
+                "asset-manager-ec2": {
+                  "name": "Asset Manager",
+                  "secret_name": "signon-app-asset-manager-ec2",
+                  "description": "Manages assets",
+                  "home_uri": "https://asset-manager.{{ .Values.publishingServiceDomainSuffix }}",
+                  "redirect_uri": "https://asset-manager.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
                   "permissions": []
                 },
                 "asset-manager": {
@@ -123,77 +131,115 @@ spec:
                   "redirect_uri": "https://draft-origin.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
                   "permissions": []
                 },
-                "link-checker-api": {
-                  "name": "Link Checker API [EKS]",
-                  "secret_name": "signon-app-link-checker-api",
-                  "description": "Checks links",
-                  "home_uri": "https://link-checker-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
-                  "redirect_uri": "https://link-checker-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                "link-checker-api-ec2": {
+                  "name": "Link Checker API",
+                  "secret_name": "signon-app-link-checker-api-ec2",
+                  "description": "Checks links on GOV.UK",
+                  "home_uri": "https://link-checker-api.{{ .Values.publishingServiceDomainSuffix }}",
+                  "redirect_uri": "https://link-checker-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
                   "permissions": []
                 },
-                "publisher-eks": {
+                "publisher": {
                   "name": "Publisher [EKS]",
-                  "secret_name": "signon-app-publisher-eks",
+                  "secret_name": "signon-app-publisher",
                   "description": "Mainstream publishing application",
                   "home_uri": "https://publisher.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "redirect_uri": "https://publisher.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
-                  "permissions": ["skip_review","govuk_editor","welsh_editor"]
+                  "permissions": ["govuk_editor", "skip_review", "welsh_editor"]
                 },
-                "publishing-api": {
+                "publishing-api-ec2": {
                   "name": "Publishing API",
-                  "secret_name": "signon-app-publishing-api",
+                  "secret_name": "signon-app-publishing-api-ec2",
                   "description": "Central store for all publishing content on GOV.UK",
                   "home_uri": "https://publishing-api.{{ .Values.publishingServiceDomainSuffix }}",
                   "redirect_uri": "https://publishing-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
                   "permissions": ["view_all"]
                 },
-                "whitehall-eks": {
+                "publishing-api": {
+                  "name": "Publishing API [EKS]",
+                  "secret_name": "signon-app-publishing-api",
+                  "description": "Central store for all publishing content on GOV.UK",
+                  "home_uri": "https://publishing-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "redirect_uri": "https://publishing-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
+                  "permissions": ["view_all"]
+                },
+                "whitehall": {
                   "name": "Whitehall [EKS]",
-                  "secret_name": "signon-app-whitehall-eks",
-                  "description": "Mainstream Whitehall application",
+                  "secret_name": "signon-app-whitehall",
+                  "description": "Create and manage non-mainstream content on GOV.UK",
                   "home_uri": "https://whitehall-admin.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "redirect_uri": "https://whitehall-admin.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
-                  "permissions": ["Coronavirus Travel Editor","Editor","Export data","GDS Admin","GDS Editor","Import CSVs","Managing Editor","Upload Executable File Attachments","VIP Editor","World Editor","World Writer"]
+                  "permissions": [
+                    "Coronavirus Travel Editor",
+                    "Editor",
+                    "Export data",
+                    "GDS Admin",
+                    "GDS Editor",
+                    "Import CSVs",
+                    "Managing Editor",
+                    "Preview Design System",
+                    "Upload Executable File Attachments",
+                    "VIP Editor",
+                    "World Editor",
+                    "World Writer"
+                  ]
                 },
-                "search-api-eks": {
+                "search-api-ec2": {
+                  "name": "Search API",
+                  "secret_name": "signon-app-search-api-ec2",
+                  "description": "Search API for GOV.UK",
+                  "home_uri": "https://search-api.{{ .Values.publishingServiceDomainSuffix }}",
+                  "redirect_uri": "https://search-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
+                  "permissions": ["ltr_training", "manage_search_indices"]
+                },
+                "search-api": {
                   "name": "Search API [EKS]",
-                  "secret_name": "signon-app-search-api-eks",
-                  "description": "Search API of GOV.UK",
+                  "secret_name": "signon-app-search-api",
+                  "description": "Search API for GOV.UK",
                   "home_uri": "https://search-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "redirect_uri": "https://search-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
-                  "permissions": ["signin", "ltr_training", "manage_search_indices"]
+                  "permissions": ["ltr_training", "manage_search_indices"]
                 },
-                "support": {
+                "support-ec2": {
                   "name": "Support",
-                  "secret_name": "signon-app-support",
+                  "secret_name": "signon-app-support-ec2",
                   "description": "Raise support requests",
                   "home_uri": "https://support.{{ .Values.publishingServiceDomainSuffix }}",
                   "redirect_uri": "https://support.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
-                  "permissions": ["signin", "api_users", "campaign_requesters", "content_requesters", "feedex", "feedex_exporters", "feedex_reviews", "single_points_of_contact", "user_managers"]
+                  "permissions": [
+                    "api_users",
+                    "campaign_requesters",
+                    "content_requesters",
+                    "feedex",
+                    "feedex_exporters",
+                    "feedex_reviews",
+                    "single_points_of_contact",
+                    "user_managers"
+                  ]
                 },
-                "support-api": {
+                "support-api-ec2": {
                   "name": "Support API",
-                  "secret_name": "signon-app-support-api",
+                  "secret_name": "signon-app-support-api-ec2",
                   "description": "Stores and retrieves anonymous feedback about pages on GOV.UK.",
                   "home_uri": "https://support-api.{{ .Values.publishingServiceDomainSuffix }}",
                   "redirect_uri": "https://support-api.{{ .Values.publishingServiceDomainSuffix }}/auth/gds/callback",
-                  "permissions": ["signin"]
+                  "permissions": []
                 },
-                "hmrc-manuals-api-eks": {
+                "hmrc-manuals-api": {
                   "name": "HMRC Manuals API [EKS]",
                   "secret_name": "signon-app-hmrc-manuals-api",
                   "description": "API for allowing HMRC to publish redacted manuals to GOV.UK",
                   "home_uri": "https://hmrc-manuals-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "redirect_uri": "https://hmrc-manuals-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
-                  "permissions": ["signin"]
+                  "permissions": []
                 },
-                "router-api-eks": {
+                "router-api": {
                   "name": "Router API [EKS]",
                   "secret_name": "signon-app-router-api",
                   "description": "Manages the Router database",
                   "home_uri": "https://router-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "redirect_uri": "https://router-api.eks.{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}/auth/gds/callback",
-                  "permissions": ["signin"]
+                  "permissions": []
                 }
               }
           - name: API_USERS
@@ -265,7 +311,7 @@ spec:
                     { "application_slug": "email-alert-api", "permissions": ["internal_app"] },
                     { "application_slug": "link-checker-api" },
                     { "application_slug": "publishing-api" },
-                    { "application_slug": "search-api-eks", "permissions": ["manage_search_indices"] }
+                    { "application_slug": "search-api", "permissions": ["manage_search_indices"] }
                   ]
                 },
                 "manuals-frontend": {
@@ -304,7 +350,7 @@ spec:
                     { "application_slug": "email-alert-api", "permissions": ["internal_app"] }
                   ]
                 },
-                "search-api-eks": {
+                "search-api": {
                   "name": "Search API",
                   "username": "search-api",
                   "email": "search-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -312,7 +358,7 @@ spec:
                     { "application_slug": "publishing-api" }
                   ]
                 },
-                "hmrc-manuals-api-eks": {
+                "hmrc-manuals-api": {
                   "name": "HMRC Manuals API",
                   "username": "hmrc-manuals-api",
                   "email": "hmrc-manuals-api@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
@@ -324,4 +370,4 @@ spec:
           - name: SIGNON_API_ENDPOINT
             value: http://signon/api/v1
           - name: GOVUK_PUBLISHING_DOMAIN
-            value: {{.Values.publishingServiceDomainSuffix}}
+            value: {{ .Values.publishingServiceDomainSuffix }}


### PR DESCRIPTION
For milestones 1 through 4, we've said we'll have frontend apps running in k8s and talking to the existing backends/APIs in EC2 - see [diagram] (link is internal only, sorry).

Ensure that we're defining EKS and non-EKS versions of Signon Applications as appropriate. Apps which are in k8s should have a corresponding `[EKS]` app in Signon. Apps which are used by frontend apps in k8s should have a non-EKS (`-ec2`) Signon app defined. Frontend apps should have tokens for the EC2 backends/APIs and use those until after [Milestone 4].

Add `-ec2` suffices to add slugs and secret names to make it clearer when we're pointing at the old stack.

Remove `-eks` suffixes from app slugs and secret names. When we've finished moving apps to k8s, those suffixes would become meaningless. The ` [EKS]` suffixes in the app names stay, because we don't want to rename the original apps in Signon just yet and we still need a way to differentiate them in the Signon UI.

Remove `-eks` suffixes from ApiUser slugs. These are internal to the bootstrap script and are not used in Signon itself. All ApiUsers created by the bootstrap script are for apps in EKS, so this suffix is redundant.

I audited the frontend apps' configs in `charts/argocd-apps/values-integration.yaml` to determine which EC2 backends are used by the frontends and therefore which backend apps need tokens in EC2, EKS or both:

- Account API isn't in k8s and email-alert-frontend has a token for it.
- Email Alert API isn't in k8s and Collections, Email Alert Frontend and Finder Frontend have tokens for it.
- Router API is in both. Content Store needs a token for it (though probably only for a rake task and not for serving). Use EC2 Router API for now. We're counting Content Store as a frontend app because Router forwards traffic to it.
- Asset Manager is in both (but still a work in progress in k8s). Whitehall has a token for it. (Probably only whitehall-admin really needs it, but all the Whitehall instances share the same config in k8s, same as in Puppet.) Safer to match the existing config than try to get away without the token on whitehall-frontend, since we have limited test coverage.
- Link Checker API isn't in k8s and Smart Answers and Whitehall have tokens for it.
- Publishing API is in both and several frontend apps have tokens for it.
- No frontend apps have tokens for Publisher (but it's already in EKS).
- No frontend apps have tokens for Whitehall (but it's already in EKS).
- Search API is in both. Whitehall has a token for it.
- Support isn't in k8s and Feedback has a token for it.
- Support API isn't in k8s and Feedback has a token for it.
- No frontend apps have tokens for HMRC Manuals API (but it's already in EKS).

Also:

- Alphabetise app permissions and consistently omit the built-in `signin` permission (which Signon always creates implicitly).

- Make the app description fields match what's actually in Signon, so that we don't inadvertently change them. In some cases our descriptions were less informative than the originals.

Testing: easiest to merge and fix forward with this one I think. I've checked for things like missing security group rules to allow traffic from the cluster to the apps in EC2.

https://trello.com/c/FmnogFnn/880

[diagram]: https://docs.google.com/presentation/d/1qz8c9A-2hIw0i5H67OtKTc7vF4QtoVp7G0pe-fC-WJw/edit#slide=id.g1152675d55e_0_515
[Milestone 4]: https://docs.google.com/presentation/d/1qz8c9A-2hIw0i5H67OtKTc7vF4QtoVp7G0pe-fC-WJw/edit#slide=id.g1152675d55e_0_632