### PR TITLE
Install only the Application resources into the Argo namespace.

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -6,6 +6,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .name }}
+  namespace: {{ $.Values.argoNamespace | default $.Release.Namespace }}
   {{- if has $.Values.govukEnvironment (list "test" "integration") }}
   {{- /* Clean up k8s resources on chart deletion in non-prod only. */}}
   finalizers:

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -6,6 +6,7 @@
 # See values-${env}.yaml for per-environment and per-app values.
 
 appsNamespace: apps
+argoNamespace: cluster-services
 govukApplications: []
 
 govukEnvironment: test

--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
-description: Bootstaps ArgoCD with initial configuration
-version: 0.1.0
+description: Bootstraps ArgoCD with initial configuration
+version: 0.2.0

--- a/charts/argo-bootstrap/templates/argocd/apps-application.yaml
+++ b/charts/argo-bootstrap/templates/argocd/apps-application.yaml
@@ -17,7 +17,7 @@ spec:
 
   destination:
     server: 'https://kubernetes.default.svc'
-    namespace: cluster-services
+    namespace: apps
 
   syncPolicy:
     automated:


### PR DESCRIPTION
Having moved a bunch of externalsecrets and configmaps into this chart which used to be in their own ArgoCD `Application`, we need those objects to be created in the `apps` namespace.

I think it's simpler and less error prone for the `apps` namespace to be the default and just set `namespace: cluster-services` in the ArgoCD `Application` resource template, rather than having to override the namespace on everything else.

Fixes alphagov/govuk-helm-charts#607.