### PR TITLE
Add Prometheus podmonitor to Asset-Manager workers

### DIFF
--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -26,6 +26,10 @@ spec:
       containers:
         - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
           command: ["bundle"]
           args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
           envFrom:

--- a/charts/asset-manager/templates/worker-podmonitor.yaml
+++ b/charts/asset-manager/templates/worker-podmonitor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.workerEnabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}-worker
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-worker
+  podMetricsEndpoints:
+  - port: metrics
+{{- end }}


### PR DESCRIPTION
Similar to #495 but added here because Asset-Manager has its own Helm
chart