### PR TITLE
updated production external domain suffix to gov.uk in line with pupp…

### DIFF
--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -1,6 +1,6 @@
 globalHelmValues:
   govukEnvironment: production
-  externalDomainSuffix: eks.production.govuk.digital
+  externalDomainSuffix: gov.uk
   publishingServiceDomainSuffix: publishing.service.gov.uk
   appResources:
     limits:


### PR DESCRIPTION
…et environment

Checking the production config in govuk puppet it looks like we pass the gov.uk as to root domain 