### PR TITLE
Add option to disable Sentry for govuk app

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -967,6 +967,8 @@ govukApplications:
 - name: govuk-replatform-test-app
   repoName: govuk-replatform-test-app
   helmValues:
+    sentry:
+      enabled: false
     uploadAssets:
       enabled: false
     appPort: 9292

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.appPort }}"
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
@@ -43,6 +44,7 @@ spec:
                   key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            {{- end }}
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}

--- a/charts/govuk-rails-app/templates/sentry-external-secret.yml
+++ b/charts/govuk-rails-app/templates/sentry-external-secret.yml
@@ -1,3 +1,4 @@
+{{- if .Values.sentry.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -20,3 +21,4 @@ spec:
       remoteRef:
         key: govuk/common/sentry
         property: {{ .Release.Name }}-dsn
+{{- end }}

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -108,3 +108,6 @@ securityContext:
   allowPrivilegeEscalation: false
   runAsUser: 1001
   runAsGroup: 1001
+
+sentry:
+  enabled: true


### PR DESCRIPTION
The test govuk app does not need Sentry configured. This adds configuration to disable creating Sentry secrets and setting env vars.

https://trello.com/c/kbrv62b4