### PR TITLE
Fix ASSET_HOST domain

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -2,6 +2,7 @@ globalHelmValues:
   govukEnvironment: integration
   externalDomainSuffix: eks.integration.govuk.digital
   publishingServiceDomainSuffix: integration.publishing.service.gov.uk
+  assetDomain: integration.publishing.service.gov.uk
   appResources:
     limits:
       cpu: 1

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -2,6 +2,7 @@ globalHelmValues:
   govukEnvironment: production
   externalDomainSuffix: eks.production.govuk.digital
   publishingServiceDomainSuffix: publishing.service.gov.uk
+  assetDomain: gov.uk
   appResources:
     limits:
       cpu: 1
@@ -70,7 +71,7 @@ govukApplications:
   helmValues:
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-        value: b5baae45-0a68-4b63-91a1-66b05640d27e 
+        value: b5baae45-0a68-4b63-91a1-66b05640d27e
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
         value: ceefedd7-3214-4774-8b57-f27c89aac90d
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -2,6 +2,7 @@ globalHelmValues:
   govukEnvironment: staging
   externalDomainSuffix: eks.staging.govuk.digital
   publishingServiceDomainSuffix: staging.publishing.service.gov.uk
+  assetDomain: staging.publishing.service.gov.uk
   appResources:
     limits:
       cpu: 1

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   {{- /* TODO: omit namespace from these user-facing URLs in the default namespace. */}}
   {{- /* TODO: delete PLEK_SERVICE_*_URI once Plek can construct http:// internal URLs. */}}
-  ASSET_HOST: https://www.{{ .Values.externalDomainSuffix }}
+  ASSET_HOST: https://www.{{ .Values.assetDomain }}
   GOVUK_APP_DOMAIN: {{ .Values.internalDomainSuffix }}
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -2,6 +2,7 @@ govukEnvironment: test
 internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital
 publishingServiceDomainSuffix: test.publishing.service.gov.uk
+assetDomain: test.publishing.service.gov.uk
 ec2InternalDomainSuffix: govuk-internal.digital
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.


### PR DESCRIPTION
Quickfix for ASSET_HOST which must have value: https://www.gov.uk
in production.