### PR TITLE
Add Plek entry for imminence & local-links-manager

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -25,6 +25,8 @@ data:
   PLEK_SERVICE_PUBLISHING_API_URI: https://publishing-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_ROUTER_API_URI: https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_MAPIT_URI: https://mapit.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_IMMINENCE_URI: https://imminence.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI: https://local-links-manager.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   # TODO: switch back to in-cluster Search API once it's fully working.
   PLEK_SERVICE_SEARCH_URI: https://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_SIGNON_URI: http://signon.{{ .Values.externalDomainSuffix }}


### PR DESCRIPTION
These 2 apps are dependencies of frontend but are not spun
in EKS so redirecting to ec2 where they reside on the backend
machine.