### PR TITLE
Fix redirect when there is a traling full stop in URL

### DIFF
--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -97,6 +97,11 @@ data:
           rewrite ^\/(.+)\/$ $scheme://$host/$1 permanent;
         }
 
+        # If slug has trailing fullstop, direct after trimming
+        location ~ ^\/(.+)\.$ {
+          rewrite ^\/(.+)\.$ $scheme://$host/$1 permanent;
+        }
+
         location = /robots.txt {
           root /usr/share/nginx/html;
         }


### PR DESCRIPTION
This was taken from ec2 varnish: [ref](https://github.com/alphagov/govuk-puppet/blob/2383a96a9188d729340d97c7303c7409a18bdf6d/modules/varnish/templates/default.vcl.erb#L41)

Needs to be added to fastly too.