### PR TITLE
Add Signon URI rewrite env vars

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -903,6 +903,10 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: SIGNON_APPS_URI_SUB_PATTERN
+        value: integration.publishing.service.gov.uk
+      - name: SIGNON_APPS_URI_SUB_REPLACEMENT
+        value: eks.integration.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -408,6 +408,10 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+      - name: SIGNON_APPS_URI_SUB_PATTERN
+        value: publishing.service.gov.uk
+      - name: SIGNON_APPS_URI_SUB_REPLACEMENT
+        value: eks.production.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -406,6 +406,10 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: SIGNON_APPS_URI_SUB_PATTERN
+        value: staging.publishing.service.gov.uk
+      - name: SIGNON_APPS_URI_SUB_REPLACEMENT
+        value: eks.staging.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This configures Signon to re-write redirect and home URIs for OAuth applications to be correct for the EKS infrastructure.