### PR TITLE
Enable JSON formatted Ngnix logs for apps

### DIFF
--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -63,6 +63,36 @@ data:
        '' "max-age=31536000; preload";
       }
 
+      log_format json_event '{ "@timestamp": "$time_iso8601", '
+                           '"remote_addr": "$remote_addr", '
+                           '"remote_user": "$remote_user", '
+                           '"body_bytes_sent": $body_bytes_sent, '
+                           '"bytes_sent": $bytes_sent, '
+                           '"request": "$request", '
+                           '"request_method": "$request_method", '
+                           '"request_uri": "$request_uri", '
+                           '"request_time": $request_time, '
+                           '"upstream_response_time": "$upstream_response_time", '
+                           '"upstream_addr": "$upstream_addr", '
+                           '"gzip_ratio": "$gzip_ratio", '
+                           '"sent_http_x_cache": "$sent_http_x_cache", '
+                           '"sent_http_location": "$sent_http_location", '
+                           '"sent_http_content_type": "$sent_http_content_type", '
+                           '"server_name": "$server_name", '
+                           '"server_port": "$server_port", '
+                           '"server_protocol": "$server_protocol", '
+                           '"status": $status, '
+                           '"http_host": "$http_host", '
+                           '"http_referer": "$http_referer", '
+                           '"http_user_agent": "$http_user_agent", '
+                           '"govuk_request_id": "$http_govuk_request_id", '
+                           '"govuk_original_url": "$http_govuk_original_url", '
+                           '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
+                           '"varnish_id": "$http_x_varnish", '
+                           '"ssl_protocol": "$ssl_protocol", '
+                           '"ssl_cipher": "$ssl_cipher", '
+                           '"http_x_forwarded_for": "$http_x_forwarded_for" }';
+
       upstream {{ .Release.Name }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }
@@ -71,6 +101,9 @@ data:
         listen {{ .Values.nginxPort }};
         proxy_connect_timeout {{ .Values.nginxProxyConnectTimeout }};
         proxy_read_timeout    {{ .Values.nginxProxyReadTimeout }};
+
+        access_log /dev/stdout json_event;
+        error_log /dev/stderr;
 
         add_header Strict-Transport-Security $sts_default;
         add_header Permissions-Policy interest-cohort=();


### PR DESCRIPTION
This changes ngnix logs to be json formatted so they can be parsed by logit.