### PR TITLE
Set Sentry environment for Router

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -769,6 +769,8 @@ govukApplications:
           secretName: router-nginx-htpasswd
     appProbes: *router-app-probes
     extraEnv:
+      - name: SENTRY_ENVIRONMENT
+        value: "integration-eks"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -281,6 +281,8 @@ govukApplications:
         failureThreshold: 2
         periodSeconds: 5
     extraEnv:
+      - name: SENTRY_ENVIRONMENT
+        value: "production-eks"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -281,6 +281,8 @@ govukApplications:
         failureThreshold: 2
         periodSeconds: 5
     extraEnv:
+      - name: SENTRY_ENVIRONMENT
+        value: "staging-eks"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR


### PR DESCRIPTION
Router app uses the Go Sentry SDK which looks for the SENTRY_ENVIRONMENT env var instead of SENTRY_CURRENT_ENV (set in common config). This fixes missing environment tags on issue reported from EKS.