### PR TITLE
Fix typo in #310 for signon-resources config

### DIFF
--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -304,7 +304,7 @@ spec:
                 },
                 "smokey": {
                   "name": "Smokey",
-                  "username": "smokey”,
+                  "username": "smokey",
                   "email": "smokey@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
                   "bearer_tokens": [
                     { "application_slug": "asset-manager" }


### PR DESCRIPTION
fix typo preventing the signon-resources from running. Tested manually.