### PR TITLE
Consistently disable API credential automounting for all app pods.

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -18,6 +18,7 @@
           mountPath: /var/lib/clamav
         - name: etc-clamav
           mountPath: /etc/clamav
+      automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
         allowPrivilegeEscalation: false

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         {{- include "asset-manager.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 1001
         runAsGroup: 1001

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: worker
         app: {{ .Release.Name }}-worker
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 1001
         runAsGroup: 1001

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -23,6 +23,7 @@ spec:
             {{- include "generic-govuk-app.labels" $ | nindent 12 }}
             app.kubernetes.io/component: app
         spec:
+          automountServiceAccountToken: false
           enableServiceLinks: false
           securityContext:
             runAsNonRoot: {{ $.Values.securityContext.runAsNonRoot }}

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -16,6 +16,7 @@ spec:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
         app.kubernetes.io/component: dbmigrate
     spec:
+      automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   template:
     spec:
+      automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
None of these containers should need to talk to kube-apiserver, so not expecting any breakage. If I'm wrong then it'll be good to shake out any unexpected stuff here anyway.