### PR TITLE
Fix unit syntax for Asset Manager resource limits.

### DIFF
--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -51,12 +51,12 @@ appResources:
     memory: 1Gi
   requests:
     cpu: 500m
-    memory: 0.7Gi
+    memory: 700Mi
 
 workerResources:
   limits:
     cpu: 1
-    memory: 2.5Gi
+    memory: 2500Mi
   requests:
     cpu: 500m
     memory: 2Gi
@@ -64,10 +64,10 @@ workerResources:
 freshclamResources:
   limits:
     cpu: 500m
-    memory: 0.2Gi
+    memory: 200Mi
   requests:
     cpu: 500m
-    memory: 0.2Gi
+    memory: 200Mi
 
 clamdResources:
   limits:
@@ -75,7 +75,7 @@ clamdResources:
     memory: 2Gi
   requests:
     cpu: 500m
-    memory: 1.5Gi
+    memory: 1500Mi
 
 # assetManagerNFS is the address of the NFSv4 (or Amazon EFS) server where uploaded
 assetManagerNFS: "asset-manager-efs.dev.gov.uk"


### PR DESCRIPTION
Amends 16296d46.