### PR TITLE
Re-label container to app name

### DIFF
--- a/charts/govuk-rails-app/templates/podMonitor.yaml
+++ b/charts/govuk-rails-app/templates/podMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
   name: {{ .Release.Name }}
-  namespace: monitoring
+  namespace: apps
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Removing the app name from the container name as part of [#444](https://github.com/alphagov/govuk-helm-charts/pull/444) removed the ability to filter by app in grafana this allows that filter to work again 
