### PR TITLE
Fix content store BACKNED_URL for router

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -223,7 +223,7 @@ govukApplications:
       - name: BACKEND_URL_collections
         value: "http://draft-collections"
       - name: BACKEND_URL_content-store
-        value: "http://draft-content-store"
+        value: "https://draft-content-store.integration.govuk-internal.digital"
       - name: BACKEND_URL_email-alert-frontend
         value: "http://draft-email-alert-frontend"
       - name: BACKEND_URL_frontend
@@ -737,7 +737,7 @@ govukApplications:
       - name: BACKEND_URL_collections
         value: "http://collections"
       - name: BACKEND_URL_content-store
-        value: "http://content-store"
+        value: "https://content-store.integration.govuk-internal.digital"
       - name: BACKEND_URL_email-alert-frontend
         value: "http://email-alert-frontend"
       - name: BACKEND_URL_frontend

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -332,7 +332,7 @@ govukApplications:
       - name: BACKEND_URL_collections
         value: "http://collections"
       - name: BACKEND_URL_content-store
-        value: "http://content-store"
+        value: "https://content-store.production.govuk-internal.digital"
       - name: BACKEND_URL_email-alert-frontend
         value: "http://email-alert-frontend"
       - name: BACKEND_URL_frontend

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -330,7 +330,7 @@ govukApplications:
       - name: BACKEND_URL_collections
         value: "http://collections"
       - name: BACKEND_URL_content-store
-        value: "http://content-store"
+        value: "https://content-store.staging.govuk-internal.digital"
       - name: BACKEND_URL_email-alert-frontend
         value: "http://email-alert-frontend"
       - name: BACKEND_URL_frontend


### PR DESCRIPTION
Content store is currently not running in the EKS infra, hence requests should be forwarded to content store in the old infra.