### PR TITLE
Update Github production team name

### DIFF
--- a/charts/argo-services/values.yaml
+++ b/charts/argo-services/values.yaml
@@ -3,4 +3,4 @@ argocdUrl:
 workflowsNamespace: apps
 rbacTeams:
   read_only: alphagov:gov-uk
-  read_write: alphagov:gov-uk-production
+  read_write: alphagov:gov-uk-production-deploy


### PR DESCRIPTION
As covered in RFC 146 - Implement "Production Deploy Access" ,
we are renaming the production team name from "GOV.UK Production"
to "GOV.UK Production Admin". This should ensure there is no
ambiguity between this level of access and "Production Deploy" access.
Users with production access will be members of both groups.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5