### PR TITLE
[wip] gds-669: Podsecuritypolicy now binds to default and apps namespaces.

### DIFF
--- a/charts/cluster-security/templates/bindings.yaml
+++ b/charts/cluster-security/templates/bindings.yaml
@@ -28,3 +28,4 @@ subjects:
   name: system:authenticated
   namespace: default
   apiGroup: rbac.authorization.k8s.io
+  

--- a/charts/cluster-security/templates/bindings.yaml
+++ b/charts/cluster-security/templates/bindings.yaml
@@ -28,4 +28,3 @@ subjects:
   name: system:authenticated
   namespace: default
   apiGroup: rbac.authorization.k8s.io
-  

--- a/charts/cluster-security/templates/bindings.yaml
+++ b/charts/cluster-security/templates/bindings.yaml
@@ -1,17 +1,30 @@
-# This role binding allows all pods in the 'default' namespace to use the baseline PSP.
+# This role binding allows all pods in the 'default' and 'apps' namespace to use the baseline PSP.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: psp-baseline-namespaces
-  namespace: default
-  labels:
-    kubernetes.io/cluster-service: "true"
-    eks.amazonaws.com/component: pod-security-policy
+  name: psp-baseline-rolebinding
+  namespace: apps
 roleRef:
-  kind: Role
-  name: psp-baseline
   apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-baseline
 subjects:
 - kind: Group
   name: system:authenticated
+  namespace: apps
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp-baseline-rolebinding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-baseline
+subjects:
+- kind: Group
+  name: system:authenticated
+  namespace: default
   apiGroup: rbac.authorization.k8s.io

--- a/charts/cluster-security/templates/roles.yaml
+++ b/charts/cluster-security/templates/roles.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: psp-baseline
-  namespace: default
   labels:
     kubernetes.io/cluster-service: "true"
     eks.amazonaws.com/component: pod-security-policy


### PR DESCRIPTION
 Tested, with a simply nginx deployment in the default namespace that has a Hostnetwork:true parameter it fails.
 
 Warning  FailedCreate  0s (x13 over 21s)  replicaset-controller  Error creating: pods "nginx-hostnetwork-deployment-76c46fdb6-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used]