### PR TITLE
Load nginx perl module in all nginx config files

### DIFF
--- a/charts/govuk-apps-conf/templates/asset-manager-nginx-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/asset-manager-nginx-configmap.yaml
@@ -12,6 +12,8 @@ data:
     error_log /dev/stderr warn;
     pid /var/run/nginx.pid;
 
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+
     events {
       worker_connections 1024;
     }

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -13,6 +13,8 @@ data:
     error_log  /dev/stderr warn;
     pid        /var/run/nginx.pid;
 
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+
     events {
       worker_connections  1024;
     }


### PR DESCRIPTION
Fixes nginx not starting with 'unknown directive' error

Trello: https://trello.com/c/uCGahIqu/862-custom-response-headers-at-origin