### PR TITLE
Stop PVC from being deleted on APP updates

### DIFF
--- a/charts/asset-manager/templates/clamav-db-persistentvolumeclaim.yaml
+++ b/charts/asset-manager/templates/clamav-db-persistentvolumeclaim.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: clamav-pvc
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
There should be no need to remove the PVC on update to the App.