### PR TITLE
Add externalsecret for Grafana database

### DIFF
--- a/charts/cluster-secrets/templates/grafana-database.yaml
+++ b/charts/cluster-secrets/templates/grafana-database.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-grafana-database
+  namespace: monitoring
+  annotations:
+    a8r.io/description: >
+      This secret contains credentials for Grafana to connect to its database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-grafana-database
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/grafana/database


### PR DESCRIPTION
Add Grafana database k8s secret from AWS Secret Manager.

Ref:
1. [govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure/pull/586)