### PR TITLE
Add Signon secret sync cron jobs

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -962,6 +962,15 @@ govukApplications:
       hosts:
       - signon.eks.integration.govuk.digital
     workerReplicaCount: 1
+    cronRakeTasks:
+      - name: "kubernetes-sync-app-secrets"
+        task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
+        schedule: "0 */1 * * *"
+        serviceAccount: signon
+      - name: "kubernetes-sync-token-secrets"
+        task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
+        schedule: "0 */1 * * *"
+        serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 759acac6-da53-4a19-b591-b7538c7c39de

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -346,6 +346,15 @@ govukApplications:
       hosts:
       - signon.eks.production.govuk.digital
     workerReplicaCount: 1
+    cronRakeTasks:
+      - name: "kubernetes-sync-app-secrets"
+        task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
+        schedule: "0 */1 * * *"
+        serviceAccount: signon
+      - name: "kubernetes-sync-token-secrets"
+        task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
+        schedule: "0 */1 * * *"
+        serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: e00e89f5-b622-4dcb-8f30-e6c70231a940

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -346,6 +346,15 @@ govukApplications:
       hosts:
       - signon.eks.staging.govuk.digital
     workerReplicaCount: 1
+    cronRakeTasks:
+      - name: "kubernetes-sync-app-secrets"
+        task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
+        schedule: "0 */1 * * *"
+        serviceAccount: signon
+      - name: "kubernetes-sync-token-secrets"
+        task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
+        schedule: "0 */1 * * *"
+        serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 112842bb-d8a4-4511-90de-57dc5c8f27ec

--- a/charts/govuk-apps-conf/templates/signon-configmap.yaml
+++ b/charts/govuk-apps-conf/templates/signon-configmap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: signon-secrets-sync-conf
+  namespace: apps
+data:
+  app_names: |
+    [
+      "Account API",
+      "Asset Manager",
+      "Collections publisher",
+      "Contacts",
+      "Content Preview",
+      "Content Publisher",
+      "Content Store",
+      "Content Tagger",
+      "Draft Content Store",
+      "Draft Router API",
+      "Email Alert API",
+      "HMRC Manuals API",
+      "Imminence",
+      "Link Checker API",
+      "Local Links Manager",
+      "Manuals Publisher",
+      "Publisher",
+      "Publishing API",
+      "Release",
+      "Router API",
+      "Search admin",
+      "Search API",
+      "Service Manual Publisher",
+      "Short URL Manager",
+      "Special Route Publisher",
+      "Specialist Publisher",
+      "Support",
+      "Support API",
+      "Travel Advice Publisher",
+      "Whitehall"
+    ]
+  api_user_emails: |
+    [
+      "govuk-accounts-developers+account-api@digital.cabinet-office.gov.uk",
+      "collections@alphagov.co.uk",
+      "collections-publisher@alphagov.co.uk",
+      "contacts@alphagov.co.uk",
+      "content-publisher@alphagov.co.uk",
+      "content-store@alphagov.co.uk",
+      "content-tagger@alphagov.co.uk",
+      "draft-content-store@alphagov.co.uk",
+      "email-alert-api@alphagov.co.uk",
+      "emailalertfrontend@alphagov.co.uk",
+      "email-alert-service@alphagov.co.uk",
+      "feedback@alphagov.co.uk",
+      "finder-frontend@alphagov.co.uk",
+      "frontend@alphagov.co.uk",
+      "government-frontend@alphagov.co.uk",
+      "hmrc-manuals-api@alphagov.co.uk",
+      "info-frontend@alphagov.co.uk",
+      "licencefinder@alphagov.co.uk",
+      "local-links-manager@alphagov.co.uk",
+      "manuals-publisher@alphagov.co.uk",
+      "need-api@alphagov.co.uk",
+      "publisher@alphagov.co.uk",
+      "publishing-api@alphagov.co.uk",
+      "searchadmin@alphagov.co.uk",
+      "service-manual-publisher@alphagov.co.uk",
+      "short-url-manager@alphagov.co.uk",
+      "smartanswers@alphagov.co.uk",
+      "special-route-publisher@alphagov.co.uk",
+      "static@alphagov.co.uk",
+      "support@alphagov.co.uk",
+      "travel-advice-publisher@alphagov.co.uk",
+      "whitehall@alphagov.co.uk"
+    ]

--- a/charts/govuk-apps-conf/templates/signon-service-account.yaml
+++ b/charts/govuk-apps-conf/templates/signon-service-account.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signon
+  namespace: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: apps
+  name: signon-secret-manager
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["signon-secrets-sync-conf"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["patch", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: signon-secret-manager-binding
+  namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: signon-secret-manager
+subjects:
+  - kind: ServiceAccount
+    name: signon

--- a/charts/govuk-rails-app/templates/rake-task-job.yaml
+++ b/charts/govuk-rails-app/templates/rake-task-job.yaml
@@ -1,0 +1,52 @@
+{{- range .Values.cronRakeTasks }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "{{ $.Release.Name }}-{{ .name }}-rake-task"
+  labels:
+    {{- include "govuk-rails-app.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  schedule: "{{ .schedule }}"
+  jobTemplate:
+    metadata:
+      name: "{{ $.Release.Name }}-{{ .name }}-rake-task"
+      labels:
+        {{- include "govuk-rails-app.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: app
+    spec:
+      template:
+        metadata:
+          name: "{{ $.Release.Name }}-{{ .name }}-rake-task"
+          labels:
+            {{- include "govuk-rails-app.labels" $ | nindent 12 }}
+            app.kubernetes.io/component: app
+        spec:
+          securityContext:
+            runAsNonRoot: {{ $.Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ $.Values.securityContext.runAsUser }}
+            runAsGroup: {{ $.Values.securityContext.runAsGroup }}
+          restartPolicy: Never
+          serviceAccountName: {{ .serviceAccount }}
+          containers:
+            - name: rake-task
+              image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
+              command: ["bundle"]
+              args: ["exec", "rails", "{{ .task }}"]
+              envFrom:
+              - configMapRef:
+                  name: govuk-apps-env
+              env:
+                - name: SENTRY_RELEASE
+                  value: "{{ $.Values.appImage.tag }}"
+              {{- with $.Values.extraEnv }}
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              {{- with $.Values.appResources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+{{- end }}


### PR DESCRIPTION
This PR add new cronJob resources to the Signon Argo app to run Rake tasks to synchronise Signon secrets as Kubernetes Secrets. One rake task is for synchronising OAuth authorisation tokens for ApiUser specified in a configmap. Another is for synchronising the client ID and secret for Signon OAuth apps. This secrets are needed by the apps running Kubernetes.

This adds a new template to all the govuk-rails-apps configure a cron job for running Rake tasks and a ServiceAccount for reading configmaps and updating secrets which is used by the containers running in the cronJob.