### PR TITLE
PSP-Baseline is now active therefore we need to update Default Helm chart

### DIFF
--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       initContainers:
       - name: {{ .Release.Name }}-copy-assets-for-upload
         image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
@@ -20,6 +22,12 @@ spec:
         volumeMounts: &volumeMounts
         - name: assets-to-upload
           mountPath: /assets-to-upload
+        {{- if .Values.securityContext.appContainer }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1001
+          runAsGroup: 1001
+        {{- end }}
       containers:
       - name: {{ .Release.Name }}-upload-assets
         image: public.ecr.aws/bitnami/aws-cli

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -24,6 +24,8 @@ spec:
         {{- include "govuk-rails-app.labels" . | nindent 8 }}
         app.kubernetes.io/component: web
     spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       restartPolicy: Never
       containers:
       - name: {{ $jobName }}
@@ -40,5 +42,11 @@ spec:
         {{- with .Values.appResources }}
         resources:
           {{- . | toYaml | trim | nindent 12 }}
+        {{- end }}
+        {{- if .Values.securityContext.appContainer }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1001
+          runAsGroup: 1001
         {{- end }}
 {{- end }}

--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -13,6 +13,8 @@ spec:
   backoffLimit: 2
   template:
     spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       containers:
         - name: upload-static-error-pages
           # TODO: find a way to keep this up-to-date


### PR DESCRIPTION
govuk-rails-app Helm chart needs updating.

PSP-Baseline will not allow new root containers from running.

I have updated all Deployments within this chart to run as non root and those containers which
use the appImage now run with UID 1001 and GID 1001.

Untested at the moment

https://trello.com/c/9Ts0i3sL/669-create-initial-podsecuritypolicies-for-the-default-and-apps-namespaces