### PR TITLE
Add back the auth-proxy shared secret in staging/prod.

### DIFF
--- a/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
@@ -1,4 +1,3 @@
-{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
@@ -20,4 +19,3 @@ spec:
     name: authenticating-proxy-jwt-auth-secret
   dataFrom:
     - key: govuk/authenticating-proxy/jwt-auth-secret
-{{- end }}


### PR DESCRIPTION
Turns out we're referring to it from whitehall-frontend. We don't strictly need it there, but it'd be nasty to have to duplicate all the Whitehall config just for this. The Secrets Manager secret already exists in the staging account, so it's easier to just put this back.

Fixes #431.