### PR TITLE
Improve formatting for slack notification for failed workflows

### DIFF
--- a/charts/argo-workflows/templates/deploy-image.yaml
+++ b/charts/argo-workflows/templates/deploy-image.yaml
@@ -44,3 +44,22 @@ spec:
                   value: "govuk-deploy-alerts"
                 - name: text
                   value: "Deploy image workflow for {{"{{workflow.parameters.repoName}}"}} in {{"{{workflow.parameters.environment}}"}} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                - name: blocks
+                  value: |
+                    [{
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "Deploy image workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                      },
+                      "accessory": {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "View workflow",
+                            "emoji": true
+                        },
+                        "url": "https://argo-workflows.eks.{{ .Values.govukEnvironment }}.govuk.digital/workflows/apps/{{"{{ workflow.name }}"}}",
+                        "action_id": "view-workflow"
+                      }
+                    }]

--- a/charts/argo-workflows/templates/notify-slack-workflow.yaml
+++ b/charts/argo-workflows/templates/notify-slack-workflow.yaml
@@ -22,9 +22,7 @@ spec:
         image: curlimages/curl
         command:
           - "curl"
-          - "-X"
-          - "POST"
-          - "--data-urlencode"
+          - "--json"
           # The double template tags {{"{{}}"}} is because Helm and Argo
           # use the same templating syntax.
           - >-

--- a/charts/argo-workflows/templates/notify-slack-workflow.yaml
+++ b/charts/argo-workflows/templates/notify-slack-workflow.yaml
@@ -26,9 +26,9 @@ spec:
           - >
               payload={
                 "channel": "#{{"{{inputs.parameters.slackChannel}}"}}",
-                "username": "Argo",
+                "username": "Argo Workflows",
                 "text": "{{"{{inputs.parameters.text}}"}}",
-                "icon_emoji": ":argocd:"
+                "icon_emoji": ":argo:"
               }
           - "$(SLACK_WEBHOOK_ENDPOINT)"
         env:

--- a/charts/argo-workflows/templates/notify-slack-workflow.yaml
+++ b/charts/argo-workflows/templates/notify-slack-workflow.yaml
@@ -8,12 +8,16 @@ spec:
     parameters:
       - name: slackChannel
       - name: text
+      - name: blocks
+        description: "Provide advanced formatting for a message using Slack's Block Kit"
+        default: ""
   templates:
     - name: notify-slack
       inputs:
         parameters:
         - name: slackChannel
         - name: text
+        - name: blocks
       container:
         image: curlimages/curl
         command:
@@ -23,11 +27,12 @@ spec:
           - "--data-urlencode"
           # The double template tags {{"{{}}"}} is because Helm and Argo
           # use the same templating syntax.
-          - >
-              payload={
+          - >-
+              {
                 "channel": "#{{"{{inputs.parameters.slackChannel}}"}}",
                 "username": "Argo Workflows",
                 "text": "{{"{{inputs.parameters.text}}"}}",
+                {{`{{= inputs.parameters.blocks != "" ? "\"blocks\": " + inputs.parameters.blocks + "," : "" }}`}}
                 "icon_emoji": ":argo:"
               }
           - "$(SLACK_WEBHOOK_ENDPOINT)"

--- a/charts/argo-workflows/templates/post-sync-workflow.yaml
+++ b/charts/argo-workflows/templates/post-sync-workflow.yaml
@@ -58,6 +58,23 @@ spec:
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
                 - name: text
-                  value: "\
-                    post-sync job ({{"{{workflow.name}}"}}) for <{{"{{workflow.parameters.argoUrl}}"}}|{{"{{workflow.parameters.application}}"}}> in {{ .Values.govukEnvironment }} {{"{{workflow.status}}"}} \
-                    (revision <https://github.com/alphagov/govuk-helm-charts/commits/{{"{{workflow.parameters.commitSha}}"}}|{{"{{workflow.parameters.commitSha}}"}}>)."
+                  value: "Post sync workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                - name: blocks
+                  value: |
+                    [{
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "Post sync workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                      },
+                      "accessory": {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "View workflow",
+                            "emoji": true
+                        },
+                        "url": "https://argo-workflows.eks.{{ .Values.govukEnvironment }}.govuk.digital/workflows/apps/{{"{{ workflow.name }}"}}",
+                        "action_id": "view-workflow"
+                      }
+                    }]


### PR DESCRIPTION
This adds the ability to format slack messages using BlockKit, which makes it easier to add links and improves the UI for messages. This updated the messages to contain link to the failed workflow instead of links ArgoCD, which isn't helpful.