### PR TITLE
Run dbmigrate jobs in the same way as upload-assets jobs.

### DIFF
--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -1,34 +1,26 @@
 {{- if .Values.dbMigrationEnabled -}}
-{{/*
-k8s Jobs are immutable but Helm still tries to patch them when they change, so
-we suffix the name with the chart version and image tag to create a new one
-when the chart or the binary changes. This workaround doesn't work when moving
-a mutable tag (like "latest"), but we shouldn't be using those anyway.
-*/}}
-{{- $chartVersionNoDots := .Chart.Version | replace "." "-" }}
-{{- $jobName := print .Release.Name "-dbmigrate-" $chartVersionNoDots "-" (trunc 7 .Values.appImage.tag) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $jobName }}
+  name: {{ .Release.Name }}-dbmigrate
   labels:
     {{- include "govuk-rails-app.labels" . | nindent 4 }}
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: dbmigrate
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/hook: PreSync
 spec:
   template:
     metadata:
-      name: {{ $jobName }}
+      name: {{ .Release.Name }}-dbmigrate
       labels:
         {{- include "govuk-rails-app.labels" . | nindent 8 }}
-        app.kubernetes.io/component: web
+        app.kubernetes.io/component: dbmigrate
     spec:
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       restartPolicy: Never
       containers:
-        - name: {{ $jobName }}
+        - name: dbmigrate
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           command: ["bundle"]
           args: ["exec", "rails", "db:migrate"]


### PR DESCRIPTION
Argo is still sometimes failing syncs by trying to change the (immutable) Job objects for the dbmigrate jobs. Change them to run in the same way as the upload-assets jobs, which don't seem to have this problem.

This makes the dbmigrate job run as a presync hook, whereas previously it just ran as part of the main sync. I think presync is probably somewhat preferable since the failure mode when the job fails is both safer (because it holds up the rollout) and more visible (because it holds up the rollout!)

As a bonus, we get to ditch a bunch of somewhat complicated guff from
the Helm chart.

Example of a sync getting stuck with the previous config:

```
one or more synchronization tasks completed unsuccessfully, reason:
error when replacing "/dev/shm/761223060":
Job.batch "signon-dbmigrate-0-1-4-37f8bf3" is invalid:
[spec.selector:
Required value, spec.template.metadata.labels:
Invalid value:
map[string]string{"app.kubernetes.io/component":"web", "app.kubernetes.io/instance":"signon", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"signon", "helm.sh/chart":"signon-0.1.4"}:
`selector` does not match template `labels`, spec.selector:
Invalid value:
"null":
field is immutable, spec.template:
Invalid value:
core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"signon-dbmigrate-0-1-4-37f8bf3", ...}}
field is immutable]. Retrying attempt #2 at 3:17PM.
```