### PR TITLE
Eliminate duplicate secrets for SENTRY_DSN.

### DIFF
--- a/charts/argocd-apps/templates/govuk-application.yaml
+++ b/charts/argocd-apps/templates/govuk-application.yaml
@@ -29,6 +29,7 @@ spec:
       # chart's values.yaml.
       values: |
         {{- toYaml $.Values.globalHelmValues | nindent 8 }}
+        repoName: {{ $reponame }}
         appImage:
           repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/{{ $reponame }}
           tag: {{ $imageTag }}

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -193,6 +193,8 @@ govukApplications:
   repoName: content-store
   helmValues:
     <<: *content-store
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
     extraEnv:
       - name: ROUTER_API_BEARER_TOKEN
         valueFrom:
@@ -226,6 +228,8 @@ govukApplications:
 - name: draft-router
   repoName: router
   helmValues:
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
     uploadAssets:
       enabled: false
     appProbes: &router-app-probes
@@ -760,6 +764,8 @@ govukApplications:
   repoName: router-api
   helmValues:
     <<: *router-api
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -1091,6 +1097,8 @@ govukApplications:
 - name: whitehall-admin
   repoName: whitehall
   helmValues:
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
     securityContext:
       # Use the same uid/gid for NFS permissions as the old stack, so that
       # files uploaded by whitehall-admin on k8s can be processed by
@@ -1120,6 +1128,11 @@ govukApplications:
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:
+    # TODO: make whitehall-frontend the pattern app and have
+    # draft-whitehall-frontend and whitehall-admin inherit from it (instead of
+    # the other way around like it is now).
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
     uploadAssets: *whitehall-upload-assets
     extraEnv: *whitehall-envs
     appResources:

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-sentry
+                  name: {{ .Values.repoName }}-sentry
                   key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"

--- a/charts/govuk-rails-app/templates/sentry-external-secret.yml
+++ b/charts/govuk-rails-app/templates/sentry-external-secret.yml
@@ -1,8 +1,8 @@
-{{- if .Values.sentry.enabled }}
+{{- if (and .Values.sentry.enabled .Values.sentry.createSecret) }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .Release.Name }}-sentry-dsn
+  name: {{ .Values.repoName }}-sentry
   labels:
     {{- include "govuk-rails-app.labels" . | nindent 4 }}
     app: {{ .Release.Name }}
@@ -15,10 +15,10 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    name: {{ .Release.Name }}-sentry
+    name: {{ .Values.repoName }}-sentry
   data:
     - secretKey: dsn
       remoteRef:
         key: govuk/common/sentry
-        property: {{ .Release.Name }}-dsn
+        property: {{ .Values.repoName }}-dsn
 {{- end }}

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-sentry
+                  name: {{ .Values.repoName }}-sentry
                   key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -111,3 +111,4 @@ securityContext:
 
 sentry:
   enabled: true
+  createSecret: true


### PR DESCRIPTION
Sentry DSNs (API keys) are unique per app repo but are not unique per app. For example, `whitehall-admin`, `whitehall-frontend` and `draft-whitehall-frontend` are all the same Sentry project and so they have the same Sentry DSN.

This change makes our k8s Secrets reflect this. We will no longer have duplicate entries in the `govuk/common/sentry` AWS Secrets Manager secret for apps which are deployed multiple times, such as apps with `draft-` versions.

This should also simplify automating fetching the Sentry secrets from the Sentry API during bootstrap, when we come to automate that.

Tested: Helm templates parse ok; inspected output with e.g.

```
helm template ../govuk-rails-app --name-template=draft-router-api --values <(
  helm template . --values values-integration.yaml |
    yq e '.|select(.metadata.name == "draft-router-api").spec.source.helm.values'
) | yq e '.|select(.kind == "Deployment")'
```
and similarly for a handful of representative combinations of `.kind == "ExternalSecret"` and `.metadata.name == "draft-whitehall-frontend"` vs. `whitehall-frontend` etc.

No changes to `values-{staging,production}.yaml` because we don't yet have any `draft-` apps there yet, nor `whitehall-admin`.

Rollout: update the `govuk/common/sentry` secretsmanager secret **in all three environments** to remove duplicates and make the keys match the app repo names, just before merging this.