### PR TITLE
Disable automountServiceAccountToken for apps and workflow jobs

### DIFF
--- a/charts/argo-services/templates/argo-workflows-rbac/service-account.yaml
+++ b/charts/argo-services/templates/argo-workflows-rbac/service-account.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-workflows-read-only
+  automountServiceAccountToken: false
   namespace: {{ .Release.Namespace }}
   annotations:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.rbacTeams.read_only }}' in groups"
@@ -11,6 +12,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-workflows-read-write
+  automountServiceAccountToken: false
   namespace: {{ .Release.Namespace }}
   annotations:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.rbacTeams.read_write }}' in groups"

--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   template:
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       initContainers:

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         {{- include "govuk-rails-app.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       containers:

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/component: worker
         app: {{ .Release.Name }}-worker
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       containers:


### PR DESCRIPTION
As our apps have no need to authenticate to the control plane, we can remove the auto-mounting of the service account token from our pods. This includes app deployments and workflows/jobs.

While this can be done on the ServiceAccount resource, we will configure it on the pod spec to avoid breaking any AWS-native stuff.

This has been tested with a smart-answers-test app and frontend-app.
`bash: cd: /var/run/secrets/kubernetes.io/serviceaccount: No such file or directory`