### PR TITLE
Configure asset-manager nginx to respond to `/__canary__`.

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -217,6 +217,15 @@ data:
           proxy_pass $download_url;
         }
 
+        # Endpoint that isn't cached, which is used to assert that an external
+        # service can receive a response from GOV.UK origin on the "assets"
+        # hostname. It is intended for Pingdom monitoring.
+        location = /__canary__ {
+          default_type application/json;
+          add_header cache-control "max-age=0,no-store,no-cache";
+          return 200 '{"message": "Tweet tweet"}\n';
+        }
+
         # Endpoint for liveness and readiness checks of the nginx container.
         location = /readyz {
           return 200 'ok\n';


### PR DESCRIPTION
Something (probably [Fastly](https://github.com/alphagov/govuk-cdn-config-secrets/blob/main/fastly/fastly.yaml)) is requesting this and it's eating resources and spewing stacktraces on the Rails app.

The old Puppet/EC2 environment serves `/__canary__` from nginx for assets-origin, as does our www-origin service in k8s, so it makes sense to add it here.