### PR TITLE
Fix default for manualDeploy input for update-image-tag

### DIFF
--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -10,7 +10,6 @@ spec:
       - name: repoName
       - name: imageTag
       - name: manualDeploy
-        default: "false"
   templates:
     - name: update-image-tag
       inputs:
@@ -19,6 +18,7 @@ spec:
           - name: repoName
           - name: imageTag
           - name: manualDeploy
+            default: "false"
       script:
         image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
         command: [/bin/bash]


### PR DESCRIPTION
This sets the default value for manualDeploy for the update-image-tag workflow template, rather than for direct invocations of update-image-tag. Previously, the [post-sync workflow failed to trigger](https://github.com/alphagov/govuk-helm-charts/blob/5a2468757badbfe4847f6bcaa43172a2441714e3/charts/argo-workflows/templates/post-sync-workflow.yaml#L36) an update-image-tag workflow as it didn't provide a value for manualDeploy. This broke automatic environment promotion for application deploys.