### PR TITLE
Adding necessary env values

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -141,7 +141,51 @@ govukApplications:
             key: bearer_token
 - name: collections-publisher
   helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    workerReplicaCount: 1
     extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-collections-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-colections-publisher
+            key: oauth_secret
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-link-checker-api
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-publishing-api
+            key: bearer_token
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: collections-publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 759acac6-da53-4a19-b591-b7538c7c39de
+      - name: PUBLISH_WITHOUT_2I_EMAIL
+        value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: collections-publisher-mysql
+            key: DATABASE_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
@@ -586,7 +630,52 @@ govukApplications:
             key: bearer_token
 - name: manuals-publisher
   helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    workerReplicaCount: 1
     extraEnv:
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-asset-manager
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-email-alert-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-manuals-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-manuals-publisher
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-publishing-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: manuals-publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: manuals-publisher-docdb
+            key: MONGODB_URI
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
@@ -965,6 +1054,53 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+- name: service_manual_publisher
+  helmValues:
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-service_manual_publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-service_manual_publisher
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-service-manual-publisher-asset-manager
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-service-manual-publisher-publishing-api
+            key: bearer_token
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: service-manual-publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 759acac6-da53-4a19-b591-b7538c7c39de
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: service-manual-publisher-mysql
+            key: DATABASE_URL
+      - name: HTTP_USERNAME
+        value: betademo 
+      - name: HTTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: service-manual-publisher-http-password
+            key: HTTP_PASSWORD
 - name: signon
   helmValues:
     dbMigrationEnabled: true
@@ -1078,7 +1214,52 @@ govukApplications:
         value: /var/apps/static
 - name: travel-advice-publisher
   helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    workerReplicaCount: 1
     extraEnv:
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publisher-asset-manager
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-travel-advice-publisher-email-alert-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publisher-publishing-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publisher-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: travel-advice-publisher-docdb
+            key: MONGODB_URI
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:

--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -630,7 +630,6 @@ govukApplications:
             key: bearer_token
 - name: manuals-publisher
   helmValues:
-    dbMigrationEnabled: true
     workerEnabled: true
     workerReplicaCount: 1
     extraEnv:
@@ -1054,18 +1053,19 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-- name: service_manual_publisher
+- name: service-manual-publisher
   helmValues:
+    dbMigrationEnabled: true
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
-            name: signon-app-service_manual_publisher
+            name: signon-app-service-manual-publisher
             key: oauth_id
       - name: GDS_SSO_OAUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: signon-app-service_manual_publisher
+            name: signon-app-service-manual-publisher
             key: oauth_secret
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
@@ -1095,7 +1095,7 @@ govukApplications:
             name: service-manual-publisher-mysql
             key: DATABASE_URL
       - name: HTTP_USERNAME
-        value: betademo 
+        value: betademo
       - name: HTTP_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -1214,14 +1214,13 @@ govukApplications:
         value: /var/apps/static
 - name: travel-advice-publisher
   helmValues:
-    dbMigrationEnabled: true
     workerEnabled: true
     workerReplicaCount: 1
     extraEnv:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-publisher-asset-manager
+            name: signon-token-travel-advice-publisher-asset-manager
             key: bearer_token
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
@@ -1231,27 +1230,27 @@ govukApplications:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
-            name: signon-app-publisher
+            name: signon-app-travel-advice-publisher
             key: oauth_id
       - name: GDS_SSO_OAUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: signon-app-publisher
+            name: signon-app-travel-advice-publisher
             key: oauth_secret
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-publisher-publishing-api
+            name: signon-token-travel-advice-publisher-publishing-api
             key: bearer_token
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-publisher-link-checker-api
+            name: signon-token-travel-advice-publisher-link-checker-api
             key: bearer_token
       - name: LINK_CHECKER_API_SECRET_TOKEN
         valueFrom:
           secretKeyRef:
-            name: publisher-link-checker-api-callback-token
+            name: travel-advice-publisher-link-checker-api-callback-token
             key: LINK_CHECKER_API_SECRET_TOKEN
       - name: MONGODB_URI
         valueFrom:

--- a/charts/govuk-apps-conf/templates/external-secrets/collections-publisher/mysql.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/collections-publisher/mysql.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: collections-publisher-mysql
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Collections publisher to connect to MYSQL.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: collections-publisher-production-mysql
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/collections_publisher_production'
+  dataFrom:
+    - extract:
+        key: govuk/collections-publisher/mysql-primary

--- a/charts/govuk-apps-conf/templates/external-secrets/collections-publisher/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/collections-publisher/notify.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: collections-publisher-notify
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      The GOV.UK Notify API key belonging to Collections publisher.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: collections-publisher-notify
+  dataFrom:
+    - extract:
+        key: govuk/collections-publisher/notify

--- a/charts/govuk-apps-conf/templates/external-secrets/manuals-publisher/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/manuals-publisher/docdb.yaml
@@ -1,0 +1,24 @@
+{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: manuals-publisher-docdb
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Manuals publisher to connect to DocumentDB (MongoDB).
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: manuals-publisher-docdb
+    template:
+      data:
+        MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/govuk_content_production'
+  dataFrom:
+    - extract:
+        key: govuk/common/shared-documentdb
+{{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/manuals-publisher/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/manuals-publisher/link-checker-api-callback-token.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: manuals-publisher-link-checker-api-callback-token
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Manuals publisher uses this for verification of batch-completion webhook
+      (i.e. callback) requests from Link Checker API. See
+      https://github.com/alphagov/link-checker-api/blob/main/docs/api.md#verifying-the-webhook-request
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: manuals-publisher-link-checker-api-callback-token
+  dataFrom:
+    - extract:
+        key: govuk/manuals-publisher/link-checker-api-callback-token

--- a/charts/govuk-apps-conf/templates/external-secrets/service-manual-publisher/http.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/service-manual-publisher/http.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: service-manual-publisher-http-password
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      HTTP password belonging to Service manual publisher.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: service-manual-publisher-http-password
+  dataFrom:
+    - extract:
+        key: govuk/service-manual-publisher/http-password

--- a/charts/govuk-apps-conf/templates/external-secrets/service-manual-publisher/notify.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/service-manual-publisher/notify.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: service-manual-publisher-notify
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      The GOV.UK Notify API key belonging to Service manual publisher.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: service-manual-publisher-notify
+  dataFrom:
+    - extract:
+        key: govuk/service-manual-publisher/notify

--- a/charts/govuk-apps-conf/templates/external-secrets/service-manual-publisher/postgres.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/service-manual-publisher/postgres.yaml
@@ -1,0 +1,24 @@
+{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: publishing-api-postgres
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Connection string for Service manual publisher DB hosted in RDS
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: service-manual-publisher-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/service-manual-publisher_production'
+  dataFrom:
+    - extract:
+        key: govuk/service-manual-publisher/postgres
+{{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/travel-advice-publisher/docdb.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/travel-advice-publisher/docdb.yaml
@@ -1,0 +1,24 @@
+{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: travel-advice-publisher-docdb
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Travel advice publisher to connect to DocumentDB (MongoDB).
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: travel-advice-publisher-docdb
+    template:
+      data:
+        MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/travel_advice_publisher_production'
+  dataFrom:
+    - extract:
+        key: govuk/common/shared-documentdb
+{{- end }}

--- a/charts/govuk-apps-conf/templates/external-secrets/travel-advice-publisher/link-checker-api-callback-token.yaml
+++ b/charts/govuk-apps-conf/templates/external-secrets/travel-advice-publisher/link-checker-api-callback-token.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: travel-advice-publisher-link-checker-api-callback-token
+  labels:
+    {{- include "govuk-apps-conf.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Travel advice publisher uses this for verification of batch-completion webhook
+      (i.e. callback) requests from Link Checker API. See
+      https://github.com/alphagov/link-checker-api/blob/main/docs/api.md#verifying-the-webhook-request
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: travel-advice-publisher-link-checker-api-callback-token
+  dataFrom:
+    - extract:
+        key: govuk/travel-advice-publisher/link-checker-api-callback-token


### PR DESCRIPTION
Adding the necessary Extra Env values along with the associated secrets for:

Collections publisher
Manuals publisher
Service manual publisher
Travel advice publisher 

All relevant external secrets have been created in AWS secrets manger also.

App env vars where sourced from puppet: https://github.com/alphagov/govuk-puppet/tree/32c1bbbb10067078c1406170666a135b4a10aaea/modules/govuk/manifests/apps
