### PR TITLE
Fix nextEnvironment value for staging

### DIFF
--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -8,7 +8,7 @@ govukApplications:
   chartPath: charts/argo-workflows
   postSyncWorkflowEnabled: "false"
   helmValues:
-    nextEnvironment: staging
+    nextEnvironment: production
 - name: collections
   helmValues:
     extraEnv:


### PR DESCRIPTION
This fixes the value the specifies the next environment to promote a release to. Staging promotes to production, otherwise it'd try to update the image tag for the same environment.