### PR TITLE
Fix RabbitMQ credentials for publishing-api.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,15 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1.1
-        with:
-          version: 3.*
+        uses: azure/setup-helm@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.*
+          python-version: 3.x
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --config ct.yml)
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> "${GITHUB_OUTPUT}"
-          fi
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yml

--- a/charts/app-config/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -1,4 +1,3 @@
-{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -7,7 +6,7 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      RabbitMQ credentials for publishing-api.
+      RabbitMQ user and password for publishing-api.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -17,5 +16,4 @@ spec:
     name: publishing-api-rabbitmq
   dataFrom:
     - extract:
-        key: govuk/common/rabbitmq-govuk
-{{- end }}
+        key: govuk/publishing-api/rabbitmq

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1006,7 +1006,10 @@ govukApplications:
             name: publishing-api-rabbitmq
             key: password
       - name: RABBITMQ_USER
-        value: publishing_api
+        valueFrom:
+          secretKeyRef:
+            name: publishing-api-rabbitmq
+            key: user
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: EVENT_LOG_AWS_BUCKETNAME


### PR DESCRIPTION
I've set the secretsmanager secret in all three environments to match what's in EC2.

Also fix the chart-testing pre-merge check.