### PR TITLE
Update image tag script for workflow to allow ECR calls to add tags

### DIFF
--- a/charts/argo-workflows/scripts/update-image-tag.sh
+++ b/charts/argo-workflows/scripts/update-image-tag.sh
@@ -18,10 +18,10 @@ change_image_tag() {
 }
 
 add_image_deployment_tag() {
-  aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
-  MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO_NAME}" --image-ids imageTag="${IMAGE_TAG}" --region eu-west-1 --query 'images[].imageManifest' --output json)
+  aws ecr get-login-password --region eu-west-1 | podman login --username AWS --password-stdin "$ECR_REGISTRY"
+  MANIFEST=$(aws ecr batch-get-image --registry-id "172025368201" --repository-name "${REPO_NAME}" --image-ids imageTag="${IMAGE_TAG}" --region eu-west-1 --query 'images[].imageManifest' --output text)
   # Every image that has a tag will then have 'deployed-to-${ENVIRONMENT}' tag added as well.
-  aws ecr put-image --repository-name "${REPO_NAME}" --image-tag "deployed-to-${ENVIRONMENT}" --image-manifest "$MANIFEST"
+  aws ecr put-image --registry-id "172025368201" --repository-name "${REPO_NAME}" --image-tag "deployed-to-${ENVIRONMENT}" --image-manifest "$MANIFEST"
 }
 
 git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"

--- a/charts/argo-workflows/templates/update-image-tag.yaml
+++ b/charts/argo-workflows/templates/update-image-tag.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: update-image-tag
+  serviceAccountName: argo-workflow
 spec:
   entrypoint: update-image-tag
   arguments:


### PR DESCRIPTION
https://trello.com/c/MK34KlBn/980-lifecycle-rules-for-ecr-to-clean-up-images

Here is the update-image-tag script that is ran whenever a new Image-tag is pushed to ECR, the new function is triggered, the registry is logged into using podman, and the image in question is tagged.
The pod that runs the tagging is assigned a service account that is annotated with a IAM role that is authorised to tag images in production ECR. (see https://github.com/alphagov/govuk-infrastructure/pull/747)
