### PR TITLE
Freshclam was not fetching latest virus signatures.

### DIFF
--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -45,6 +45,20 @@ spec:
             allowPrivilegeEscalation: false
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
+        - name: clamdb
+          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          command: ["/bin/sh"]
+          args: ["-c", "freshclam -d"]
+          resources:
+            requests:
+               memory: "64Mi"
+               cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: clam-virus-db
+              mountPath: /var/lib/clamav
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
@@ -54,4 +68,6 @@ spec:
         nfs:
           server: "{{ .Values.nfsServer }}"
           path: /
+      - name: clam-virus-db
+        emptyDir: {}
 {{- end }}


### PR DESCRIPTION
Added extra container to the worker pod  which run `freshclam -d` and updates virus db in a `emptyDir` volume mount  @/var/lib/clamav. Mount is also mounted on the worker pod which runs Clamscan.

This whole approach needs to be updated in the near future, somewhat explained in - https://trello.com/c/uIygWIgc/789-dockerized-clamdscan-clamscan-for-scanning-assets

https://trello.com/c/02lrQ2So/881-freshclam-virus-updater-for-asset-manager