### PR TITLE
Use HTTP probes for nginx and increase the timeouts a bit.

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               port: http
             failureThreshold: 10
             periodSeconds: 3
-            timeoutSeconds: 5
+            timeoutSeconds: 15
           livenessProbe:
             <<: *app-probe
             failureThreshold: 3
@@ -66,21 +66,21 @@ spec:
             - name: http
               containerPort: {{ .Values.nginxPort }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /__canary__
               port: http
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 10
-            failureThreshold: 6
-            successThreshold: 1
-          readinessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
+            initialDelaySeconds: 2
             failureThreshold: 3
-            successThreshold: 1
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /__canary__
+              port: http
+            initialDelaySeconds: 2
+            failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 15
           volumeMounts:
           - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf


### PR DESCRIPTION
The TCP probes were generating spurious "499" (client closed connection early) response codes in the nginx logs. Make the timeouts a bit more generous so that we don't unnecessarily kill containers when things get a bit slow. Chances are if one container is responding slowly, others are too, and we don't want to invite cascading failures.

Also increase the default timeouts on the app container.