### PR TITLE
Fix name for `search-api` in `PLEK_UNPREFIXABLE_DOMAINS`.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -28,7 +28,7 @@ data:
   GOVUK_PERSONALISATION_SECURITY_URI: "https://integration.account.gov.uk?link=security-privacy"
   {{- end }}
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
-  PLEK_UNPREFIXABLE_DOMAINS: account-api,feedback,imminence,info-frontend,licensify,local-links-manager,search,signon
+  PLEK_UNPREFIXABLE_DOMAINS: account-api,feedback,imminence,info-frontend,licensify,local-links-manager,search-api,signon
   PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   RAILS_LOG_TO_STDOUT: "true"
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}-eks


### PR DESCRIPTION
See https://github.com/alphagov/gds-api-adapters/pull/1170.

Rollout: requires a `rollout restart` for deployments to pick up the change.