### PR TITLE
Switch back to our proprietary RABBITMQ_* vars for now.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -309,11 +309,23 @@ govukApplications:
           secretKeyRef:
             name: signon-token-content-data-api-support-api
             key: bearer_token
-      - name: RABBITMQ_URL
+      - name: RABBITMQ_PASSWORD
         valueFrom:
           secretKeyRef:
             name: content-data-api-rabbitmq
-            key: RABBITMQ_URL
+            key: password
+      - name: RABBITMQ_USER
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-rabbitmq
+            key: username
+      - name: RABBITMQ_HOSTS
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-rabbitmq
+            key: host
+      - name: RABBITMQ_VHOST
+        value: /
       - name: RABBITMQ_QUEUE
         value: content_data_api
       - name: RABBITMQ_QUEUE_BULK
@@ -664,11 +676,21 @@ govukApplications:
           secretKeyRef:
             name: signon-token-email-alert-service-email-alert-api
             key: bearer_token
-      - name: RABBITMQ_URL
+      - name: RABBITMQ_HOSTS
         valueFrom:
           secretKeyRef:
             name: email-alert-service-rabbitmq
-            key: RABBITMQ_URL
+            key: host
+      - name: RABBITMQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-service-rabbitmq
+            key: password
+      - name: RABBITMQ_USER
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-service-rabbitmq
+            key: username
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 - name: feedback
@@ -1539,11 +1561,23 @@ govukApplications:
           secretKeyRef:
             name: signon-token-search-api-publishing-api
             key: bearer_token
-      - name: RABBITMQ_URL
+      - name: RABBITMQ_HOSTS
         valueFrom:
           secretKeyRef:
             name: search-api-rabbitmq
-            key: RABBITMQ_URL
+            key: host
+      - name: RABBITMQ_VHOST
+        value: /
+      - name: RABBITMQ_USER
+        valueFrom:
+          secretKeyRef:
+            name: search-api-rabbitmq
+            key: username
+      - name: RABBITMQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: search-api-rabbitmq
+            key: password
       - name: TENSORFLOW_SAGEMAKER_ENDPOINT
         value: govuk-integration-search-ltr-endpoint
 - name: service-manual-frontend


### PR DESCRIPTION
Apps which use [govuk_message_queue_consumer](https://github.com/alphagov/govuk_message_queue_consumer) can't be configured with the `RABBITMQ_URL` env var yet, even though the underlying Bunny client library supports it.

Work is underway to [eliminate the config-wrapping stuff in govuk_message_queue_consumer](https://github.com/alphagov/govuk_message_queue_consumer/pull/80) but until that lands, we'll need to use the many `RABBITMQ_*` env vars.

Fixes #698 / 2a98317.