### PR TITLE
Trigger deploy promotion in Production

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/secrets.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/secrets.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.nextEnvironment }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: deploy-image-webhook-endpoint
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: deploy-image-webhook-endpoint
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: govuk/argo-workflows/deploy-image-webhook-endpoint
+{{- end }}

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -31,9 +31,7 @@ spec:
           {{ if .Values.nextEnvironment }}
           - name: promote-release
             depends: smoke-test.Succeeded
-            templateRef:
-              name: update-image-tag
-              template: update-image-tag
+            template: send-webhook
             arguments:
               parameters:
                 - name: environment
@@ -42,7 +40,41 @@ spec:
                   value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: imageTag
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
+                - name: manualDeploy
+                  value: "false"
           {{- end }}
+
+    - name: send-webhook
+      inputs:
+        parameters:
+        - name: environment
+        - name: repoName
+        - name: imageTag
+        - name: manualDeploy
+      script:
+        image: curlimages/curl
+        command:
+          - sh
+        source: >
+          curl -s "${WEBHOOK_URL}/update-image-tag" \
+            -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+            --json '{
+              "environment": "{{"{{inputs.parameters.environment}}"}}",
+              "repoName": "{{"{{inputs.parameters.repoName}}"}}",
+              "imageTag": "{{"{{inputs.parameters.imageTag}}"}}",
+              "manualDeploy": "{{"{{inputs.parameters.manualDeploy}}"}}"
+            }'
+        env:
+          - name: WEBHOOK_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: deploy-image-webhook-endpoint
+                key: token
+          - name: WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                name: deploy-image-webhook-endpoint
+                key: url
 
     - name: exit-handler
       steps:


### PR DESCRIPTION
This changes the post-sync workflow to trigger the deploy image workflow in Production, instead of running the update image tag workflow in the current environment. This is because the deploy image workflow in Production is also configured to retag images with a `deployed-to-<env>` tag. Currently only the production cluster has permissions to retag images in AWS ECR (which is also in the Production account). Due to AWS IAM permissions being to granular ("ecr:PutImage"), permission to retag an image, also allows you to push a binary, which we didn't want to grant to our non-production environments.