### PR TITLE
Pass through existing X-Forwarded-Host header

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -49,6 +49,12 @@ http {
     }
   ';
 
+  # Map the passed in X-Forwarded-Host if present and default to the server host otherwise.
+  map $http_x_forwarded_host $proxy_add_x_forwarded_host {
+    default $http_x_forwarded_host;
+    ''      $http_host;
+  }
+
   # This map creates a $sts_default variable for later use.
   # If this header is already set by upstream, then $sts_default will
   # be an empty string, which will later lead to:
@@ -130,7 +136,7 @@ http {
       proxy_set_header   Host $http_host;
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-Server $host;
-      proxy_set_header   X-Forwarded-Host $http_host;
+      proxy_set_header   X-Forwarded-Host $proxy_add_x_forwarded_host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   Cookie '';
 
@@ -166,7 +172,7 @@ http {
       proxy_set_header   Host $http_host;
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-Server $host;
-      proxy_set_header   X-Forwarded-Host $http_host;
+      proxy_set_header   X-Forwarded-Host $proxy_add_x_forwarded_host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
@@ -226,7 +232,7 @@ http {
       proxy_set_header   Host $http_host;
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-Server $host;
-      proxy_set_header   X-Forwarded-Host $http_host;
+      proxy_set_header   X-Forwarded-Host $proxy_add_x_forwarded_host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 
       # Licensify sends custom 500 errors, and we need to send No-Fallback: true


### PR DESCRIPTION
Pass through the exisiting X-Forwarded-Host header if present on the client request. This ensures X-Forwarded-Host represents the original host (from Fastly). Previously we re-set the header to the Nginx host, which break redirects in Rails as it uses the header to determine the original host for the client request.