### PR TITLE
Fix labels on govuk-rails-app PodMonitor.

### DIFF
--- a/charts/govuk-rails-app/templates/podmonitor.yaml
+++ b/charts/govuk-rails-app/templates/podmonitor.yaml
@@ -1,12 +1,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  labels:
-    app: {{ .Release.Name }}
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/part-of: kube-prometheus
   name: {{ .Release.Name }}
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
- Remove some labels which made it look like the PodMonitor was being installed by kube-prometheus-operator.
- Add the common labels which everything's supposed to have.
- Make the filename consistent with the others.

Tested: just ran `helm template .`