### PR TITLE
Fix and improve the upload-static-error-pages job.

### DIFF
--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -8,17 +8,14 @@ metadata:
   name: upload-static-error-pages
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
-  backoffLimit: 2
   template:
     spec:
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       containers:
         - name: upload-static-error-pages
-          # TODO: find a way to keep this up-to-date
-          image: amazon/aws-cli:2.4.25
+          image: public.ecr.aws/bitnami/aws-cli
           env:
             - name: GOVUK_ENVIRONMENT
               value: {{ .Values.govukEnvironment }}

--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -1,13 +1,13 @@
-{{- /*
-To debug this template, run `helm template . --name-template=static`.
-*/}}
-{{- if eq .Release.Name "static" }}
+{{- if or .Values.uploadStaticErrorPagesEnabled (eq .Release.Name "static") }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: upload-static-error-pages
+  name: {{ .Release.Name }}-upload-error-pages
   annotations:
     argocd.argoproj.io/hook: PostSync
+    kubernetes.io/description: >
+      Fetch "static" error pages from the Static service and upload them to S3.
+      ArgoCD runs this job after each deployment of the Static app.
 spec:
   template:
     spec:
@@ -19,6 +19,8 @@ spec:
           env:
             - name: GOVUK_ENVIRONMENT
               value: {{ .Values.govukEnvironment }}
+            - name: SERVICE
+              value: {{ .Release.Name }}
           command:
             - "/bin/sh"
             - "-c"

--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -12,10 +12,14 @@ spec:
   template:
     spec:
       securityContext:
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
       containers:
         - name: upload-static-error-pages
-          image: public.ecr.aws/bitnami/aws-cli
+          image: public.ecr.aws/bitnami/aws-cli:2
+          securityContext:
+            allowPrivilegeEscalation: false
           env:
             - name: GOVUK_ENVIRONMENT
               value: {{ .Values.govukEnvironment }}

--- a/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/static-error-page-upload-job.yaml
@@ -26,9 +26,9 @@ spec:
             - name: SERVICE
               value: {{ .Release.Name }}
           command:
-            - "/bin/sh"
+            - "/bin/bash"
             - "-c"
-            - |-
+            - |
               {{- .Files.Get "upload-static-error-pages.sh" | nindent 14 }}
           {{- with .Values.jobResources }}
           resources:

--- a/charts/govuk-rails-app/upload-static-error-pages.sh
+++ b/charts/govuk-rails-app/upload-static-error-pages.sh
@@ -2,7 +2,7 @@
 set -eux
 
 ERROR_PAGES="400 401 403 404 405 406 410 422 429 500 502 503 504"
-OUTPUT_PATH=/var/error_pages
+OUTPUT_PATH=/tmp
 
 mkdir -p "${OUTPUT_PATH}"
 for page in $ERROR_PAGES; do

--- a/charts/govuk-rails-app/upload-static-error-pages.sh
+++ b/charts/govuk-rails-app/upload-static-error-pages.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -eux
 
 ERROR_PAGES="400 401 403 404 405 406 410 422 429 500 502 503 504"
 OUTPUT_PATH=/var/error_pages
@@ -7,7 +7,7 @@ OUTPUT_PATH=/var/error_pages
 mkdir -p "${OUTPUT_PATH}"
 for page in $ERROR_PAGES; do
   echo "${page}"
-  curl --fail --output "${OUTPUT_PATH}/${page}.html" "http://static/templates/${page}.html.erb"
+  curl --fail --output "${OUTPUT_PATH}/${page}.html" "http://${SERVICE}/templates/${page}.html.erb"
 done
 
 aws s3 sync "${OUTPUT_PATH}/" "s3://govuk-app-assets-${GOVUK_ENVIRONMENT}/error_pages/"

--- a/charts/govuk-rails-app/upload-static-error-pages.sh
+++ b/charts/govuk-rails-app/upload-static-error-pages.sh
@@ -1,13 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 
-ERROR_PAGES="400 401 403 404 405 406 410 422 429 500 502 503 504"
-OUTPUT_PATH=/tmp
+ERROR_PAGES='400 401 403 404 405 406 410 422 429 500 502 503 504'
+ERROR_PAGES_COMMA_SEPARATED=${ERROR_PAGES// /,}
+OUTPUT_PATH=/tmp/output
 
 mkdir -p "${OUTPUT_PATH}"
-for page in $ERROR_PAGES; do
-  echo "${page}"
-  curl --fail --output "${OUTPUT_PATH}/${page}.html" "http://${SERVICE}/templates/${page}.html.erb"
-done
-
-aws s3 sync "${OUTPUT_PATH}/" "s3://govuk-app-assets-${GOVUK_ENVIRONMENT}/error_pages/"
+cd "${OUTPUT_PATH}"
+curl --fail-early -fo '#1.html' "${SERVICE}/templates/{${ERROR_PAGES_COMMA_SEPARATED}}.html.erb"
+eval ls "{$ERROR_PAGES_COMMA_SEPARATED}.html" || (echo Failed to download one or more files.; exit 1)
+aws s3 sync . "s3://govuk-app-assets-${GOVUK_ENVIRONMENT}/error_pages/"


### PR DESCRIPTION
* Make it run as a non-root user. I didn't use the Helm values for this since they're transitional so it's cleaner to just specify the user. I.e. we don't want ultimately running as non-root to be a configuration option.
* Use the ECR-hosted Bitnami image for aws-cli instead of DockerHub.
* Make it easier to test and debug.
* Hopefully avoid the need to delete the job and manually cancel the ArgoCD sync to recover from a failure.
* Speed up the job a bit by reusing the same HTTP connection for all the requests and add a check to make really sure we've got all the files before we upload.

See individual commits for more detail.

#### Testing

Log output from a failed run looks like this. In this case the Job has started just before the `static` service was ready to serve requests.

```
+ ERROR_PAGES='400 401 403 404 405 406 410 422 429 500 502 503 504'
+ ERROR_PAGES_COMMA_SEPARATED=400,401,403,404,405,406,410,422,429,500,502,503,504
+ OUTPUT_PATH=/tmp/output
+ mkdir -p /tmp/output
+ cd /tmp/output
+ curl --fail-early -fo '#1.html' 'chris-test-static/templates/{400,401,403,404,405,406,410,422,429,500,502,503,504}.html.erb'

[1/13]: chris-test-static/templates/400.html.erb --> 400.html
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to chris-test-static port 80: Connection refused

[2/13]: chris-test-static/templates/401.html.erb --> 401.html
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to chris-test-static port 80: Connection refused

[3/13]: chris-test-static/templates/403.html.erb --> 403.html
100 56325    0 56325    0     0  50697      0 --:--:--  0:00:01 --:--:-- 50697

[4/13]: chris-test-static/templates/404.html.erb --> 404.html
100 56443    0 56443    0     0  6124k      0 --:--:-- --:--:-- --:--:-- 6124k

[5/13]: chris-test-static/templates/405.html.erb --> 405.html
100 56329    0 56329    0     0   670k      0 --:--:-- --:--:-- --:--:--  670k

[6/13]: chris-test-static/templates/406.html.erb --> 406.html
100 56505    0 56505    0     0  6131k      0 --:--:-- --:--:-- --:--:-- 6131k

[7/13]: chris-test-static/templates/410.html.erb --> 410.html
100 56577    0 56577    0     0  6138k      0 --:--:-- --:--:-- --:--:-- 6138k

[8/13]: chris-test-static/templates/422.html.erb --> 422.html
100 56300    0 56300    0     0  6872k      0 --:--:-- --:--:-- --:--:-- 6872k

[9/13]: chris-test-static/templates/429.html.erb --> 429.html
100 56356    0 56356    0     0  6879k      0 --:--:-- --:--:-- --:--:-- 6879k

[10/13]: chris-test-static/templates/500.html.erb --> 500.html
100 56337    0 56337    0     0  6877k      0 --:--:-- --:--:-- --:--:-- 6877k

[11/13]: chris-test-static/templates/502.html.erb --> 502.html
100 56337    0 56337    0     0  7859k      0 --:--:-- --:--:-- --:--:-- 7859k

[12/13]: chris-test-static/templates/503.html.erb --> 503.html
100 56337    0 56337    0     0  7859k      0 --:--:-- --:--:-- --:--:-- 7859k

[13/13]: chris-test-static/templates/504.html.erb --> 504.html
100 56337    0 56337    0     0  7859k      0 --:--:-- --:--:-- --:--:-- 7859k
+ eval ls '{400,401,403,404,405,406,410,422,429,500,502,503,504}.html'
++ ls 400.html 401.html 403.html 404.html 405.html 406.html 410.html 422.html 429.html 500.html 502.html 503.html 504.html
ls: cannot access '400.html': No such file or directory
ls: cannot access '401.html': No such file or directory
Failed to download one or more files.
+ echo Failed to download one or more files.
+ exit 1
```

Log output from a successful run looks like this:

```
+ ERROR_PAGES='400 401 403 404 405 406 410 422 429 500 502 503 504'
+ ERROR_PAGES_COMMA_SEPARATED=400,401,403,404,405,406,410,422,429,500,502,503,504
+ OUTPUT_PATH=/tmp/output
+ mkdir -p /tmp/output
+ cd /tmp/output
+ curl --fail-early -fo '#1.html' 'chris-test-static/templates/{400,401,403,404,405,406,410,422,429,500,502,503,504}.html.erb'

[1/13]: chris-test-static/templates/400.html.erb --> 400.html
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 56300    0 56300    0     0   561k      0 --:--:-- --:--:-- --:--:--  561k

[2/13]: chris-test-static/templates/401.html.erb --> 401.html
100 56325    0 56325    0     0  5000k      0 --:--:-- --:--:-- --:--:-- 5000k

[3/13]: chris-test-static/templates/403.html.erb --> 403.html
100 56325    0 56325    0     0  4583k      0 --:--:-- --:--:-- --:--:-- 4583k

[4/13]: chris-test-static/templates/404.html.erb --> 404.html
100 56443    0 56443    0     0  5512k      0 --:--:-- --:--:-- --:--:-- 5512k

[5/13]: chris-test-static/templates/405.html.erb --> 405.html
100 56329    0 56329    0     0  6112k      0 --:--:-- --:--:-- --:--:-- 6112k

[6/13]: chris-test-static/templates/406.html.erb --> 406.html
100 56505    0 56505    0     0  5518k      0 --:--:-- --:--:-- --:--:-- 5518k

[7/13]: chris-test-static/templates/410.html.erb --> 410.html
100 56577    0 56577    0     0  6138k      0 --:--:-- --:--:-- --:--:-- 6138k

[8/13]: chris-test-static/templates/422.html.erb --> 422.html
100 56300    0 56300    0     0  6108k      0 --:--:-- --:--:-- --:--:-- 6108k

[9/13]: chris-test-static/templates/429.html.erb --> 429.html
100 56356    0 56356    0     0   561k      0 --:--:-- --:--:-- --:--:--  561k

[10/13]: chris-test-static/templates/500.html.erb --> 500.html
100 56337    0 56337    0     0  5501k      0 --:--:-- --:--:-- --:--:-- 5501k

[11/13]: chris-test-static/templates/502.html.erb --> 502.html
100 56337    0 56337    0     0  5501k      0 --:--:-- --:--:-- --:--:-- 5501k

[12/13]: chris-test-static/templates/503.html.erb --> 503.html
100 56337    0 56337    0     0  6112k      0 --:--:-- --:--:-- --:--:-- 6112k

[13/13]: chris-test-static/templates/504.html.erb --> 504.html
100 56337    0 56337    0     0  5501k      0 --:--:-- --:--:-- --:--:-- 5501k
+ eval ls '{400,401,403,404,405,406,410,422,429,500,502,503,504}.html'
++ ls 400.html 401.html 403.html 404.html 405.html 406.html 410.html 422.html 429.html 500.html 502.html 503.html 504.html
+ aws s3 sync . s3://govuk-app-assets-integration/error_pages/
upload: ./403.html to s3://govuk-app-assets-integration/error_pages/403.html
upload: ./401.html to s3://govuk-app-assets-integration/error_pages/401.html
upload: ./404.html to s3://govuk-app-assets-integration/error_pages/404.html
upload: ./504.html to s3://govuk-app-assets-integration/error_pages/504.html
upload: ./410.html to s3://govuk-app-assets-integration/error_pages/410.html
upload: ./405.html to s3://govuk-app-assets-integration/error_pages/405.html
upload: ./400.html to s3://govuk-app-assets-integration/error_pages/400.html
upload: ./429.html to s3://govuk-app-assets-integration/error_pages/429.html
upload: ./502.html to s3://govuk-app-assets-integration/error_pages/502.html
upload: ./406.html to s3://govuk-app-assets-integration/error_pages/406.html
upload: ./422.html to s3://govuk-app-assets-integration/error_pages/422.html
upload: ./500.html to s3://govuk-app-assets-integration/error_pages/500.html
upload: ./503.html to s3://govuk-app-assets-integration/error_pages/503.html
```