### PR TITLE
Update router alert rule serverity to page

### DIFF
--- a/charts/govuk-apps-conf/rules/router/alerts.yaml
+++ b/charts/govuk-apps-conf/rules/router/alerts.yaml
@@ -5,7 +5,7 @@ groups:
     expr: sum(rate(router_backend_handler_response_duration_seconds_count{response_code=~"^5..", job="apps/router"}[5m])) / sum(rate(router_backend_handler_response_duration_seconds_count{job="apps/router"}[5m])) > 0.1
     for: 10m
     labels:
-        severity: critical
+        severity: page
     annotations:
         summary: "High 5xx error rate for apps/router"
         description: "apps/router has high 5xx error rate for more than 10 minutes."

--- a/charts/govuk-apps-conf/rules/router/tests.yaml
+++ b/charts/govuk-apps-conf/rules/router/tests.yaml
@@ -19,7 +19,7 @@ tests:
             exp_alerts:
                 # This alert will trigger when the apps/router error ratio is >0.1 for more than 10 minutes.
                 - exp_labels:
-                      severity: critical
+                      severity: page
                   exp_annotations:
                       summary: "High 5xx error rate for apps/router"
                       description: "apps/router has high 5xx error rate for more than 10 minutes."


### PR DESCRIPTION
## What 

update router alert severity to page so that it will trigger a pagerduty call when there are high number of router alerts.