### PR TITLE
Revert the use of build metadata in the chart version.

### DIFF
--- a/charts/app-config/Chart.yaml
+++ b/charts/app-config/Chart.yaml
@@ -3,4 +3,4 @@
 apiVersion: v2
 name: app-config
 description: Configuration of apps managed by ArgoCD.
-version: 1.0.0+versioning-not-in-use-for-this-chart
+version: 1.0.0


### PR DESCRIPTION
Turns out our `Release Charts` GitHub Action doesn't like semver build metadata :(

This reverts commit cdc98cf (from #607).