### PR TITLE
Pass manualDeploy webhook to update-image-tag workflow

### DIFF
--- a/charts/argo-services/templates/events/update-image-tag-sensor.yaml
+++ b/charts/argo-services/templates/events/update-image-tag-sensor.yaml
@@ -31,6 +31,10 @@ spec:
             src:
               dependencyName: update-image-tag
               dataKey: body.imageTag
+          - dest: spec.arguments.parameters.3.value
+            src:
+              dependencyName: update-image-tag
+              dataKey: body.manualDeploy
           - dest: metadata.generateName
             src:
               dependencyName: update-image-tag
@@ -49,5 +53,6 @@ spec:
                   - name: environment
                   - name: repoName
                   - name: imageTag
+                  - name: manualDeploy
               workflowTemplateRef:
                 name: update-image-tag


### PR DESCRIPTION
This updates the argo sensor to pass the manualDeploy parameter from the webhook body as an input to the update-image-tag workflow. This will allow GitHub Actions to tell Argo when it's a manual deploy.