### PR TITLE
Remove update image tag logic from set automatic deployments workflow

### DIFF
--- a/charts/argo-services/scripts/set-automatic-deploys-enabled.sh
+++ b/charts/argo-services/scripts/set-automatic-deploys-enabled.sh
@@ -2,10 +2,6 @@
 set -euo pipefail
 
 BRANCH="update-image-tag/${REPO_NAME}/${ENVIRONMENT}/${AUTOMATIC_DEPLOYS_ENABLED}"
-if [[ -n "${IMAGE_TAG}" ]]; then
-  BRANCH="update-image-tag/${REPO_NAME}/${ENVIRONMENT}/${AUTOMATIC_DEPLOYS_ENABLED}/${IMAGE_TAG}"
-fi
-
 FILE="charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}"
 CHANGED=false
 
@@ -17,46 +13,17 @@ gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
 
 cd "govuk-helm-charts" || exit 1
 
-commit() {
-  git add "${FILE}"
-  git commit -m "${1}"
-  echo "${1}"
-  CHANGED=true
-}
-
-update_image_tag() {
-  if [[ -n "${IMAGE_TAG}" ]]; then
-    yq -i '.image_tag = env(IMAGE_TAG)' "${FILE}"
-
-    if [[ "$(git status --porcelain)" ]]; then
-      commit "Update ${REPO_NAME} image tag to ${IMAGE_TAG} for ${ENVIRONMENT}"
-    else
-      echo "No change in image_tag"
-    fi
-  else
-    echo "Received image_tag empty, skipping update"
-  fi
-}
-
-set_automatic_deploys_enabled() {
-  yq -i '.automatic_deploys_enabled = env(AUTOMATIC_DEPLOYS_ENABLED)' "${FILE}"
-
-  if [[ "$(git status --porcelain)" ]]; then
-    commit "Set ${REPO_NAME} automatic_deploys_enabled to ${AUTOMATIC_DEPLOYS_ENABLED} for ${ENVIRONMENT}"
-  else
-    echo "No change in automatic_deploys_enabled"
-  fi
-}
-
-git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
-git config --global user.name "${GIT_NAME}"
-
-gh auth setup-git
-gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
 git checkout -b "${BRANCH}"
 
-update_image_tag
-set_automatic_deploys_enabled
+yq -i '.automatic_deploys_enabled = env(AUTOMATIC_DEPLOYS_ENABLED)' "${FILE}"
+
+if [[ "$(git status --porcelain)" ]]; then
+  git add "${FILE}"
+  git commit -m "Set ${REPO_NAME} automatic_deploys_enabled to ${AUTOMATIC_DEPLOYS_ENABLED} for ${ENVIRONMENT}"
+  CHANGED=true
+else
+  echo "No change in automatic_deploys_enabled"
+fi
 
 if [[ "${CHANGED}" = true ]]; then
   git push -u origin "${BRANCH}"

--- a/charts/argo-services/templates/workflows/set-automatic-deploys/sensor.yaml
+++ b/charts/argo-services/templates/workflows/set-automatic-deploys/sensor.yaml
@@ -30,10 +30,6 @@ spec:
           - dest: spec.arguments.parameters.2.value
             src:
               dependencyName: set-automatic-deploys-enabled
-              dataKey: body.imageTag
-          - dest: spec.arguments.parameters.3.value
-            src:
-              dependencyName: set-automatic-deploys-enabled
               dataKey: body.automaticDeploysEnabled
           - dest: metadata.generateName
             src:
@@ -52,7 +48,6 @@ spec:
                 parameters:
                   - name: environment
                   - name: repoName
-                  - name: imageTag
                   - name: automaticDeploysEnabled
               workflowTemplateRef:
                 name: set-automatic-deploys-enabled

--- a/charts/argo-services/templates/workflows/set-automatic-deploys/workflow.yaml
+++ b/charts/argo-services/templates/workflows/set-automatic-deploys/workflow.yaml
@@ -8,7 +8,6 @@ spec:
     parameters:
       - name: environment
       - name: repoName
-      - name: imageTag
       - name: automaticDeploysEnabled
   templates:
     - name: set-automatic-deploys-enabled
@@ -16,7 +15,6 @@ spec:
         parameters:
           - name: environment
           - name: repoName
-          - name: imageTag
           - name: automaticDeploysEnabled
             default: "true"
       script:
@@ -33,8 +31,6 @@ spec:
               secretKeyRef:
                 name: govuk-ci-github-creds
                 key: token
-          - name: IMAGE_TAG
-            value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: ENVIRONMENT
             value: "{{"{{inputs.parameters.environment}}"}}"
           - name: REPO_NAME


### PR DESCRIPTION
This workflow should only be concerned with enable/disabling automatic deployments. This PR removes logic from modifying the image tag - that can be done with the update image tag workflow. This functionality was originally introduced to allow user to reset the image tag to main when re-enabling automatic deployments. However, this is an untested need and the maintenance of the extra complexity outweighs the time saved to trigger the update image tag workflow.   