### PR TITLE
Remove disused image-tags files for manuals-frontend.

### DIFF
--- a/charts/argocd-apps/image-tags/integration/manuals-frontend
+++ b/charts/argocd-apps/image-tags/integration/manuals-frontend
@@ -1,2 +1,0 @@
-image_tag: 20d7006ab5f30d01bec92c04f860db1ec7b2e63e
-automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/production/manuals-frontend
+++ b/charts/argocd-apps/image-tags/production/manuals-frontend
@@ -1,2 +1,0 @@
-image_tag: latest
-automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/staging/manuals-frontend
+++ b/charts/argocd-apps/image-tags/staging/manuals-frontend
@@ -1,2 +1,0 @@
-image_tag: latest
-automatic_deploys_enabled: true

--- a/charts/argocd-apps/image-tags/test/manuals-frontend
+++ b/charts/argocd-apps/image-tags/test/manuals-frontend
@@ -1,2 +1,0 @@
-image_tag: latest
-automatic_deploys_enabled: true


### PR DESCRIPTION
manuals-frontend was decommissioned in June.

Searched for any other references to `/manuals.frontend/` in this repo and found none.