### PR TITLE
Add SENTRY_RELEASE env to govuk containers

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.appPort }}"
+            - name: SENTRY_RELEASE
+              value: "{{ .Values.appImage.tag }}"
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - configMapRef:
                 name: govuk-apps-env
           env:
+            - name: SENTRY_RELEASE
+              value: "{{ .Values.appImage.tag }}"
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -36,6 +36,8 @@ spec:
           - configMapRef:
               name: govuk-apps-env
         env:
+          - name: SENTRY_RELEASE
+            value: "{{ .Values.appImage.tag }}"
         {{- with .Values.extraEnv }}
           {{- . | toYaml | trim | nindent 12 }}
         {{- end }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.appPort }}"
+            - name: SENTRY_RELEASE
+              value: "{{ .Values.appImage.tag }}"
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - configMapRef:
                 name: govuk-apps-env
           env:
+            - name: SENTRY_RELEASE
+              value: "{{ .Values.appImage.tag }}"
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
In the EC2 world, Capistrano adds a REVISION file with the release
version of the app inside. This is then used by the Sentry SDK/gem
when sending reports to Sentry.

In GOV.UK EKS, we just use an environment variable `SENTRY_RELEASE`
with value of the image tag. The Sentry SDK supports that as shown
in the ref.

Ref:
1. [trello card](https://trello.com/c/QdYaqqv2/915-send-webhook-to-sentry-when-a-deploy-occurs)
2. [Sentry SDK](https://github.com/getsentry/sentry-ruby/blob/efcf170b5f6dd65c3b047825bddd8fde87fc6b7b/sentry-ruby/lib/sentry/release_detector.rb#L7)