### PR TITLE
Copying over what seems to be missing values from Nginx http block

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -19,6 +19,20 @@ data:
     }
 
     http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+      
       upstream {{ .Release.Name }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }


### PR DESCRIPTION
Copying values from default chart nginx-config.
https://github.com/alphagov/govuk-helm-charts/blob/f5a2c421c54fe3076f0892246a15e51d7af62748/charts/govuk-rails-app/templates/nginx-configmap.yaml#L22

Currently Asset-manager Nginx container is failing due to the following
error:
2022/05/10 09:07:25 [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (30: Read-only file system)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (30: Read-only file system)