### PR TITLE
Updating external secret name

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -313,7 +313,7 @@ govukApplications:
       - name: PUBLISHING_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: signon-token-content-data-api-publishing-api
+            name: signon-token-content-performance-manager-publishing-api
             key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:


### PR DESCRIPTION
API user email in Signon external secrets is set to `content_performance_manager@alphagov.co.uk` for Content admin API app.
Therefore the publishing api bearer token is stored as `signon-token-content-performance-manager-publishing-api` within kubernetes secrets.