### PR TITLE
Adding a PLEK for asset-manager URI in Smokey

### DIFF
--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -61,3 +61,5 @@ spec:
             secretKeyRef:
               name: signon-token-smokey-asset-manager
               key: bearer_token
+        - name: PLEK_SERVICE_ASSET_MANAGER_URI
+          value: http://asset-manager.{{ .Values.internalDomainSuffix }}


### PR DESCRIPTION
Adding ENV value for asset-manager URI in Smokey.

I am hoping this will update the uri from https to http while Cucumber test are run for uploading assets to asset-manager internally.
 ```
 https://asset-manager.apps.svc.cluster.local/assets/513a0efbed915d425e000002
  to
  http://asset-manager.apps.svc.cluster.local/assets/513a0efbed915d425e000002

```
https://trello.com/c/nbTUgshN/882-fix-asset-manger-smokey-upload-failures