### PR TITLE
Sync k8s auto-deploys-enabled flags with EC2.

### DIFF
--- a/charts/argocd-apps/image-tags/integration/asset-manager
+++ b/charts/argocd-apps/image-tags/integration/asset-manager
@@ -1,2 +1,2 @@
 image_tag: 645f4e31c4da1f707c9189374e835394c7b5985f
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/authenticating-proxy
+++ b/charts/argocd-apps/image-tags/integration/authenticating-proxy
@@ -1,2 +1,2 @@
 image_tag: 0e655f12302c9582ae68a14148bff108edec19e8
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/collections
+++ b/charts/argocd-apps/image-tags/integration/collections
@@ -1,2 +1,2 @@
 image_tag: 689ea04309b44e664b0ff949b399a5578f2c78ee
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/router-api
+++ b/charts/argocd-apps/image-tags/integration/router-api
@@ -1,2 +1,2 @@
 image_tag: 11bee1b2382681d9936eba01f11c0ed8ae7ef161
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/search-api
+++ b/charts/argocd-apps/image-tags/integration/search-api
@@ -1,2 +1,2 @@
 image_tag: 34b89513f1a5b62e4f1045c152acb7b4a39704f5
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/smokey
+++ b/charts/argocd-apps/image-tags/integration/smokey
@@ -1,2 +1,2 @@
 image_tag: 82fdbc8ca6c2519cd31216044bf5da5af0ca782d
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/integration/static
+++ b/charts/argocd-apps/image-tags/integration/static
@@ -1,2 +1,2 @@
 image_tag: dea9d162882005b2205575a368d1b771744effcb
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/smokey
+++ b/charts/argocd-apps/image-tags/production/smokey
@@ -1,2 +1,2 @@
 image_tag: 82fdbc8ca6c2519cd31216044bf5da5af0ca782d
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/collections
+++ b/charts/argocd-apps/image-tags/staging/collections
@@ -1,2 +1,2 @@
 image_tag: 87ceef2facfee5c38d3b8f24c2ca62d5db52c2ec
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/email-alert-frontend
+++ b/charts/argocd-apps/image-tags/staging/email-alert-frontend
@@ -1,2 +1,2 @@
 image_tag: 97e18c151b5005f0cf857e7c55cc354916b9fba5
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/licence-finder
+++ b/charts/argocd-apps/image-tags/staging/licence-finder
@@ -1,2 +1,2 @@
 image_tag: d513c84fcd8dff5aeb956759976fc29627422177
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/argocd-apps/image-tags/staging/router
+++ b/charts/argocd-apps/image-tags/staging/router
@@ -1,2 +1,2 @@
 image_tag: d4da1ee595b9dbeb0a39495295d59e21dd2c2d41
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/argocd-apps/image-tags/staging/signon
+++ b/charts/argocd-apps/image-tags/staging/signon
@@ -1,2 +1,2 @@
 image_tag: 510bf4b2460be2639e37016f153d1d94967dbb19
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/argocd-apps/image-tags/staging/smokey
+++ b/charts/argocd-apps/image-tags/staging/smokey
@@ -1,2 +1,2 @@
 image_tag: 82fdbc8ca6c2519cd31216044bf5da5af0ca782d
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/static
+++ b/charts/argocd-apps/image-tags/staging/static
@@ -1,2 +1,2 @@
 image_tag: 0d773ffd938d1c1704353d89be70a138b039c31a
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false


### PR DESCRIPTION
Router, licence-finder, static and signon are still manually deployed; everything else should be auto. Everything in integration should be auto.