### PR TITLE
Fix release promotion process 

### DIFF
--- a/charts/argo-services/cd-notifications-config.yaml
+++ b/charts/argo-services/cd-notifications-config.yaml
@@ -23,7 +23,7 @@ template.send-argo-events-webhook: |
           "argoUrl": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
           "slackChannel": "{{.app.metadata.annotations.slackChannel}}",
           "repoName": "{{.app.metadata.annotations.repoName}}",
-          "imageTag": "{{.app.metadata.annotations.imageTag}}",
+          "imageTag": "{{.app.metadata.annotations.imageTag}}"
         }
       method: "POST"
       path: "/argocd"

--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -36,8 +36,6 @@ spec:
               template: update-image-tag
             arguments:
               parameters:
-                - name: imageTag
-                  value: "{{"{{workflow.parameters.commitSha}}"}}"
                 - name: environment
                   value: "{{ .Values.nextEnvironment }}"
                 - name: application

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -6,7 +6,6 @@ spec:
   entrypoint: update-image-tag 
   arguments:
     parameters:
-      - name: imageTag
       - name: environment
       - name: application
       - name: repoName
@@ -15,7 +14,6 @@ spec:
     - name: update-image-tag
       inputs:
         parameters:
-          - name: imageTag
           - name: environment
           - name: application
           - name: repoName


### PR DESCRIPTION
This fixes two issues:

- the body of the webhook sent by the post sync notification was invalid JSON
- there are duplicated `imageTag` workflow arguments