### PR TITLE
Fix Clamav for Asset-manager

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -22,13 +22,14 @@ govukApplications:
       hosts:
       - name: asset-manager.eks.integration.govuk.digital
     workerReplicaCount: 1
-    nfsServer: &assets-nfs assets.blue.integration.govuk-internal.digital
+    assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
+    clamavNFS: clamav-db-govuk.integration.govuk-internal.digital
     nginxConfigMap:
       create: false
       name: asset-manager-nginx-conf
     extraEnv:
       - name: ASSET_MANAGER_CLAMSCAN_PATH
-        value: /usr/bin/clamscan  # TODO: Clamscan hasn't been tested yet, will update it to correct values after testing
+        value: /usr/bin/clamdscan
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -1,0 +1,41 @@
+{{- define "asset-manager.freshclam.podspec" }}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    # Asset Manager needs to run as 2899 since it shares the same NFS volume with
+    # EC2 counterpart
+    runAsUser: 2899
+    runAsGroup: 2899
+    fsGroup: 2899
+  containers:
+    - name: freshclam
+      image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+      imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+      command: ["freshclam"]
+      {{ with .Values.freshclamResources }}
+      resources:
+        {{- . | toYaml | trim | nindent 15 }}
+      {{ end }}
+      volumeMounts:
+        - name: clam-virus-db
+          mountPath: /var/lib/clamav
+        - name: clamd-conf
+          mountPath: /etc/clamav/clamd.conf
+          subPath: clamd.conf
+        - name: freshclam-conf
+          mountPath: /etc/clamav/freshclam.conf
+          subPath: freshclam.conf
+      securityContext:
+        allowPrivilegeEscalation: false
+  volumes:
+  - name: clam-virus-db
+    nfs:
+      server: "{{ .Values.clamavNFS }}"
+      path: /
+  - name: clamd-conf
+    configMap:
+      name: {{ .Release.Name }}-clamd-conf
+  - name: freshclam-conf
+    configMap:
+      name: {{ .Release.Name }}-freshclam-conf
+{{- end }}

--- a/charts/asset-manager/templates/clamd-configmap.yaml
+++ b/charts/asset-manager/templates/clamd-configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-clamd-conf
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clamd
+data:
+  clamd.conf: |-
+
+    LogTime yes
+    LogSyslog yes
+    LogVerbose yes
+    ExtendedDetectionInfo yes
+    TCPSocket 3310
+    TCPAddr 127.0.0.1
+    MaxConnectionQueueLength 50
+    StreamMaxLength 50M
+    MaxThreads 20
+    ReadTimeout 120
+    DetectPUA no
+    AlgorithmicDetection yes
+    ScanPE yes
+    ScanELF yes
+    ScanOLE2 yes
+    OLE2BlockMacros no
+    ScanPDF yes
+    ScanMail yes
+    MaxScanSize 250M
+    MaxFileSize 105M
+    TemporaryDirectory /tmp

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           volumeMounts:
-            - name: {{ .Release.Name }}-asset-uploads-efs
+            - name: assets-efs
               mountPath: /var/apps/
           ports:
             - name: http
@@ -118,7 +118,7 @@ spec:
       {{- with .Values.extraVolumes }}
         {{ . | toYaml | trim | nindent 6 }}
       {{- end }}
-      - name: {{ .Release.Name }}-asset-uploads-efs
+      - name: assets-efs
         nfs:
-          server: {{ .Values.nfsServer }}
+          server: {{ .Values.assetManagerNFS }}
           path: /

--- a/charts/asset-manager/templates/freshclam-configmap.yaml
+++ b/charts/asset-manager/templates/freshclam-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-freshclam-conf
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: freshclam
 data:
   freshclam.conf: |-
 

--- a/charts/asset-manager/templates/freshclam-cronjob.yaml
+++ b/charts/asset-manager/templates/freshclam-cronjob.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-freshclam
+spec:
+  schedule: "19 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- include "asset-manager.freshclam.podspec" . | indent 8 }}
+          restartPolicy: Never

--- a/charts/asset-manager/templates/freshclam-presync.yaml
+++ b/charts/asset-manager/templates/freshclam-presync.yaml
@@ -1,0 +1,10 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-update-freshclam
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+spec:
+  template:
+    spec:
+      {{- include "asset-manager.freshclam.podspec" . | indent 4 }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.workerEnabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,7 +50,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: {{ .Release.Name }}-asset-uploads-efs
+            - name: assets-efs
               mountPath: /var/apps/
             - name: clam-virus-db
               mountPath: /var/lib/clamav
@@ -62,23 +61,23 @@ spec:
             allowPrivilegeEscalation: false
           # TODO: consider implementing a liveness probe for Sidekiq
           # e.g. https://github.com/arturictus/sidekiq_alive
-        - name: freshclam
+        - name: clamd
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-          command: ["/bin/sh"]
-          args: ["-c", "freshclam -d --stdout --foreground"]
-          {{- with .Values.workerResources }}
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+          command: ["clamd"]
+          args: ["-d"]
+          {{- with .Values.clamdResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: assets-efs
+              mountPath: /var/apps/
             - name: clam-virus-db
               mountPath: /var/lib/clamav
             - name: clamd-conf
               mountPath: /etc/clamav/clamd.conf
               subPath: clamd.conf
-            - name: freshclam-conf
-              mountPath: /etc/clamav/freshclam.conf
-              subPath: freshclam.conf
           securityContext:
             allowPrivilegeEscalation: false
       {{- with .Values.dnsConfig }}
@@ -86,16 +85,17 @@ spec:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ .Release.Name }}-asset-uploads-efs
+      - name: assets-efs
         nfs:
-          server: "{{ .Values.nfsServer }}"
+          server: "{{ .Values.assetManagerNFS }}"
           path: /
       - name: clam-virus-db
-        emptyDir: {}
+        nfs:
+          server: "{{ .Values.clamavNFS }}"
+          path: /
       - name: clamd-conf
         configMap:
           name: {{ .Release.Name }}-clamd-conf
       - name: freshclam-conf
         configMap:
           name: {{ .Release.Name }}-freshclam-conf
-{{- end }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -20,8 +20,6 @@ ingress:
 
 replicaCount: 1
 
-# workerEnabled should be true if the app uses Sidekiq, false otherwise.
-workerEnabled: true
 workerReplicaCount: 1
 
 appImage:
@@ -63,8 +61,26 @@ workerResources:
     cpu: 500m
     memory: 2Gi
 
-# nfsServer is the address of the NFSv4 (or Amazon EFS) server where uploaded
-nfsServer: "assets"
+freshclamResources:
+  limits:
+    cpu: 1
+    memory: 512Mi
+  requests:
+    cpu: 500m
+    memory: 256Mi
+
+clamdResources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi
+
+# assetManagerNFS is the address of the NFSv4 (or Amazon EFS) server where uploaded
+assetManagerNFS: "asset-manager-efs.dev.gov.uk"
+# assetManagerNFS is the address of the NFSv4 (or Amazon EFS) server where Clamav stores virus database
+clamavNFS: "clamav-efs.dev.gov.uk"
 
 # dnsConfig is passed directly into the pod specs in the app and worker
 # deployment templates.


### PR DESCRIPTION
Fixes:

1. In the worker pod, we run clamd (daemon verion of clamav).
   This seems to lead to no killed clamav scans and also this is
   how it is currently run in EC2 rather than being run standalone.

2. Remove the freshclam (updates virus database of clamav)
   container from continuously running in the worker pod and set
   it to run as presync and then run a cronjob every hour for it.

3. Use clamav EFS to share virus databases across all clamav containers.
   (https://github.com/alphagov/govuk-infrastructure/pull/725)

Related PRs:
1. [asset-manager dockerfile](https://github.com/alphagov/asset-manager/pull/938)