### PR TITLE
Add the draft flavour of content-store in integration.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -148,7 +148,7 @@ govukApplications:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
 - name: content-store
-  helmValues:
+  helmValues: &content-store
     uploadAssets:
       enabled: false
     extraEnv:
@@ -179,6 +179,39 @@ govukApplications:
           mongo-1.integration.govuk-internal.digital,\
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
+      - name: GOVUK_APP_NAME
+        value: content-store
+- name: draft-content-store
+  helmValues:
+    <<: *content-store
+    extraEnv:
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-draft-content-store-draft-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-content-store
+            key: oauth_secret
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: DEFAULT_TTL
+        value: "1"
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          mongo-1.integration.govuk-internal.digital,\
+          mongo-2.integration.govuk-internal.digital,\
+          mongo-3.integration.govuk-internal.digital/draft_content_store_production"
       - name: GOVUK_APP_NAME
         value: content-store
 - name: draft-router


### PR DESCRIPTION
The differences in env vars between regular and draft content-store come from
https://github.com/alphagov/govuk-puppet/blob/main/hieradata_aws/class/draft_content_store.yaml

Recall that YAML alias overrides (`<<: *foo`) are shallow, not recursive/deep.

I don't believe the k8s secrets for the Signon tokens for this exist yet, but that's currently in a state of flux and I don't think there's anywhere for us to configure those right now. So for now, I expect the pods to fail to start because one or more non-optional Secrets won't exist. The idea is that those k8s Secrets be automatically populated one way or another.

Tested by inspecting `helm template` output, for example:

    helm template ../govuk-rails-app --name-template=draft-content-store --values <(
      helm template . --values values-integration.yaml | \
        yq e '.|select(.metadata.name == "draft-content-store").spec.source.helm.values'
    ) | yq e '.|select(.kind == "Deployment")'