### PR TITLE
Make MongoDB connection strings match cluster nodenames.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -236,6 +236,9 @@ applications:
       requests:
         cpu: 2
         memory: 1Gi
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.integration.govuk-internal.digital
     ingress:
       enabled: true
       annotations:
@@ -279,11 +282,11 @@ applications:
         value: ":3000"
       - name: ROUTER_APIADDR
         value: ":3001"
-      - name: ROUTER_MONGO_URL
+      - name: ROUTER_MONGO_URL  # Hostnames should match those shown in MongoDB rs.status().
         value: &router_mongo_hosts "\
-          router-backend-1.blue.integration.govuk-internal.digital,\
-          router-backend-2.blue.integration.govuk-internal.digital,\
-          router-backend-3.blue.integration.govuk-internal.digital"
+          router-backend-1,\
+          router-backend-2,\
+          router-backend-3"
       - name: BACKEND_URL_collections
         value: "http://collections"
       - name: BACKEND_URL_content-store
@@ -500,11 +503,11 @@ applications:
             key: SECRET_KEY_BASE
       - name: DEFAULT_TTL
         value: "1800"
-      - name: MONGODB_URI
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
         value: "mongodb://\
-          mongo-1.blue.integration.govuk-internal.digital,\
-          mongo-2.blue.integration.govuk-internal.digital,\
-          mongo-3.blue.integration.govuk-internal.digital/content_store_production"
+          mongo-1.integration.govuk-internal.digital,\
+          mongo-2.integration.govuk-internal.digital,\
+          mongo-3.integration.govuk-internal.digital/content_store_production"
       - name: GOVUK_APP_NAME
         value: content-store
 - name: signon-resources
@@ -963,6 +966,9 @@ applications:
         value: "1"
 - name: router-api
   helmValues:
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.integration.govuk-internal.digital
     uploadAssets:
       enabled: false
     extraEnv:
@@ -976,8 +982,11 @@ applications:
           secretKeyRef:
             name: signon-app-router-api
             key: oauth_secret
-      - name: MONGODB_URI
-        value: mongodb://router-backend-1.blue.integration.govuk-internal.digital,router-backend-2.blue.integration.govuk-internal.digital,router-backend-3.blue.integration.govuk-internal.digital/router
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          router-backend-1,\
+          router-backend-2,\
+          router-backend-3/router"
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
When a Mongo client connect to a cluster (replicaset), the client library connects to one or more of the hosts given in the connection string and requests list of nodes. It then tries to connect to the hostnames in that list. The client libraries that we use seem to remove the original hostnames (the ones in the connection string) from the list of nodes that they'll connect to in future.  In some cases, this leads to the client library being unable to reconnect because it's discarded all the reachable hosts from the connection string and replaced them with unreachable/unresolveable hosts that the cluster told it about.

The `mongoid` client library that we use in our Ruby apps seem to be more brittle regarding this issue than the `mgo` library in Router, but in both cases it's a good idea for stability to have the hostnames in the connection string match what the cluster returns.

Annoyingly, the Mongo clusters are not configured consistently in this regard: the Router one (on router_backend machines) has short hostnames as nodenames whereas the other Mongo cluster uses FQDNs (without the "stackname" component, i.e. `blue`).

We include the stackname where specifying the additional search suffix for Router, because we might as well save a DNS query. The `blue` thing isn't going to change in the remaining lifetime of the GOV.UK EC2 stack.

This should fix some stability issues with the publisher apps that we're running so far in k8s.