### PR TITLE
Remove "application" param from update image tag workflow

### DIFF
--- a/charts/argo-services/templates/events/update-image-tag-sensor.yaml
+++ b/charts/argo-services/templates/events/update-image-tag-sensor.yaml
@@ -26,19 +26,15 @@ spec:
           - dest: spec.arguments.parameters.1.value
             src:
               dependencyName: update-image-tag
-              dataKey: body.application
-          - dest: spec.arguments.parameters.2.value
-            src:
-              dependencyName: update-image-tag
               dataKey: body.repoName
-          - dest: spec.arguments.parameters.3.value
+          - dest: spec.arguments.parameters.2.value
             src:
               dependencyName: update-image-tag
               dataKey: body.imageTag
           - dest: metadata.generateName
             src:
               dependencyName: update-image-tag
-              dataKey: body.application
+              dataKey: body.repoName
             operation: prepend
         source:
           resource:
@@ -51,7 +47,6 @@ spec:
               arguments:
                 parameters:
                   - name: environment
-                  - name: application
                   - name: repoName
                   - name: imageTag
               workflowTemplateRef:

--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BRANCH="update-image-tag/${APPLICATION}/${ENVIRONMENT}/${IMAGE_TAG}"
+BRANCH="update-image-tag/${REPO_NAME}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${REPO_NAME}"
 LATEST_GIT_SHA=$(git ls-remote "https://github.com/alphagov/${REPO_NAME}" HEAD | cut -f 1)
 
@@ -20,7 +20,7 @@ if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
   echo "${IMAGE_TAG}" > "${FILE}"
 
   git add "${FILE}"
-  git commit -m "Deploy ${APPLICATION}:${IMAGE_TAG} to ${ENVIRONMENT}"
+  git commit -m "Update ${REPO_NAME} image tag to ${IMAGE_TAG} for ${ENVIRONMENT}"
 
   git push -u origin "${BRANCH}"
   gh api repos/alphagov/govuk-helm-charts/merges -f head="${BRANCH}" -f base=main

--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -37,8 +37,6 @@ spec:
               parameters:
                 - name: environment
                   value: "{{ .Values.nextEnvironment }}"
-                - name: application
-                  value: "{{"{{workflow.parameters.application}}"}}"
                 - name: repoName
                   value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: imageTag

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -7,7 +7,6 @@ spec:
   arguments:
     parameters:
       - name: environment
-      - name: application
       - name: repoName
       - name: imageTag
   templates:
@@ -15,7 +14,6 @@ spec:
       inputs:
         parameters:
           - name: environment
-          - name: application
           - name: repoName
           - name: imageTag
       script:
@@ -36,8 +34,6 @@ spec:
             value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: ENVIRONMENT
             value: "{{"{{inputs.parameters.environment}}"}}"
-          - name: APPLICATION
-            value: "{{"{{inputs.parameters.application}}"}}"
           - name: REPO_NAME
             value: "{{"{{inputs.parameters.repoName}}"}}"
         source: |


### PR DESCRIPTION
The "application" parameter was incorrectly used to reference which image tag was being updated in the commit message and the branch name. The image names correspond with the repository name not the application i.e. we don't have separate images for `draft-whitehall-frontend`, `whitehall-backend` etc... they all use whitehall. 