### PR TITLE
Redirect if URL finishes with a trailing slash

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -92,6 +92,11 @@ data:
           return 404;
         }
 
+        # If slug has trailing URL, direct after trimming
+        location ~ ^\/(.+)\/$ {
+          rewrite ^\/(.+)\/$ $scheme://$host/$1 permanent;
+        }
+
         location = /robots.txt {
           root /usr/share/nginx/html;
         }


### PR DESCRIPTION
redirect if URL finishes with a trailing slash to
URL without trailing slash.

Might need to add this to fastly too.

This was set in varnish before, [see](https://github.com/alphagov/govuk-puppet/blob/2383a96a9188d729340d97c7303c7409a18bdf6d/modules/varnish/templates/default.vcl.erb#L36)