### PR TITLE
Add Prometheus podmonitor to workers

### DIFF
--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -26,6 +26,10 @@ spec:
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
           command: ["bundle"]
           args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
           envFrom:

--- a/charts/govuk-rails-app/templates/worker-podmonitor.yaml
+++ b/charts/govuk-rails-app/templates/worker-podmonitor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.workerEnabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    {{- include "govuk-rails-app.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}-worker
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-worker
+  podMetricsEndpoints:
+  - port: metrics
+{{- end }}


### PR DESCRIPTION
Sidekiq-based workers will now exposed Sidekiq metrics in a
Prometheus format so adding a Prometheus pod monitor.

While all the workers of the same app will exposed "same" metrics
since they have the "same" view of the queue, this is better than
other discussed alternatives.

Ref:
1. [trello card](https://trello.com/c/K8aUtwz4/974-graphs-for-sidekiq-queues-in-grafana)