### PR TITLE
Fix Signon Rails assets

### DIFF
--- a/charts/govuk-rails-app/templates/nginx-configmap.yaml
+++ b/charts/govuk-rails-app/templates/nginx-configmap.yaml
@@ -138,12 +138,14 @@ data:
             expires max;
             add_header Cache-Control "public, immutable";
             add_header Surrogate-Key "assets assets-{{ .Release.Name }}";
+            proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
 
             # Set CORS allow origin for fonts only
             location ~* \.(eot|otf|ttf|woff|woff2)$ {
               add_header Access-Control-Allow-Origin "*";
               add_header Access-Control-Allow-Methods "GET, OPTIONS";
               add_header Access-Control-Allow-Headers "origin, authorization";
+              proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
             }
           }
         }


### PR DESCRIPTION
Rails assets of Signon, e.g. https://signon.eks.integration.govuk.digital/users/sign_in, were not appearing with 404 http errors.

Further investigations and fixes have led to the fact that the proxy_pass directive is not being inherited. This fixes that.