### PR TITLE
Fix #462 router nginx config cookie stripping

### DIFF
--- a/charts/govuk-apps-conf/templates/router-nginx-config.tpl
+++ b/charts/govuk-apps-conf/templates/router-nginx-config.tpl
@@ -105,7 +105,7 @@ http {
     # Allow cookie headers to pass for services that require them
     # Requests for these services will use this location as nginx will select the most
     # specific location directive for a given request
-    location ~* ^/(?!apply-for-a-licence|email|brexit-eu-funding|find-coronavirus-support) {
+    location ~* ^/(apply-for-a-licence|email|sign-in\/callback) {
       proxy_pass         http://router;
       proxy_redirect     off;
     }


### PR DESCRIPTION
In #462, we were supposed strip cookies for paths that do not
match:
/apply-for-a-licence
/email
/sign-in/callback

The regex for the `not stripping` location is not correct. This PR
fixes that and also removes/adds some services that have been removed/added from
govuk, see [here](https://github.com/alphagov/govuk-puppet/blob/b0c574616f70f6427a9ffa13baf99b1533095a0a/modules/varnish/templates/default.vcl.erb#L86)