### PR TITLE
Add missing ingress for hmrc-manuals-api (in integration).

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -472,6 +472,12 @@ govukApplications:
   postSyncWorkflowEnabled: "false"
 - name: hmrc-manuals-api
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: hmrc-manuals-api
+      hosts:
+      - hmrc-manuals-api.eks.integration.govuk.digital
     nginxProxyReadTimeout: 300s
     uploadAssets:
       enabled: false


### PR DESCRIPTION
HMRC Manuals API is supposed to serve traffic from the outside world.

Access controls are the same as for the existing setup in EC2 integration: anyone can send requests but the app itself requires a valid `Authorization` header to perform any actions other than browsing the documentation.