### PR TITLE
Updating Publisher Signon token names

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -556,12 +556,12 @@ govukApplications:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-publisher-asset-manager
+            name: signon-token-publisher-asset-manager-ec2
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-publisher-publishing-api
+            name: signon-token-publisher-publishing-api-ec2
             key: bearer_token
       - name: FACT_CHECK_USERNAME
         valueFrom:
@@ -586,7 +586,7 @@ govukApplications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-publisher-link-checker-api
+            name: signon-token-publisher-link-checker-api-ec2
             key: bearer_token
       - name: LINK_CHECKER_API_SECRET_TOKEN
         valueFrom:


### PR DESCRIPTION
Updating Publisher signon token names with those set in `signon-resources` Helm chart.