### PR TITLE
Add explicit namespaces in for ExternalSecrets

### DIFF
--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argocd
-  namespace: "{{ .Values.clusterServicesNamespace }}"
+  namespace: {{ .Values.clusterServicesNamespace }}
   labels:
     app.kubernetes.io/part-of: argocd
   annotations:

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-github
-  namespace: "{{ .Values.clusterServicesNamespace }}"
+  namespace: {{ .Values.clusterServicesNamespace }}
   annotations:
     a8r.io/description: >
       This secret is used to allow Dex (https://dexidp.io/), a federated

--- a/charts/cluster-secrets/templates/fastly-api.yaml
+++ b/charts/cluster-secrets/templates/fastly-api.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-fastly-api
-  namespace: monitoring
+  namespace: {{ .Values.monitoringNamespace }}
   annotations:
     a8r.io/description: >
       This secret contains the Fastly API token which fastly-exporter to expose

--- a/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
+++ b/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-ci-github-creds
+  namespace: {{ .Values.appsNamespace }}
   annotations:
     a8r.io/description: >
        Personal access token for govuk-ci GitHub user 

--- a/charts/cluster-secrets/templates/grafana-database.yaml
+++ b/charts/cluster-secrets/templates/grafana-database.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: govuk-grafana-database
-  namespace: monitoring
+  namespace: {{ .Values.monitoringNamespace }}
   annotations:
     a8r.io/description: >
       This secret contains credentials for Grafana to connect to its database

--- a/charts/cluster-secrets/templates/logit_host_external_secret.yaml
+++ b/charts/cluster-secrets/templates/logit_host_external_secret.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: logit-host
+  namespace: {{ .Values.appsNamespace }}
   annotations:
     a8r.io/description: >
       This secret contains necessary credentials to send logs to logit

--- a/charts/cluster-secrets/templates/slack-webhook-url.yaml
+++ b/charts/cluster-secrets/templates/slack-webhook-url.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: slack-webhook-url
+  namespace: {{ .Values.appsNamespace }}
   annotations:
     a8r.io/description: >
       This secret contains the slack webhook to post on Slack

--- a/charts/cluster-secrets/values.yaml
+++ b/charts/cluster-secrets/values.yaml
@@ -1,5 +1,6 @@
 clusterServicesNamespace: cluster-services
 monitoringNamespace: monitoring
+appsNamespace: apps
 # TODO: remove these and just use monitoringNamespace in templates now that
 # we're using a Role and RoleBinding to allow aws-load-balancer-controller to
 # read just the secrets that it needs, and therefore no longer need to


### PR DESCRIPTION
Several secrets were missing namespaces in their config, this prevents secrets from being created in the incorrect namespace and being inaccessible to other resources in the correct namespace.

This was an issue when we changed the deployment of the cluster-secrets chart from ArgoCD to Terraform. Terraform was deploying into a different default namespace, which was adopted by be secrets with explicit config. 