### PR TITLE
Fix nondescript name of the Helm lint CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: linting
 on: [push]
 jobs:
-  test:
+  chart-testing:
+    name: Chart testing
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code


### PR DESCRIPTION
This changes the name in the GitHub UI from `test` (which tells the user essentially nothing) to `Chart testing`, which is pretty much what the job currently does.

Tested: see checks which ran on this PR.

Rollout: I've had to temporarily remove the `test` check (i.e. the previous version of what is now `Chart testing`) in order for the pre-merge conditions to pass on this PR. I'll add it back (under its new name) after merge.