### PR TITLE
Check if `automatic_deploys_enabled` before updating image tag during manual deploys

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -5,19 +5,7 @@ BRANCH="update-image-tag/${REPO_NAME}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/argocd-apps/image-tags/${ENVIRONMENT}/${REPO_NAME}"
 LATEST_GIT_SHA=$(git ls-remote "https://github.com/alphagov/${REPO_NAME}" HEAD | cut -f 1)
 
-git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
-git config --global user.name "${GIT_NAME}"
-
-gh auth setup-git
-gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
-
-cd "govuk-helm-charts" || exit 1
-
-# Exit successfully if image tag already set
-if [[ $(<"${FILE}") = "${IMAGE_TAG}" ]]; then
-  echo "Image tag already set as ${IMAGE_TAG}"
-# Relies on the assumption the IMAGE_TAG is a commit SHA
-elif [[ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]] || [[ "${MANUAL_DEPLOY}" = true ]]; then
+change_image_tag() {
   git checkout -b "${BRANCH}"
 
   yq -i '.image_tag = env(IMAGE_TAG)' "${FILE}"
@@ -29,7 +17,36 @@ elif [[ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]] || [[ "${MANUAL_DEPLOY}" = true 
   gh api repos/alphagov/govuk-helm-charts/merges -f head="${BRANCH}" -f base=main
   git push origin --delete "${BRANCH}"
 
-  echo "Done!"
+  echo "Pushed image_tag change to GitHub"
+}
+
+git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
+git config --global user.name "${GIT_NAME}"
+
+gh auth setup-git
+gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
+
+cd "govuk-helm-charts" || exit 1
+
+# Exit successfully if image tag already set
+current_image_tag="$(yq '.image_tag' "${FILE}")"
+if [[ "${current_image_tag}" = "${IMAGE_TAG}" ]]; then
+  echo "Image tag already set as ${IMAGE_TAG}"
+
+elif [[ "${MANUAL_DEPLOY}" = true ]]; then
+  change_image_tag
+
+# If automatic deploys, check automatic_deploys_enabled before proceeding.
+# Relies on the assumption the IMAGE_TAG is a commit SHA
+elif [[ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]]; then
+  auto_deploys="$(yq '.automatic_deploys_enabled' "${FILE}")"
+  # Auto deploys are enabled unless explicitly set to "false" (case insensitive).
+  if [[ "${auto_deploys,,}" != "false" ]]; then
+    change_image_tag
+  else
+    echo "Did not update image tag because automatic_deploys_enabled is set to false for app"
+  fi
+
 else
   echo "Image tag not updated for ${ENVIRONMENT}: image tag not the latest commit on main."
 fi

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -3,7 +3,7 @@ kind: WorkflowTemplate
 metadata:
   name: update-image-tag
 spec:
-  entrypoint: update-image-tag 
+  entrypoint: update-image-tag
   arguments:
     parameters:
       - name: environment

--- a/charts/argocd-apps/image-tags/integration/asset-manager
+++ b/charts/argocd-apps/image-tags/integration/asset-manager
@@ -1,1 +1,2 @@
 image_tag: e56fac303c873bb81287f95f24cd1876b2fe1e16
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/authenticating-proxy
+++ b/charts/argocd-apps/image-tags/integration/authenticating-proxy
@@ -1,1 +1,2 @@
 image_tag: a86ccf17ecd5f894873096fbe291dea97c96da9f
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/collections
+++ b/charts/argocd-apps/image-tags/integration/collections
@@ -1,1 +1,2 @@
 image_tag: 74afb231b0e5c922acb52ec9cacca01f1dcd2192
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/contacts-admin
+++ b/charts/argocd-apps/image-tags/integration/contacts-admin
@@ -1,1 +1,2 @@
 image_tag: 28b140a03bb20d50a17082cce75fc7bc12936418
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/content-store
+++ b/charts/argocd-apps/image-tags/integration/content-store
@@ -1,1 +1,2 @@
 image_tag: 5ae05c1cf4ac897c3aa4bc794a4fa2e1f789c8c0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/email-alert-frontend
+++ b/charts/argocd-apps/image-tags/integration/email-alert-frontend
@@ -1,1 +1,2 @@
 image_tag: ba8520d8109057e4aac260473fa07bed7fbe85a1
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/feedback
+++ b/charts/argocd-apps/image-tags/integration/feedback
@@ -1,1 +1,2 @@
 image_tag: f06809b06d61b202031cdff0fb5b1e2e811177e1
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/finder-frontend
+++ b/charts/argocd-apps/image-tags/integration/finder-frontend
@@ -1,1 +1,2 @@
 image_tag: bd6327e2af3e66d2cca4decd5fdaa7c29d8f671b
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/frontend
+++ b/charts/argocd-apps/image-tags/integration/frontend
@@ -1,1 +1,2 @@
 image_tag: 88534cd64114ea1ff4989f80e246f98d4b02fa6c
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/government-frontend
+++ b/charts/argocd-apps/image-tags/integration/government-frontend
@@ -1,1 +1,2 @@
 image_tag: f31a27c40b66d42cd0ff958197de2ccf6cff6b9f
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/hmrc-manuals-api
+++ b/charts/argocd-apps/image-tags/integration/hmrc-manuals-api
@@ -1,1 +1,2 @@
 image_tag: 10d61362daaf4ad904ec3f1c40672b825e22baba5
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/info-frontend
+++ b/charts/argocd-apps/image-tags/integration/info-frontend
@@ -1,1 +1,2 @@
 image_tag: 726cc2db1c5c7e68bd60785d503697f4c37c9dad
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/licence-finder
+++ b/charts/argocd-apps/image-tags/integration/licence-finder
@@ -1,1 +1,2 @@
 image_tag: 21d0531c5c56ada43873a14dc10463fb54f71130
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/manuals-frontend
+++ b/charts/argocd-apps/image-tags/integration/manuals-frontend
@@ -1,1 +1,2 @@
 image_tag: 20d7006ab5f30d01bec92c04f860db1ec7b2e63e
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/publisher
+++ b/charts/argocd-apps/image-tags/integration/publisher
@@ -1,1 +1,2 @@
 image_tag: 2e676e8970a9aa28b8472410af550d4ad6c5343b
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/publishing-api
+++ b/charts/argocd-apps/image-tags/integration/publishing-api
@@ -1,1 +1,2 @@
 image_tag: c92cc3101346c2cb1075c359d32851b970874b3a
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/router
+++ b/charts/argocd-apps/image-tags/integration/router
@@ -1,1 +1,2 @@
 image_tag: d6fcffbecf6ab56184370cf32258514cffcb6f87
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/router-api
+++ b/charts/argocd-apps/image-tags/integration/router-api
@@ -1,1 +1,2 @@
 image_tag: c915bf9bbb93784882a6d4b16f326786b8e7a7a2
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/search-api
+++ b/charts/argocd-apps/image-tags/integration/search-api
@@ -1,1 +1,2 @@
 image_tag: 2a6e5c7a91824fd67caa6c2275754ef1e532af29
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/service-manual-frontend
+++ b/charts/argocd-apps/image-tags/integration/service-manual-frontend
@@ -1,1 +1,2 @@
 image_tag: 723cb8ad6e87f5afbf2b238afd594da97d919a22
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/signon
+++ b/charts/argocd-apps/image-tags/integration/signon
@@ -1,1 +1,2 @@
 image_tag: 64210df60432aef80a65ae82611e0ccfe11cc189
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/signon-resources
+++ b/charts/argocd-apps/image-tags/integration/signon-resources
@@ -1,1 +1,2 @@
 image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/smart-answers
+++ b/charts/argocd-apps/image-tags/integration/smart-answers
@@ -1,1 +1,2 @@
 image_tag: f3befa20dc22a1b39ecf1e7430fc3dd30c4b93b8
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/smokey
+++ b/charts/argocd-apps/image-tags/integration/smokey
@@ -1,1 +1,2 @@
 image_tag: df376a76d47444ae64cee28c147a38935c8023d0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/static
+++ b/charts/argocd-apps/image-tags/integration/static
@@ -1,1 +1,2 @@
 image_tag: b95f85f64d8a4c6d54d0a6b72eb97383241a47a7
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/whitehall
+++ b/charts/argocd-apps/image-tags/integration/whitehall
@@ -1,1 +1,2 @@
 image_tag: d4453899f1f88e79576af7652e54891f95a52a00
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/asset-manager
+++ b/charts/argocd-apps/image-tags/production/asset-manager
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/authenticating-proxy
+++ b/charts/argocd-apps/image-tags/production/authenticating-proxy
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/collections
+++ b/charts/argocd-apps/image-tags/production/collections
@@ -1,1 +1,2 @@
 image_tag: 1b3850286eb358cdb45b8f9db2e70e9d42d0e7f2
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/contacts-admin
+++ b/charts/argocd-apps/image-tags/production/contacts-admin
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/content-store
+++ b/charts/argocd-apps/image-tags/production/content-store
@@ -1,1 +1,2 @@
 image_tag: e3203f1186ad4a839e71a0f6824cdbc039c42455
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/email-alert-frontend
+++ b/charts/argocd-apps/image-tags/production/email-alert-frontend
@@ -1,1 +1,2 @@
 image_tag: f56ca3e26bf15205515d490fb99794fd7ec16cf7
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/feedback
+++ b/charts/argocd-apps/image-tags/production/feedback
@@ -1,1 +1,2 @@
 image_tag: 8b5a602c37ede9402553258240a3ae751c75fe20
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/finder-frontend
+++ b/charts/argocd-apps/image-tags/production/finder-frontend
@@ -1,1 +1,2 @@
 image_tag: 66ccbd80429270c3ba9ef818fc364eab5654e6e5
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/frontend
+++ b/charts/argocd-apps/image-tags/production/frontend
@@ -1,1 +1,2 @@
 image_tag: d61aacc2cb0088ae12c0053c3be8e0a5bb6ac83f
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/government-frontend
+++ b/charts/argocd-apps/image-tags/production/government-frontend
@@ -1,1 +1,2 @@
 image_tag: 118ccab9ecdd8c35b60be42ad9aeb18e599065de
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/hmrc-manuals-api
+++ b/charts/argocd-apps/image-tags/production/hmrc-manuals-api
@@ -1,1 +1,2 @@
 image_tag: 555d4b2d49626fc02130bfdc24e0d3526ab075bc
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/info-frontend
+++ b/charts/argocd-apps/image-tags/production/info-frontend
@@ -1,1 +1,2 @@
 image_tag: 726cc2db1c5c7e68bd60785d503697f4c37c9dad
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/licence-finder
+++ b/charts/argocd-apps/image-tags/production/licence-finder
@@ -1,1 +1,2 @@
 image_tag: 21d0531c5c56ada43873a14dc10463fb54f71130
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/manuals-frontend
+++ b/charts/argocd-apps/image-tags/production/manuals-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/publisher
+++ b/charts/argocd-apps/image-tags/production/publisher
@@ -1,1 +1,2 @@
 image_tag: 45f683bb7d35c82b0ec2a2f910be2835923b0eca
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/publishing-api
+++ b/charts/argocd-apps/image-tags/production/publishing-api
@@ -1,1 +1,2 @@
 image_tag: 51d48c16d47ddedade8385df397c024046a6625d
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/router
+++ b/charts/argocd-apps/image-tags/production/router
@@ -1,1 +1,2 @@
 image_tag: fdf35ae8af7b88525e8933e1ad54c7e4b45247f0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/router-api
+++ b/charts/argocd-apps/image-tags/production/router-api
@@ -1,1 +1,2 @@
 image_tag: 43ddc56033b0e7b920af3fcb14f7eea57d3a4e8d
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/search-api
+++ b/charts/argocd-apps/image-tags/production/search-api
@@ -1,1 +1,2 @@
 image_tag: 0e1fe244eced6296560502e631459c5598e7de45
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/service-manual-frontend
+++ b/charts/argocd-apps/image-tags/production/service-manual-frontend
@@ -1,1 +1,2 @@
 image_tag: 723cb8ad6e87f5afbf2b238afd594da97d919a22
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/signon
+++ b/charts/argocd-apps/image-tags/production/signon
@@ -1,1 +1,2 @@
 image_tag: e2d48a22a2afe1842cf88921da67490f04582cf2
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/signon-resources
+++ b/charts/argocd-apps/image-tags/production/signon-resources
@@ -1,1 +1,2 @@
 image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/smart-answers
+++ b/charts/argocd-apps/image-tags/production/smart-answers
@@ -1,1 +1,2 @@
 image_tag: eff026ad542fb7400d447d812512e732ef70b2ac
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/smokey
+++ b/charts/argocd-apps/image-tags/production/smokey
@@ -1,1 +1,2 @@
 image_tag: df376a76d47444ae64cee28c147a38935c8023d0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/static
+++ b/charts/argocd-apps/image-tags/production/static
@@ -1,1 +1,2 @@
 image_tag: fcba69b2a2d5fc57825b1b25a4f1fbf91f022073
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/whitehall
+++ b/charts/argocd-apps/image-tags/production/whitehall
@@ -1,1 +1,2 @@
 image_tag: 59865fac6d10f760b36afb67788e5cc3393368df
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/asset-manager
+++ b/charts/argocd-apps/image-tags/staging/asset-manager
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/authenticating-proxy
+++ b/charts/argocd-apps/image-tags/staging/authenticating-proxy
@@ -1,1 +1,2 @@
 image_tag: 4feb06e7f173cc99f7584fe370877897ef45ab5e
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/collections
+++ b/charts/argocd-apps/image-tags/staging/collections
@@ -1,1 +1,2 @@
 image_tag: 1b3850286eb358cdb45b8f9db2e70e9d42d0e7f2
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/contacts-admin
+++ b/charts/argocd-apps/image-tags/staging/contacts-admin
@@ -1,1 +1,2 @@
 image_tag: 28b140a03bb20d50a17082cce75fc7bc12936418
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/content-store
+++ b/charts/argocd-apps/image-tags/staging/content-store
@@ -1,1 +1,2 @@
 image_tag: 5ae05c1cf4ac897c3aa4bc794a4fa2e1f789c8c0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/draft-router
+++ b/charts/argocd-apps/image-tags/staging/draft-router
@@ -1,1 +1,2 @@
 image_tag: a5c4f8814fa556a4461ae0b87751652cdbe86a30
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/draft-whitehall-frontend
+++ b/charts/argocd-apps/image-tags/staging/draft-whitehall-frontend
@@ -1,1 +1,2 @@
 image_tag: 340353d4f9ed595a6a898613acfae811ccf38f91
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/email-alert-frontend
+++ b/charts/argocd-apps/image-tags/staging/email-alert-frontend
@@ -1,1 +1,2 @@
 image_tag: fec9615aa0a3ba6d854fea70534115385ce722f9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/feedback
+++ b/charts/argocd-apps/image-tags/staging/feedback
@@ -1,1 +1,2 @@
 image_tag: f06809b06d61b202031cdff0fb5b1e2e811177e1
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/finder-frontend
+++ b/charts/argocd-apps/image-tags/staging/finder-frontend
@@ -1,1 +1,2 @@
 image_tag: 3ee8686f95adcbf87840a1007eeb2e7fb22ac5e1
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/frontend
+++ b/charts/argocd-apps/image-tags/staging/frontend
@@ -1,1 +1,2 @@
 image_tag: 88534cd64114ea1ff4989f80e246f98d4b02fa6c
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/government-frontend
+++ b/charts/argocd-apps/image-tags/staging/government-frontend
@@ -1,1 +1,2 @@
 image_tag: e8f6d17276f2e403f4bd62a4b1221b9b2a3637a3c
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/hmrc-manuals-api
+++ b/charts/argocd-apps/image-tags/staging/hmrc-manuals-api
@@ -1,1 +1,2 @@
 image_tag: 0d61362daaf4ad904ec3f1c40672b825e22baba5
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/info-frontend
+++ b/charts/argocd-apps/image-tags/staging/info-frontend
@@ -1,1 +1,2 @@
 image_tag: 726cc2db1c5c7e68bd60785d503697f4c37c9dad
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/licence-finder
+++ b/charts/argocd-apps/image-tags/staging/licence-finder
@@ -1,1 +1,2 @@
 image_tag: 21d0531c5c56ada43873a14dc10463fb54f71130
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/manuals-frontend
+++ b/charts/argocd-apps/image-tags/staging/manuals-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/publisher
+++ b/charts/argocd-apps/image-tags/staging/publisher
@@ -1,1 +1,2 @@
 image_tag: 0b6a37b6e74dffc116477e3e3a3e07405330a3bb
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/publishing-api
+++ b/charts/argocd-apps/image-tags/staging/publishing-api
@@ -1,1 +1,2 @@
 image_tag: 660ac3b951a1dd1df265308fd020cafbc4b31182
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/router
+++ b/charts/argocd-apps/image-tags/staging/router
@@ -1,1 +1,2 @@
 image_tag: fdf35ae8af7b88525e8933e1ad54c7e4b45247f0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/router-api
+++ b/charts/argocd-apps/image-tags/staging/router-api
@@ -1,1 +1,2 @@
 image_tag: c915bf9bbb93784882a6d4b16f326786b8e7a7a2
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/search-api
+++ b/charts/argocd-apps/image-tags/staging/search-api
@@ -1,1 +1,2 @@
 image_tag: 2a6e5c7a91824fd67caa6c2275754ef1e532af29
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/service-manual-frontend
+++ b/charts/argocd-apps/image-tags/staging/service-manual-frontend
@@ -1,1 +1,2 @@
 image_tag: 723cb8ad6e87f5afbf2b238afd594da97d919a22
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/signon
+++ b/charts/argocd-apps/image-tags/staging/signon
@@ -1,1 +1,2 @@
 image_tag: 2ebaed80bf0c84e0f0a57e39e85029f5efdfadc9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/signon-resources
+++ b/charts/argocd-apps/image-tags/staging/signon-resources
@@ -1,1 +1,2 @@
 image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/smart-answers
+++ b/charts/argocd-apps/image-tags/staging/smart-answers
@@ -1,1 +1,2 @@
 image_tag: c2f7017213db9b688a334822605d80ae380d901d
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/smartanswers
+++ b/charts/argocd-apps/image-tags/staging/smartanswers
@@ -1,1 +1,2 @@
 image_tag: 64438bd21054add4c5e1de574757c565a3c4e979
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/smokey
+++ b/charts/argocd-apps/image-tags/staging/smokey
@@ -1,1 +1,2 @@
 image_tag: df376a76d47444ae64cee28c147a38935c8023d0
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/static
+++ b/charts/argocd-apps/image-tags/staging/static
@@ -1,1 +1,2 @@
 image_tag: b95f85f64d8a4c6d54d0a6b72eb97383241a47a7
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/whitehall
+++ b/charts/argocd-apps/image-tags/staging/whitehall
@@ -1,1 +1,2 @@
 image_tag: d4453899f1f88e79576af7652e54891f95a52a00
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/whitehall-admin
+++ b/charts/argocd-apps/image-tags/staging/whitehall-admin
@@ -1,1 +1,2 @@
 image_tag: 56978fdcc6f02fe9e55c40bfa2e0c844befc6002
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/asset-manager
+++ b/charts/argocd-apps/image-tags/test/asset-manager
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/authenticating-proxy
+++ b/charts/argocd-apps/image-tags/test/authenticating-proxy
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/collections
+++ b/charts/argocd-apps/image-tags/test/collections
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/contacts-admin
+++ b/charts/argocd-apps/image-tags/test/contacts-admin
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/content-store
+++ b/charts/argocd-apps/image-tags/test/content-store
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/email-alert-frontend
+++ b/charts/argocd-apps/image-tags/test/email-alert-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/feedback
+++ b/charts/argocd-apps/image-tags/test/feedback
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/finder-frontend
+++ b/charts/argocd-apps/image-tags/test/finder-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/frontend
+++ b/charts/argocd-apps/image-tags/test/frontend
@@ -1,1 +1,2 @@
 image_tag: 4d8ed134afe5ecf676ffd047154210aa5dc943b9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/government-frontend
+++ b/charts/argocd-apps/image-tags/test/government-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/hmrc-manuals-api
+++ b/charts/argocd-apps/image-tags/test/hmrc-manuals-api
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/info-frontend
+++ b/charts/argocd-apps/image-tags/test/info-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/licence-finder
+++ b/charts/argocd-apps/image-tags/test/licence-finder
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/manuals-frontend
+++ b/charts/argocd-apps/image-tags/test/manuals-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/publisher
+++ b/charts/argocd-apps/image-tags/test/publisher
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/publishing-api
+++ b/charts/argocd-apps/image-tags/test/publishing-api
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/router
+++ b/charts/argocd-apps/image-tags/test/router
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/router-api
+++ b/charts/argocd-apps/image-tags/test/router-api
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/search-api
+++ b/charts/argocd-apps/image-tags/test/search-api
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/service-manual-frontend
+++ b/charts/argocd-apps/image-tags/test/service-manual-frontend
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/signon
+++ b/charts/argocd-apps/image-tags/test/signon
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/signon-resources
+++ b/charts/argocd-apps/image-tags/test/signon-resources
@@ -1,1 +1,2 @@
 image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/smart-answers
+++ b/charts/argocd-apps/image-tags/test/smart-answers
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/smokey
+++ b/charts/argocd-apps/image-tags/test/smokey
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/static
+++ b/charts/argocd-apps/image-tags/test/static
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/whitehall
+++ b/charts/argocd-apps/image-tags/test/whitehall
@@ -1,1 +1,2 @@
 image_tag: latest
+automatic_deploys_enabled: true


### PR DESCRIPTION
If automatic deploy is triggered in GH workflow, check `automatic_deploys_enabled` before changing image tag.

Ref:
1. [trello card](https://trello.com/c/5uj2U5rS/900-prevent-manual-deploys-being-overridden-by-cd)