### PR TITLE
Avoid duplicating jobs/resources for draft-government-frontend.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -807,6 +807,10 @@ govukApplications:
 - name: draft-government-frontend
   repoName: government-frontend
   helmValues:
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    uploadAssets:
+      enabled: false
     extraEnv:
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-


### PR DESCRIPTION
Sentry ExternalSecrets and Rails assets are common to the draft and non-draft versions of an app.

Fixes 98f8724 / #685.