### PR TITLE
Add missing volumeMounts for /tmp.

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -1,29 +1,29 @@
 {{- define "asset-manager.freshclam.podspec" }}
-  automountServiceAccountToken: false
-  enableServiceLinks: false
-  securityContext:
-    seccompProfile:
-      type: RuntimeDefault
-    runAsUser: 1001
-    runAsGroup: 1001
-  containers:
-    - name: freshclam
-      image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-      imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
-      command: ["freshclam"]
-      {{ with .Values.freshclamResources }}
-      resources:
-        {{- . | toYaml | trim | nindent 15 }}
-      {{ end }}
-      volumeMounts:
-        - name: clam-virus-db
-          mountPath: /var/lib/clamav
-        - name: etc-clamav
-          mountPath: /etc/clamav
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-  volumes:
+automountServiceAccountToken: false
+enableServiceLinks: false
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
+  runAsUser: 1001
+  runAsGroup: 1001
+containers:
+  - name: freshclam
+    image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+    imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+    command: ["freshclam"]
+    {{ with .Values.freshclamResources }}
+    resources:
+      {{- . | toYaml | trim | nindent 8 }}
+    {{ end }}
+    volumeMounts:
+      - name: clam-virus-db
+        mountPath: /var/lib/clamav
+      - name: etc-clamav
+        mountPath: /etc/clamav
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+volumes:
   - name: clam-virus-db
     nfs:
       server: "{{ .Values.assetManagerNFS }}"
@@ -31,5 +31,5 @@
   - name: etc-clamav
     configMap:
       name: {{ .Release.Name }}-etc-clamav
-  restartPolicy: Never
+restartPolicy: Never
 {{- end }}

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -24,16 +24,21 @@ spec:
         - name: app
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           volumeMounts:
+            - name: app-tmp
+              mountPath: /tmp
             - name: asset-manager-efs
               mountPath: &uploads-path /mnt/asset-manager
+            {{- with .Values.appExtraVolumeMounts }}
+              {{ . | toYaml | trim | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.appPort }}
             - name: metrics
               containerPort: {{ .Values.metricsPort }}
           envFrom:
-          - configMapRef:
-              name: govuk-apps-env
+            - configMapRef:
+                name: govuk-apps-env
           env:
             - name: GOVUK_UPLOADS_ROOT
               value: *uploads-path
@@ -48,15 +53,15 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
-          {{- with .Values.extraEnv }}
-            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
-          {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
           {{- with .Values.appResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          {{- if .Values.appProbes }}
-          {{- .Values.appProbes | toYaml | trim | nindent 10 }}
+          {{- with .Values.appProbes }}
+            {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
           startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
             httpGet:
@@ -106,14 +111,14 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 15
           volumeMounts:
-          - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
-          - name: tmp
-            mountPath: /tmp
-          {{- with .Values.nginxExtraVolumeMounts }}
-            {{ . | toYaml | trim | nindent 10 }}
-          {{- end }}
+            - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-tmp
+              mountPath: /tmp
+            {{- with .Values.nginxExtraVolumeMounts }}
+              {{ . | toYaml | trim | nindent 12 }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -123,15 +128,17 @@ spec:
       {{- end }}
       enableServiceLinks: false
       volumes:
-      - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-        configMap:
-          name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-      - name: tmp
-        emptyDir: {}
-      {{- with .Values.extraVolumes }}
-        {{ . | toYaml | trim | nindent 6 }}
-      {{- end }}
-      - name: asset-manager-efs
-        nfs:
-          server: {{ .Values.assetManagerNFS }}
-          path: /asset-manager
+        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+          configMap:
+            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+        - name: app-tmp
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: asset-manager-efs
+          nfs:
+            server: {{ .Values.assetManagerNFS }}
+            path: /asset-manager
+        {{- with .Values.extraVolumes }}
+          {{ . | toYaml | trim | nindent 8 }}
+        {{- end }}

--- a/charts/asset-manager/templates/freshclam-cronjob.yaml
+++ b/charts/asset-manager/templates/freshclam-cronjob.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       template:
         spec:
-          {{- include "asset-manager.freshclam.podspec" . | indent 8 }}
+          {{- include "asset-manager.freshclam.podspec" . | indent 10 }}

--- a/charts/asset-manager/templates/freshclam-presync.yaml
+++ b/charts/asset-manager/templates/freshclam-presync.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   template:
     spec:
-      {{- include "asset-manager.freshclam.podspec" . | indent 4 }}
+      {{- include "asset-manager.freshclam.podspec" . | indent 6 }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -35,10 +35,15 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}
           volumeMounts:
+            - name: app-tmp
+              mountPath: /tmp
             - name: asset-manager-efs
               mountPath: &uploads-path /mnt/asset-manager
             - name: etc-clamav
               mountPath: /etc/clamav
+            {{- with .Values.appExtraVolumeMounts }}
+              {{ . | toYaml | trim | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: govuk-apps-env
@@ -47,9 +52,9 @@ spec:
               value: *uploads-path
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
-          {{- with .Values.extraEnv }}
-            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
-          {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
           {{- with .Values.workerResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
@@ -75,6 +80,8 @@ spec:
               mountPath: *uploads-path
             - name: clam-virus-db
               mountPath: /var/lib/clamav
+            - name: clamd-tmp
+              mountPath: /tmp
             - name: etc-clamav
               mountPath: /etc/clamav
           securityContext:
@@ -86,15 +93,22 @@ spec:
       {{- end }}
       enableServiceLinks: false
       volumes:
-      - name: asset-manager-efs
-        nfs:
-          server: "{{ .Values.assetManagerNFS }}"
-          path: /asset-manager
-      - name: clam-virus-db
-        nfs:
-          server: "{{ .Values.assetManagerNFS }}"
-          path: /clamav-db
-          readOnly: true
-      - name: etc-clamav
-        configMap:
-          name: {{ .Release.Name }}-etc-clamav
+        - name: app-tmp
+          emptyDir: {}
+        - name: clamd-tmp
+          emptyDir: {}
+        - name: asset-manager-efs
+          nfs:
+            server: "{{ .Values.assetManagerNFS }}"
+            path: /asset-manager
+        - name: clam-virus-db
+          nfs:
+            server: "{{ .Values.assetManagerNFS }}"
+            path: /clamav-db
+            readOnly: true
+        - name: etc-clamav
+          configMap:
+            name: {{ .Release.Name }}-etc-clamav
+        {{- with .Values.extraVolumes }}
+          {{ . | toYaml | trim | nindent 8 }}
+        {{- end }}

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -17,37 +17,37 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
       initContainers:
-      - name: {{ .Release.Name }}-copy-assets-for-upload
-        image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
-        command:
-        - sh
-        - -c
-        - "cp -R {{ $sourcePath }}/* /assets-to-upload"
-        volumeMounts: &volumeMounts
-        - name: assets-to-upload
-          mountPath: /assets-to-upload
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+        - name: {{ .Release.Name }}-copy-assets-for-upload
+          image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
+          command:
+            - sh
+            - -c
+            - "cp -R {{ $sourcePath }}/* /assets-to-upload"
+          volumeMounts: &volumeMounts
+            - name: assets-to-upload
+              mountPath: /assets-to-upload
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       containers:
-      - name: {{ .Release.Name }}-upload-assets
-        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
-        command:
-        - aws
-        - s3
-        - sync
-        - /assets-to-upload
-        - "{{- printf "s3://govuk-app-assets-%s/assets/%s/" .Values.govukEnvironment $destDir }}"
-        {{- with .Values.jobResources }}
-        resources:
-          {{- . | toYaml | trim | nindent 12 }}
-        {{- end }}
-        volumeMounts: *volumeMounts
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+        - name: {{ .Release.Name }}-upload-assets
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+          command:
+            - aws
+            - s3
+            - sync
+            - /assets-to-upload
+            - "{{- printf "s3://govuk-app-assets-%s/assets/%s/" .Values.govukEnvironment $destDir }}"
+          {{- with .Values.jobResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          volumeMounts: *volumeMounts
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       restartPolicy: Never
       volumes:
-      - name: assets-to-upload
-        emptyDir: {}
+        - name: assets-to-upload
+          emptyDir: {}
 {{- end }}

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -31,6 +31,12 @@ spec:
             runAsGroup: {{ $.Values.securityContext.runAsGroup }}
           restartPolicy: Never
           {{ if .serviceAccount }}serviceAccountName: {{ .serviceAccount }}{{- end }}
+          volumes:
+            - name: app-tmp
+              emptyDir: {}
+            {{- with $.Values.extraVolumes }}
+              {{- . | toYaml | trim | nindent 12 }}
+            {{- end }}
           containers:
             - name: cron-task
               image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
@@ -42,14 +48,14 @@ spec:
               args: ["-c", "{{ .command }}"]
               {{- end }}
               envFrom:
-              - configMapRef:
-                  name: govuk-apps-env
+                - configMapRef:
+                    name: govuk-apps-env
               env:
                 - name: SENTRY_RELEASE
                   value: "{{ $.Values.appImage.tag }}"
-              {{- with $.Values.extraEnv }}
-                {{- . | toYaml | trim | nindent 16 }}
-              {{- end }}
+                {{- with $.Values.extraEnv }}
+                  {{- . | toYaml | trim | nindent 16 }}
+                {{- end }}
               {{- with $.Values.appResources }}
               resources:
                 {{- . | toYaml | trim | nindent 16 }}
@@ -57,4 +63,10 @@ spec:
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: app-tmp
+                  mountPath: /tmp
+                {{- with $.Values.appExtraVolumeMounts }}
+                  {{- . | toYaml | trim | nindent 16 }}
+                {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -23,20 +23,26 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
       restartPolicy: Never
+      volumes:
+        - name: app-tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+          {{- . | toYaml | trim | nindent 8 }}
+        {{- end }}
       containers:
         - name: dbmigrate
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           command: ["bundle"]
           args: ["exec", "rails", "db:migrate"]
           envFrom:
-          - configMapRef:
-              name: govuk-apps-env
+            - configMapRef:
+                name: govuk-apps-env
           env:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
-          {{- with .Values.extraEnv }}
-            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
-          {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
           {{- with .Values.appResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
@@ -44,4 +50,10 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: app-tmp
+              mountPath: /tmp
+            {{- with .Values.appExtraVolumeMounts }}
+              {{- . | toYaml | trim | nindent 12 }}
+            {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}
           envFrom:
-          - configMapRef:
-              name: govuk-apps-env
+            - configMapRef:
+                name: govuk-apps-env
           env:
             - name: PORT
               value: "{{ .Values.appPort }}"
@@ -45,15 +45,15 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
-          {{- with .Values.extraEnv }}
-            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
-          {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
           {{- with .Values.appResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          {{- if .Values.appProbes }}
-          {{- .Values.appProbes | toYaml | trim | nindent 10 }}
+          {{- with .Values.appProbes }}
+            {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
           startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
             httpGet:
@@ -77,10 +77,12 @@ spec:
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
             readOnlyRootFilesystem: true
-          {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
+            - name: app-tmp
+              mountPath: /tmp
+            {{- with .Values.appExtraVolumeMounts }}
+              {{- . | toYaml | trim | nindent 12 }}
+            {{- end }}
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}
@@ -111,25 +113,27 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           volumeMounts:
-          - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
-          - name: tmp
-            mountPath: /tmp
-          {{- with .Values.nginxExtraVolumeMounts }}
-          {{ . | toYaml | trim | nindent 10 }}
-          {{- end }}
+            - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-tmp
+              mountPath: /tmp
+            {{- with .Values.nginxExtraVolumeMounts }}
+              {{ . | toYaml | trim | nindent 12 }}
+            {{- end }}
       enableServiceLinks: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-        configMap:
-          name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-      - name: tmp
-        emptyDir: {}
-      {{- with .Values.extraVolumes }}
-        {{- . | toYaml | trim | nindent 6 }}
-      {{- end }}
+        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+          configMap:
+            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+        - name: app-tmp
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+          {{- . | toYaml | trim | nindent 8 }}
+        {{- end }}

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -17,6 +17,9 @@ spec:
         runAsNonRoot: true
         runAsUser: 1001
         runAsGroup: 1001
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: upload-static-error-pages
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
@@ -37,5 +40,8 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
       restartPolicy: Never
 {{- end }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -47,9 +47,9 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
-          {{- with .Values.extraEnv }}
-            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
-          {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
           {{- with .Values.workerResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
@@ -57,19 +57,21 @@ spec:
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
             readOnlyRootFilesystem: true
-          {{- with .Values.appExtraVolumeMounts }}
           volumeMounts:
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
-          # TODO: consider implementing a liveness probe for Sidekiq
-          # e.g. https://github.com/arturictus/sidekiq_alive
+            - name: app-tmp
+              mountPath: /tmp
+            {{- with .Values.appExtraVolumeMounts }}
+              {{- . | toYaml | trim | nindent 12 }}
+            {{- end }}
       enableServiceLinks: false
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
-      {{- with .Values.extraVolumes }}
       volumes:
-        {{- . | toYaml | trim | nindent 8 }}
-      {{- end }}
+        - name: app-tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+          {{- . | toYaml | trim | nindent 8 }}
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
Turns out we'd been writing to /tmp inside the image filesystem and getting away with it until recently because we hadn't set readOnlyRootFilesystem.

This should fix most (maybe all?) of the fallout from #711 / d337216.

Also clean up the indentation on all the templates that we're touching. This should help to avoid a repeat of #702. (We need a linter/fixer for this, but that could be a bit tricky because we're dealing with YAML generated by Go templates, rather than just YAML.)

Tested: successfully deployed `asset-manager`, `publisher` and `static` using Helm, e.g. `helm install chris-static ../generic-govuk-app --values <(helm template . --values values-integration.yaml |yq e '. |select(.metadata.name == "static").spec.source.helm.values') --set sentry.createSecret=false`.