### PR TITLE
Add a `/readyz` to nginx for use by probes.

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -50,4 +50,9 @@ data:
           return 200 '{"message": "Tweet tweet"}\n';
         }
       }
+
+      # Endpoint for liveness and readiness checks of the nginx container.
+      location = /readyz {
+        return 200 'ok\n';
+      }
     }

--- a/charts/govuk-apps-conf/templates/router-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/router-configmap.yaml
@@ -80,6 +80,11 @@ data:
           return 200 '{"message": "Tweet tweet"}\n';
         }
 
+        # Endpoint for liveness and readiness checks of the nginx container.
+        location = /readyz {
+          return 200 'ok\n';
+        }
+
         # If slug contains no lowercase letters then lowercase it
         # eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
         # eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -64,5 +64,10 @@ data:
           return 200 '{"message": "Tweet tweet"}\n';
         }
       }
+
+      # Endpoint for liveness and readiness checks of the nginx container.
+      location = /readyz {
+        return 200 'ok\n';
+      }
     }
 {{- end }}


### PR DESCRIPTION
Initially we'll use this instead of `/` (the homepage) for the Fastly healthcheck. (We'll probably want to terminate the Fastly healthcheck at the load balancer, ultimately, though.)

We'll also use it for the nginx container's liveness and readiness checks instead of misusing `/__canary__`.

`readyz` is probably the closest fit as regards a [conventional name](https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health) for this.

https://trello.com/c/RkVL0rMF/788