### PR TITLE
Prometheus switch for app monitoring only on EKS cluster

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
+  GOVUK_PROMETHEUS_EXPORTER: "true"
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
   # TODO: switch back to in-cluster Account API once it's fully working.
   PLEK_SERVICE_ACCOUNT_API_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}

--- a/charts/govuk-rails-app/templates/service.yaml
+++ b/charts/govuk-rails-app/templates/service.yaml
@@ -16,8 +16,5 @@ spec:
     - name: app
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
-    - name: metrics
-      port: {{ .Values.service.metrics }}
-      targetPort: {{ .Values.metricsPort }}
   selector:
     app: {{ .Release.Name }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -4,7 +4,6 @@ service:
   type: NodePort
   annotations: {}
   port: 80
-  metrics: 9394
 
 ingress:
   enabled: false


### PR DESCRIPTION
Added Environment variable to the apps config map to enable the monitoring on the EKS cluster. https://github.com/alphagov/govuk_app_config/pull/231
Cleaned up service ports from earlier testing that are not needed.