### PR TITLE
Eliminate a duplicate secret for the basic auth creds.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1095,12 +1095,15 @@ govukApplications:
             name: service-manual-publisher-postgres
             key: DATABASE_URL
       - name: HTTP_USERNAME
-        value: betademo
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: username
       - name: HTTP_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: service-manual-publisher-http-password
-            key: HTTP_PASSWORD
+            name: basic-auth
+            key: password
 - name: signon
   helmValues:
     dbMigrationEnabled: true


### PR DESCRIPTION
The same Basic Auth credentials are used in a bunch of other places and we now have a canonical Secrets Manager secret for them as of #638.