### PR TITLE
Use `/readyz` for nginx container probes.

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
               containerPort: {{ .Values.nginxPort }}
           livenessProbe:
             httpGet:
-              path: /__canary__
+              path: /readyz
               port: http
             initialDelaySeconds: 2
             failureThreshold: 3
@@ -75,7 +75,7 @@ spec:
             timeoutSeconds: 20
           readinessProbe:
             httpGet:
-              path: /__canary__
+              path: /readyz
               port: http
             initialDelaySeconds: 2
             failureThreshold: 2


### PR DESCRIPTION
This is preferable to misusing `/__canary__`, which is meant for use by a blackbox prober.

We'll want to return 404 for this from the load balancer, but there are a whole bunch of other paths that need the same treatment so we'll deal with those all at once later.

Deployment: needs #300 merged and rolled out first.