### PR TITLE
Govuk-rails-app: fix security context

### DIFF
--- a/charts/govuk-rails-app/templates/assets-upload-job.yaml
+++ b/charts/govuk-rails-app/templates/assets-upload-job.yaml
@@ -13,6 +13,8 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
       initContainers:
       - name: {{ .Release.Name }}-copy-assets-for-upload
         image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
@@ -25,8 +27,6 @@ spec:
           mountPath: /assets-to-upload
         securityContext:
           allowPrivilegeEscalation: false
-          runAsUser: 1001
-          runAsGroup: 1001
       containers:
       - name: {{ .Release.Name }}-upload-assets
         image: public.ecr.aws/bitnami/aws-cli

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -18,6 +18,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
       restartPolicy: Never
       containers:
         - name: dbmigrate
@@ -39,6 +41,4 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsUser: 1001
-            runAsGroup: 1001
 {{- end }}

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -67,8 +69,6 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.securityContext.runAsGroup }}
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
             {{- . | toYaml | trim | nindent 12 }}
@@ -101,8 +101,6 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsUser: 1001
-            runAsGroup: 1001
           volumeMounts:
           - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -23,6 +23,8 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -47,8 +49,6 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.securityContext.runAsGroup }}
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
             {{- . | toYaml | trim | nindent 12 }}


### PR DESCRIPTION
Set runAsUser and runAsGroup at the pod level throughout.
Keeps things consistent for an app.

Solve the issue with upload-assets job with error:
"Init:container has runAsNonRoot and image has non-numeric user (app), cannot verify user is non-root"