### PR TITLE
Fix missing repoName for draft content store

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -190,6 +190,7 @@ govukApplications:
       - name: GOVUK_APP_NAME
         value: content-store
 - name: draft-content-store
+  repoName: content-store
   helmValues:
     <<: *content-store
     extraEnv:


### PR DESCRIPTION
The draft content store deployment needs the repoName to be set to content store to reference the correct image.