### PR TITLE
Use `$GITHUB_OUTPUT` file instead of deprecated `::set-output`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/update-image-tag.yml
+++ b/.github/workflows/update-image-tag.yml
@@ -50,7 +50,7 @@ jobs:
         id: get-sha
         run: |
           LATEST_COMMIT_SHA=$(git ls-remote "https://github.com/alphagov/${repo}" HEAD | cut -f 1)
-          echo "::set-output name=latest_commit_sha::${LATEST_COMMIT_SHA}"
+          echo "latest_commit_sha=${LATEST_COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
 
       - name: Update image tag
         id: update-image-tag
@@ -61,7 +61,7 @@ jobs:
           yq -i '.image_tag = env(image_tag)' "${config_file}"
 
           UPDATED=$([-z git status --porcelain] && echo 'true' || echo 'false')
-          echo "::set-output name=updated::${UPDATED}"
+          echo "updated=${UPDATED}" >> "${GITHUB_OUTPUT}"
 
       - name: Push changes
         if: ${{ steps.update-image-tag.outputs.updated }}


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/