### PR TITLE
Add the nosniff header as recommended by Cyber

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -32,7 +32,7 @@ data:
 
       sendfile        on;
       keepalive_timeout  65;
-      
+
       upstream {{ .Release.Name }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }
@@ -55,7 +55,7 @@ data:
         '$gzip_ratio $sent_http_x_cache $sent_http_location $http_host '
         '$ssl_protocol $ssl_cipher '
         '$http_x_forwarded_for';
-    
+
       log_format json_event '{ "@timestamp": "$time_iso8601", '
                            '"remote_addr": "$remote_addr", '
                            '"remote_user": "$remote_user", '
@@ -110,6 +110,7 @@ data:
         add_header Strict-Transport-Security $sts_default;
 
         add_header Permissions-Policy interest-cohort=();
+        add_header X-Content-Type-Options "nosniff" always;
 
         listen {{ .Values.nginxPort }};
 

--- a/charts/govuk-apps-conf/templates/router-nginx-config.tpl
+++ b/charts/govuk-apps-conf/templates/router-nginx-config.tpl
@@ -87,6 +87,7 @@ http {
     {{- end }}
 
     add_header Permissions-Policy interest-cohort=();
+    add_header X-Content-Type-Options "nosniff" always;
 
     {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
     auth_basic "Enter the GOV.UK username/password (not your personal username/password)";

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -12,7 +12,7 @@ data:
 
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
-    
+
     load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
 
     events {
@@ -22,7 +22,7 @@ data:
     http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;
-      
+
       client_body_temp_path /tmp/client_temp;
       proxy_temp_path       /tmp/proxy_temp_path;
       fastcgi_temp_path     /tmp/fastcgi_temp;
@@ -76,6 +76,7 @@ data:
         add_header Strict-Transport-Security $sts_default;
         add_header Permissions-Policy interest-cohort=();
         proxy_set_header GOVUK-Request-Id $govuk_request_id;
+        add_header X-Content-Type-Options "nosniff" always;
 
         {{- if ( or (ne .Values.govukEnvironment "production") (eq .Values.nginxDenyCrawlers true ) ) }}
         add_header X-Robots-Tag "noindex";


### PR DESCRIPTION
Set an X-Content-Type-Options header to disable content sniffing,
limit exposure to cross-site scripting.

Ref:
1. [cyber pentest report](https://docs.google.com/document/d/1ryB-yxm9NvNlU4_CdZw6l1FPX0Qru9HPd17kn2-qEyI/edit#)
2. [nginx docs ref](https://www.attosol.com/http-security-headers-with-nginx/#:~:text=add_header%20X%2DContent%2DType%2D,including%20internally%20generated%20error%20responses.)