### PR TITLE
Use our image for upload jobs as Bitnami's no longer includes `curl`.

### DIFF
--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -29,7 +29,7 @@ spec:
           allowPrivilegeEscalation: false
       containers:
       - name: {{ .Release.Name }}-upload-assets
-        image: public.ecr.aws/bitnami/aws-cli
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
         command:
         - aws
         - s3

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -17,7 +17,7 @@ spec:
         runAsGroup: 1001
       containers:
         - name: upload-static-error-pages
-          image: public.ecr.aws/bitnami/aws-cli:2
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
           securityContext:
             allowPrivilegeEscalation: false
           env:


### PR DESCRIPTION
This was causing the `static-upload-error-pages` job to fail in staging. It was only succeeding in integration because we were using the `v2` tag without setting `pullPolicy` 🙃