### PR TITLE
Replace resources list with wildcard for argo workflows user roles

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.12
+version: 0.1.13

--- a/charts/argo-services/templates/argo-workflows-rbac/role.yaml
+++ b/charts/argo-services/templates/argo-workflows-rbac/role.yaml
@@ -6,16 +6,7 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - workflows
-  - workflows/finalizers
-  - workfloweventbindings
-  - workfloweventbindings/finalizers
-  - workflowtemplates
-  - workflowtemplates/finalizers
-  - cronworkflows
-  - cronworkflows/finalizers
-  - clusterworkflowtemplates
-  - clusterworkflowtemplates/finalizers
+  - '*'
   verbs:
   - get
   - list
@@ -29,18 +20,7 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - workflows
-  - workflows/finalizers
-  - workfloweventbindings
-  - workfloweventbindings/finalizers
-  - workflowtasksets
-  - workflowtasksets/finalizers
-  - workflowtemplates
-  - workflowtemplates/finalizers
-  - cronworkflows
-  - cronworkflows/finalizers
-  - clusterworkflowtemplates
-  - clusterworkflowtemplates/finalizers
+  - '*'
   verbs:
   - create
   - delete


### PR DESCRIPTION
Some resources were missed in the initial list, so this just allows access to all resources in the argoproj.io API group.

Trello: https://trello.com/c/TRdEXluH/876-align-roles-within-argo-workflows-with-the-k8s-roles