### PR TITLE
Use in-cluster content-store and search-api in integration.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1432,7 +1432,7 @@ govukApplications:
       - name: BACKEND_URL_collections
         value: "http://collections"
       - name: BACKEND_URL_content-store
-        value: "https://content-store.integration.govuk-internal.digital"
+        value: "http://content-store"
       - name: BACKEND_URL_email-alert-frontend
         value: "http://email-alert-frontend"
       - name: BACKEND_URL_frontend
@@ -1447,7 +1447,7 @@ govukApplications:
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
         value: "http://whitehall-frontend"
-        # TODO: switch back to in-cluster account-api once it's fully working (similarly for draft).
+        # TODO: switch back to in-cluster account-api once it's working.
       - name: BACKEND_URL_account-api
         value: "https://account-api.integration.govuk-internal.digital"
       - name: BACKEND_URL_feedback
@@ -1460,9 +1460,8 @@ govukApplications:
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify
         value: "https://licensify.integration.govuk-internal.digital"
-        # TODO: switch back to in-cluster search-api once it's fully working (similarly for draft).
       - name: BACKEND_URL_search-api
-        value: "https://search-api.integration.govuk-internal.digital"
+        value: "http://search-api"
 - name: search-admin
   helmValues:
     dbMigrationEnabled: true


### PR DESCRIPTION
These two are now running in Kubernetes, so we should switch to using them instead of their EC2 counterparts.