### PR TITLE
Use the right OAuth secrets for Authenticating Proxy.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -103,12 +103,12 @@ govukApplications:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
-            name: signon-app-authenticating-proxy
+            name: signon-app-content-preview
             key: oauth_id
       - name: GDS_SSO_OAUTH_SECRET
         valueFrom:
           secretKeyRef:
-            name: signon-app-authenticating-proxy
+            name: signon-app-content-preview
             key: oauth_secret
       - name: GOVUK_UPSTREAM_URI
         value: "http://draft-router"


### PR DESCRIPTION
Since #574 / #596, the OAuth secrets that are synced automatically from Signon are named after the Signon (Doorkeeper) app names rather than the app repo names.

No changes to staging/prod values needed since we're only running authenticating-proxy in integration at the moment.

Rollout: I've deleted the old secrets in all three clusters so we won't trip over them in future.