### PR TITLE
Asset-manager Nginx container failing due to missing Nginx config

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -65,33 +65,39 @@ spec:
             - name: http
               containerPort: {{ .Values.nginxPort }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /readyz
               port: http
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 10
-            failureThreshold: 6
-            successThreshold: 1
-          readinessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
+            initialDelaySeconds: 2
             failureThreshold: 3
-            successThreshold: 1
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 15
           volumeMounts:
-          - name: {{ .Release.Name }}-nginx-conf
+          - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+          {{- with .Values.nginxExtraVolumeMounts }}
+          {{ . | toYaml | trim | nindent 10 }}
+          {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ .Release.Name }}-nginx-conf
+      - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
         configMap:
-          name: {{ .Release.Name }}-nginx-conf
+          name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+      {{- with .Values.nginxExtraVolumes }}
+      {{ . | toYaml | trim | nindent 6 }}
+      {{- end }}
       - name: {{ .Release.Name }}-asset-uploads-efs
         nfs:
           server: {{ .Values.nfsServer }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -36,12 +36,16 @@ appPort: 3000
 appProbes: {}
 
 nginxImage:
-  repository: nginx
+  repository: nginxinc/nginx-unprivileged
   pullPolicy: Always
-  tag: stable
+  tag: stable-perl
 nginxPort: 8080
 nginxProxyConnectTimeout: 1s
 nginxProxyReadTimeout: 15s
+nginxConfigMap:
+  create: true
+nginxExtraVolumeMounts: []
+nginxExtraVolumes: []
 
 appResources:
   limits:


### PR DESCRIPTION
Updating asset manager Helm chart to match changes made in https://github.com/alphagov/govuk-helm-charts/commit/d05448780e5955c956efcd81f6170ffdca8dcb2c

error message on Asset-manager:
```
2022/03/31 21:20:29 [emerg] 1#1: dlopen() "/usr/lib/nginx/modules/ngx_http_perl_module.so" failed (/usr/lib/nginx/modules/ngx_http_perl_module.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.conf:6
1
nginx: [emerg] dlopen() "/usr/lib/nginx/modules/ngx_http_perl_module.so" failed (/usr/lib/nginx/modules/ngx_http_perl_module.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.conf:6
```

