### PR TITLE
Add Nginx Prometheus exporter

### DIFF
--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -102,6 +102,39 @@ spec:
           {{- with .Values.nginxExtraVolumeMounts }}
           {{ . | toYaml | trim | nindent 10 }}
           {{- end }}
+        {{- if .Values.nginxPrometheusExporter }}
+        - name: nginx-prometheus-exporter
+          image: quay.io/martinhelmich/prometheus-nginxlog-exporter:v1.9.2
+          args: ["-config-file", "/etc/prometheus-nginxlog-exporter/config.hcl"]
+          ports:
+            - name: nginxMetrics
+              containerPort: {{ .Values.nginxExporterPort }}
+            - name: syslog
+              containerPort: {{ .Values.syslogPort }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: nginxMetrics
+            initialDelaySeconds: 2
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: nginxMetrics
+            initialDelaySeconds: 2
+            failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 15
+          {{- with .Values.nginxPrometheusExporterResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-nginx-prometheus-exporter-config
+              mountPath: /etc/prometheus-nginxlog-exporter
+          {{- end }}
       enableServiceLinks: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
@@ -113,6 +146,11 @@ spec:
           name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
       - name: tmp
         emptyDir: {}
+      {{- if .Values.nginxPrometheusExporter }}
+      - name: {{ .Release.Name }}-nginx-prometheus-exporter-config
+        configMap:
+          name: {{ .Release.Name }}-nginx-prometheus-exporter-conf
+      {{- end }}
       {{- with .Values.nginxExtraVolumes }}
       {{ . | toYaml | trim | nindent 6 }}
       {{- end }}

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -12,7 +12,7 @@ data:
 
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
-    
+
     load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
 
     events {
@@ -22,7 +22,7 @@ data:
     http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;
-      
+
       client_body_temp_path /tmp/client_temp;
       proxy_temp_path       /tmp/proxy_temp_path;
       fastcgi_temp_path     /tmp/fastcgi_temp;
@@ -30,6 +30,18 @@ data:
       scgi_temp_path        /tmp/scgi_temp;
 
       server_tokens off;
+
+      log_format timed_combined '$remote_addr - $remote_user [$time_local]  '
+        '"$request" $status $body_bytes_sent '
+        '"$http_referer" "$http_user_agent" '
+        '$request_time $upstream_response_time '
+        '$gzip_ratio $sent_http_x_cache $sent_http_location $http_host '
+        '$ssl_protocol $ssl_cipher '
+        '$http_x_forwarded_for';
+
+      {{- if .Values.nginxPrometheusExporter }}
+      access_log syslog:server=127.0.0.1:{{ .Values.syslogPort }},tag=nginx,severity=info timed_combined;
+      {{- end }}
 
       sendfile        on;
       keepalive_timeout  65;

--- a/charts/govuk-rails-app/templates/nginx-prometheus-exporter-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-prometheus-exporter-configmap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.nginxPrometheusExporter }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nginx-prometheus-exporter-conf
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+data:
+  config.hcl: |-
+    listen {
+      port = 4040
+    }
+
+    namespace "nginx" {
+      source = {
+        syslog {
+          listen_address = "udp://127.0.0.1:{{ .Values.syslogPort }}"
+          format = "auto"
+          tags = [
+            "nginx"
+          ]
+        }
+      }
+
+      format = "$remote_addr - $remote_user [$time_local]  \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" $request_time $upstream_response_time $gzip_ratio $sent_http_x_cache $sent_http_location $http_host $ssl_protocol $ssl_cipher $http_x_forwarded_for"
+
+
+      labels {
+        app = "{{ .Release.Name }}"
+      }
+    }
+{{- end }}

--- a/charts/govuk-rails-app/templates/nginx-prometheus-exporter-podMonitor.yaml
+++ b/charts/govuk-rails-app/templates/nginx-prometheus-exporter-podMonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.nginxPrometheusExporter }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+  name: {{ .Release.Name }}-nginx-prometheus-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+    - apps
+  podMetricsEndpoints:
+  - port: nginxMetrics
+{{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -99,3 +99,15 @@ metricsPort: 9394
 securityContext:
   runAsNonRoot: true
   appContainer: true
+
+nginxPrometheusExporter: true
+nginxExporterPort: 4040
+syslogPort: 8123
+
+nginxPrometheusExporterResources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
Adds a Nginx Prometheus exporter to govuk-rails-apps helm chart
as a trial to see if it can replace the Rails Prometheus exporter.

Ref:
1. [nginx log prometheus exported](https://github.com/martin-helmich/prometheus-nginxlog-exporter)