### PR TITLE
Have ArgoCD replace assets-upload-job instead of modifying it.

### DIFF
--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Release.Name }}-upload-assets
   annotations:
     argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   backoffLimit: 2  # Retry once, in case of network error.
   template:


### PR DESCRIPTION
Job objects are immutable, but ArgoCD doesn't know this. So because we were telling it to delete the job only after it succeeds (`hook-delete-policy: HookSucceeded`), a failed Job causes the subsequent sync to fail, which means the broken Job will never replaced, even after a fix has been checked in.

Hopefully fixes the intermittent sync failures on assets-upload-job.

Since this Job runs as a PreSync hook, we set its [deletion policy] to `BeforeHookCreation`. This is the default, so we just remove the override. (If this weren't a PreSync hook, we'd set `syncOptions: Replace=true` instead.)

[deletion policy]: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies