### PR TITLE
Rightsize response buffers in nginx reverse proxies.

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -20,6 +20,11 @@ http {
   uwsgi_temp_path       /tmp/uwsgi_temp;
   scgi_temp_path        /tmp/scgi_temp;
 
+  proxy_buffer_size 16k;  # Max total size of response headers.
+  # n * m = max response size before spooling to disk. p95 response size should
+  # fit comfortably within this in order to avoid performance issues.
+  proxy_buffers 24 16k;
+
   server_tokens off;
 
   sendfile        on;

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -28,6 +28,11 @@ data:
       uwsgi_temp_path       /tmp/uwsgi_temp;
       scgi_temp_path        /tmp/scgi_temp;
 
+      proxy_buffer_size 16k;  # Max total size of response headers.
+      # n * m = max response size before spooling to disk. p95 response size should
+      # fit comfortably within this in order to avoid performance issues.
+      proxy_buffers 24 16k;
+
       server_tokens off;
 
       sendfile        on;


### PR DESCRIPTION
This allows:
- the sum of the response headers on any given request to be up to 16 kB (up from 4 kB) without failing with `upstream sent too big header while reading response header`.
- the response body to be up to 384 kB (up from 32 kB) before nginx starts spooling to disk (which is deleterious to performance — we want to avoid disk writes for the vast majority of requests).

This was prompted by alphagov/govuk-puppet#11846.

See
https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx for a good explanation of what these parameters mean in practice.

Nginx docs: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers