### PR TITLE
Remove the commitUrl for sync-notifcation webhook body

### DIFF
--- a/charts/argo-services/cd-notifications-config.yaml
+++ b/charts/argo-services/cd-notifications-config.yaml
@@ -19,7 +19,6 @@ template.send-argo-events-webhook: |
           "application": "{{.app.metadata.name}}",
           "state": "{{.app.status.operationState.phase}}",
           "commitSha": "{{.app.status.sync.revision}}",
-          "commitUrl": "https://github.com/alphagov/govuk-helm-charts/commits/{{.app.status.sync.revision}}",
           "argoUrl": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
           "slackChannel": "{{.app.metadata.annotations.slackChannel}}",
           "repoName": "{{.app.metadata.annotations.repoName}}",

--- a/charts/argo-services/templates/events/sync_notification_sensor.yaml
+++ b/charts/argo-services/templates/events/sync_notification_sensor.yaml
@@ -30,20 +30,16 @@ spec:
           - dest: spec.arguments.parameters.2.value
             src:
               dependencyName: sync-notification
-              dataKey: body.commitUrl
+              dataKey: body.argoUrl
           - dest: spec.arguments.parameters.3.value
             src:
               dependencyName: sync-notification
-              dataKey: body.argoUrl
+              dataKey: body.slackChannel
           - dest: spec.arguments.parameters.4.value
             src:
               dependencyName: sync-notification
-              dataKey: body.slackChannel
-          - dest: spec.arguments.parameters.5.value
-            src:
-              dependencyName: sync-notification
               dataKey: body.repoName
-          - dest: spec.arguments.parameters.6.value
+          - dest: spec.arguments.parameters.5.value
             src:
               dependencyName: sync-notification
               dataKey: body.imageTag
@@ -65,7 +61,6 @@ spec:
                 # values overridden by sync-notification payload
                 - name: application
                 - name: commitSha
-                - name: commitUrl
                 - name: argoUrl
                 - name: slackChannel
                 - name: repoName

--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -12,7 +12,6 @@ spec:
     parameters:
       - name: application
       - name: commitSha
-      - name: commitUrl
       - name: argoUrl
       - name: slackChannel
       - name: repoName
@@ -62,4 +61,4 @@ spec:
                 - name: text
                   value: "\
                     post-sync job ({{"{{workflow.name}}"}}) for <{{"{{workflow.parameters.argoUrl}}"}}|{{"{{workflow.parameters.application}}"}}> in {{ .Values.govukEnvironment }} {{"{{workflow.status}}"}} \
-                    (revision <{{"{{workflow.parameters.commitUrl}}"}}|{{"{{workflow.parameters.commitSha}}"}}>)."
+                    (revision <https://github.com/alphagov/govuk-helm-charts/commits/{{"{{workflow.parameters.commitSha}}"}}|{{"{{workflow.parameters.commitSha}}"}}>)."


### PR DESCRIPTION
This is a derived attribute from the commitSha, so no need to send it separately in the notification as it can be constructed in the final message. This simplifies the config for the workflow templates.