### PR TITLE
Revert EC2 assets fallback

### DIFF
--- a/charts/govuk-apps-conf/templates/router-nginx-config.tpl
+++ b/charts/govuk-apps-conf/templates/router-nginx-config.tpl
@@ -49,11 +49,6 @@ http {
     }
   ';
 
-  upstream assets_s3 {
-    server govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
-    server www-origin.{{ .Values.publishingServiceDomainSuffix }} backup;
-  }
-
   # This map creates a $sts_default variable for later use.
   # If this header is already set by upstream, then $sts_default will
   # be an empty string, which will later lead to:
@@ -179,17 +174,13 @@ http {
       proxy_set_header   Authorization "";
       proxy_set_header   Connection "";
       proxy_set_header   X-Real-IP $remote_addr;  # TODO: pass the actual end-client address
-      proxy_set_header   X-Forwarded-Server $host;
-      proxy_set_header   X-Forwarded-Host $http_host;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_hide_header  x-amz-id-2;
       proxy_hide_header  x-amz-meta-server-side-encryption;
       proxy_hide_header  x-amz-request-id;
       proxy_hide_header  x-amz-server-side-encryption;
       proxy_hide_header  x-amz-version-id;
       proxy_intercept_errors on;
-      proxy_pass         https://assets_s3;
-      proxy_next_upstream http_404;
+      proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
 
       add_header Cache-Control "max-age=31536000, public, immutable";
       add_header "Access-Control-Allow-Origin" "*";

--- a/charts/govuk-apps-conf/templates/router-nginx-config.tpl
+++ b/charts/govuk-apps-conf/templates/router-nginx-config.tpl
@@ -50,8 +50,8 @@ http {
   ';
 
   upstream assets_s3 {
-    server govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com:443;
-    server www-origin.{{ .Values.publishingServiceDomainSuffix }}:443 backup;
+    server govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
+    server www-origin.{{ .Values.publishingServiceDomainSuffix }} backup;
   }
 
   # This map creates a $sts_default variable for later use.

--- a/charts/govuk-apps-conf/templates/router-nginx-config.tpl
+++ b/charts/govuk-apps-conf/templates/router-nginx-config.tpl
@@ -182,8 +182,6 @@ http {
       proxy_set_header   X-Forwarded-Server $host;
       proxy_set_header   X-Forwarded-Host $http_host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-      # TODO: Remove workaround after traffic experiment
-      proxy_set_header   Host 'govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com';
       proxy_hide_header  x-amz-id-2;
       proxy_hide_header  x-amz-meta-server-side-encryption;
       proxy_hide_header  x-amz-request-id;


### PR DESCRIPTION
This reverts attempts to make Nginx fallback to EC2 for asset requests. This was to original fix an issue where assets where not being built the same in both EKS and EC2 environments, and asset request needed to proxied to the same infra. These changes tried to make Nginx try both origins to serve asset request. However we discovered this didn't work and could implement this behaviour at Fastly instead.