### PR TITLE
Use `RABBITMQ_URL` throughout instead of separate vars.

### DIFF
--- a/charts/app-config/templates/external-secrets/content-data-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/content-data-api/rabbitmq.yaml
@@ -1,4 +1,3 @@
-{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -7,7 +6,8 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      RabbitMQ user and password for Content Data API.
+      RabbitMQ connection string for content-data-api. Fields in SecretsManager
+      are username, password, host, port.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -15,7 +15,9 @@ spec:
     kind: ClusterSecretStore
   target:
     name: content-data-api-rabbitmq
+    template:
+      data:
+        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/content-data-api/rabbitmq
-{{- end }}

--- a/charts/app-config/templates/external-secrets/email-alert-service/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/email-alert-service/rabbitmq.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      RabbitMQ user and password for email alert service.
+      RabbitMQ connection string for email-alert-service. Fields in
+      SecretsManager are username, password, host, port.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -14,6 +15,9 @@ spec:
     kind: ClusterSecretStore
   target:
     name: email-alert-service-rabbitmq
+    template:
+      data:
+        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/email-alert-service/rabbitmq

--- a/charts/app-config/templates/external-secrets/publishing-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/publishing-api/rabbitmq.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      RabbitMQ connection string for publishing-api.
+      RabbitMQ connection string for publishing-api. Fields in SecretsManager
+      are username, password, host, port.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:

--- a/charts/app-config/templates/external-secrets/search-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/search-api/rabbitmq.yaml
@@ -1,4 +1,3 @@
-{{- if not (has $.Values.govukEnvironment (list "staging" "production")) }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -7,7 +6,8 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      Credentials used by search-api to access RabbitMQ
+      RabbitMQ connection string for search-api. Fields in SecretsManager are
+      username, password, host, port.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -15,7 +15,9 @@ spec:
     kind: ClusterSecretStore
   target:
     name: search-api-rabbitmq
+    template:
+      data:
+        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/search-api/rabbitmq
-{{- end }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -309,20 +309,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-content-data-api-support-api
             key: bearer_token
-      - name: RABBITMQ_PASSWORD
+      - name: RABBITMQ_URL
         valueFrom:
           secretKeyRef:
             name: content-data-api-rabbitmq
-            key: password
-      - name: RABBITMQ_USER
-        valueFrom:
-          secretKeyRef:
-            name: content-data-api-rabbitmq
-            key: user
-      - name: RABBITMQ_HOSTS
-        value: rabbitmq
-      - name: RABBITMQ_VHOST
-        value: /
+            key: RABBITMQ_URL
       - name: RABBITMQ_QUEUE
         value: content_data_api
       - name: RABBITMQ_QUEUE_BULK
@@ -684,18 +675,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-email-alert-service-email-alert-api
             key: bearer_token
-      - name: RABBITMQ_HOSTS
-        value: rabbitmq.integration.govuk-internal.digital
-      - name: RABBITMQ_PASSWORD
+      - name: RABBITMQ_URL
         valueFrom:
           secretKeyRef:
             name: email-alert-service-rabbitmq
-            key: password
-      - name: RABBITMQ_USER
-        valueFrom:
-          secretKeyRef:
-            name: email-alert-service-rabbitmq
-            key: user
+            key: RABBITMQ_URL
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 - name: feedback
@@ -1566,20 +1550,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-search-api-publishing-api
             key: bearer_token
-      - name: RABBITMQ_HOSTS
-        value: rabbitmq.integration.govuk-internal.digital
-      - name: RABBITMQ_VHOST
-        value: /
-      - name: RABBITMQ_USER
+      - name: RABBITMQ_URL
         valueFrom:
           secretKeyRef:
             name: search-api-rabbitmq
-            key: user
-      - name: RABBITMQ_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: search-api-rabbitmq
-            key: password
+            key: RABBITMQ_URL
       - name: TENSORFLOW_SAGEMAKER_ENDPOINT
         value: govuk-integration-search-ltr-endpoint
       - name: TENSORFLOW_SAGEMAKER_VARIANTS


### PR DESCRIPTION
Using a connection string constructed by a template in the ExternalSecret makes the configuration a bit simpler and more readable.

Also makes it easier to automate rotation of the secrets, should we choose to.

Remove the environment conditions from the ExternalSecrets.

Rollout: secrets are updated to fit the expected format in all three accounts.