### PR TITLE
Remove disused env vars and Helm values from Smokey.

### DIFF
--- a/charts/smokey/templates/secrets.yaml
+++ b/charts/smokey/templates/secrets.yaml
@@ -2,13 +2,17 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
-  name: smokey
+  name: {{ .Release.Name }}-signon-account
+  annotations:
+    kubernetes.io/description: >
+      Email address and password for the Signon account which Smokey uses when
+      testing publisher apps. Field names are `email` and `password`.
 spec:
-  refreshInterval: 2m
+  refreshInterval: 1h
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    name: {{ .Release.Name }}
+    name: {{ .Release.Name }}-signon-account
   dataFrom:
-  - key: govuk/smokey
+  - key: govuk/smokey/signon-account

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -40,22 +40,15 @@ spec:
               name: govuk-apps-env
               key: GOVUK_APP_DOMAIN_EXTERNAL
         - name: SIGNON_EMAIL
-          value: "signon@alphagov.co.uk"
+          valueFrom:
+            secretKeyRef:
+              name: smokey-signon-account
+              key: email
         - name: SIGNON_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: smokey
-              key: signon_password
-        - name: AUTH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: smokey
-              key: auth_username
-        - name: AUTH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: smokey
-              key: auth_password
+              name: smokey-signon-account
+              key: password
         - name: BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -1,8 +1,3 @@
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey
   tag: latest
-
-jobTtl: 3600
-
-secrets:
-  - SMOKEY_SIGNON_PASSWORD


### PR DESCRIPTION
Smokey no longer supports authenticating to the website under test via Basic Auth, as of https://github.com/alphagov/smokey/pull/913.

* Remove the environment variables which used to configure this, since they no longer have any effect.
* Fix up the name, description and specification of Smokey's remaining ExternalSecret so that it serves a single, specific purpose.
* Bring the refreshInterval in line with all the other ExternalSecrets. (Setting these to be too aggressively fast creates unnecessary load on etcd, which is a Bad Thing.)
* Remove a couple of unused Helm values.

Tested: `helm template .` output looks sensible.

Rollout: need to remember to delete the old secrets afterwards in each account.