### PR TITLE
Redirect straight to https for signon during login.

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -39,7 +39,7 @@ data:
   PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   # TODO: switch back to in-cluster Search API once it's fully working.
   PLEK_SERVICE_SEARCH_URI: https://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_SIGNON_URI: http://signon.{{ .Values.externalDomainSuffix }}
+  PLEK_SERVICE_SIGNON_URI: https://signon.{{ .Values.externalDomainSuffix }}
   PLEK_SERVICE_STATIC_URI: http://static.{{ .Values.internalDomainSuffix }}
   PLEK_SERVICE_SUPPORT_URI: https://support.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
   PLEK_SERVICE_SUPPORT_API_URI: https://support-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}


### PR DESCRIPTION
Internal requests (from publisher apps to signon within the cluster) use this same endpoint URL. Presumably the client library was following the http->https redirect, otherwise it wouldn't have been working.

Ideally we'd have the internal requests go to `http://signon` (which the local resolver will expand to `signon.apps.svc.cluster.local.`) but we'd need to modify Plek to support that, which takes time because it involves a gem version increment for every app.