### PR TITLE
Add draft-government-frontend and delete an unused env var.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -804,8 +804,16 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-      - name: MEMCACHE_SERVERS
-        value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+- name: draft-government-frontend
+  helmValues:
+    extraEnv:
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
 - name: hmrc-manuals-api
   helmValues:
     ingress:


### PR DESCRIPTION
The `government-frontend` app doesn't use `MEMCACHE_SERVERS`; this was presumably a copy-pasto.

Co-authored-by: @dj-maisy