### PR TITLE
Fix #501 security asset-manager

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: {{ .Release.Name }}
     spec:
       securityContext:
-        allowPrivilegeEscalation: false
         runAsUser: 1001
         runAsGroup: 1001
         fsGroup: 1001
@@ -69,6 +68,8 @@ spec:
             failureThreshold: 2
             periodSeconds: 5
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
@@ -99,6 +100,8 @@ spec:
           {{- with .Values.nginxExtraVolumeMounts }}
           {{ . | toYaml | trim | nindent 10 }}
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
       securityContext:
         runAsUser: 1001
         runAsGroup: 1001
-        fsGroup: 1001
       containers:
         - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -70,6 +69,10 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            # Asset Manager needs to run as 2899 since it shares the same NFS volume with
+            # EC2 counterpart
+            runAsUser: 2899
+            runAsGroup: 2899
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -23,7 +23,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-        allowPrivilegeEscalation: false
         runAsUser: 1001
         runAsGroup: 1001
         fsGroup: 1001
@@ -54,6 +53,8 @@ spec:
               mountPath: /var/apps/
             - name: clam-virus-db
               mountPath: /var/lib/clamav
+          securityContext:
+            allowPrivilegeEscalation: false
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
         - name: freshclam
@@ -67,6 +68,8 @@ spec:
           volumeMounts:
             - name: clam-virus-db
               mountPath: /var/lib/clamav
+          securityContext:
+            allowPrivilegeEscalation: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -23,9 +23,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-        runAsUser: 1001
-        runAsGroup: 1001
-        fsGroup: 1001
+        # Asset Manager needs to run as 2899 since it shares the same NFS volume with 
+        # EC2 counterpart
+        runAsUser: 2899
+        runAsGroup: 2899
       containers:
         - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"


### PR DESCRIPTION
1. AllowPrivilegeEscalation can only be used at container level
2. Asset Manager needs to run as 2899 since it shares the same NFS volume with
EC2 counterpart