### PR TITLE
Keep 5 replicasets instead of 10 to reduce ArgoCD UI clutter.

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -110,3 +110,4 @@ spec:
         nfs:
           server: {{ .Values.nfsServer }}
           path: /
+      revisionHistoryLimit: 5

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -75,4 +75,5 @@ spec:
           path: /
       - name: clam-virus-db
         emptyDir: {}
+      revisionHistoryLimit: 5
 {{- end }}

--- a/charts/fastly-exporter/templates/deployment.yaml
+++ b/charts/fastly-exporter/templates/deployment.yaml
@@ -64,3 +64,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      revisionHistoryLimit: 5

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
           name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
       - name: tmp
         emptyDir: {}
+      revisionHistoryLimit: 5
       {{- with .Values.nginxExtraVolumes }}
       {{ . | toYaml | trim | nindent 6 }}
       {{- end }}
+      revisionHistoryLimit: 5

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -50,4 +50,5 @@ spec:
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
+      revisionHistoryLimit: 5
 {{- end }}


### PR DESCRIPTION
We're highly unlikely to want to roll back to an old replicaset anyway, and it's even harder to imagine a situation where we'd care about some config from more than 5 updates ago.