### PR TITLE
Updating default chart to enable Non-Root containers and UID

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -117,9 +117,6 @@ govukApplications:
             key: SECRET_KEY_BASE
 - name: collections
   helmValues:
-    securityContext:
-      runAsNonRoot: true
-      appContainer: true
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:
@@ -990,9 +987,6 @@ govukApplications:
   chartPath: charts/smokey
 - name: static
   helmValues:
-    securityContext:
-      runAsNonRoot: false
-      appContainer: false
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/component: worker
         app: {{ .Release.Name }}-worker
     spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -34,6 +36,12 @@ spec:
           {{- with .Values.workerResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext.appContainer }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1001
+            runAsGroup: 1001
           {{- end }}
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -81,5 +81,5 @@ uploadAssets:
 metricsPort: 9394
 
 securityContext:
-  runAsNonRoot: false
-  appContainer: false
+  runAsNonRoot: true
+  appContainer: true


### PR DESCRIPTION
This change will update both App and Worker containers.

    adds UID and GID 1001

https://trello.com/c/9Ts0i3sL/669-create-initial-podsecuritypolicies-for-the-default-and-apps-namespaces