### PR TITLE
Remove ASSET_HOST for Whitehall

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -261,8 +261,6 @@ govukApplications:
     extraEnv: &whitehall-envs
       - name: NODE_ENV
         value: production
-      - name: ASSET_HOST
-        value: https://www.integration.publishing.service.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -517,8 +517,6 @@ govukApplications:
     extraEnv: &whitehall-envs
       - name: NODE_ENV  # TODO: move NODE_ENV=production to the Dockerfile
         value: production
-      - name: ASSET_HOST
-        value: https://www.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -517,8 +517,6 @@ govukApplications:
     extraEnv: &whitehall-envs
       - name: NODE_ENV  # TODO: move NODE_ENV=production to the Dockerfile
         value: production
-      - name: ASSET_HOST
-        value: https://www.staging.publishing.service.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
The ASSET_HOST doesn't need to be set as we serve assets on the same domain. This was originally needed for CSV preview pages which are rendered by Whitehall, however hosted on the asset.publishing.service.gov.uk domain. This currently only applies to our old infra (we don't serve asset traffic yet). This is being fixed in the old infra by adding a proxy to deal with assets request, rather than setting ASSET_HOST.