### PR TITLE
Set ASSET_HOST for only whitehall

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -2,7 +2,6 @@ globalHelmValues:
   govukEnvironment: integration
   externalDomainSuffix: eks.integration.govuk.digital
   publishingServiceDomainSuffix: integration.publishing.service.gov.uk
-  assetDomain: integration.publishing.service.gov.uk
   appResources:
     limits:
       cpu: 1
@@ -262,6 +261,8 @@ govukApplications:
     extraEnv: &whitehall-envs
       - name: NODE_ENV
         value: production
+      - name: ASSET_HOST
+        value: https://www.integration.publishing.service.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -2,7 +2,6 @@ globalHelmValues:
   govukEnvironment: production
   externalDomainSuffix: eks.production.govuk.digital
   publishingServiceDomainSuffix: publishing.service.gov.uk
-  assetDomain: gov.uk
   appResources:
     limits:
       cpu: 1
@@ -518,6 +517,8 @@ govukApplications:
     extraEnv: &whitehall-envs
       - name: NODE_ENV  # TODO: move NODE_ENV=production to the Dockerfile
         value: production
+      - name: ASSET_HOST
+        value: https://www.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -2,7 +2,6 @@ globalHelmValues:
   govukEnvironment: staging
   externalDomainSuffix: eks.staging.govuk.digital
   publishingServiceDomainSuffix: staging.publishing.service.gov.uk
-  assetDomain: staging.publishing.service.gov.uk
   appResources:
     limits:
       cpu: 1
@@ -518,6 +517,8 @@ govukApplications:
     extraEnv: &whitehall-envs
       - name: NODE_ENV  # TODO: move NODE_ENV=production to the Dockerfile
         value: production
+      - name: ASSET_HOST
+        value: https://www.staging.publishing.service.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -7,7 +7,6 @@ metadata:
 data:
   {{- /* TODO: omit namespace from these user-facing URLs in the default namespace. */}}
   {{- /* TODO: delete PLEK_SERVICE_*_URI once Plek can construct http:// internal URLs. */}}
-  ASSET_HOST: https://www.{{ .Values.assetDomain }}
   GOVUK_APP_DOMAIN: {{ .Values.internalDomainSuffix }}
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -2,7 +2,6 @@ govukEnvironment: test
 internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital
 publishingServiceDomainSuffix: test.publishing.service.gov.uk
-assetDomain: test.publishing.service.gov.uk
 ec2InternalDomainSuffix: govuk-internal.digital
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.


### PR DESCRIPTION
ASSET_HOST doesn't need to be set for all GOV.UK Rails applications. It's used by Rails to specify a alternative domain for links to assets, however we now serve all assets from the same origin and can use relative paths. The only exception is Whitehall which renders CSV preview pages from the assets.publishing.services.gov.uk domain and needs to know to retireve assets from the original origin.

Unclear for previous history, why we set this in the first place.