### PR TITLE
Remove nonexistent permission from Licence Finder API user.

### DIFF
--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -371,7 +371,7 @@ spec:
                   "username": "licence-finder",
                   "email": "licence-finder@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "bearer_tokens": [
-                    { "application_slug": "publishing-api-ec2", "permissions": ["internal_app"] }
+                    { "application_slug": "publishing-api-ec2" }
                   ]
                 }
               }


### PR DESCRIPTION
This was causing the Signon API to crash when attempting to create the Authorisation.

Licence Finder doesn't currently have any additional permissions on its Authorisation for Publishing API. Publishing API doesn't have a permission called `internal_app` (or anything similar).

https://trello.com/c/F7vSHnws/841