### PR TITLE
Added correct indent for envfrom configmap

### DIFF
--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -34,7 +34,7 @@ spec:
           args: ["exec", "rails", "db:migrate"]
           envFrom:
           - configMapRef:
-            name: govuk-apps-env
+              name: govuk-apps-env
           env:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"


### PR DESCRIPTION
had missed this from yesterdays fix:
https://github.com/alphagov/govuk-helm-charts/pull/447

https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/