### PR TITLE
Add notifications for failed image deployments

### DIFF
--- a/charts/argo-services/templates/events/update-image-tag-sensor.yaml
+++ b/charts/argo-services/templates/events/update-image-tag-sensor.yaml
@@ -45,7 +45,7 @@ spec:
             apiVersion: argoproj.io/v1alpha1
             kind: Workflow
             metadata:
-              generateName: -update-image-tag-
+              generateName: -deploy-image-
               namespace: {{ .Values.workflowsNamespace }}
             spec:
               arguments:
@@ -55,4 +55,4 @@ spec:
                   - name: imageTag
                   - name: manualDeploy
               workflowTemplateRef:
-                name: update-image-tag
+                name: deploy-image

--- a/charts/argo-workflows/templates/deploy-image.yaml
+++ b/charts/argo-workflows/templates/deploy-image.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: deploy-image
+spec:
+  entrypoint: deploy-image
+  onExit: exit-handler
+  arguments:
+    parameters:
+      - name: environment
+      - name: repoName
+      - name: imageTag
+      - name: manualDeploy
+  templates:
+    - name: deploy-image
+      steps:
+        - - name: update-image-tag
+            templateRef:
+              name: update-image-tag
+              template: update-image-tag
+            arguments:
+              parameters:
+                - name: environment
+                  value: "{{"{{workflow.parameters.environment}}"}}"
+                - name: repoName
+                  value: "{{"{{workflow.parameters.repoName}}"}}"
+                - name: imageTag
+                  value: "{{"{{workflow.parameters.imageTag}}"}}"
+                - name: manualDeploy
+                  value: "{{"{{workflow.parameters.manualDeploy}}"}}"
+
+    - name: exit-handler
+      steps:
+        - - name: notify-slack
+            when: "{{"{{workflow.status}}"}} != Succeeded"
+            templateRef:
+              name: notify-slack
+              template: notify-slack
+            arguments:
+              parameters:
+                - name: slackChannel
+                  # NOTE: Change to {{"{{workflow.parameters.slackChannel}}"}} to
+                  # send to team slack channel.
+                  value: "govuk-deploy-alerts"
+                - name: text
+                  value: "Deploy image workflow for {{"{{workflow.parameters.repoName}}"}} in {{"{{workflow.parameters.environment}}"}} has {{"{{= sprig.lower(workflow.status) }}"}}."


### PR DESCRIPTION
This creates a new workflow that wraps update-image-tag with an exit
handler. This exit handler will send a notification if the workflow
fails. This is improves the observability of failure when deployments
are triggered from GitHub whereby only the update-image-tag workflow
runs, not the post-sync workflow.
