### PR TITLE
Add DatabaseMirror to freshclam config

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -28,6 +28,7 @@ data:
     TCPAddr 127.0.0.1
     TCPSocket 3310
   freshclam.conf: |
+    DatabaseMirror database.clamav.net
     Foreground yes
     LogTime yes
     LogVerbose yes


### PR DESCRIPTION
This config is needed to allow clamav to update. Since this was missing the update job was unable to complete blocking Argo syncing the entire application.