### PR TITLE
Mark assets as public and immutable to aid caching

### DIFF
--- a/charts/govuk-apps-conf/templates/router-nginx-config.tpl
+++ b/charts/govuk-apps-conf/templates/router-nginx-config.tpl
@@ -110,7 +110,7 @@ http {
       proxy_intercept_errors on;
       proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
 
-      add_header Cache-Control max-age=31536000;
+      add_header Cache-Control "max-age=31536000, public, immutable";
       add_header "Access-Control-Allow-Origin" "*";
       add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
       add_header "Access-Control-Allow-Headers" "origin, authorization";


### PR DESCRIPTION
This marks assets as public and immutable, meaning they can be cached indefinitely, will never change and can be stored in public caches.

Trello: https://trello.com/c/uCGahIqu/623-custom-response-headers-at-origin