### PR TITLE
Add grafana dashboard for govuk rails apps

### DIFF
--- a/charts/grafana-dashboards/apps-dashboard.json
+++ b/charts/grafana-dashboards/apps-dashboard.json
@@ -1,0 +1,432 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 37,
+  "iteration": 1652709705140,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "aliasColors": {
+        "Errors": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(http_requests_total{container=\"${app}\"}[1m]))",
+          "interval": "",
+          "legendFormat": "${app}",
+          "refId": "A",
+          "target": "alias(scaleToSeconds(apps.backend.backend_01.counters.requests.count, 1), 'Requests/s')"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Total requests per second",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:504",
+          "format": "reqps",
+          "label": "Total requests per second",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:505",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {
+        "Errors": "#E24D42",
+        "code_400": "#EAB839",
+        "code_500": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "HTTP Request Errors",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.5",
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(http_requests_total{container=\"${app}\", status=~\"${error_status}\"}[1m])) or vector(0)",
+          "interval": "",
+          "legendFormat": "${app}",
+          "refId": "A",
+          "target": "aliasByNode(apps.fakesite.web_server_01.counters.request_status.{code_500,code_400}.count, 5)"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "HTTP Request Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1022",
+          "format": "reqps",
+          "label": "Error HTTP Requests per second",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1023",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {
+        "Errors": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Time in Millisecond to process a request",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "avg(http_request_duration_seconds{container=\"${app}\",quantile=~\"${quantile}\"}) BY (quantile)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{quantile}} quantile $app",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Request Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:108",
+          "format": "s",
+          "label": "Time (s)",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:109",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [
+    "demo"
+  ],
+  "templating": {
+    "list": [
+      {
+        "hide": 2,
+        "name": "namespace",
+        "query": "apps",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "government-frontend",
+          "value": "government-frontend"
+        },
+        "definition": "label_values(http_request_duration_seconds, container)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "app",
+        "options": [],
+        "query": {
+          "query": "label_values(http_request_duration_seconds, container)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "0.9"
+          ],
+          "value": [
+            "0.9"
+          ]
+        },
+        "definition": "label_values(http_request_duration_seconds{container=\"${app}\"}, quantile)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "quantile",
+        "multi": true,
+        "name": "quantile",
+        "options": [],
+        "query": {
+          "query": "label_values(http_request_duration_seconds{container=\"${app}\"}, quantile)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(http_requests_total{container=\"${app}\"}, status)",
+        "description": "HTTP error status",
+        "hide": 0,
+        "includeAll": true,
+        "label": "HTTP Error Status",
+        "multi": true,
+        "name": "error_status",
+        "options": [],
+        "query": {
+          "query": "label_values(http_requests_total{container=\"${app}\"}, status)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^([45][0-9][0-9])$/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "App: request rates, errors, durations",
+  "uid": "000000109",
+  "version": 41,
+  "weekStart": ""
+}

--- a/charts/grafana-dashboards/templates/apps-dashboard-configmap.yaml
+++ b/charts/grafana-dashboards/templates/apps-dashboard-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apps-dashboard
+  labels:
+    # This label key and value pair must exist for the Grafana sidecar to detect this configmap
+    # Ref: https://github.com/prometheus-community/helm-charts/blob/47c064f180319f721867f43bf1814100e2141255/charts/kube-prometheus-stack/values.yaml#L719
+    grafana_dashboard: "1"
+    namespace: monitoring
+data:
+  # Original source of the dashboard is: https://github.com/mrnetops/fastly-dashboards/blob/main/grafana/provisioning/dashboards/Fastly-Dashboard.json
+  # with some modifications to fit GOV.UK needs
+  dashboard.json: |-
+    {{- .Files.Get "apps-dashboard.json" | nindent 4 }}


### PR DESCRIPTION
GOV.UK apps need the R(ate) E(rror) and D(uration/latency) metrics in
Grafana for ease of troubleshooting and capacity planning.

This PR adds a Grafana dashboard via a config map template. Most
GOV.UK apps are Ruby and use the same library.

![RED dashboard for GOV.UK apps](https://user-images.githubusercontent.com/43747728/168624965-2088d0c4-3cf5-4b4d-977e-502b16b8b95a.png)


Ref:
1. [trello card](https://trello.com/c/MPQsEn9q/754-create-a-grafana-dashboard-for-rails-app-red-metrics)