### PR TITLE
Revert "Tag images that are in use "

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -17,13 +17,6 @@ change_image_tag() {
   CHANGED=true
 }
 
-add_image_deployment_tag() {
-  aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
-  MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO_NAME}" --image-ids imageTag="${IMAGE_TAG}" --region eu-west-1 --query 'images[].imageManifest' --output json)
-  # Every image that has a tag will then have 'deployed-to-${ENVIRONMENT}' tag added as well.
-  aws ecr put-image --repository-name "${REPO_NAME}" --image-tag "deployed-to-${ENVIRONMENT}" --image-manifest "$MANIFEST"
-}
-
 git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
 git config --global user.name "${GIT_NAME}"
 
@@ -47,7 +40,6 @@ elif [[ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]]; then
   # Auto deploys are enabled unless explicitly set to "false" (case insensitive).
   if [[ "${auto_deploys,,}" != "false" ]]; then
     change_image_tag
-    add_image_deployment_tag
   else
     echo "Did not update image tag because automatic_deploys_enabled is set to false for app"
   fi

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -41,8 +41,6 @@ spec:
             value: "{{"{{inputs.parameters.repoName}}"}}"
           - name: MANUAL_DEPLOY
             value: "{{"{{inputs.parameters.manualDeploy}}"}}"
-          - name: ECR_REGISTRY
-            value: "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
         source: |
           {{- .Files.Get "scripts/update-image-tag.sh" | nindent 14 }}
   podSpecPatch: |


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#562

At the moment, the workflows are failing as the github-cli image doesn't have aws-cli and docker packages needed to execute the calls in the new function.
Reverting for the meanwhile while I focus on the fix.