### PR TITLE
remove retired manuals-frontend app

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -228,8 +228,6 @@ govukApplications:
         value: "http://draft-frontend"
       - name: BACKEND_URL_government-frontend
         value: "http://draft-government-frontend"
-      - name: BACKEND_URL_manuals-frontend
-        value: "http://draft-manuals-frontend"
       - name: BACKEND_URL_service-manual-frontend
         value: "http://draft-service-manual-frontend"
       - name: BACKEND_URL_smartanswers
@@ -518,19 +516,6 @@ govukApplications:
           secretKeyRef:
             name: signon-token-licence-finder-publishing-api-ec2
             key: bearer_token
-- name: manuals-frontend
-  helmValues:
-    extraEnv:
-      - name: SECRET_KEY_BASE
-        valueFrom:
-          secretKeyRef:
-            name: rails-secret-key-base
-            key: SECRET_KEY_BASE
-      - name: PUBLISHING_API_BEARER_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: signon-token-manuals-frontend-publishing-api-ec2
-            key: bearer_token
 - name: publisher
   helmValues:
     dbMigrationEnabled: true
@@ -762,8 +747,6 @@ govukApplications:
         value: "http://frontend"
       - name: BACKEND_URL_government-frontend
         value: "http://government-frontend"
-      - name: BACKEND_URL_manuals-frontend
-        value: "http://manuals-frontend"
       - name: BACKEND_URL_service-manual-frontend
         value: "http://service-manual-frontend"
       - name: BACKEND_URL_smartanswers

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -200,19 +200,6 @@ govukApplications:
           secretKeyRef:
             name: signon-token-licence-finder-publishing-api-ec2
             key: bearer_token
-- name: manuals-frontend
-  helmValues:
-    extraEnv:
-      - name: SECRET_KEY_BASE
-        valueFrom:
-          secretKeyRef:
-            name: rails-secret-key-base
-            key: SECRET_KEY_BASE
-      - name: PUBLISHING_API_BEARER_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: signon-token-manuals-frontend-publishing-api-ec2
-            key: bearer_token
 - name: router
   helmValues:
     uploadAssets:
@@ -317,8 +304,6 @@ govukApplications:
         value: "http://frontend"
       - name: BACKEND_URL_government-frontend
         value: "http://government-frontend"
-      - name: BACKEND_URL_manuals-frontend
-        value: "http://manuals-frontend"
       - name: BACKEND_URL_service-manual-frontend
         value: "http://service-manual-frontend"
       - name: BACKEND_URL_smartanswers

--- a/charts/signon-resources/templates/bootstrap-job.yaml
+++ b/charts/signon-resources/templates/bootstrap-job.yaml
@@ -317,14 +317,6 @@ spec:
                     { "application_slug": "publishing-api-ec2" }
                   ]
                 },
-                "manuals-frontend": {
-                  "name": "Manuals Frontend [EKS]",
-                  "username": "manuals-frontend",
-                  "email": "manuals-frontend@{{ .Values.govukEnvironment }}.{{ .Values.govukDomainExternal }}",
-                  "bearer_tokens": [
-                    { "application_slug": "publishing-api-ec2" }
-                  ]
-                },
                 "publisher": {
                   "name": "Publisher [EKS]",
                   "username": "publisher",


### PR DESCRIPTION
Manuals Frontend app is retired, remove mentions.

https://trello.com/c/OtjBZRjL/1131-manuals-deprecate-manuals-frontend