### PR TITLE
Add custom response headers in nginx

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -255,9 +255,6 @@ applications:
       - name: router-nginx-htpasswd
         secret:
           secretName: router-nginx-htpasswd
-    nginxImage: &router-nginx-image
-      tag: stable-perl
-      pullPolicy: Always
     appProbes: &router-app-probes
       startupProbe: &router-probe
         httpGet:
@@ -328,7 +325,6 @@ applications:
   helmValues:
     uploadAssets:
       enabled: false
-    nginxImage: *router-nginx-image
     appProbes: *router-app-probes
     appResources:
       limits:
@@ -664,6 +660,9 @@ applications:
       - name: asset-manager.eks.integration.govuk.digital
     workerReplicaCount: 1
     nfsServer: assets.blue.integration.govuk-internal.digital
+    nginxConfigMap:
+      create: false
+      name: asset-manager-nginx-conf
     extraEnv:
       - name: ASSET_MANAGER_CLAMSCAN_PATH
         value: /usr/bin/clamscan  # TODO: Clamscan hasn't been tested yet, will update it to correct values after testing

--- a/charts/govuk-apps-conf/templates/asset-manager-nginx-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/asset-manager-nginx-configmap.yaml
@@ -1,0 +1,167 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: asset-manager-nginx-conf
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  nginx.conf: |-
+    user nginx;
+
+    error_log /dev/stderr warn;
+    pid /var/run/nginx.pid;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      upstream asset-manager-proxy {
+        server localhost:3000;
+      }
+
+      # Set GOVUK-Request-Id if not set
+      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+      perl_modules perl/lib;
+      perl_set $govuk_request_id '
+        sub {
+          my $r = shift;
+          my $current_header = $r->header_in("GOVUK-Request-Id");
+
+          if (defined $current_header && $current_header ne "") {
+            return $current_header;
+          } else {
+            my $pid = $r->variable("pid");
+            my $msec = $r->variable("msec");
+            my $remote_addr = $r->variable("remote_addr");
+            my $request_length = $r->variable("request_length");
+            return "$pid-$msec-$remote_addr-$request_length";
+          }
+        }
+      ';
+
+      server {
+        server_name asset-manager asset-manager.*  ;
+        # Send the Strict-Transport-Security header
+        add_header Strict-Transport-Security $sts_default;
+
+        add_header Permissions-Policy interest-cohort=();
+
+        listen 80;
+
+        proxy_set_header Host $http_host;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header GOVUK-Request-Id $govuk_request_id;
+        proxy_redirect off;
+        proxy_connect_timeout 1s;
+        proxy_read_timeout 60;
+
+        access_log /dev/stderr timed_combined;
+        access_log /dev/stdout json_event;
+        error_log /dev/stderr;
+
+        location / {
+          try_files $uri/index.html $uri.html $uri @app;
+        }
+
+        location @app {
+          proxy_pass http://asset-manager-proxy;
+
+        }
+
+        client_max_body_size 500m;
+
+        # Store values from Rails response headers for use in the
+        # cloud-storage-proxy location block below.
+        set $etag_from_rails $upstream_http_etag;
+        set $last_modified_from_rails $upstream_http_last_modified;
+        set $x_frame_options_from_rails $upstream_http_x_frame_options;
+        set $link_from_rails $upstream_http_link;
+
+        # For public assets requests, the Rails app will respond with the
+        # X-Accel-Redirect header set to a path prefixed with
+        # /cloud-storage-proxy/. This triggers an Nginx internal redirect
+        # to that path which is then handled by this location block.
+        location ~ /cloud-storage-proxy/(.*) {
+          # Prevent requests to this location from outside Nginx
+          internal;
+
+          # Construct download URL from:
+          # $1:       Host + path from regexp match in location
+          # $is_args: Optional ? delimiter
+          # $args:    Optional querystring params
+          set $download_url $1$is_args$args;
+
+          # The X-Accel-Redirect header contains a signed URL, $download_url, for
+          # the asset on S3. The signature of this URL is based in part on the
+          # request headers set in the asset-manager Rails app at the time the URL
+          # is generated. The headers we send now must match otherwise Nginx will
+          # not be allowed to make the request. Since this location block inherits
+          # `proxy_set_header` directives from previous levels[1], we explicitly
+          # set the Host so that the inherited headers are over-written.
+          #
+          # [1] http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
+          proxy_set_header Host $proxy_host;
+
+          # Set response headers in the proxied response based on values stored
+          # from the Rails response headers. This is so that the Rails app can
+          # remain the canonical source of response headers, even though we are
+          # proxying the request to S3. This is particularly relevant in the case
+          # of ETag & Last-Modified, because we want keep these the same as when
+          # Nginx serves the files from NFS to avoid unnecessary cache
+          # invalidation. Note that Cache-Control, Content-Disposition and Content-Type
+          # headers are copied from the Rails response into the proxied response by
+          # default, so we do not have to do that explicitly here.
+          add_header ETag $etag_from_rails;
+          add_header Last-Modified $last_modified_from_rails;
+          # Respect the optional Link header set by the Rails application,
+          # this optional header refers to the asset's owning document.
+          add_header Link $link_from_rails;
+
+
+          # Additionally, we always prohibit passing on these headers from S3 to
+          # the client as they are very likely to be wrong. There appears to be
+          # a race condition or similar in Nginx that allows the S3 headers to
+          # overwrite those set here or by Rails, possibly depending on the order
+          # in which S3 sends them.
+          proxy_hide_header ETag;
+          proxy_hide_header Last-Modified;
+          proxy_hide_header Content-Type;
+          proxy_hide_header Content-Disposition;
+          proxy_hide_header Cache-Control;
+
+          # Control whether the asset can be embedded in other pages[1] by
+          # respecting X-Frame-Options from the Rails application.
+          # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+          add_header X-Frame-Options $x_frame_options_from_rails;
+
+          # Remove S3 HTTP headers including those listed in:
+          # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+          # This keeps this HTTP response as similar as possible to the response
+          # sent when using Sendfile to serve files from NFS
+          proxy_hide_header x-amz-delete-marker;
+          proxy_hide_header x-amz-id-2;
+          proxy_hide_header x-amz-request-id;
+          proxy_hide_header x-amz-version-id;
+          proxy_hide_header x-amz-replication-status;
+          proxy_hide_header x-amz-meta-md5-hexdigest;
+
+          # Strip any Authorization header from the client, as this will cause
+          # S3 to return an error.  We do not use proxy_hide_header here, as
+          # that hides response headers sent FROM S3 to the client; whereas we
+          # want to unset a request header sent TO S3 by nginx.
+          proxy_set_header Authorization "";
+
+          # Add CloudFlare and Google DNS server to avoid "no resolver defined to resolve"
+          # errors when trying to connect to S3.
+          resolver 1.1.1.1 8.8.8.8 8.8.4.4;
+
+          # Download the file and send it to client
+          proxy_pass $download_url;
+        }
+      }
+    }

--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -11,7 +11,7 @@ data:
 
     load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
 
-    error_log  /var/log/nginx/error.log warn;
+    error_log  /dev/stderr warn;
     pid        /var/run/nginx.pid;
 
     events {
@@ -32,6 +32,36 @@ data:
         return lc($r->uri);
       }';
 
+      # Set GOVUK-Request-Id if not set
+      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+      perl_modules perl/lib;
+      perl_set $govuk_request_id '
+        sub {
+          my $r = shift;
+          my $current_header = $r->header_in("GOVUK-Request-Id");
+          if (defined $current_header && $current_header ne "") {
+            return $current_header;
+          } else {
+            my $pid = $r->variable("pid");
+            my $msec = $r->variable("msec");
+            my $remote_addr = $r->variable("remote_addr");
+            my $request_length = $r->variable("request_length");
+            return "$pid-$msec-$remote_addr-$request_length";
+          }
+        }
+      ';
+
+      # This map creates a $sts_default variable for later use.
+      # If this header is already set by upstream, then $sts_default will
+      # be an empty string, which will later lead to:
+      #    add_header Strict-Transport-Security ''
+      # which will be ignored according to http://serverfault.com/a/598106
+      # If the header is not set by upstream, then $sts_default will be set
+      # and later uses in add_header will be effective.
+      map $upstream_http_strict_transport_security $sts_default {
+       '' "max-age=31536000; preload";
+      }
+
       upstream router {
         server 127.0.0.1:3000;
       }
@@ -46,6 +76,16 @@ data:
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_read_timeout 20s;
         proxy_intercept_errors on;
+
+
+        add_header Strict-Transport-Security $sts_default;
+        proxy_set_header GOVUK-Request-Id $govuk_request_id;
+
+        {{- if ne .Values.govukEnvironment "production" -}}
+        add_header X-Robots-Tag "noindex";
+        {{- end -}}
+
+        add_header Permissions-Policy interest-cohort=();
 
         {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
         auth_basic "Enter the GOV.UK username/password (not your personal username/password)";

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -10,7 +10,7 @@ data:
   nginx.conf: |-
     user nginx;
 
-    error_log  /var/log/nginx/error.log warn;
+    error_log  /dev/stderr warn;
     pid        /var/run/nginx.pid;
 
     events {
@@ -26,6 +26,36 @@ data:
       sendfile        on;
       keepalive_timeout  65;
 
+      # Set GOVUK-Request-Id if not set
+      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+      perl_modules perl/lib;
+      perl_set $govuk_request_id '
+        sub {
+          my $r = shift;
+          my $current_header = $r->header_in("GOVUK-Request-Id");
+          if (defined $current_header && $current_header ne "") {
+            return $current_header;
+          } else {
+            my $pid = $r->variable("pid");
+            my $msec = $r->variable("msec");
+            my $remote_addr = $r->variable("remote_addr");
+            my $request_length = $r->variable("request_length");
+            return "$pid-$msec-$remote_addr-$request_length";
+          }
+        }
+      ';
+
+      # This map creates a $sts_default variable for later use.
+      # If this header is already set by upstream, then $sts_default will
+      # be an empty string, which will later lead to:
+      #    add_header Strict-Transport-Security ''
+      # which will be ignored according to http://serverfault.com/a/598106
+      # If the header is not set by upstream, then $sts_default will be set
+      # and later uses in add_header will be effective.
+      map $upstream_http_strict_transport_security $sts_default {
+       '' "max-age=31536000; preload";
+      }
+
       upstream {{ .Release.Name }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }
@@ -35,12 +65,21 @@ data:
         proxy_connect_timeout {{ .Values.nginxProxyConnectTimeout }};
         proxy_read_timeout    {{ .Values.nginxProxyReadTimeout }};
 
+        add_header Strict-Transport-Security $sts_default;
+        add_header Permissions-Policy interest-cohort=();
+        proxy_set_header GOVUK-Request-Id $govuk_request_id;
+
+        {{- if ne .Values.govukEnvironment "production" -}}
+        add_header X-Robots-Tag "noindex";
+        {{- end -}}
+
         location / {
           proxy_set_header   Host $http_host;
           proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://{{ .Release.Name }};
           proxy_redirect     off;
         }
+
         location /assets {
           proxy_set_header   Authorization "";
           proxy_set_header   Connection "";
@@ -53,6 +92,19 @@ data:
           add_header         Cache-Control max-age=31536000;
           proxy_intercept_errors on;
           proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
+
+          location ~ "-[0-9a-f]{32,}\." {
+            expires max;
+            add_header Cache-Control "public, immutable";
+            add_header Surrogate-Key "assets assets-{{ .Release.Name }}";
+
+            # Set CORS allow origin for fonts only
+            location ~* \.(eot|otf|ttf|woff|woff2)$ {
+              add_header Access-Control-Allow-Origin "*";
+              add_header Access-Control-Allow-Methods "GET, OPTIONS";
+              add_header Access-Control-Allow-Headers "origin, authorization";
+            }
+          }
         }
 
         # Endpoint that isn't cached, which is used to assert that an external

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -41,7 +41,7 @@ appProbes: {}
 nginxImage:
   repository: nginx
   pullPolicy: Always
-  tag: stable
+  tag: stable-perl
 nginxPort: 8080
 nginxProxyConnectTimeout: 1s
 nginxProxyReadTimeout: 15s


### PR DESCRIPTION
Add headers to default nginx config:
* Strict-Transport-Security
* GOVUK-Request-Id
* X-Frame-Options
* X-Robots-Tag
* Cache-Control and Surrogate-Key for `/assets`

Add new nginx config for asset-manager that replicates functionality on EC2

Co-authored-by: samsimpson1 <sam.simpson@digital.cabinet-office.gov.uk>
Co-authored-by: jibolaolu <seun.adiomowo@digital.cabinet-office.gov.uk>

Trello: https://trello.com/c/uCGahIqu/862-custom-response-headers-at-origin