### PR TITLE
Run publishing-api AMQP "heartbeat" cron less often.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1005,7 +1005,7 @@ govukApplications:
     cronTasks:
       - name: heartbeat
         task: "heartbeat_messages:send"
-        schedule: "* * * * *"
+        schedule: "*/4 * * * *"
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
We can probably get rid of this job without too much trouble - it seems to be just a workaround for some iffy [Icinga monitoring](https://github.com/alphagov/govuk-developer-docs/blob/cb58575/source/manual/alerts/rabbitmq-no-consumers-listening.html.md#no-activity-for-x-seconds-idle-times-are-x-y-z) - but for now let's just set it to run 1/4 as often so it doesn't make the ArgoCD UI quite so unusable when it fails.

The threshold for the questionable Icinga monitoring is 5 minutes, so running this every 4 minutes should be perfectly adequate.