### PR TITLE
Rightsize resource requests in integration.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -2,6 +2,13 @@ globalHelmValues:
   govukEnvironment: integration
   externalDomainSuffix: eks.integration.govuk.digital
   publishingServiceDomainSuffix: integration.publishing.service.gov.uk
+  appResources:
+    limits:
+      cpu: 1
+      memory: 1500Mi
+    requests:
+      cpu: 0.1
+      memory: 800Mi
 
 govukApplications:
 - name: asset-manager
@@ -196,13 +203,6 @@ govukApplications:
           port: 3001
         failureThreshold: 2
         periodSeconds: 5
-    appResources:
-      limits:
-        cpu: 1
-        memory: 1.5Gi
-      requests:
-        cpu: 500m
-        memory: 1Gi
     extraEnv:
       - name: ROUTER_PUBADDR
         value: ":3000"
@@ -632,13 +632,6 @@ govukApplications:
     workerEnabled: true
     workerReplicaCount: 1
     appProbes: {}
-    appResources:
-      limits:
-        cpu: 1
-        memory: 2Gi
-      requests:
-        cpu: 1
-        memory: 2Gi
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -731,13 +724,6 @@ govukApplications:
   helmValues:
     uploadAssets:
       enabled: false
-    appResources:
-      limits:
-        cpu: 3
-        memory: 2Gi
-      requests:
-        cpu: 2
-        memory: 1Gi
     dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
       searches:
         - blue.integration.govuk-internal.digital
@@ -1016,12 +1002,14 @@ govukApplications:
     extraEnv: *whitehall-envs
 - name: whitehall-frontend
   repoName: whitehall
-  appResources:
-    limits:
-      memory: 2Gi
-    requests:
-      memory: 1.5Gi
   helmValues:
     securityContext: *disable-non-root
     uploadAssets: *whitehall-upload-assets
     extraEnv: *whitehall-envs
+    appResources:
+      limits:
+        cpu: 1
+        memory: 2Gi
+      requests:
+        cpu: 0.1
+        memory: 1Gi


### PR DESCRIPTION
This should drastically improve our utilisation.

I checked recent usage so I don't expect this to cause any problems, e.g. https://grafana.eks.integration.govuk.digital/goto/PvZT8CQ7z?orgId=1