### PR TITLE
Increment argo-services chart version for rollout.

### DIFF
--- a/charts/argo-services/Chart.yaml
+++ b/charts/argo-services/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-services
 description: Installs Argo service configuration (cd, events, notifications, workflows)
-version: 0.1.19
+version: 0.2.0


### PR DESCRIPTION
This chart is rolled out via `helm install` (by Terraform) so the chart version matters.