### PR TITLE
Be bug-compatible with the naming of `licencefinder`.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -992,12 +992,10 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-- name: licence-finder
+- name: licencefinder
+  repoName: licence-finder
   helmValues:
     replicaCount: 1
-    uploadAssets:
-      path: "/app/public/assets/licencefinder"
-      s3Directory: "licencefinder"
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:


### PR DESCRIPTION
Also known as `licence-finder`. The repo name has the dash but the domain name omits the dash. The assets path also omits the dash, as does the Router backend name.

This should fix Router's inability to forward traffic to Licence Finder.

I'm leaving the name of the Signon app / ApiUser as `licence-finder`, because it's easier that way and it's already inconsistent whether we like it or not, so 🤷

I [checked](https://sourcegraph.com/search?q=context:global+repo:alphagov+file:rb%24+Plek.find%5C%28.lic&patternType=regexp) that there are no calls to `Plek.find` for licence-finder (with and without dash), so we don't need to set a `PLEK_SERVICE_...` env var this time.

This is the exact same problem and solution as for `smartanswers`/`smart-answers`.

https://trello.com/c/F7vSHnws/841