### PR TITLE
Configure Sentry logging for Asset Manager.

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -36,8 +36,15 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.appPort }}"
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.repoName }}-sentry
+                  key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            {{- end }}
           {{- with .Values.extraEnv }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}

--- a/charts/asset-manager/templates/sentry-external-secret.yml
+++ b/charts/asset-manager/templates/sentry-external-secret.yml
@@ -1,0 +1,24 @@
+{{- if (and .Values.sentry.enabled .Values.sentry.createSecret) }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.repoName }}-sentry
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/description: >
+      Client key for the associated Sentry project.
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.repoName }}-sentry
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: govuk/common/sentry
+        property: {{ .Values.repoName }}-dsn
+{{- end }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -89,3 +89,7 @@ dnsConfig: {}
 #    value: "true"
 
 metricsPort: 9394
+
+sentry:
+  enabled: true
+  createSecret: true


### PR DESCRIPTION
Rollout: the AWS Secrets Manager secret already contains the necessary key for this so no change needed there.

Tested: Helm template parses ok; inspected output for Sentry env vars and ExternalSecret by running:

    helm template . --name-template=asset-manager --values <(
      cd ../argocd-apps && helm template . --values values-integration.yaml |
        yq e '.|select(.metadata.name == "asset-manager").spec.source.helm.values'
    )