### PR TITLE
Ensure that all images are being pulled from ecr

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
             failureThreshold: 2
             periodSeconds: 5
             timeoutSeconds: 15
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1001
+            runAsGroup: 1001
           volumeMounts:
           - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -7,8 +7,7 @@ metadata:
     app.kubernetes.io/component: web
 data:
   nginx.conf: |-
-    user nginx;
-
+  
     error_log /dev/stderr warn;
     pid /tmp/nginx.pid;
 

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -36,7 +36,7 @@ appPort: 3000
 appProbes: {}
 
 nginxImage:
-  repository: nginxinc/nginx-unprivileged
+  repository: public.ecr.aws/nginx/nginx
   pullPolicy: Always
   tag: stable-perl
 nginxPort: 8080

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
+          {{- if .Values.securityContext.appContainer }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1001
+            runAsGroup: 1001
+          {{- end }}
           volumeMounts:
           - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf

--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/component: web
 data:
   nginx.conf: |-
-    user nginx;
 
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -39,7 +39,7 @@ appPort: 3000
 appProbes: {}
 
 nginxImage:
-  repository: nginxinc/nginx-unprivileged
+  repository: public.ecr.aws/nginx/nginx
   pullPolicy: Always
   tag: stable-perl
 nginxPort: 8080


### PR DESCRIPTION
For https://trello.com/c/PmdZFhCy/567-ensure-that-all-images-are-being-pulled-from-ecr

changed nginx image to pull from public-ecr, removed user directive and added sec-context for nginx container
This was tested by running a 'my-frontend' app in integration and checking the nginx container health.
At first I was receiving non-root errors for the nginx container
`Error: container has runAsNonRoot and image will run as root (pod: "my-frontend-599f5bc7c5-59gh5_apps(36259e5d-c067-4c75-8722-4ba825733ba1)"...`
Adding the securitycontext to the nginx container deployment spec worked.

` Normal  Pulling    27s   kubelet            Pulling image "public.ecr.aws/nginx/nginx:stable-perl"
  Normal  Pulled     24s   kubelet            Successfully pulled image "public.ecr.aws/nginx/nginx:stable-perl" in 2.979113709s
  Normal  Created    24s   kubelet            Created container nginx
  Normal  Started    24s   kubelet            Started container nginx`
  
  edit:
Asset-manager is working:
`test-assetmgr-68796d9d55-f2b8w                        2/2     Running     0          4m12s
test-assetmgr-worker-7fd585b96-dmg2n                  2/2     Running     0          4m12s`

