### PR TITLE
Add ExternalSecret for Signon field-level DB encryption.

### DIFF
--- a/charts/app-config/templates/external-secrets/signon/active-record-encryption.yaml
+++ b/charts/app-config/templates/external-secrets/signon/active-record-encryption.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: active-record-encryption
+  labels:
+    {{- include "app-config.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY and
+      ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT for Signon field-level
+      database encryption.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: active-record-encryption
+  dataFrom:
+    - extract:
+        key: govuk/signon/active-record-encryption

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1127,6 +1127,16 @@ govukApplications:
         value: 759acac6-da53-4a19-b591-b7538c7c39de
       - name: INSTANCE_NAME
         value: integration
+      - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+        valueFrom:
+          secretKeyRef:
+            name: active-record-encryption
+            key: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+      - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+        valueFrom:
+          secretKeyRef:
+            name: active-record-encryption
+            key: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -364,6 +364,16 @@ govukApplications:
         value: production
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+        valueFrom:
+          secretKeyRef:
+            name: active-record-encryption
+            key: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+      - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+        valueFrom:
+          secretKeyRef:
+            name: active-record-encryption
+            key: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -361,6 +361,16 @@ govukApplications:
         value: 112842bb-d8a4-4511-90de-57dc5c8f27ec
       - name: INSTANCE_NAME
         value: staging
+      - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+        valueFrom:
+          secretKeyRef:
+            name: active-record-encryption
+            key: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+      - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+        valueFrom:
+          secretKeyRef:
+            name: active-record-encryption
+            key: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This is needed in order for Signon to work after alphagov/signon#1965.

Secrets Manager secrets are already there in all three accounts.