### PR TITLE
Currently Origin LB is stating unhealthy Router pods

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -712,6 +712,7 @@ govukApplications:
       enabled: true
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
+        alb.ingress.kubernetes.io/healthcheck-path: /readyz
       hosts:
       - www-origin.eks.integration.govuk.digital
     nginxConfigMap:


### PR DESCRIPTION
This is due to using incorrect HTTP path on port 8080.

Updating health check to` /readyz `- this is the Nginx container health check on port 8080.