### PR TITLE
Add Helm values for ArgoCD apps in the staging environment. 

### DIFF
--- a/charts/argocd-apps/ci/staging-values.yaml
+++ b/charts/argocd-apps/ci/staging-values.yaml
@@ -1,0 +1,1 @@
+../values-staging.yaml

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -63,13 +63,13 @@ applications:
   helmValues:
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-        value: 93109fea-34d9-4c38-ac7e-1ebc75e7416b
+        value: d33f7857-7514-4458-81b9-0995f48e2ac5
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
-        value: 47cef7ea-0849-48aa-9676-0ee0f7baa4ae
+        value: b67971ed-a249-4afa-b05e-9adad9da551a
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
-        value: fee22233-2f28-4b0b-8b6c-4410979f2275
+        value: d1f54751-80a8-420a-9077-d34c7d6cc734
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
-        value: eb9ba220-7d74-4aab-975a-bdbe718f69a3
+        value: 8a8d98c0-42c8-4f56-b61f-77c89417a171
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
@@ -140,6 +140,8 @@ applications:
             key: bearer_token
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 2844a647-6bf1-4b01-a25c-569d2cc00849
       - name: GOVUK_PERSONALISATION_MANAGE_URI
         value: https://staging.account.gov.uk?link=manage-account
       - name: ELECTIONS_API_KEY
@@ -187,7 +189,7 @@ applications:
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
       - name: ELASTICSEARCH_URI
-        value: "https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com"
+        value: "https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com"
       - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
         value: "mongodb://\
           mongo-1.staging.govuk-internal.digital,\
@@ -334,6 +336,15 @@ applications:
       - signon.eks.staging.govuk.digital
     workerReplicaCount: 1
     extraEnv:
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 112842bb-d8a4-4511-90de-57dc5c8f27ec
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: signon-mysql
+            key: DATABASE_URL
       - name: DEVISE_PEPPER
         valueFrom:
           secretKeyRef:
@@ -349,13 +360,6 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-      - name: DATABASE_URL
-        valueFrom:
-          secretKeyRef:
-            name: signon-mysql
-            key: DATABASE_URL
-      - name: REDIS_URL
-        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -376,8 +380,6 @@ applications:
   repoName: smart-answers
   helmValues:
     extraEnv:
-      - name: EXPOSE_GOVSPEAK
-        value: "1"
       - name: COMPANIES_HOUSE_API_KEY
         valueFrom:
           secretKeyRef:
@@ -439,7 +441,7 @@ applications:
       path: "/app/public/assets/whitehall"
       s3Directory: "whitehall"
     extraEnv: &whitehall-envs
-      - name: NODE_ENV
+      - name: NODE_ENV  # TODO: move NODE_ENV=production to the Dockerfile
         value: production
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -481,8 +483,10 @@ applications:
           secretKeyRef:
             name: signon-token-whitehall-publishing-api-ec2
             key: bearer_token
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-staging-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID
-        value: 759acac6-da53-4a19-b591-b7538c7c39de
+        value: 112842bb-d8a4-4511-90de-57dc5c8f27ec
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       - name: MEMCACHE_SERVERS

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -1,0 +1,499 @@
+globalHelmValues:
+  govukEnvironment: staging
+  externalDomainSuffix: eks.staging.govuk.digital
+  publishingServiceDomainSuffix: staging.publishing.service.gov.uk
+
+applications:
+- name: argo-workflows
+  chartPath: charts/argo-workflows
+  postSyncWorkflowEnabled: "false"
+  helmValues:
+    nextEnvironment: staging
+- name: cluster-secrets
+  chartPath: charts/cluster-secrets
+  postSyncWorkflowEnabled: "false"
+- name: collections
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-email-alert-api-ec2
+            key: bearer_token
+- name: email-alert-frontend
+  helmValues:
+    extraEnv:
+      - name: SUBSCRIPTION_MANAGEMENT_ENABLED
+        value: "yes"
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: ACCOUNT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-email-alert-frontend-account-api-ec2
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-email-alert-frontend-email-alert-api-ec2
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-email-alert-frontend-publishing-api-ec2
+            key: bearer_token
+      - name: EMAIL_ALERT_AUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-auth
+            key: token
+- name: feedback
+  helmValues:
+    extraEnv:
+      - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
+        value: 93109fea-34d9-4c38-ac7e-1ebc75e7416b
+      - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
+        value: 47cef7ea-0849-48aa-9676-0ee0f7baa4ae
+      - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
+        value: fee22233-2f28-4b0b-8b6c-4410979f2275
+      - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
+        value: eb9ba220-7d74-4aab-975a-bdbe718f69a3
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: SUPPORT_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-feedback-support-ec2
+            key: bearer_token
+      - name: SUPPORT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-feedback-support-api-ec2
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-feedback-publishing-api-ec2
+            key: bearer_token
+      - name: ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY
+        valueFrom:
+          secretKeyRef:
+            name: feedback-assisted-digital-google-sheet
+            key: sheet_id
+      - name: GOOGLE_CLIENT_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: feedback-assisted-digital-google-sheet
+            key: client_email
+      - name: GOOGLE_PRIVATE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: feedback-assisted-digital-google-sheet
+            key: private_key
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: feedback-notify
+            key: GOVUK_NOTIFY_API_KEY
+- name: finder-frontend
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-finder-frontend-email-alert-api-ec2
+            key: bearer_token
+- name: frontend
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-publishing-api-ec2
+            key: bearer_token
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+      - name: GOVUK_PERSONALISATION_MANAGE_URI
+        value: https://staging.account.gov.uk?link=manage-account
+      - name: ELECTIONS_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: frontend-elections-api
+            key: key
+      - name: ELECTIONS_API_URL
+        valueFrom:
+          secretKeyRef:
+            name: frontend-elections-api
+            key: url
+      - name: ACCOUNT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-account-api-ec2
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-email-alert-api-ec2
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-publishing-api-ec2
+            key: bearer_token
+- name: government-frontend
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+- name: govuk-apps-conf
+  chartPath: charts/govuk-apps-conf
+  postSyncWorkflowEnabled: "false"
+- name: licencefinder
+  repoName: licence-finder
+  helmValues:
+    extraEnv:
+      # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
+      # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
+      - name: ELASTICSEARCH_URI
+        value: "https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com"
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          mongo-1.staging.govuk-internal.digital,\
+          mongo-2.staging.govuk-internal.digital,\
+          mongo-3.staging.govuk-internal.digital/licence_finder_production"
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-licence-finder-publishing-api-ec2
+            key: bearer_token
+- name: manuals-frontend
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-frontend-publishing-api-ec2
+            key: bearer_token
+- name: router
+  helmValues:
+    uploadAssets:
+      enabled: false
+    appResources:
+      limits:
+        cpu: 3
+        memory: 2Gi
+      requests:
+        cpu: 2
+        memory: 1Gi
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.staging.govuk-internal.digital
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: www-origin
+      hosts:
+      - www-origin.eks.staging.govuk.digital
+    nginxConfigMap:
+      create: false
+      name: router-nginx-conf
+    nginxExtraVolumeMounts:
+      - name: router-nginx-conf
+        mountPath: /usr/share/nginx/html/robots.txt
+        subPath: robots.txt
+      - name: router-nginx-htpasswd
+        mountPath: /etc/nginx/htpasswd
+    nginxExtraVolumes:
+      - name: router-nginx-htpasswd
+        secret:
+          secretName: router-nginx-htpasswd
+    appProbes: &router-app-probes
+      startupProbe: &router-probe
+        httpGet:
+          path: /healthcheck
+          port: 3001
+        failureThreshold: 10
+        periodSeconds: 1
+        timeoutSeconds: 1
+      livenessProbe:
+        <<: *router-probe
+        failureThreshold: 3
+        periodSeconds: 5
+      readinessProbe:
+        <<: *router-probe
+        httpGet:
+          path: /healthcheck
+          port: 3001
+        failureThreshold: 2
+        periodSeconds: 5
+    extraEnv:
+      - name: ROUTER_PUBADDR
+        value: ":3000"
+      - name: ROUTER_APIADDR
+        value: ":3001"
+      - name: ROUTER_MONGO_URL
+        value: &router_mongo_hosts "\
+          router-backend-1,\
+          router-backend-2,\
+          router-backend-3"
+      - name: BACKEND_URL_collections
+        value: "http://collections"
+      - name: BACKEND_URL_content-store
+        value: "http://content-store"
+      - name: BACKEND_URL_email-alert-frontend
+        value: "http://email-alert-frontend"
+      - name: BACKEND_URL_frontend
+        value: "http://frontend"
+      - name: BACKEND_URL_government-frontend
+        value: "http://government-frontend"
+      - name: BACKEND_URL_manuals-frontend
+        value: "http://manuals-frontend"
+      - name: BACKEND_URL_service-manual-frontend
+        value: "http://service-manual-frontend"
+      - name: BACKEND_URL_smartanswers
+        value: "http://smartanswers"
+      - name: BACKEND_URL_static
+        value: "http://static"
+      - name: BACKEND_URL_whitehall-frontend
+        value: "http://whitehall-frontend"
+        # TODO: switch back to in-cluster account-api once it's fully working (similarly for draft).
+      - name: BACKEND_URL_account-api
+        value: "https://account-api.staging.govuk-internal.digital"
+      - name: BACKEND_URL_feedback
+        value: "http://feedback"
+      - name: BACKEND_URL_finder-frontend
+        value: "http://finder-frontend"
+      - name: BACKEND_URL_info-frontend
+        value: "http://info-frontend"
+      - name: BACKEND_URL_licencefinder
+        value: "http://licencefinder"
+      - name: BACKEND_URL_licensify
+        value: "https://licensify.staging.govuk-internal.digital"
+        # TODO: switch back to in-cluster search-api once it's fully working (similarly for draft).
+      - name: BACKEND_URL_search-api
+        value: "https://search-api.staging.govuk-internal.digital"
+- name: service-manual-frontend
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+- name: signon
+  helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: signon
+      hosts:
+      - signon.eks.staging.govuk.digital
+    workerReplicaCount: 1
+    extraEnv:
+      - name: DEVISE_PEPPER
+        valueFrom:
+          secretKeyRef:
+            name: signon-devise-pepper
+            key: DEVISE_PEPPER
+      - name: DEVISE_SECRET_KEY
+        valueFrom:
+          secretKeyRef:
+            name: signon-devise-secret
+            key: DEVISE_SECRET_KEY
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: signon-mysql
+            key: DATABASE_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: SIGNON_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: signon-auth-token
+            key: token
+- name: signon-resources
+  chartPath: charts/signon-resources
+  postSyncWorkflowEnabled: "false"
+- name: info-frontend
+  helmValues:
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+- name: smartanswers
+  repoName: smart-answers
+  helmValues:
+    extraEnv:
+      - name: EXPOSE_GOVSPEAK
+        value: "1"
+      - name: COMPANIES_HOUSE_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: smartanswers-companies-house
+            key: api_key
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-smartanswers-link-checker-api-ec2
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-smartanswers-publishing-api-ec2
+            key: bearer_token
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: ZENDESK_CLIENT_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: smartanswers-zendesk-client
+            key: username
+      - name: ZENDESK_CLIENT_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: smartanswers-zendesk-client
+            key: password
+- name: smokey
+  chartPath: charts/smokey
+- name: static
+  helmValues:
+    securityContext:
+      runAsNonRoot: false
+      appContainer: false
+    extraEnv:
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: GA_UNIVERSAL_ID
+        value: UA-26179049-20
+      - name: GOVUK_APP_ROOT
+        value: /var/apps/static
+- name: whitehall-frontend
+  repoName: whitehall
+  appResources:
+    limits:
+      memory: 2Gi
+    requests:
+      memory: 1.5Gi
+  helmValues:
+    uploadAssets: &whitehall-upload-assets
+      path: "/app/public/assets/whitehall"
+      s3Directory: "whitehall"
+    extraEnv: &whitehall-envs
+      - name: NODE_ENV
+        value: production
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-whitehall
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-whitehall
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-asset-manager-ec2
+            key: bearer_token
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-link-checker-api-ec2
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-publishing-api-ec2
+            key: bearer_token
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 759acac6-da53-4a19-b591-b7538c7c39de
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: whitehall-mysql
+            key: DATABASE_URL
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE


### PR DESCRIPTION
We only want to run the frontend apps (and Signon) in the staging environment initially. We'll bring in the publisher apps and draft stack etc. later, once they're fully configured and working properly. The main reason for this is that we want staging to be a reasonably accurate model of production, and we wouldn't want to deploy a bunch of half-working apps to production (even if we wouldn't be sending traffic to them).

https://trello.com/c/gipscM7t/873