### PR TITLE
Fix erroneous use of Publisher secrets in Whitehall.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -279,7 +279,7 @@ govukApplications:
       - name: GOVUK_NOTIFY_API_KEY
         valueFrom:
           secretKeyRef:
-            name: publisher-notify
+            name: whitehall-notify
             key: GOVUK_NOTIFY_API_KEY
       - name: JWT_AUTH_SECRET
         valueFrom:
@@ -294,7 +294,7 @@ govukApplications:
       - name: LINK_CHECKER_API_SECRET_TOKEN
         valueFrom:
           secretKeyRef:
-            name: publisher-link-checker-api-callback-token
+            name: whitehall-link-checker-api-callback-token
             key: LINK_CHECKER_API_SECRET_TOKEN
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -499,7 +499,7 @@ govukApplications:
       - name: GOVUK_NOTIFY_API_KEY
         valueFrom:
           secretKeyRef:
-            name: publisher-notify
+            name: whitehall-notify
             key: GOVUK_NOTIFY_API_KEY
       - name: JWT_AUTH_SECRET
         valueFrom:
@@ -514,7 +514,7 @@ govukApplications:
       - name: LINK_CHECKER_API_SECRET_TOKEN
         valueFrom:
           secretKeyRef:
-            name: publisher-link-checker-api-callback-token
+            name: whitehall-link-checker-api-callback-token
             key: LINK_CHECKER_API_SECRET_TOKEN
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:


### PR DESCRIPTION
The ExternalSecrets for these already exist, as do the Secrets Manager secrets backing them. I checked that the secret values are correct for integration and staging and fixed one of the them. They're now all in sync with Puppet/EC2.

https://trello.com/c/gipscM7t/873