### PR TITLE
Change param name from manualCommit to manualDeploy

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -14,7 +14,7 @@ gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
 cd "govuk-helm-charts" || exit 1
 
 # Relies on the assumption the IMAGE_TAG is a commit SHA
-if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ] || [ "${MANUAL_COMMIT}" = true ]; then
+if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ] || [ "${MANUAL_DEPLOY}" = true ]; then
   git checkout -b "${BRANCH}"
 
   echo "${IMAGE_TAG}" > "${FILE}"

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -9,7 +9,7 @@ spec:
       - name: environment
       - name: repoName
       - name: imageTag
-      - name: manualCommit
+      - name: manualDeploy
         default: "false"
   templates:
     - name: update-image-tag
@@ -18,7 +18,7 @@ spec:
           - name: environment
           - name: repoName
           - name: imageTag
-          - name: manualCommit
+          - name: manualDeploy
       script:
         image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
         command: [/bin/bash]
@@ -39,7 +39,7 @@ spec:
             value: "{{"{{inputs.parameters.environment}}"}}"
           - name: REPO_NAME
             value: "{{"{{inputs.parameters.repoName}}"}}"
-          - name: MANUAL_COMMIT
-            value: "{{"{{inputs.parameters.manualCommit}}"}}"
+          - name: MANUAL_DEPLOY
+            value: "{{"{{inputs.parameters.manualDeploy}}"}}"
         source: |
           {{- .Files.Get "scripts/update-image-tag.sh" | nindent 14 }}


### PR DESCRIPTION
This updates the name of the parameter responsible for specifying if the deployment was manually triggered. Using the terminology to deploy to make it more clear that it's about a manual deployment rather than a git commit.