### PR TITLE
Name containers within pods more consistently.

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ .Release.Name }}
+        - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           volumeMounts:
             - name: {{ .Release.Name }}-asset-uploads-efs
@@ -66,7 +66,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsUser: 1001
             runAsGroup: 1001
-        - name: {{ .Release.Name }}-nginx
+        - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
             - name: http

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             runAsGroup: 1001
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
-        - name: clamdb
+        - name: freshclam
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           command: ["/bin/sh"]
           args: ["-c", "freshclam -d --stdout --foreground"]

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       containers:
-        - name: {{ .Release.Name }}
+        - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
           ports:
@@ -69,7 +69,7 @@ spec:
             runAsUser: 1001
             runAsGroup: 1001
           {{- end }}
-        - name: {{ .Release.Name }}-nginx
+        - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}
           ports:


### PR DESCRIPTION
There's no need to include the name of the app/deployment in the container name, since it's already in the pod name. On the other hand, it's super annoying having to keep typing these different, long names all the time when debugging.

The container names now make sense in the context of the pod (as they should) and no longer contain any (unhelpful) redundant information.