### PR TITLE
Fix typo in promotion shell script

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -25,7 +25,7 @@ LATEST_GIT_SHA=$(git rev-parse main)
 if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
   git checkout -b "${BRANCH}"
 
-  echo "${IMAGE_TAG}" > "{$FILE}"
+  echo "${IMAGE_TAG}" > "${FILE}"
 
   git add "${FILE}"
   git commit -m "Deploy ${APPLICATION}:${IMAGE_TAG} to ${ENVIRONMENT}"


### PR DESCRIPTION
Fix type in bash script which causes script to fail when
its argo workflow is running.