### PR TITLE
Add workflow to retag images with `deployed-to-<env>`

### DIFF
--- a/charts/argo-bootstrap/values.yaml
+++ b/charts/argo-bootstrap/values.yaml
@@ -1,3 +1,4 @@
+awsAccountId:
 govukEnvironment:
 argocdUrl:
 argoWorkflowsUrl:

--- a/charts/argo-bootstrap/values.yaml
+++ b/charts/argo-bootstrap/values.yaml
@@ -6,3 +6,7 @@ argoEventsHost:
 rbacTeams:
   read_only:
   read_write:
+iamRoleServiceAccounts:
+  tagImageWorkflow:
+    name:
+    iamRoleArn:

--- a/charts/argo-services/scripts/add-tag-to-image.sh
+++ b/charts/argo-services/scripts/add-tag-to-image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get existing image manifest from AWS ECR
+MANIFEST=$(aws ecr batch-get-image \
+  --registry-id "${AWS_ACCOUNT}" \
+  --repository-name "${REPOSITORY_NAME}" \
+  --image-ids imageTag="${REFERENCE_TAG}" \
+  --query 'images[].imageManifest' \
+  --output text)
+
+# Add tag to image
+aws ecr put-image \
+  --registry-id "${AWS_ACCOUNT}" \
+  --repository-name "${REPOSITORY_NAME}" \
+  --image-tag "${NEW_TAG}" \
+  --image-manifest "${MANIFEST}"

--- a/charts/argo-services/templates/workflows/add-tag-to-image/service-account.yaml
+++ b/charts/argo-services/templates/workflows/add-tag-to-image/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.name }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.iamRoleArn }}

--- a/charts/argo-services/templates/workflows/add-tag-to-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/add-tag-to-image/workflow.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: add-tag-to-image
+spec:
+  entrypoint: add-tag-to-image
+  arguments:
+    parameters:
+      - name: awsRegion
+      - name: awsAccount
+      - name: repositoryName
+      - name: referenceTag
+      - name: newTag
+  templates:
+    - name: add-tag-to-image
+      inputs:
+        parameters:
+          - name: awsRegion
+            default: "eu-west-1"
+          - name: awsAccount
+          - name: repositoryName
+          - name: referenceTag
+          - name: newTag
+      script:
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+        command: [/bin/bash]
+        env:
+          - name: AWS_DEFAULT_REGION
+            value: "{{"{{inputs.parameters.awsRegion}}"}}"
+          - name: AWS_ACCOUNT
+            value: "{{"{{inputs.parameters.awsAccount}}"}}"
+          - name: REPOSITORY_NAME
+            value: "{{"{{inputs.parameters.repositoryName}}"}}"
+          - name: REFERENCE_TAG
+            value: "{{"{{inputs.parameters.referenceTag}}"}}"
+          - name: NEW_TAG
+            value: "{{"{{inputs.parameters.newTag}}"}}"
+        source: |
+          {{- .Files.Get "scripts/add-tag-to-image.sh" | nindent 14 }}
+  podSpecPatch: |
+    containers:
+      - resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 512Mi

--- a/charts/argo-services/templates/workflows/add-tag-to-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/add-tag-to-image/workflow.yaml
@@ -13,6 +13,7 @@ spec:
       - name: newTag
   templates:
     - name: add-tag-to-image
+      serviceAccountName: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.name }}
       inputs:
         parameters:
           - name: awsRegion

--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -28,6 +28,20 @@ spec:
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
                 - name: manualDeploy
                   value: "{{"{{workflow.parameters.manualDeploy}}"}}"
+        - - name: add-deployed-to-tag
+            templateRef:
+              name: add-tag-to-image
+              template: add-tag-to-image
+            arguments:
+              parameters:
+                - name: awsAccount
+                  value: "{{ .Values.awsAccountId }}"
+                - name: repositoryName
+                  value: "{{"{{workflow.parameters.repoName}}"}}"
+                - name: referenceTag
+                  value: "{{"{{workflow.parameters.imageTag}}"}}"
+                - name: newTag
+                  value: "deployed-to-{{"{{workflow.parameters.environment}}"}}"
 
     - name: exit-handler
       steps:

--- a/charts/argo-services/values.yaml
+++ b/charts/argo-services/values.yaml
@@ -9,3 +9,7 @@ enableWebhookIngress: false
 rbacTeams:
   read_only:
   read_write:
+iamRoleServiceAccounts:
+  tagImageWorkflow:
+    name: service-account-name
+    iamRoleArn: arn:aws:iam::$account_id:role/$role_name

--- a/charts/argo-services/values.yaml
+++ b/charts/argo-services/values.yaml
@@ -1,3 +1,4 @@
+awsAccountId: "1112223334"
 govukEnvironment: test
 argocdUrl:
 argoWorkflowsUrl:


### PR DESCRIPTION
This PR adds the `add-tag-to-image` workflow which can retag an image in AWS ECR with a new tag. This workflow is now called by the deploy image workflow to add a `deployed-to-<env>` tag to the image that's been deployed. This allows us to create AWS ECR lifecycle rules and have a rule to protect images that are currently in use.

This also creates a Service Account the use an IAM Role to gain AWS permissions to push the new image tag. The IAM Role is created in Terraform and the ARN is passed via argo-bootstrap in Helm Values. https://github.com/alphagov/govuk-infrastructure/pull/758

Tested and works by manually syncing with Argo.