### PR TITLE
Fix whitehall-admin attachment/image uploads.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -727,7 +727,7 @@ govukApplications:
         subPath: robots.txt
       - name: router-nginx-htpasswd
         mountPath: /etc/nginx/htpasswd
-    nginxExtraVolumes:
+    extraVolumes:
       - name: router-nginx-htpasswd
         secret:
           secretName: router-nginx-htpasswd

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -968,6 +968,12 @@ govukApplications:
 - name: whitehall-admin
   repoName: whitehall
   helmValues:
+    securityContext:
+      # Use the same uid/gid for NFS permissions as the old stack, so that
+      # files uploaded by whitehall-admin on k8s can be processed by
+      # whitehall-admin on EC2 and vice versa. 2899 is the "deploy" user.
+      runAsUser: 2899
+      runAsGroup: 2899
     dbMigrationEnabled: true
     workerEnabled: true
     uploadAssets: *whitehall-upload-assets

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -22,7 +22,7 @@ govukApplications:
       hosts:
       - name: asset-manager.eks.integration.govuk.digital
     workerReplicaCount: 1
-    nfsServer: assets.blue.integration.govuk-internal.digital
+    nfsServer: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false
       name: asset-manager-nginx-conf
@@ -980,6 +980,14 @@ govukApplications:
       - whitehall-admin.eks.integration.govuk.digital
     workerReplicaCount: 1
     extraEnv: *whitehall-envs
+    extraVolumes:
+      - name: asset-uploads-efs
+        nfs:
+          server: *assets-nfs
+          path: /whitehall  # TODO: does this work on an new/empty EFS instance?
+    appExtraVolumeMounts:
+      - name: asset-uploads-efs
+        mountPath: /uploads
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -477,9 +477,6 @@ govukApplications:
     requests:
       memory: 1.5Gi
   helmValues:
-    securityContext:
-      runAsNonRoot: false
-      appContainer: false
     uploadAssets: &whitehall-upload-assets
       path: "/app/public/assets/whitehall"
       s3Directory: "whitehall"

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -475,9 +475,6 @@ govukApplications:
     requests:
       memory: 1.5Gi
   helmValues:
-    securityContext:
-      runAsNonRoot: false
-      appContainer: false
     uploadAssets: &whitehall-upload-assets
       path: "/app/public/assets/whitehall"
       s3Directory: "whitehall"

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           - name: tmp
             mountPath: /tmp
           {{- with .Values.nginxExtraVolumeMounts }}
-          {{ . | toYaml | trim | nindent 10 }}
+            {{ . | toYaml | trim | nindent 10 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -115,8 +115,8 @@ spec:
           name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
       - name: tmp
         emptyDir: {}
-      {{- with .Values.nginxExtraVolumes }}
-      {{ . | toYaml | trim | nindent 6 }}
+      {{- with .Values.extraVolumes }}
+        {{ . | toYaml | trim | nindent 6 }}
       {{- end }}
       - name: {{ .Release.Name }}-asset-uploads-efs
         nfs:

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -64,7 +64,7 @@ workerResources:
     memory: 2Gi
 
 # nfsServer is the address of the NFSv4 (or Amazon EFS) server where uploaded
-nfsServer: "nfs-server"
+nfsServer: "assets"
 
 # dnsConfig is passed directly into the pod specs in the app and worker
 # deployment templates.

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -45,7 +45,7 @@ nginxProxyReadTimeout: 15s
 nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []
-nginxExtraVolumes: []
+extraVolumes: []
 
 appResources:
   limits:

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
             runAsUser: 1001
             runAsGroup: 1001
           {{- end }}
+          {{- with .Values.appExtraVolumeMounts }}
+          volumeMounts:
+            {{ . | toYaml | trim | nindent 12 }}
+          {{- end }}
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -65,12 +65,10 @@ spec:
             failureThreshold: 2
             periodSeconds: 5
           {{- end }}
-          {{- if .Values.securityContext.appContainer }}
           securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 1001
-            runAsGroup: 1001
-          {{- end }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
             {{- . | toYaml | trim | nindent 12 }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           {{- end }}
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
-            {{ . | toYaml | trim | nindent 12 }}
+            {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
@@ -128,5 +128,5 @@ spec:
       - name: tmp
         emptyDir: {}
       {{- with .Values.extraVolumes }}
-        {{ . | toYaml | trim | nindent 6 }}
+        {{- . | toYaml | trim | nindent 6 }}
       {{- end }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -123,6 +123,6 @@ spec:
           name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
       - name: tmp
         emptyDir: {}
-      {{- with .Values.nginxExtraVolumes }}
-      {{ . | toYaml | trim | nindent 6 }}
+      {{- with .Values.extraVolumes }}
+        {{ . | toYaml | trim | nindent 6 }}
       {{- end }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -51,6 +51,10 @@ spec:
             runAsUser: 1001
             runAsGroup: 1001
           {{- end }}
+          {{- with .Values.appExtraVolumeMounts }}
+          volumeMounts:
+            {{ . | toYaml | trim | nindent 12 }}
+          {{- end }}
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
       enableServiceLinks: false

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -45,12 +45,10 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          {{- if .Values.securityContext.appContainer }}
           securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 1001
-            runAsGroup: 1001
-          {{- end }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
             {{- . | toYaml | trim | nindent 12 }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -53,13 +53,17 @@ spec:
           {{- end }}
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
-            {{ . | toYaml | trim | nindent 12 }}
+            {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
       enableServiceLinks: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -48,7 +48,7 @@ nginxProxyReadTimeout: 15s
 nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []
-nginxExtraVolumes: []
+extraVolumes: []
 nginxDenyCrawlers: false
 
 appResources:

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -105,4 +105,6 @@ metricsPort: 9394
 
 securityContext:
   runAsNonRoot: true
-  appContainer: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1001
+  runAsGroup: 1001

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -26,8 +26,8 @@ workerReplicaCount: 2
 # dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
 dbMigrationEnabled: false
 
-# extraVolumes defines Volumes on the app Pods (in both the worker Deployment
-# and the regular Deployment).
+# extraVolumes defines Volumes on the app Pods (in both deployment.yaml and
+# worker-deployment.yaml).
 extraVolumes: []
 
 appImage:
@@ -35,8 +35,8 @@ appImage:
   pullPolicy: Always
   tag: latest
 appPort: 3000
-# appExtraVolumeMounts defines VolumeMounts on the app container (in both the
-# regular Deployment and the worker Deployment).
+# appExtraVolumeMounts defines VolumeMounts on the app container (in both
+# deployment.yaml and worker-deployment.yaml).
 appExtraVolumeMounts: []
 
 # appProbes defines liveness/readiness/startup probes for the app container.

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -26,11 +26,18 @@ workerReplicaCount: 2
 # dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
 dbMigrationEnabled: false
 
+# extraVolumes defines Volumes on the app Pods (in both the worker Deployment
+# and the regular Deployment).
+extraVolumes: []
+
 appImage:
   repository: ""  # Dummy value, overridden in ArgoCD config.
   pullPolicy: Always
   tag: latest
 appPort: 3000
+# appExtraVolumeMounts defines VolumeMounts on the app container (in both the
+# regular Deployment and the worker Deployment).
+appExtraVolumeMounts: []
 
 # appProbes defines liveness/readiness/startup probes for the app container.
 # See templates/deployment.yaml file for the default values.
@@ -48,7 +55,6 @@ nginxProxyReadTimeout: 15s
 nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []
-extraVolumes: []
 nginxDenyCrawlers: false
 
 appResources:


### PR DESCRIPTION
`whitehall-admin` assumes that all of its processes share the same filesystem for uploading asset files.

- Rename nginxExtraVolumes to extraVolumes. There's never been anything nginx-specific about it; it's inherently a pod-level thing.
- Allow passing extra volumeMounts into the app pod spec in charts/govuk-rails-app.
- Use the same NFS (EFS) filer for whitehall-admin asset uploads as for asset-manager asset uploads.
- Use the same UID/GID for whitehall-admin as the old EC2 stack so that we can run in parallel without filesystem permissions issues on the NFS filer.

Tested: installed `whitehall-admin` and `frontend` via Helm and checked that they start up without errors. e.g. `cd charts/argocd-apps && helm install chris-test-wh-admin ../govuk-rails-app --values <(helm template . --values values-integration.yaml |yq e '.|select(.metadata.name=="whitehall-admin").spec.source.helm.values')`