### PR TITLE
government-frontend does use memcached after all.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -799,6 +799,8 @@ govukApplications:
 - name: government-frontend
   helmValues:
     extraEnv:
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
@@ -812,6 +814,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
       - name: SECRET_KEY_BASE


### PR DESCRIPTION
Despite there being [no config in govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/cddc3d/modules/govuk/manifests/apps/government_frontend.pp) for it, government-frontend expects to be able to connect to memcache on `localhost:11211` unless `MEMCACHE_SERVERS` is set to an alternative address.

This rather opaque reference is what configures its usage of memcache: https://github.com/alphagov/government-frontend/blob/e2acb52/config/environments/production.rb#L58

Fixes 98f87246.