### PR TITLE
Remove base 64 decoding for repository SSH keys

### DIFF
--- a/charts/argo-services/templates/argocd/repository-credentials.yaml
+++ b/charts/argo-services/templates/argocd/repository-credentials.yaml
@@ -21,7 +21,7 @@ spec:
         url: git@github.com:alphagov # prefix-matched to repositories
         # Helm and External Secrets use the same template language and conflict
         sshPrivateKey: "{{
-          "{{ .sshPrivateKey | base64decode | toString }}"
+          "{{ .sshPrivateKey | toString }}"
         }}"
   data:
     - secretKey: sshPrivateKey


### PR DESCRIPTION
The key can be stored without being base 64 encoded and no longer needs to be decoded by External Secrets. Originally it might have been encoded to preserve newline formatting when inputting into AWS Secret Manager. However, newlines are preserved if secret is created using JSON with '\n' characters. Ultimately this removes unnecessary complexity in the External Secret configuration.