### PR TITLE
Allow cross communication between EKS and EC2 www-origins

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -711,6 +711,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - www-origin.eks.integration.govuk.digital

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -254,44 +254,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
-        # This is the union of these two lists:
-        # - https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
-        # - https://api.fastly.com/public-ip-list
-        # TODO: move this ACL into Terraform by defining a security group in TF
-        # (using the Fastly TF provider to fetch the Fastly netblocks from
-        # their API, plus the GDS netblocks), passing the security group ID
-        # into the chart and associating it with the ALB using the
-        # alb.ingress.kubernetes.io/security-groups annotation.
-        alb.ingress.kubernetes.io/inbound-cidrs: >-
-          213.86.153.211/32,
-          213.86.153.212/32,
-          213.86.153.213/32,
-          213.86.153.214/32,
-          213.86.153.231/32,
-          213.86.153.235/32,
-          213.86.153.236/32,
-          213.86.153.237/32,
-          51.149.8.0/25,
-          51.149.8.128/29,
-          23.235.32.0/20,
-          43.249.72.0/22,
-          103.244.50.0/24,
-          103.245.222.0/23,
-          103.245.224.0/24,
-          104.156.80.0/20,
-          140.248.64.0/18,
-          140.248.128.0/17,
-          146.75.0.0/17,
-          151.101.0.0/16,
-          157.52.64.0/18,
-          167.82.0.0/17,
-          167.82.128.0/20,
-          167.82.160.0/20,
-          167.82.224.0/20,
-          172.111.64.0/18,
-          185.31.16.0/22,
-          199.27.72.0/21,
-          199.232.0.0/16
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - www-origin.eks.production.govuk.digital

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -251,44 +251,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
-        # This is the union of these two lists:
-        # - https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
-        # - https://api.fastly.com/public-ip-list
-        # TODO: move this ACL into Terraform by defining a security group in TF
-        # (using the Fastly TF provider to fetch the Fastly netblocks from
-        # their API, plus the GDS netblocks), passing the security group ID
-        # into the chart and associating it with the ALB using the
-        # alb.ingress.kubernetes.io/security-groups annotation.
-        alb.ingress.kubernetes.io/inbound-cidrs: >-
-          213.86.153.211/32,
-          213.86.153.212/32,
-          213.86.153.213/32,
-          213.86.153.214/32,
-          213.86.153.231/32,
-          213.86.153.235/32,
-          213.86.153.236/32,
-          213.86.153.237/32,
-          51.149.8.0/25,
-          51.149.8.128/29,
-          23.235.32.0/20,
-          43.249.72.0/22,
-          103.244.50.0/24,
-          103.245.222.0/23,
-          103.245.224.0/24,
-          104.156.80.0/20,
-          140.248.64.0/18,
-          140.248.128.0/17,
-          146.75.0.0/17,
-          151.101.0.0/16,
-          157.52.64.0/18,
-          167.82.0.0/17,
-          167.82.128.0/20,
-          167.82.160.0/20,
-          167.82.224.0/20,
-          172.111.64.0/18,
-          185.31.16.0/22,
-          199.27.72.0/21,
-          199.232.0.0/16
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
       hosts:
       - www-origin.eks.staging.govuk.digital


### PR DESCRIPTION
See [PR](https://github.com/alphagov/govuk-infrastructure/pull/730)
for security group created and consequences.