### PR TITLE
Remove an unused env var TENSORFLOW_SAGEMAKER_VARIANTS.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1557,8 +1557,6 @@ govukApplications:
             key: RABBITMQ_URL
       - name: TENSORFLOW_SAGEMAKER_ENDPOINT
         value: govuk-integration-search-ltr-endpoint
-      - name: TENSORFLOW_SAGEMAKER_VARIANTS
-        value: null  # value is empty
 - name: service-manual-frontend
   helmValues:
     extraEnv:


### PR DESCRIPTION
Verified that this env var is not set in EC2 in any of the environments.