### PR TITLE
Fix external-secrets interpretation of refreshInterval

### DIFF
--- a/charts/argo-services/templates/argocd-notifications/secret.yaml
+++ b/charts/argo-services/templates/argocd-notifications/secret.yaml
@@ -1,6 +1,6 @@
 # NOTE: This assumes that an AWS SecretsManager secret `govuk/slack-webhook-url`
 # exists with key `url`.
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: argocd-notifications-secret

--- a/charts/argo-services/templates/argocd/repository-credentials.yaml
+++ b/charts/argo-services/templates/argocd/repository-credentials.yaml
@@ -1,6 +1,6 @@
 # NOTE: This assumes that an AWS SecretsManager secret `govuk/alphagov-repo-creds`
 # exists with key `sshPrivateKey` (belonging to govuk-ci user).
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: alphagov-repo-creds

--- a/charts/cluster-secret-store/templates/cluster_secret_store.yaml
+++ b/charts/cluster-secret-store/templates/cluster_secret_store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: aws-secretsmanager

--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argo-workflows
@@ -17,4 +17,5 @@ spec:
     name: govuk-dex-argo-workflows
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/dex/argo-workflows
+    - extract:
+        key: govuk/dex/argo-workflows

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argocd
@@ -19,4 +19,5 @@ spec:
     name: govuk-dex-argocd
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/dex/argocd
+  - extract:
+      key: govuk/dex/argocd

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-github
@@ -16,4 +16,5 @@ spec:
     name: govuk-dex-github
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/dex/github
+    - extract:
+        key: govuk/dex/github

--- a/charts/cluster-secrets/templates/dex-grafana.yaml
+++ b/charts/cluster-secrets/templates/dex-grafana.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.dexGrafanaSecretsNamespaces}}
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-grafana
@@ -19,5 +19,6 @@ spec:
     name: govuk-dex-grafana
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/dex/grafana
+    - extract:
+        key: govuk/dex/grafana
 {{- end }}

--- a/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
+++ b/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.dexAlertManagerSecretsNamespaces}}
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-alert-manager
@@ -22,11 +22,12 @@ spec:
     name: govuk-dex-alert-manager
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/dex/alert-manager
+  - extract:
+      key: govuk/dex/alert-manager
 {{- end }}
 {{- range .Values.dexPrometheusSecretsNamespaces}}
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-prometheus
@@ -48,7 +49,8 @@ spec:
     name: govuk-dex-prometheus
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/dex/prometheus
+    - extract:
+        key: govuk/dex/prometheus
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cluster-secrets/templates/fastly-api.yaml
+++ b/charts/cluster-secrets/templates/fastly-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-fastly-api
@@ -16,4 +16,5 @@ spec:
     name: govuk-fastly-api
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/fastly/api
+    - extract:
+        key: govuk/fastly/api

--- a/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
+++ b/charts/cluster-secrets/templates/govuk-ci-github-creds.yaml
@@ -1,11 +1,11 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-ci-github-creds
   namespace: {{ .Values.appsNamespace }}
   annotations:
     kubernetes.io/description: >
-       Personal access token for govuk-ci GitHub user 
+       Personal access token for govuk-ci GitHub user
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -15,4 +15,5 @@ spec:
     name: govuk-ci-github-creds
     creationPolicy: Owner
   dataFrom:
-    - key: govuk/github/govuk-ci
+    - extract:
+        key: govuk/github/govuk-ci

--- a/charts/cluster-secrets/templates/grafana-database.yaml
+++ b/charts/cluster-secrets/templates/grafana-database.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: govuk-grafana-database
@@ -15,4 +15,5 @@ spec:
     name: govuk-grafana-database
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/grafana/database
+    - extract:
+        key: govuk/grafana/database

--- a/charts/cluster-secrets/templates/logit-host.yaml
+++ b/charts/cluster-secrets/templates/logit-host.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: logit-host
@@ -20,4 +20,5 @@ spec:
     name: logit-host
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/logit-host
+    - extract:
+        key: govuk/logit-host

--- a/charts/cluster-secrets/templates/slack-webhook-url.yaml
+++ b/charts/cluster-secrets/templates/slack-webhook-url.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: slack-webhook-url
@@ -15,4 +15,5 @@ spec:
     name: slack-webhook-url
     creationPolicy: Owner
   dataFrom:
-  - key: govuk/slack-webhook-url
+    - extract:
+        key: govuk/slack-webhook-url

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/docdb.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: asset-manager-docdb
@@ -19,5 +19,6 @@ spec:
       data:
         MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/govuk_assets_production'
   dataFrom:
-    - key: govuk/common/shared-documentdb
+    - extract:
+        key: govuk/common/shared-documentdb
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/asset-manager/s3.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/asset-manager/s3.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: asset-manager-s3
@@ -19,5 +19,6 @@ spec:
   target:
     name: asset-manager-s3
   dataFrom:
-    - key: govuk/asset-manager/s3
+    - extract:
+        key: govuk/asset-manager/s3
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/authenticating-proxy/jwt-auth-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: authenticating-proxy-jwt-auth-secret
@@ -18,4 +18,5 @@ spec:
   target:
     name: authenticating-proxy-jwt-auth-secret
   dataFrom:
-    - key: govuk/authenticating-proxy/jwt-auth-secret
+    - extract:
+        key: govuk/authenticating-proxy/jwt-auth-secret

--- a/charts/govuk-apps-conf/templates/external-secrets/content-store/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/content-store/docdb.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: content-store-docdb
@@ -19,5 +19,6 @@ spec:
       data:
         MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/govuk_content_production'
   dataFrom:
-    - key: govuk/common/shared-documentdb
+    - extract:
+        key: govuk/common/shared-documentdb
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/email-alert/auth.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/email-alert/auth.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: email-alert-auth
@@ -17,4 +17,5 @@ spec:
   target:
     name: email-alert-auth
   dataFrom:
-    - key: govuk/email-alert/auth
+    - extract:
+        key: govuk/email-alert/auth

--- a/charts/govuk-apps-conf/templates/external-secrets/feedback/assisted-digital-google-sheet.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/feedback/assisted-digital-google-sheet.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: feedback-assisted-digital-google-sheet
@@ -17,4 +17,5 @@ spec:
   target:
     name: feedback-assisted-digital-google-sheet
   dataFrom:
-    - key: govuk/feedback/assisted-digital-google-sheet
+    - extract:
+        key: govuk/feedback/assisted-digital-google-sheet

--- a/charts/govuk-apps-conf/templates/external-secrets/feedback/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/feedback/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: feedback-notify
@@ -15,4 +15,5 @@ spec:
   target:
     name: feedback-notify
   dataFrom:
-    - key: govuk/feedback/notify
+    - extract:
+        key: govuk/feedback/notify

--- a/charts/govuk-apps-conf/templates/external-secrets/frontend/elections-api.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/frontend/elections-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: frontend-elections-api
@@ -15,4 +15,5 @@ spec:
   target:
     name: frontend-elections-api
   dataFrom:
-    - key: govuk/frontend/elections-api
+    - extract:
+        key: govuk/frontend/elections-api

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/docdb.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publisher-docdb
@@ -19,5 +19,6 @@ spec:
       data:
         MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/govuk_content_production'
   dataFrom:
-    - key: govuk/common/shared-documentdb
+    - extract:
+        key: govuk/common/shared-documentdb
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/fact-check-email-account.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/fact-check-email-account.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publisher-fact-check-email-account
@@ -17,5 +17,6 @@ spec:
   target:
     name: publisher-fact-check-email-account
   dataFrom:
-    - key: govuk/publisher/fact-check-email-account
+    - extract:
+        key: govuk/publisher/fact-check-email-account
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/link-checker-api-callback-token.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publisher-link-checker-api-callback-token
@@ -18,5 +18,6 @@ spec:
   target:
     name: publisher-link-checker-api-callback-token
   dataFrom:
-    - key: govuk/publisher/link-checker-api-callback-token
+    - extract:
+        key: govuk/publisher/link-checker-api-callback-token
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publisher/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publisher/notify.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publisher-notify
@@ -16,5 +16,6 @@ spec:
   target:
     name: publisher-notify
   dataFrom:
-    - key: govuk/publisher/notify
+    - extract:
+        key: govuk/publisher/notify
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/postgres.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/postgres.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publishing-api-postgres
@@ -19,5 +19,6 @@ spec:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/publishing_api_production'
   dataFrom:
-    - key: govuk/publishing-api/postgres
+    - extract:
+        key: govuk/publishing-api/postgres
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publishing-api-rabbitmq
@@ -16,5 +16,6 @@ spec:
   target:
     name: publishing-api-rabbitmq
   dataFrom:
-    - key: govuk/common/rabbitmq-govuk
+    - extract:
+        key: govuk/common/rabbitmq-govuk
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/publishing-api/sentry-dsn.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/publishing-api/sentry-dsn.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: publishing-api-sentry-dsn
@@ -16,5 +16,6 @@ spec:
   target:
     name: publishing-api-sentry-dsn
   dataFrom:
-    - key: govuk/common/publishing-api-sentry-dsn
+    - extract:
+        key: govuk/common/publishing-api-sentry-dsn
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/rails-secret-key-base.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/rails-secret-key-base.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: rails-secret-key-base
@@ -16,4 +16,5 @@ spec:
   target:
     name: rails-secret-key-base
   dataFrom:
-    - key: govuk/common/rails-secret-key-base
+    - extract:
+        key: govuk/common/rails-secret-key-base

--- a/charts/govuk-apps-conf/templates/external-secrets/router/nginx-htpasswd.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/router/nginx-htpasswd.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: router-nginx-htpasswd
@@ -17,5 +17,6 @@ spec:
   target:
     name: router-nginx-htpasswd
   dataFrom:
-    - key: govuk/router/htpasswd
+    - extract:
+        key: govuk/router/htpasswd
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/search-api/google-analytics.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/search-api/google-analytics.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: search-api-google-analytics
@@ -16,5 +16,6 @@ spec:
   target:
     name: search-api-google-analytics
   dataFrom:
-    - key: govuk/search-api/google-analytics
+    - extract:
+        key: govuk/search-api/google-analytics
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/search-api/google-bigquery.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/search-api/google-bigquery.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: search-api-google-bigquery
@@ -16,5 +16,6 @@ spec:
   target:
     name: search-api-google-bigquery
   dataFrom:
-    - key: govuk/search-api/google-bigquery
+    - extract:
+        key: govuk/search-api/google-bigquery
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/search-api/rabbitmq.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/search-api/rabbitmq.yaml
@@ -1,5 +1,5 @@
 {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: search-api-rabbitmq
@@ -16,5 +16,6 @@ spec:
   target:
     name: search-api-rabbitmq
   dataFrom:
-    - key: govuk/search-api/rabbitmq
+    - extract:
+        key: govuk/search-api/rabbitmq
 {{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/devisePepper.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/devisePepper.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: signon-devise-pepper
@@ -15,4 +15,5 @@ spec:
   target:
     name: signon-devise-pepper
   dataFrom:
-    - key: govuk/signon/devise-pepper
+    - extract:
+        key: govuk/signon/devise-pepper

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/deviseSecret.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/deviseSecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: signon-devise-secret
@@ -15,4 +15,5 @@ spec:
   target:
     name: signon-devise-secret
   dataFrom:
-    - key: govuk/signon/devise-secret
+    - extract:
+        key: govuk/signon/devise-secret

--- a/charts/govuk-apps-conf/templates/external-secrets/signon/mysql.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/signon/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: signon-mysql
@@ -18,4 +18,5 @@ spec:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/signon_production'
   dataFrom:
-    - key: govuk/signon/mysql
+    - extract:
+        key: govuk/signon/mysql

--- a/charts/govuk-apps-conf/templates/external-secrets/smartanswers/zendesk-client.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/smartanswers/zendesk-client.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: smartanswers-zendesk-client
@@ -15,4 +15,5 @@ spec:
   target:
     name: smartanswers-zendesk-client
   dataFrom:
-    - key: govuk/smartanswers/zendesk-client
+    - extract:
+        key: govuk/smartanswers/zendesk-client

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/link-checker-api-callback-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: whitehall-link-checker-api-callback-token
@@ -17,4 +17,5 @@ spec:
   target:
     name: whitehall-link-checker-api-callback-token
   dataFrom:
-    - key: govuk/whitehall/link-checker-api-callback-token
+    - extract:
+        key: govuk/whitehall/link-checker-api-callback-token

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/mysql.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: whitehall-mysql
@@ -18,4 +18,5 @@ spec:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/whitehall_production'
   dataFrom:
-    - key: govuk/whitehall/mysql-primary
+    - extract:
+        key: govuk/whitehall/mysql-primary

--- a/charts/govuk-apps-conf/templates/external-secrets/whitehall/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/whitehall/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: whitehall-notify
@@ -15,4 +15,5 @@ spec:
   target:
     name: whitehall-notify
   dataFrom:
-    - key: govuk/whitehall/notify
+    - extract:
+        key: govuk/whitehall/notify

--- a/charts/smokey/templates/secrets.yaml
+++ b/charts/smokey/templates/secrets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Release.Name }}-signon-account
@@ -15,4 +15,5 @@ spec:
   target:
     name: {{ .Release.Name }}-signon-account
   dataFrom:
-  - key: govuk/smokey/signon-account
+    - extract:
+        key: govuk/smokey/signon-account


### PR DESCRIPTION
Argo is trying to always rewrite the refresh interval to 1h from
1h0m0s.

See bug description:
https://github.com/external-secrets/external-secrets/pull/1028