### PR TITLE
Add back missing `RABBITMQ_VHOST` env var to email-alert-service.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -696,6 +696,8 @@ govukApplications:
           secretKeyRef:
             name: email-alert-service-rabbitmq
             key: username
+      - name: RABBITMQ_VHOST
+        value: /
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 - name: feedback


### PR DESCRIPTION
Amends #707.