### PR TITLE
Remove finalizer from monitoring-config Argo app.

### DIFF
--- a/charts/app-config/templates/monitoring-application.yaml
+++ b/charts/app-config/templates/monitoring-application.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   name: monitoring-config
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
   annotations:
     repoName: monitoring-config
 spec:


### PR DESCRIPTION
This isn't needed (for monitoring config) and just seems to cause deadlocks when deleting or moving the app.

\the_architect{this is the sixth time I've kubectl edited out the finaliser on the monitoring chart and I'm becoming very efficient at it}

#620.