### PR TITLE
Add Clamav config

### DIFF
--- a/charts/asset-manager/templates/clamd-configmap.yaml
+++ b/charts/asset-manager/templates/clamd-configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-freshclam-conf
+  name: {{ .Release.Name }}-clamd-conf
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
 data:
-  freshclam.conf: |-
+  clamd.conf: |-
 
     LogTime yes
     LogSyslog yes

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -54,6 +54,9 @@ spec:
               mountPath: /var/apps/
             - name: clam-virus-db
               mountPath: /var/lib/clamav
+            - name: clamd-conf
+              mountPath: /etc/clamav/clamd.conf
+              subPath: clamd.conf
           securityContext:
             allowPrivilegeEscalation: false
           # TODO: consider implementing a liveness probe for Sidekiq
@@ -72,6 +75,9 @@ spec:
             - name: clamd-conf
               mountPath: /etc/clamav/clamd.conf
               subPath: clamd.conf
+            - name: freshclam-conf
+              mountPath: /etc/clamav/freshclam.conf
+              subPath: freshclam.conf
           securityContext:
             allowPrivilegeEscalation: false
       {{- with .Values.dnsConfig }}
@@ -88,4 +94,7 @@ spec:
       - name: clamd-conf
         configMap:
           name: {{ .Release.Name }}-clamd-conf
+      - name: freshclam-conf
+        configMap:
+          name: {{ .Release.Name }}-freshclam-conf
 {{- end }}


### PR DESCRIPTION
Add missing freshclam [config](https://github.com/alphagov/govuk-puppet/blob/32c1bbbb10067078c1406170666a135b4a10aaea/modules/clamav/manifests/config.pp#L14).

Add clamd config to worker containers as well, before it was only on the
freshclam containers but this is a shared config.