### PR TITLE
Don't require basic auth on draft-router.

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -125,9 +125,11 @@ http {
     add_header Permissions-Policy interest-cohort=();
     add_header X-Content-Type-Options "nosniff" always;
 
+    {{- if ne .Stack "draft" }}
     {{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
     auth_basic "Enter the GOV.UK username/password (not your personal username/password)";
     auth_basic_user_file /etc/nginx/htpasswd/htpasswd;
+    {{- end }}
     {{- end }}
 
     # The directives in this block don't apply when one of the more specific


### PR DESCRIPTION
The draft flavour of Router sits behind `authenticating-proxy` and doesn't have its own Ingress. It's therefore not supposed to have Basic Auth.

This should fix another thing that was stopping `draft-origin` (content preview) from working.

Rollout: I'll restart draft-router to pick up the new configmap once this is merged.