### PR TITLE
Use `kubernetes.io/description` instead of `a8r.io/description`.

### DIFF
--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -4,7 +4,7 @@ metadata:
   name: govuk-dex-argo-workflows
   namespace: "{{ .Values.clusterServicesNamespace }}"
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret contains the OAUTH secret which allows Argo-Workflows to
       authenticate with Dex (https://dexidp.io/), a federated
       OpenID connect provider

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: argocd
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret contains the OAUTH secret which allows ArgoCD to
       authenticate with Dex (https://dexidp.io/), a federated
       OpenID connect provider

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -4,7 +4,7 @@ metadata:
   name: govuk-dex-github
   namespace: {{ .Values.clusterServicesNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret is used to allow Dex (https://dexidp.io/), a federated
       OpenID connect provider, to use GitHub as an identity provider
 spec:

--- a/charts/cluster-secrets/templates/dex-grafana.yaml
+++ b/charts/cluster-secrets/templates/dex-grafana.yaml
@@ -6,7 +6,7 @@ metadata:
   name: govuk-dex-grafana
   namespace: "{{ . }}"
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret contains the OAUTH secret which allows Grafana to
       authenticate with Dex (https://dexidp.io/), a federated
       OpenID connect provider

--- a/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
+++ b/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
@@ -6,7 +6,7 @@ metadata:
   name: govuk-dex-alert-manager
   namespace: "{{ . }}"
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Contains the OAuth secret which allows the Alert Manager ingress to
       require user authentication with Dex (https://dexidp.io/), a federated
       OpenID Connect provider. The requirement that users be authenticated is
@@ -32,7 +32,7 @@ metadata:
   name: govuk-dex-prometheus
   namespace: "{{ . }}"
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Contains the OAuth secret which allows the Prometheus ingress to
       require user authentication with Dex (https://dexidp.io/), a federated
       OpenID Connect provider. The requirement that users be authenticated is
@@ -57,7 +57,7 @@ metadata:
   name: prom-stack-oidc-secrets-reader
   namespace: {{ .Values.monitoringNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Allows reading the OIDC OAuth secrets which are ultimately needed by the
       load balancers which serve the Prometheus and Alert Manager ingresses.
 rules:

--- a/charts/cluster-secrets/templates/fastly-api.yaml
+++ b/charts/cluster-secrets/templates/fastly-api.yaml
@@ -4,7 +4,7 @@ metadata:
   name: govuk-fastly-api
   namespace: {{ .Values.monitoringNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret contains the Fastly API token which fastly-exporter to expose
       Fastly metrics to Prometheus
 spec:

--- a/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
+++ b/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: govuk-ci-github-creds
   namespace: {{ .Values.appsNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
        Personal access token for govuk-ci GitHub user 
 spec:
   refreshInterval: 1h

--- a/charts/cluster-secrets/templates/grafana-database.yaml
+++ b/charts/cluster-secrets/templates/grafana-database.yaml
@@ -4,7 +4,7 @@ metadata:
   name: govuk-grafana-database
   namespace: {{ .Values.monitoringNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret contains credentials for Grafana to connect to its database
 spec:
   refreshInterval: 1h

--- a/charts/cluster-secrets/templates/logit-host.yaml
+++ b/charts/cluster-secrets/templates/logit-host.yaml
@@ -4,7 +4,7 @@ metadata:
   name: logit-host
   namespace: {{ .Values.clusterServicesNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Logstash endpoint where Filebeat (which runs as a daemonset) will send
       logs to. The `host` field is the "Logstash endpoint" under "Logstash
       Inputs" for the relevant stack (e.g. "GOV.UK Staging EKS") in the LogIt

--- a/charts/cluster-secrets/templates/slack-webhook-url.yaml
+++ b/charts/cluster-secrets/templates/slack-webhook-url.yaml
@@ -4,7 +4,7 @@ metadata:
   name: slack-webhook-url
   namespace: {{ .Values.appsNamespace }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       This secret contains the slack webhook to post on Slack
 spec:
   refreshInterval: 1h

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-access-key.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-access-key.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       AWS access key to access AWS Asset-manager S3 bucket.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-secret-key.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/aws-secret-key.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Secret key to access AWS Asset-manager S3 bucket.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/docdb.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials for Asset Manager to connect to DocumentDB (MongoDB).
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Secret key for encrypting/decrypting JWT authentication tokens for
       authenticating-proxy. Shared between authenticating-proxy, which decodes
       the tokens, and asset-manager, publisher, content-publisher and

--- a/charts/govuk-apps-conf/templates/external-secrets/content-store/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/content-store/docdb.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials for Content Store to connect to DocumentDB (MongoDB).
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/email-alert/auth.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/email-alert/auth.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
        Token used to validate messages in email-alert-frontend/api
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/feedback/assisted-digital-google-sheet.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/feedback/assisted-digital-google-sheet.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Google service account for accessing the spreadsheet for Assisted Digital feedback,
       plus the ID of the sheet itself.
       https://github.com/alphagov/feedback/blob/264cd13/docs/assisted_digital_feedback.md

--- a/charts/govuk-apps-conf/templates/external-secrets/feedback/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/feedback/notify.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       The GOV.UK Notify API key belonging to Feedback.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/frontend/elections-api.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/frontend/elections-api.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials used by Frontend to access external Elections API service
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/docdb.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials for Publisher to connect to DocumentDB (MongoDB).
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/fact-check-email-account.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/fact-check-email-account.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Username and password for the factcheck Gmail account. See
       https://github.com/alphagov/publisher/blob/main/docs/fact-checking.md
 spec:

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/link-checker-api-callback-token.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Publisher uses this for verification of batch-completion webhook
       (i.e. callback) requests from Link Checker API. See
       https://github.com/alphagov/link-checker-api/blob/main/docs/api.md#verifying-the-webhook-request

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/notify.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       The GOV.UK Notify API key belonging to Publisher.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/postgres.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/postgres.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Connection string for Publishing API DB hosted in RDS
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       RabbitMQ credentials for publishing-api.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/sentry-dsn.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/sentry-dsn.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Client key for Sentry publishing-api project.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/test-ec2-database-url.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/test-ec2-database-url.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Connection string for Publishing API DB hosted in EC2.
       !!! IMPORTANT: This should only be used by the TEST AWS environment !!!
 spec:

--- a/charts/govuk-apps-conf/templates/external-secrets/rails-secret-key-base.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/rails-secret-key-base.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Rails SECRET_KEY_BASE, primarily used for encrypting Rails session
       cookies.
 spec:

--- a/charts/govuk-apps-conf/templates/external-secrets/router/nginx-htpasswd.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/router/nginx-htpasswd.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       htpasswd file containing Basic Auth usernames and password hashes for the
       nginx in front of Router. Not used in production or staging.
 spec:

--- a/charts/govuk-apps-conf/templates/external-secrets/search-api/google-analytics.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/search-api/google-analytics.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials used by search-api to access Google analytics tools
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/search-api/google-bigquery.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/search-api/google-bigquery.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials used by search-api to access Google Bigquery
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/search-api/rabbitmq.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/search-api/rabbitmq.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials used by search-api to access RabbitMQ
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/devisePepper.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/devisePepper.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Devise pepper authentication solution belonging to Signon.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/deviseSecret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/deviseSecret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Devise secret authentication solution belonging to Signon.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/mysql.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/mysql.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials for Signon to connect to MYSQL.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/smartanswers/zendesk-client.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/smartanswers/zendesk-client.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
        Username/Password used by Smart-answers to access Zendesk
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/link-checker-api-callback-token.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Whitehall uses this for verification of batch-completion webhook
       (i.e. callback) requests from Link Checker API. See
       https://github.com/alphagov/link-checker-api/blob/main/docs/api.md#verifying-the-webhook-request

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/mysql.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/mysql.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       Credentials for Whitehall to connect to MYSQL.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/notify.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
   annotations:
-    a8r.io/description: >
+    kubernetes.io/description: >
       The GOV.UK Notify API key belonging to Whitehall.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}


### PR DESCRIPTION
[`kubernetes.io/description`](https://kubernetes.io/docs/reference/labels-annotations-taints/#description) was recently introduced as a well-known annotation, so let's use it in favour of `a8r.io/description`.

Generated with `find . -type f -name '*.yaml' -exec gsed -i 's/a8r.io\/description/kubernetes.io\/description/g' {} \;`