### PR TITLE
Bump whitehall_frontend memory

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -613,6 +613,11 @@ applications:
             key: SECRET_KEY_BASE
 - name: whitehall-frontend
   repoName: whitehall
+  appResources:
+    limits:
+      memory: 2Gi
+    requests:
+      memory: 1.5Gi
   helmValues:
     replicaCount: 1
     uploadAssets: *whitehall-upload-assets


### PR DESCRIPTION
Sometimes whitehall-frontend is quite sluggish, this might solve
the issue temporarily until we fixed it properly via load testing.