### PR TITLE
Remove Cluster wide access from Argo Sensor roles

### DIFF
--- a/charts/argo-services/templates/events/service-account.yaml
+++ b/charts/argo-services/templates/events/service-account.yaml
@@ -8,7 +8,7 @@ metadata:
 ---
 # Similarly you can use a ClusterRole and ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: operate-workflow-role
 rules:
@@ -41,14 +41,13 @@ rules:
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: operate-workflow-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: operate-workflow-role
 subjects:
   - kind: ServiceAccount
     name: operate-workflow-sa
-    namespace: cluster-services


### PR DESCRIPTION
The service account used by Sensors don't need Cluster wide permissions to trigger workflows in the same namespace.