### PR TITLE
Use AMQP connection string instead of separate env vars.

### DIFF
--- a/charts/app-config/externalsecrets-templates/amqp-conn-string.tpl
+++ b/charts/app-config/externalsecrets-templates/amqp-conn-string.tpl
@@ -1,0 +1,1 @@
+amqp://{{ .username | toString }}:{{ .password | toString }}@{{ .host | toString }}:{{ .port | toString }}

--- a/charts/app-config/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      RabbitMQ user and password for publishing-api.
+      RabbitMQ connection string for publishing-api.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -14,6 +14,9 @@ spec:
     kind: ClusterSecretStore
   target:
     name: publishing-api-rabbitmq
+    template:
+      data:
+        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/publishing-api/rabbitmq

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -998,18 +998,11 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-      - name: RABBITMQ_HOSTS
-        value: rabbitmq.integration.govuk-internal.digital
-      - name: RABBITMQ_PASSWORD
+      - name: RABBITMQ_URL
         valueFrom:
           secretKeyRef:
             name: publishing-api-rabbitmq
-            key: password
-      - name: RABBITMQ_USER
-        valueFrom:
-          secretKeyRef:
-            name: publishing-api-rabbitmq
-            key: user
+            key: RABBITMQ_URL
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: EVENT_LOG_AWS_BUCKETNAME


### PR DESCRIPTION
This is marginally neater, consistent with how we're configuring database backends and - more practically - avoids the problem of `RABBITMQ_URL` being already set in the Dockerfile and taking precedence over `RABBITMQ_HOSTS` etc.

Tested: manually inspected output of `helm template . --values values-integration.yaml |yq e '.|select(.kind == "ExternalSecret" and .metadata.name == "publishing-api-rabbitmq")'` and `helm template ../generic-govuk-app --values <(helm template . --values values-integration.yaml |yq e '. |select(.metadata.name == "publishing-api").spec.source.helm.values') |yq e '.|select(.kind == "Deployment")'`

Rollout: I've updated the secretsmanager secrets in all three accounts to reflect the new format `{username, password, host, port}`.