### PR TITLE
Make container image filesystems read-only.

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -20,6 +20,7 @@
           mountPath: /etc/clamav
       securityContext:
         allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
   volumes:
   - name: clam-virus-db
     nfs:

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             # Asset Manager needs to run as 2899 since it shares the same NFS volume with
             # EC2 counterpart
             runAsUser: 2899
@@ -114,6 +115,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -55,6 +55,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             # Asset Manager needs to run as 2899 since it shares an NFS volume
             # with its EC2 counterpart.
             runAsUser: 2899
@@ -77,6 +78,7 @@ spec:
               mountPath: /etc/clamav
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -27,6 +27,7 @@ spec:
           mountPath: /assets-to-upload
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       containers:
       - name: {{ .Release.Name }}-upload-assets
         image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
@@ -41,6 +42,9 @@ spec:
           {{- . | toYaml | trim | nindent 12 }}
         {{- end }}
         volumeMounts: *volumeMounts
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       restartPolicy: Never
       volumes:
       - name: assets-to-upload

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -54,4 +54,5 @@ spec:
               {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
 {{- end }}

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -41,4 +41,5 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
 {{- end }}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: true
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
             {{- . | toYaml | trim | nindent 12 }}
@@ -108,6 +109,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           volumeMounts:
           - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
             mountPath: /etc/nginx/nginx.conf

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -20,6 +20,7 @@ spec:
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           env:
             - name: GOVUK_ENVIRONMENT
               value: {{ .Values.govukEnvironment }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -56,6 +56,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: true
           {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
             {{- . | toYaml | trim | nindent 12 }}


### PR DESCRIPTION
App code shouldn't need to write to the image filesystem.

We're already mounting an emptyDir volume on `/tmp`, so most cases where apps need to write to a local filesystem should already be covered by that. This change might flush out a few as-yet-unnoticed cases of apps writing to other locations, which is a good thing.

For background as to why this is good practice, see for example https://kubesec.io/basics/containers-securitycontext-readonlyrootfilesystem-true/