### PR TITLE
Asset-Manager: switch to EFS CSI driver and PersistentVolumeClaim

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -23,7 +23,6 @@ govukApplications:
       - name: asset-manager.eks.integration.govuk.digital
     workerReplicaCount: 1
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
-    clamavNFS: clamav-db-govuk.integration.govuk-internal.digital
     nginxConfigMap:
       create: false
       name: asset-manager-nginx-conf

--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -29,9 +29,8 @@
         allowPrivilegeEscalation: false
   volumes:
   - name: clam-virus-db
-    nfs:
-      server: "{{ .Values.clamavNFS }}"
-      path: /
+    persistentVolumeClaim:
+        claimName: clamav-db
   - name: clamd-conf
     configMap:
       name: {{ .Release.Name }}-clamd-conf

--- a/charts/asset-manager/templates/clamav-db-persistentvolumeclaim.yaml
+++ b/charts/asset-manager/templates/clamav-db-persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clamav-db
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: clamav-db-efs-sc
+  resources:
+    requests:
+      storage: 1Gi

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -90,9 +90,8 @@ spec:
           server: "{{ .Values.assetManagerNFS }}"
           path: /
       - name: clam-virus-db
-        nfs:
-          server: "{{ .Values.clamavNFS }}"
-          path: /
+        persistentVolumeClaim:
+          claimName: clamav-db
       - name: clamd-conf
         configMap:
           name: {{ .Release.Name }}-clamd-conf

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -79,8 +79,6 @@ clamdResources:
 
 # assetManagerNFS is the address of the NFSv4 (or Amazon EFS) server where uploaded
 assetManagerNFS: "asset-manager-efs.dev.gov.uk"
-# clamavNFS is the address of the NFSv4 (or Amazon EFS) server where Clamav stores virus database
-clamavNFS: "clamav-efs.dev.gov.uk"
 
 # dnsConfig is passed directly into the pod specs in the app and worker
 # deployment templates.


### PR DESCRIPTION
Due to the issue with non-root asset-manager trying to use a root
NFS volume created in AWS/terraform directly. We move to using the
EFS CSI driver and PersistentVolumeClaim.

See related PR: https://github.com/alphagov/govuk-infrastructure/pull/725