### PR TITLE
Stop exposing Signon to the public Internet.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -1109,6 +1109,7 @@ govukApplications:
       enabled: true
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: signon
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
       hosts:
       - signon.eks.integration.govuk.digital
     workerReplicaCount: 1

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -343,6 +343,7 @@ govukApplications:
       enabled: true
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: signon
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
       hosts:
       - signon.eks.production.govuk.digital
     workerReplicaCount: 1

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -343,6 +343,7 @@ govukApplications:
       enabled: true
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: signon
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
       hosts:
       - signon.eks.staging.govuk.digital
     workerReplicaCount: 1


### PR DESCRIPTION
Not so much a system security issue as a confusion risk, especially now that [GOV.UK Sign In](https://www.sign-in.service.gov.uk/) is an extremely similarly named website aimed at the general public. Sooner or later someone's going to get them mixed up and Signon will get misreported as a phishing site, etc.

See https://github.com/alphagov/govuk-aws/pull/1638