### PR TITLE
Updating ClamAV-DB path to NFS share which ClamAV daemon already uses…

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -29,8 +29,9 @@
         allowPrivilegeEscalation: false
   volumes:
   - name: clam-virus-db
-    persistentVolumeClaim:
-      claimName: clamav-db-efs
+    nfs:
+      server: "{{ .Values.assetManagerNFS }}"
+      path: /asset-manager/clamav-db
   - name: clamd-conf
     configMap:
       name: {{ .Release.Name }}-clamd-conf

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -90,8 +90,9 @@ spec:
           server: "{{ .Values.assetManagerNFS }}"
           path: /
       - name: clam-virus-db
-        persistentVolumeClaim:
-          claimName: clamav-db-efs
+        nfs:
+          server: "{{ .Values.assetManagerNFS }}"
+          path: /asset-manager/clamav-db
       - name: clamd-conf
         configMap:
           name: {{ .Release.Name }}-clamd-conf


### PR DESCRIPTION
Updating ClamAV-DB path to AWS EFS/NFS share which ClamAV daemon already uses for storing scanned assets and infected assets.

Currently testing this change.