### PR TITLE
Fix automountServiceAccountToken for workflows SA

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.14
+version: 0.1.15

--- a/charts/argo-services/templates/argo-workflows-rbac/service-account.yaml
+++ b/charts/argo-services/templates/argo-workflows-rbac/service-account.yaml
@@ -2,18 +2,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-workflows-read-only
-  automountServiceAccountToken: false
   namespace: {{ .Release.Namespace }}
   annotations:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.rbacTeams.read_only }}' in groups"
     workflows.argoproj.io/rbac-rule-precedence: "1"
+automountServiceAccountToken: false
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-workflows-read-write
-  automountServiceAccountToken: false
   namespace: {{ .Release.Namespace }}
   annotations:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.rbacTeams.read_write }}' in groups"
     workflows.argoproj.io/rbac-rule-precedence: "2"
+automountServiceAccountToken: false


### PR DESCRIPTION
This property should be specified at the root level rather than an attribute of metadata.