### PR TITLE
Stop overriding `PLEK_SERVICE_*_URI` for every service.

### DIFF
--- a/charts/govuk-apps-conf/templates/configmap.yaml
+++ b/charts/govuk-apps-conf/templates/configmap.yaml
@@ -7,15 +7,13 @@ metadata:
   labels:
     {{- include "govuk-apps-conf.labels" . | nindent 4 }}
 data:
-  {{- /* TODO: omit namespace from these user-facing URLs in the default namespace. */}}
-  {{- /* TODO: delete PLEK_SERVICE_*_URI once Plek can construct http:// internal URLs. */}}
-  GOVUK_APP_DOMAIN: {{ .Values.internalDomainSuffix }}
+  GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   GOVUK_PROMETHEUS_EXPORTER: "true"
-  GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
+  GOVUK_PERSONALISATION_FEEDBACK_URI: https://signin.account.gov.uk/support
   {{- if eq .Values.govukEnvironment "production" }}
   GOVUK_PERSONALISATION_MANAGE_URI: "https://account.gov.uk?link=manage-account"
   GOVUK_PERSONALISATION_SECURITY_URI: "https://account.gov.uk?link=security-privacy"
@@ -23,28 +21,32 @@ data:
   GOVUK_PERSONALISATION_MANAGE_URI: "https://integration.account.gov.uk?link=manage-account"
   GOVUK_PERSONALISATION_SECURITY_URI: "https://integration.account.gov.uk?link=security-privacy"
   {{- end }}
-  GOVUK_PERSONALISATION_FEEDBACK_URI: https://signin.account.gov.uk/support
-  # TODO: switch back to in-cluster Account API once it's fully working.
-  PLEK_SERVICE_ACCOUNT_API_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_ASSETS_URI: https://assets.{{ .Values.publishingServiceDomainSuffix }}
-  PLEK_SERVICE_ASSET_MANAGER_URI: https://asset-manager.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_DRAFT_ORIGIN_URI: https://draft-origin.{{ .Values.externalDomainSuffix }}
-  PLEK_SERVICE_EMAIL_ALERT_API_URI: https://email-alert-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_FRONTEND_URI: http://frontend.{{ .Values.internalDomainSuffix }}
-  PLEK_SERVICE_LINK_CHECKER_API_URI: https://link-checker-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api.{{ .Values.internalDomainSuffix }}
-  PLEK_SERVICE_ROUTER_API_URI: https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_MAPIT_URI: https://mapit.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_IMMINENCE_URI: https://imminence.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI: https://local-links-manager.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  # TODO: switch back to in-cluster Search API once it's fully working.
-  PLEK_SERVICE_SEARCH_URI: https://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_SIGNON_URI: https://signon.{{ .Values.externalDomainSuffix }}
-  PLEK_SERVICE_STATIC_URI: http://static.{{ .Values.internalDomainSuffix }}
-  PLEK_SERVICE_SUPPORT_URI: https://support.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_SUPPORT_API_URI: https://support-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  PLEK_SERVICE_WHITEHALL_FRONTEND_URI: http://whitehall-frontend.{{ .Values.internalDomainSuffix }}
+  GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
+  PLEK_UNPREFIXABLE_DOMAINS: feedback,imminence,info-frontend,licensify,local-links-manager,search,signon
+  PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   RAILS_LOG_TO_STDOUT: "true"
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}-eks
+
+  # TODO: remove once assets serving path is in place (https://trello.com/c/NxNtX9JE).
+  PLEK_SERVICE_ASSETS_URI: https://assets.{{ .Values.publishingServiceDomainSuffix }}
+
+  # Services which remain in EC2 for a while after "MVP launch".
+  PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_MAPIT_URI: https://mapit.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+
+  {{- /* Special-case hackery for running frontends in k8s but APIs/backends in EC2. */}}
+  {{- /* TODO: get rid of this before launch. */}}
+  {{- if ne .Values.govukEnvironment "integration" }}
+  PLEK_SERVICE_ACCOUNT_API_URI: https://account-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_ASSET_MANAGER_URI: https://asset-manager.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_CONTENT_STORE_URI: https://content-store.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_EMAIL_ALERT_API_URI: https://email-alert-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_LINK_CHECKER_API_URI: https://link-checker-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_ROUTER_API_URI: https://router-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_IMMINENCE_URI: https://imminence.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI: https://local-links-manager.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_SEARCH_URI: https://search-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_SIGNON_URI: https://signon.{{ .Values.externalDomainSuffix }}
+  PLEK_SERVICE_SUPPORT_URI: https://support.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  PLEK_SERVICE_SUPPORT_API_URI: https://support-api.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
+  {{- end }}

--- a/charts/govuk-apps-conf/values.yaml
+++ b/charts/govuk-apps-conf/values.yaml
@@ -1,5 +1,4 @@
 govukEnvironment: test
-internalDomainSuffix: apps.svc.cluster.local
 externalDomainSuffix: eks.test.govuk.digital
 publishingServiceDomainSuffix: test.publishing.service.gov.uk
 ec2InternalDomainSuffix: govuk-internal.digital


### PR DESCRIPTION
Turns out this isn't practical when it comes to configuring the draft stack vs. regular stack x 3 environments. It's way simpler and less error-prone to avoid constructing FQDNs entirely and let the local resolver do its thing. This also paves the way for getting rid of Plek in the future.

So for internal (app-to-app) API traffic, apps will just use short hostnames like `frontend` when calling `getaddrinfo()` and the local resolver will expand that to `frontend.apps.svc.cluster.local.` as nature intended.

We have to keep most of the overrides in staging/production for now, until the second live-traffic experiment is out of the way.

We no longer need `internalDomainSuffix`, so get rid of that.

See https://github.com/alphagov/plek/blob/main/CHANGELOG.md#410 for descriptions of the new Plek env vars.

https://trello.com/c/R86kPYPL