### PR TITLE
Fix router Prometheus metrics

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -188,7 +188,7 @@ govukApplications:
       startupProbe: &router-probe
         httpGet:
           path: /healthcheck
-          port: 3001
+          port: 9394
         failureThreshold: 10
         periodSeconds: 1
         timeoutSeconds: 1
@@ -200,7 +200,7 @@ govukApplications:
         <<: *router-probe
         httpGet:
           path: /healthcheck
-          port: 3001
+          port: 9394
         failureThreshold: 2
         periodSeconds: 5
     nginxConfigMap:
@@ -210,7 +210,7 @@ govukApplications:
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR
-        value: ":3001"
+        value: ":9394"
       - name: ROUTER_MONGO_URL  # Hostnames should match those shown in MongoDB rs.status().
         value: &router_mongo_hosts "\
           router-backend-1,\
@@ -749,7 +749,7 @@ govukApplications:
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR
-        value: ":3001"
+        value: ":9394"
       - name: ROUTER_MONGO_URL
         value: *router_mongo_hosts
       - name: BACKEND_URL_collections

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -282,7 +282,7 @@ govukApplications:
       startupProbe: &router-probe
         httpGet:
           path: /healthcheck
-          port: 3001
+          port: 9394
         failureThreshold: 10
         periodSeconds: 1
         timeoutSeconds: 1
@@ -294,14 +294,14 @@ govukApplications:
         <<: *router-probe
         httpGet:
           path: /healthcheck
-          port: 3001
+          port: 9394
         failureThreshold: 2
         periodSeconds: 5
     extraEnv:
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR
-        value: ":3001"
+        value: ":9394"
       - name: ROUTER_MONGO_URL
         value: &router_mongo_hosts "\
           router-backend-1,\


### PR DESCRIPTION
Prometheus can't currently scrape router metrics on port 9394.
We need to set the api_port to 9394 in router via an env var.
Note that the api_port will be use only for metrics and
healthchecks and it is no longer used by router_api to trigger
router to reload routes in its memory.

Ref:
1. [trello card](https://trello.com/c/ozKdr7Et/933-fix-scraping-of-router-metrics)