### PR TITLE
default health check path update

### DIFF
--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -12,7 +12,7 @@ ingress:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
-    alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
+    alb.ingress.kubernetes.io/healthcheck-path: /readyz
   rules:
   - path: /
     pathType: Prefix


### PR DESCRIPTION
As the Ingress target port is set to the Nginx container, therefore updating the health check path to match what is set in Nginx deployment.
https://github.com/alphagov/govuk-helm-charts/blob/b36296164fa7e0fbd469bb593ae7699fa95c76b1/charts/govuk-rails-app/templates/deployment.yaml#L91

Annotations are used to customise kubernetes Ingress and Service
objects:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/guide/ingress/annotations.md