### PR TITLE
Send deployment annotations to Grafana

### DIFF
--- a/charts/argo-services/cd-notifications-config.yaml
+++ b/charts/argo-services/cd-notifications-config.yaml
@@ -13,6 +13,9 @@ service.webhook.slack_webhook: |
   - name: "Content-Type"
     value: "application/json"
   url: "$slack_url"
+service.grafana: |
+  apiUrl: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local/api
+  apiKey: $grafana_api_key
 template.send-argo-events-webhook: |
   webhook:
     argo_events:
@@ -53,6 +56,13 @@ template.send-slack: |
           }]
         }
       method: "POST"
+template.send-grafana: |
+  message: |
+    "Application {{.app.metadata.name}} is now running new version of deployments manifests. Revision: {{.app.status.sync.revision}}"
+trigger.deployment: |
+  - oncePer: "app.status.operationState.syncResult.revision"
+    send: ["send-grafana"]
+    when: "app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'"
 trigger.on-deployed: |
   - send: ["send-argo-events-webhook"]
     when: "app.status.operationState.phase in ['Succeeded'] and app.status.health.status

--- a/charts/argo-services/templates/argocd-notifications/secret.yaml
+++ b/charts/argo-services/templates/argocd-notifications/secret.yaml
@@ -24,6 +24,9 @@ spec:
         argo_events_webhook_token: "{{
           "{{ .argoEventsWebhookToken | toString}}"
         }}"
+        grafana_api_key: "{{
+          "{{ .grafanaApiKey | toString}}"
+        }}"
   data:
     - secretKey: slackUrl
       remoteRef:
@@ -33,3 +36,7 @@ spec:
       remoteRef:
         key: govuk/argo-events-webhook-token
         property: token
+    - secretKey: grafanaApiKey
+      remoteRef:
+        key: govuk/argo-notifications/grafana
+        property: grafana-api-key

--- a/charts/argocd-apps/templates/govuk-application.yaml
+++ b/charts/argocd-apps/templates/govuk-application.yaml
@@ -15,6 +15,7 @@ metadata:
     repoName: "{{ $reponame }}"
     imageTag: "{{ $imageTag }}"
     notifications.argoproj.io/subscribe.on-deployed.argo_events: ""
+    notifications.argoproj.io/subscribe.deployment.grafana: "deployment|{{ .name }}"
     postSyncWorkflowEnabled: "{{ .postSyncWorkflowEnabled | default "true" }}"
 spec:
   project: govuk

--- a/charts/grafana-dashboards/apps-dashboard.json
+++ b/charts/grafana-dashboards/apps-dashboard.json
@@ -8,14 +8,16 @@
           "uid": "grafana"
         },
         "enable": true,
-        "hide": true,
+        "hide": false,
         "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
+        "name": "Deployments",
         "target": {
           "limit": 100,
           "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
+          "tags": [
+            "$app", "deployment"
+          ],
+          "type": "tags"
         },
         "type": "dashboard"
       }
@@ -25,8 +27,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 37,
-  "iteration": 1652709705140,
+  "iteration": 1653320477417,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -425,6 +426,6 @@
   "timezone": "browser",
   "title": "App: request rates, errors, durations",
   "uid": "000000109",
-  "version": 41,
+  "version": 42,
   "weekStart": ""
 }


### PR DESCRIPTION
This enable Argo Notifications to send annotation events to Grafana. The annotations represent when Argo Application (for GOV.UK apps) sync successfully. Whilst a sync can occur for other reasons than a deployment, it's the closest event to map to a deployment (and it's useful when other application state might change). Annotations are tagged with the Argo Application name and "deployment". This also updates the "App: request rates, errors, durations" Grafana dashboard to display the annotations for the selected app.