### PR TITLE
Create Smokey Asset-manager bearer token

### DIFF
--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -302,6 +302,14 @@ spec:
                     { "application_slug": "router-api" }
                   ]
                 },
+                "smokey": {
+                  "name": "Smokey",
+                  "username": "smokey”,
+                  "email": "smokey@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
+                  "bearer_tokens": [
+                    { "application_slug": "asset-manager" }
+                  ]
+                },
                 "whitehall": {
                   "name": "Whitehall",
                   "username": "whitehall",

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -51,3 +51,8 @@ spec:
             secretKeyRef:
               name: smokey
               key: auth_password
+        - name: BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-smokey-asset-manager
+              key: bearer_token


### PR DESCRIPTION
Adding Smokey bearer token which authenticates while testing GET of an asset on Asset-manger app. 

Link to code on Smokey which show the need of an bearer_token ENV to authenticate. https://github.com/alphagov/smokey/blob/db2af4e5803d167f006fabe7ca204f52a511620a/features/support/http_requests.rb#L88

Paired with @kengds