### PR TITLE
Fix Argo Notifications secret namespace

### DIFF
--- a/charts/argo-services/templates/notifications/secret.yaml
+++ b/charts/argo-services/templates/notifications/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: argocd-notifications-secret
+  namespace: "{{ .Values.argoNamespace }}"
   labels:
     argocd.argoproj.io/secret-type: argocd-notifications-secret
 spec:


### PR DESCRIPTION
Argo Notifications cannot access these secrets as they deployed into the apps namespace, rather than same namespaces as Argo Notification and the Argo Applications.