### PR TITLE
Simplify PodMonitors

### DIFF
--- a/charts/asset-manager/templates/podMonitor.yaml
+++ b/charts/asset-manager/templates/podMonitor.yaml
@@ -7,13 +7,9 @@ metadata:
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
   name: {{ .Release.Name }}
-  namespace: monitoring
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
-  namespaceSelector: 
-    matchNames: 
-    - apps
   podMetricsEndpoints:
   - port: metrics

--- a/charts/govuk-rails-app/templates/podMonitor.yaml
+++ b/charts/govuk-rails-app/templates/podMonitor.yaml
@@ -7,13 +7,9 @@ metadata:
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
   name: {{ .Release.Name }}
-  namespace: apps
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
-  namespaceSelector: 
-    matchNames: 
-    - apps
   podMetricsEndpoints:
   - port: metrics


### PR DESCRIPTION
Simplify PodMonitors by removing the namespace fields so that
the PodMonitor will find the endpoint to scrape base on the
`current` namespace of the PodMonitor.