### PR TITLE
Use github-cli image for update-image-tag workflow

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-apt-get update && apt-get install -y git curl
-
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-
-apt-get update && apt-get install -y gh
-
 BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${REPO_NAME}"
 LATEST_GIT_SHA=$(git ls-remote "https://github.com/alphagov/${REPO_NAME}" HEAD | cut -f 1)

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: repoName
           - name: imageTag
       script:
-        image: bitnami/minideb:latest
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
         command: [/bin/bash]
         env:
           - name: GIT_NAME


### PR DESCRIPTION
This updates the workflow to use the internally [built github-cli image](https://github.com/alphagov/govuk-infrastructure/pull/592). This images comes with git and the GitHub CLI pre-installed. It also runs as a non-root user to improve security.