### PR TITLE
Notify slack only on failure for post sync workflows

### DIFF
--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -47,6 +47,7 @@ spec:
     - name: exit-handler
       steps:
         - - name: notify-slack
+            when: "{{"{{workflow.status}}"}} != Succeeded"
             templateRef:
               name: notify-slack
               template: notify-slack


### PR DESCRIPTION
This changes the notifications to only be sent when the workflow fails or errors, instead of also when it succeeds. Send notification aren't actionable and create noise in Slack. We really only care when it fails.