### PR TITLE
Add missing GOVUK_APP_DOMAIN_EXTERNAL to smokey app

### DIFF
--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -34,6 +34,11 @@ spec:
             configMapKeyRef:
               name: govuk-apps-env
               key: GOVUK_WEBSITE_ROOT
+        - name: GOVUK_APP_DOMAIN_EXTERNAL
+          valueFrom:
+            configMapKeyRef:
+              name: govuk-apps-env
+              key: GOVUK_APP_DOMAIN_EXTERNAL
         - name: SIGNON_EMAIL
           value: "signon@alphagov.co.uk"
         - name: SIGNON_PASSWORD


### PR DESCRIPTION
This is needed for smokey to resolve external addresses of apps,
see [here](https://github.com/alphagov/smokey/blob/2ba441d489c1cfb4a96401b46c8f07a5c279cd99/features/support/base_urls.rb#L19)