### PR TITLE
Work around apps referring to `search-api` as `search`.

### DIFF
--- a/charts/app-config/templates/search-api-alias.yaml
+++ b/charts/app-config/templates/search-api-alias.yaml
@@ -1,0 +1,16 @@
+# TODO: change [remaining usage] of "search" to "search-api" throughout alphagov,
+# then remove this.
+# [remaining usage]: https://sourcegraph.com/search?q=repo:alphagov+Plek.*[%27%22]search[%27%22]&patternType=regexp
+apiVersion: v1
+kind: Service
+metadata:
+  name: search
+  labels:
+    {{- include "app-config.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Workaround for some apps which still connect to search-api using its old
+      name, "search".
+spec:
+  type: ExternalName
+  externalName: search-api.{{ .Values.appsNamespace }}.svc.cluster.local


### PR DESCRIPTION
This essentially adds `search CNAME search-api` to cluster DNS. The `externalName` has to be an FDQN, btw.

We can remove it once we've [cleaned up all the usage of the legacy name](https://github.com/alphagov/gds-api-adapters/pull/1170), but that's probably going to take a while.

This fixes Collections, among other things. For example https://www-origin.eks.integration.govuk.digital/browse/driving/teaching-people-to-drive

Tested: `k create -f <(helm template . |yq e '.|select(.metadata.name=="search")')` in integration.