### PR TITLE
Fix names of smart-answers Signon token secrets.

### DIFF
--- a/charts/argocd-apps/values-integration.yaml
+++ b/charts/argocd-apps/values-integration.yaml
@@ -1175,12 +1175,12 @@ govukApplications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-link-checker-api
+            name: signon-token-smart-answers-link-checker-api
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-publishing-api
+            name: signon-token-smart-answers-publishing-api
             key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:

--- a/charts/argocd-apps/values-production.yaml
+++ b/charts/argocd-apps/values-production.yaml
@@ -407,12 +407,12 @@ govukApplications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-link-checker-api
+            name: signon-token-smart-answers-link-checker-api
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-publishing-api
+            name: signon-token-smart-answers-publishing-api
             key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:

--- a/charts/argocd-apps/values-staging.yaml
+++ b/charts/argocd-apps/values-staging.yaml
@@ -407,12 +407,12 @@ govukApplications:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-link-checker-api
+            name: signon-token-smart-answers-link-checker-api
             key: bearer_token
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-smartanswers-publishing-api
+            name: signon-token-smart-answers-publishing-api
             key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:


### PR DESCRIPTION
Since https://github.com/alphagov/signon/pull/1953 / https://github.com/alphagov/govuk-helm-charts/pull/589 these are consistently named after the apps' Git repos rather than their internal hostnames.