### PR TITLE
Remove promotion step when nextEnvironment is not set

### DIFF
--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -28,6 +28,7 @@ spec:
               parameters:
                 - name: extra-args
                   value: "{{" and @app-{{workflow.parameters.application}}"}}"
+          {{ if .Values.nextEnvironment }}
           - name: promote-release
             depends: smoke-test.Succeeded
             templateRef:
@@ -41,6 +42,7 @@ spec:
                   value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: imageTag
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
+          {{- end }}
 
     - name: exit-handler
       steps:


### PR DESCRIPTION
This removes the deployment promotion step from the postsync workflow when the nextEnvironment variable is not set. This fixes an issue in production where no promotion is required - however the postsync job fails as workflow tries to promote the deploy without a nextEnvironment.