### PR TITLE
Prevent returning error when image tag isn't promoted

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -29,5 +29,5 @@ if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
   echo "Done!"
 else
   echo "Image tag not updated for ${ENVIRONMENT}: image tag not the latest commit on main."
-  exit 1
+  exit 0
 fi


### PR DESCRIPTION
This updates the update image tag script to successfully return instead of an error. This was confusing because the script has indeed followed the correct behaviour and not promoted the non latest release commit.