### PR TITLE
Fix Argo Notification configmap namespaces

### DIFF
--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -7,7 +7,7 @@ service.webhook.argo_events: |
     value: "application/json"
   - name: Authorization
     value: Bearer $argo_events_webhook_token
-  url: "http://argo-events-service.cluster-services.svc.cluster.local:12000"
+  url: "http://argo-events-service.apps.svc.cluster.local:12000"
 service.webhook.slack_webhook: |
   headers:
   - name: "Content-Type"

--- a/charts/argo-services/templates/notifications/cm.yaml
+++ b/charts/argo-services/templates/notifications/cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-notifications-cm
+  namespace: {{ .Values.argoNamespace }}
 data:
   context: |
     argocdUrl: "{{ .Values.argocdUrl }}"


### PR DESCRIPTION
This corrects the namespace references for Argo Events and the configmap used by Argo Notifications.