### PR TITLE
Add RBAC permissions to see logs and events in Workflows UI

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.13
+version: 0.1.14

--- a/charts/argo-services/templates/argo-workflows-rbac/role.yaml
+++ b/charts/argo-services/templates/argo-workflows-rbac/role.yaml
@@ -11,6 +11,22 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -29,4 +45,20 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
   - watch


### PR DESCRIPTION
This adds the relevant RBAC permissions so users logged into the Argo Workflow UI can see logs and events. This helps with debugging workflows and events within the UI itself.