### PR TITLE
Prevent workflow failure if image already has `deployed-to-<env>` tag

### DIFF
--- a/charts/argo-services/scripts/add-tag-to-image.sh
+++ b/charts/argo-services/scripts/add-tag-to-image.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Check if image is already tagged
+TAG_EXISTS=$(aws ecr describe-images \
+  --registry-id "${AWS_ACCOUNT}" \
+  --repository-name "${REPOSITORY_NAME}" \
+  --image-ids imageTag="${REFERENCE_TAG}" \
+  --query "imageDetails[].imageTags | [] | contains(@, '${NEW_TAG}')")
+
+if [[ "${TAG_EXISTS}" = true ]]; then
+  echo "Image tagged ${REFERENCE_TAG} already has ${NEW_TAG} tag."
+  exit 0
+fi
+
 # Get existing image manifest from AWS ECR
 MANIFEST=$(aws ecr batch-get-image \
   --registry-id "${AWS_ACCOUNT}" \


### PR DESCRIPTION
The workflow now checks if the image already has the tag and exits successfully, rather than "failing" to re-tag the image.