### PR TITLE
Add a Helm chart fastly-exporter

### DIFF
--- a/charts/cluster-secrets/templates/fastly-api.yaml
+++ b/charts/cluster-secrets/templates/fastly-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: govuk-fastly-api
+  namespace: monitoring
+  annotations:
+    a8r.io/description: >
+      This secret contains the Fastly API token which fastly-exporter to expose
+      Fastly metrics to Prometheus
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-fastly-api
+    creationPolicy: Owner
+  dataFrom:
+  - key: govuk/fastly/api

--- a/charts/fastly-exporter/.helmignore
+++ b/charts/fastly-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/fastly-exporter/Chart.yaml
+++ b/charts/fastly-exporter/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: fastly-exporter
+description: A Helm chart which exposes Fastly metrics to Prometheus
+type: application
+version: 0.1.0

--- a/charts/fastly-exporter/templates/_helpers.tpl
+++ b/charts/fastly-exporter/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fastly-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fastly-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fastly-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fastly-exporter.labels" -}}
+helm.sh/chart: {{ include "fastly-exporter.chart" . }}
+{{ include "fastly-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fastly-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fastly-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/fastly-exporter/templates/deployment.yaml
+++ b/charts/fastly-exporter/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fastly-exporter.fullname" . }}
+  labels:
+    {{- include "fastly-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fastly-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fastly-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: false
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 2000
+            runAsGroup: 3000
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: FASTLY_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fastlyAPIToken.k8sSecretName }}
+                  key: {{ .Values.fastlyAPIToken.k8sSecretKey }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/fastly-exporter/templates/podMonitor.yaml
+++ b/charts/fastly-exporter/templates/podMonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: {{ include "fastly-exporter.fullname" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+  name: {{ include "fastly-exporter.fullname" . }}
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      {{- include "fastly-exporter.selectorLabels" . | nindent 5 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - port: http

--- a/charts/fastly-exporter/templates/service.yaml
+++ b/charts/fastly-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fastly-exporter.fullname" . }}
+  labels:
+    {{- include "fastly-exporter.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fastly-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/fastly-exporter/templates/serviceMonitor.yaml
+++ b/charts/fastly-exporter/templates/serviceMonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ include "fastly-exporter.fullname" . }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+  name: {{ include "fastly-exporter.fullname" . }}
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      {{- include "fastly-exporter.selectorLabels" . | nindent 5 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+    path: /metrics

--- a/charts/fastly-exporter/values.yaml
+++ b/charts/fastly-exporter/values.yaml
@@ -1,0 +1,30 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/peterbourgon/fastly-exporter
+  pullPolicy: Always
+  tag: v7.2.1
+
+fastlyAPIToken:
+  k8sSecretName: govuk-fastly-api
+  k8sSecretKey: token
+
+podAnnotations: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/schemas/servicemonitor_v1.json
+++ b/schemas/servicemonitor_v1.json
@@ -1,0 +1,680 @@
+{
+  "description": "ServiceMonitor defines monitoring for a set of services.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Service selection for target discovery by Prometheus.",
+      "properties": {
+        "endpoints": {
+          "description": "A list of endpoints allowed as part of this ServiceMonitor.",
+          "items": {
+            "description": "Endpoint defines a scrapeable endpoint serving Prometheus metrics.",
+            "properties": {
+              "authorization": {
+                "description": "Authorization section for this endpoint",
+                "properties": {
+                  "credentials": {
+                    "description": "The secret's key that contains the credentials of the request",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "description": "Set the authentication type. Defaults to Bearer, Basic will cause an error",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "basicAuth": {
+                "description": "BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints",
+                "properties": {
+                  "password": {
+                    "description": "The secret in the service monitor namespace that contains the password for authentication.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "username": {
+                    "description": "The secret in the service monitor namespace that contains the username for authentication.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "bearerTokenFile": {
+                "description": "File to read bearer token for scraping targets.",
+                "type": "string"
+              },
+              "bearerTokenSecret": {
+                "description": "Secret to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator.",
+                "properties": {
+                  "key": {
+                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Specify whether the Secret or its key must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "followRedirects": {
+                "description": "FollowRedirects configures whether scrape requests follow HTTP 3xx redirects.",
+                "type": "boolean"
+              },
+              "honorLabels": {
+                "description": "HonorLabels chooses the metric's labels on collisions with target labels.",
+                "type": "boolean"
+              },
+              "honorTimestamps": {
+                "description": "HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.",
+                "type": "boolean"
+              },
+              "interval": {
+                "description": "Interval at which metrics should be scraped",
+                "type": "string"
+              },
+              "metricRelabelings": {
+                "description": "MetricRelabelConfigs to apply to samples before ingestion.",
+                "items": {
+                  "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
+                  "properties": {
+                    "action": {
+                      "default": "replace",
+                      "description": "Action to perform based on regex matching. Default is 'replace'",
+                      "enum": [
+                        "replace",
+                        "keep",
+                        "drop",
+                        "hashmod",
+                        "labelmap",
+                        "labeldrop",
+                        "labelkeep"
+                      ],
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1'",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. default is ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.",
+                      "items": {
+                        "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, as well as underscores.",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action. It is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "oauth2": {
+                "description": "OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.",
+                "properties": {
+                  "clientId": {
+                    "description": "The secret or configmap containing the OAuth2 client id",
+                    "properties": {
+                      "configMap": {
+                        "description": "ConfigMap containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "Secret containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "clientSecret": {
+                    "description": "The secret containing the OAuth2 client secret",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "endpointParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Parameters to append to the token URL",
+                    "type": "object"
+                  },
+                  "scopes": {
+                    "description": "OAuth2 scopes used for the token request",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tokenUrl": {
+                    "description": "The URL to fetch the token from",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clientId",
+                  "clientSecret",
+                  "tokenUrl"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "Optional HTTP URL parameters",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path to scrape for metrics.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Name of the service port this endpoint refers to. Mutually exclusive with targetPort.",
+                "type": "string"
+              },
+              "proxyUrl": {
+                "description": "ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.",
+                "type": "string"
+              },
+              "relabelings": {
+                "description": "RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job's name is available via the `__tmp_prometheus_job_name` label. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                "items": {
+                  "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
+                  "properties": {
+                    "action": {
+                      "default": "replace",
+                      "description": "Action to perform based on regex matching. Default is 'replace'",
+                      "enum": [
+                        "replace",
+                        "keep",
+                        "drop",
+                        "hashmod",
+                        "labelmap",
+                        "labeldrop",
+                        "labelkeep"
+                      ],
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1'",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. default is ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.",
+                      "items": {
+                        "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, as well as underscores.",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action. It is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "scheme": {
+                "description": "HTTP scheme to use for scraping.",
+                "type": "string"
+              },
+              "scrapeTimeout": {
+                "description": "Timeout after which the scrape is ended",
+                "type": "string"
+              },
+              "targetPort": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port.",
+                "x-kubernetes-int-or-string": true
+              },
+              "tlsConfig": {
+                "description": "TLS configuration to use when scraping the endpoint",
+                "properties": {
+                  "ca": {
+                    "description": "Struct containing the CA cert to use for the targets.",
+                    "properties": {
+                      "configMap": {
+                        "description": "ConfigMap containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "Secret containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "caFile": {
+                    "description": "Path to the CA cert in the Prometheus container to use for the targets.",
+                    "type": "string"
+                  },
+                  "cert": {
+                    "description": "Struct containing the client cert file for the targets.",
+                    "properties": {
+                      "configMap": {
+                        "description": "ConfigMap containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "Secret containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "certFile": {
+                    "description": "Path to the client cert file in the Prometheus container for the targets.",
+                    "type": "string"
+                  },
+                  "insecureSkipVerify": {
+                    "description": "Disable target certificate validation.",
+                    "type": "boolean"
+                  },
+                  "keyFile": {
+                    "description": "Path to the client key file in the Prometheus container for the targets.",
+                    "type": "string"
+                  },
+                  "keySecret": {
+                    "description": "Secret containing the client key file for the targets.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "serverName": {
+                    "description": "Used to verify the hostname for the targets.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "jobLabel": {
+          "description": "Chooses the label of the Kubernetes `Endpoints`. Its value will be used for the `job`-label's value of the created metrics. \n Default & fallback value: the name of the respective Kubernetes `Endpoint`.",
+          "type": "string"
+        },
+        "labelLimit": {
+          "description": "Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "labelNameLengthLimit": {
+          "description": "Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "labelValueLengthLimit": {
+          "description": "Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "namespaceSelector": {
+          "description": "Selector to select which namespaces the Kubernetes Endpoints objects are discovered from.",
+          "properties": {
+            "any": {
+              "description": "Boolean describing whether all namespaces are selected in contrast to a list restricting them.",
+              "type": "boolean"
+            },
+            "matchNames": {
+              "description": "List of namespace names to select from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podTargetLabels": {
+          "description": "PodTargetLabels transfers labels on the Kubernetes `Pod` onto the created metrics.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sampleLimit": {
+          "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector to select Endpoints objects.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetLabels": {
+          "description": "TargetLabels transfers labels from the Kubernetes `Service` onto the created metrics.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "targetLimit": {
+          "description": "TargetLimit defines a limit on the number of scraped targets that will be accepted.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
A Helm chart is created for [faslty-exporter](https://github.com/peterbourgon/fastly-exporter).
The Helm chart deploys a simple deployment/pod that expose the
Fastly metrics so that Prometheus can scrape them.

Manually-tested