### PR TITLE
Use draft backends for draft-content-store.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -223,6 +223,20 @@ govukApplications:
           mongo-1.integration.govuk-internal.digital,\
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/draft_content_store_production"
+      # Draft apps use draft backends by default so that any misconfiguration
+      # leads to obvious errors rather than draft content being unknowingly
+      # made public.
+      # TODO: fix Plek so that we don't need all this error-prone config for
+      # each draft app.
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+      # https://github.com/alphagov/govuk-puppet/pull/10316/commits/899ac50
+      - name: PLEK_SERVICE_SIGNON_API_URI
+        value: https://signon.{{ .Values.externalDomainSuffix }}
+      - name: PLEK_SERVICE_FEEDBACK_URI
+        value: http://feedback
+      - name: PLEK_SERVICE_INFO_FRONTEND_URI
+        value: http://support
       - name: GOVUK_APP_NAME
         value: content-store
 - name: draft-router

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
           {{- with .Values.extraEnv }}
-            {{- . | toYaml | trim | nindent 12 }}
+            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.appResources }}
           resources:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
           {{- with .Values.extraEnv }}
-            {{- . | toYaml | trim | nindent 12 }}
+            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.workerResources }}
           resources:

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -84,9 +84,14 @@ assetManagerNFS: "asset-manager-efs.dev.gov.uk"
 # deployment templates.
 dnsConfig: {}
 
-# extraEnv:
+# extraEnv is a list of (name, value) pairs representing additional environment
+# variables to pass to app containers. extraEnv is evaluated through `tpl`, so
+# Helm values can be substituted using Go template syntax. Use sparingly.
+extraEnv: {}
 #  - name: RETICULATE_SPLINES
 #    value: "true"
+#  - name: SPLINE_SERVER
+#    value: "https://splines.{{ .Values.externalDomain }}"
 
 metricsPort: 9394
 

--- a/charts/govuk-rails-app/templates/dbmigration-job.yaml
+++ b/charts/govuk-rails-app/templates/dbmigration-job.yaml
@@ -33,7 +33,7 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
           {{- with .Values.extraEnv }}
-            {{- . | toYaml | trim | nindent 12 }}
+            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.appResources }}
           resources:

--- a/charts/govuk-rails-app/templates/deployment.yaml
+++ b/charts/govuk-rails-app/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
           {{- with .Values.extraEnv }}
-            {{- . | toYaml | trim | nindent 12 }}
+            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.appResources }}
           resources:

--- a/charts/govuk-rails-app/templates/worker-deployment.yaml
+++ b/charts/govuk-rails-app/templates/worker-deployment.yaml
@@ -48,7 +48,7 @@ spec:
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
           {{- with .Values.extraEnv }}
-            {{- . | toYaml | trim | nindent 12 }}
+            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
           {{- end }}
           {{- with .Values.workerResources }}
           resources:

--- a/charts/govuk-rails-app/values.yaml
+++ b/charts/govuk-rails-app/values.yaml
@@ -93,9 +93,14 @@ nginxResources:
 # deployment templates.
 dnsConfig: {}
 
-# extraEnv:
+# extraEnv is a list of (name, value) pairs representing additional environment
+# variables to pass to app containers. extraEnv is evaluated through `tpl`, so
+# Helm values can be substituted using Go template syntax. Use sparingly.
+extraEnv: {}
 #  - name: RETICULATE_SPLINES
 #    value: "true"
+#  - name: SPLINE_SERVER
+#    value: "https://splines.{{ .Values.externalDomain }}"
 
 govukEnvironment: test
 uploadAssets:


### PR DESCRIPTION
See individual commit messages for context and rationale as to why this particular approach.

Other ideas welcome — it's always possible we've missed a simpler way.

I plan to clean up Plek so that we at least don't have to specify all the non-draft backend addresses on every draft app.

Tested: inspected `helm template` output (see commit messages for example commands)