### PR TITLE
Add support for running arbitrary commands in cron jobs

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1344,7 +1344,7 @@ govukApplications:
       hosts:
       - signon.eks.integration.govuk.digital
     workerReplicaCount: 1
-    cronRakeTasks:
+    cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
         schedule: "0 */1 * * *"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -343,7 +343,7 @@ govukApplications:
       hosts:
       - signon.eks.production.govuk.digital
     workerReplicaCount: 1
-    cronRakeTasks:
+    cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
         schedule: "0 */1 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -342,7 +342,7 @@ govukApplications:
       hosts:
       - signon.eks.staging.govuk.digital
     workerReplicaCount: 1
-    cronRakeTasks:
+    cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
         schedule: "0 */1 * * *"

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -1,9 +1,9 @@
-{{- range .Values.cronRakeTasks }}
+{{- range .Values.cronTasks }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ $.Release.Name }}-{{ .name }}-rake-task"
+  name: "{{ $.Release.Name }}-{{ .name }}-cron-task"
   labels:
     {{- include "generic-govuk-app.labels" $ | nindent 4 }}
     app.kubernetes.io/component: app
@@ -11,14 +11,14 @@ spec:
   schedule: "{{ .schedule }}"
   jobTemplate:
     metadata:
-      name: "{{ $.Release.Name }}-{{ .name }}-rake-task"
+      name: "{{ $.Release.Name }}-{{ .name }}-cron-task"
       labels:
         {{- include "generic-govuk-app.labels" $ | nindent 8 }}
         app.kubernetes.io/component: app
     spec:
       template:
         metadata:
-          name: "{{ $.Release.Name }}-{{ .name }}-rake-task"
+          name: "{{ $.Release.Name }}-{{ .name }}-cron-task"
           labels:
             {{- include "generic-govuk-app.labels" $ | nindent 12 }}
             app.kubernetes.io/component: app
@@ -30,10 +30,15 @@ spec:
           restartPolicy: Never
           {{ if .serviceAccount }}serviceAccountName: {{ .serviceAccount }}{{- end }}
           containers:
-            - name: rake-task
+            - name: cron-task
               image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
+              {{- if .task }}
               command: ["bundle"]
               args: ["exec", "rails", "{{ .task }}"]
+              {{- else if .command }}
+              command: ["/bin/bash"]
+              args: ["-c", "{{ .command }}"]
+              {{- end }}
               envFrom:
               - configMapRef:
                   name: govuk-apps-env


### PR DESCRIPTION
Some apps need to run scripts instead of rake tasks, so we need to support this

https://trello.com/c/ppfM0Sw8/1025-ensure-scheduled-tasks-by-the-whenever-gem-can-run