### PR TITLE
Fix invalid schema in cluster-secrets template.

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.9.0
+version: 0.9.1

--- a/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
+++ b/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
@@ -56,9 +56,10 @@ kind: Role
 metadata:
   name: prom-stack-oidc-secrets-reader
   namespace: {{ .Values.monitoringNamespace }}
-  a8r.io/description: >
-    Allows reading the OIDC OAuth secrets which are ultimately needed by the
-    load balancers which serve the Prometheus and Alert Manager ingresses.
+  annotations:
+    a8r.io/description: >
+      Allows reading the OIDC OAuth secrets which are ultimately needed by the
+      load balancers which serve the Prometheus and Alert Manager ingresses.
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
D'oh. Fixes #348 / f57a5f1.

https://trello.com/c/gipscM7t/873

Tested: `helm install . -n cluster-services` works.