### PR TITLE
Disable k8s service links for asset-manager.

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -116,6 +116,7 @@ spec:
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
         configMap:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -84,6 +84,7 @@ spec:
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       - name: assets-efs
         nfs:


### PR DESCRIPTION
This declutters the environment by removing the 5 unused env vars for every k8s Service in the namespace. This makes troubleshooting anything to do with environment variables just a little bit more operator-friendly.

We already do this for all the other apps, so this just brings asset-manager into line.