### PR TITLE
Fix ExternalSecrets for govuk_message_queue_consumer apps.

### DIFF
--- a/charts/app-config/templates/external-secrets/content-data-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/content-data-api/rabbitmq.yaml
@@ -15,9 +15,6 @@ spec:
     kind: ClusterSecretStore
   target:
     name: content-data-api-rabbitmq
-    template:
-      data:
-        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/content-data-api/rabbitmq

--- a/charts/app-config/templates/external-secrets/email-alert-service/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/email-alert-service/rabbitmq.yaml
@@ -15,9 +15,6 @@ spec:
     kind: ClusterSecretStore
   target:
     name: email-alert-service-rabbitmq
-    template:
-      data:
-        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/email-alert-service/rabbitmq

--- a/charts/app-config/templates/external-secrets/search-api/rabbitmq.yaml
+++ b/charts/app-config/templates/external-secrets/search-api/rabbitmq.yaml
@@ -15,9 +15,6 @@ spec:
     kind: ClusterSecretStore
   target:
     name: search-api-rabbitmq
-    template:
-      data:
-        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
   dataFrom:
     - extract:
         key: govuk/search-api/rabbitmq


### PR DESCRIPTION
Specifying ExternalSecret.spec.target.template means the fields from the Secrets Manager secret aren't automatically copied into the k8s Secret.

Since we need those fields for these apps for now (until https://github.com/alphagov/govuk_message_queue_consumer/pull/80 or similar lands), let's just revert the template change.