### PR TITLE
Use ClusterRoleBindings instead of RoleBindings for argo workflows service accounts

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.10
+version: 0.1.11

--- a/charts/argo-services/templates/argo-workflows-rbac/role-binding.yaml
+++ b/charts/argo-services/templates/argo-workflows-rbac/role-binding.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: argo-workflows-read-only
-  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,10 +12,9 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: argo-workflows-read-write
-  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
This allows users to access workflows in all namespaces instead of just the cluster-services one

Trello: https://trello.com/c/TRdEXluH/876-align-roles-within-argo-workflows-with-the-k8s-roles