### PR TITLE
Enable webhook endpoint for CD in production

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -86,7 +86,6 @@ govukApplications:
   postSyncWorkflowEnabled: "false"
   helmValues:
     nextEnvironment: staging
-    enableWebhookIngress: true
 - name: authenticating-proxy
   helmValues:
     ingress:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -21,6 +21,7 @@ govukApplications:
   # TODO: Handle case where production doesn't promote deployments
   helmValues:
     nextEnvironment: ""
+    enableWebhookIngress: true
 - name: collections
   helmValues:
     extraEnv:


### PR DESCRIPTION
This is part of moving the CD workloads to the production cluster instead of integration.