### PR TITLE
Fix Grafana Dashboards

### DIFF
--- a/charts/grafana-dashboards/templates/apps-dashboard-configmap.yaml
+++ b/charts/grafana-dashboards/templates/apps-dashboard-configmap.yaml
@@ -8,7 +8,5 @@ metadata:
     grafana_dashboard: "1"
     namespace: monitoring
 data:
-  # Original source of the dashboard is: https://github.com/mrnetops/fastly-dashboards/blob/main/grafana/provisioning/dashboards/Fastly-Dashboard.json
-  # with some modifications to fit GOV.UK needs
-  dashboard.json: |-
+  apps.json: |-
     {{- .Files.Get "apps-dashboard.json" | nindent 4 }}

--- a/charts/grafana-dashboards/templates/router-dashboard-configmap.yaml
+++ b/charts/grafana-dashboards/templates/router-dashboard-configmap.yaml
@@ -8,7 +8,5 @@ metadata:
     grafana_dashboard: "1"
     namespace: monitoring
 data:
-  # Original source of the dashboard is: https://github.com/mrnetops/fastly-dashboards/blob/main/grafana/provisioning/dashboards/Fastly-Dashboard.json
-  # with some modifications to fit GOV.UK needs
-  dashboard.json: |-
+  router.json: |-
     {{- .Files.Get "router-dashboard.json" | nindent 4 }}

--- a/charts/grafana-dashboards/templates/sidekiq-dashboard-configmap.yaml
+++ b/charts/grafana-dashboards/templates/sidekiq-dashboard-configmap.yaml
@@ -8,7 +8,5 @@ metadata:
     grafana_dashboard: "1"
     namespace: monitoring
 data:
-  # Original source of the dashboard is: https://github.com/mrnetops/fastly-dashboards/blob/main/grafana/provisioning/dashboards/Fastly-Dashboard.json
-  # with some modifications to fit GOV.UK needs
-  dashboard.json: |-
+  sidekiq.json: |-
     {{- .Files.Get "sidekiq-dashboard.json" | nindent 4 }}


### PR DESCRIPTION
1. some config maps shared the same key: dasboards.json which
   can lead to conflicts because they are projected on the same files.
2. remove some notes copied by error