### PR TITLE
Pin publishing-api to sengi/schemas branch for testing for now.

### DIFF
--- a/charts/app-config/image-tags/integration/publishing-api
+++ b/charts/app-config/image-tags/integration/publishing-api
@@ -1,2 +1,2 @@
-image_tag: cb2203d920ad40c94643101289dffeaeab4babee
-automatic_deploys_enabled: true
+image_tag: release-51beff7ee5388f2b1b47270e823d7e9ec4bd7fb5
+automatic_deploys_enabled: false


### PR DESCRIPTION
This should let us test things which require pubapi to have govuk-content-schemas in place, until content schemas are built into pubapi.

I have a reminder to re-enable auto rollouts next week.