### PR TITLE
Fix Clamav of Asset-manager

### DIFF
--- a/charts/asset-manager/templates/freshclam-configmap.yaml
+++ b/charts/asset-manager/templates/freshclam-configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-clamd-conf
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  clamd.conf: |-
+
+    LogTime yes
+    LogSyslog yes
+    LogVerbose yes
+    ExtendedDetectionInfo yes
+    TCPSocket 3310
+    TCPAddr 127.0.0.1
+    MaxConnectionQueueLength 50
+    StreamMaxLength 50M
+    MaxThreads 20
+    ReadTimeout 120
+    DetectPUA no
+    AlgorithmicDetection yes
+    ScanPE yes
+    ScanELF yes
+    ScanOLE2 yes
+    OLE2BlockMacros no
+    ScanPDF yes
+    ScanMail yes
+    MaxScanSize 250M
+    MaxFileSize 105M
+    TemporaryDirectory /tmp

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-        # Asset Manager needs to run as 2899 since it shares the same NFS volume with 
+        # Asset Manager needs to run as 2899 since it shares the same NFS volume with
         # EC2 counterpart
         runAsUser: 2899
         runAsGroup: 2899
@@ -69,6 +69,9 @@ spec:
           volumeMounts:
             - name: clam-virus-db
               mountPath: /var/lib/clamav
+            - name: clamd-conf
+              mountPath: /etc/clamav/clamd.conf
+              subPath: clamd.conf
           securityContext:
             allowPrivilegeEscalation: false
       {{- with .Values.dnsConfig }}
@@ -82,4 +85,7 @@ spec:
           path: /
       - name: clam-virus-db
         emptyDir: {}
+      - name: clamd-conf
+        configMap:
+          name: {{ .Release.Name }}-clamd-conf
 {{- end }}


### PR DESCRIPTION
It is currently complaining about missing the clamd.conf so added it
from EC2 integration