### PR TITLE
Add SENTRY_DSN to workers containers

### DIFF
--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -38,8 +38,15 @@ spec:
             - configMapRef:
                 name: govuk-apps-env
           env:
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-sentry
+                  key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            {{- end }}
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
This adds missing env var needed to configure sentry on govuk-app worker containers.

https://trello.com/c/kbrv62b4