### PR TITLE
Remove cluster-secrets chart from ArgoCD.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -115,9 +115,6 @@ applications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-- name: cluster-secrets
-  chartPath: charts/cluster-secrets
-  postSyncWorkflowEnabled: "false"
 - name: collections
   helmValues:
     extraEnv:

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -9,9 +9,6 @@ applications:
   postSyncWorkflowEnabled: "false"
   helmValues:
     nextEnvironment: staging
-- name: cluster-secrets
-  chartPath: charts/cluster-secrets
-  postSyncWorkflowEnabled: "false"
 - name: collections
   helmValues:
     extraEnv:

--- a/charts/cluster-secrets/README.md
+++ b/charts/cluster-secrets/README.md
@@ -1,3 +1,12 @@
 The `cluster-secrets` chart defines ExternalSecrets for **cluster-wide services**.
 
-Apps' ExternalSecrets go in [../govuk-apps-conf](../govuk-apps-conf) for now (until we have invidual app charts).
+Please avoid adding ExternalSecrets for apps to this chart. Apps'
+ExternalSecrets belong in the apps' own charts, or in
+[../govuk-apps-conf](../govuk-apps-conf) for apps which use the generic
+`govuk-rails-app` chart.
+
+**This chart is deployed by the `cluster-services` Terraform module, not by
+ArgoCD.** See [Applying Terraform] for how to deploy the cluster-services
+module.
+
+[Applying Terraform]: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/docs/applying-terraform.md


### PR DESCRIPTION
It's risky and problematic to deploy this from both Terraform and ArgoCD. It leads to a race that breaks cluster turnup in most cases. We could work around that (e.g. with depends_on and ignore_changes in Terraform) but to do so would be to add complexity and brittleness just to preserve something which is fairly self-evidently undesirable: having two different deployment tools managing the same objects is unwise.

https://trello.com/c/gipscM7t/873