### PR TITLE
Rename asset ingress from asset-manager to assets-origin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -22,10 +22,10 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
-        alb.ingress.kubernetes.io/load-balancer-name: asset-manager
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
       hosts:
-      - name: asset-manager.eks.integration.govuk.digital
+      - name: assets-origin.eks.integration.govuk.digital
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false
@@ -44,7 +44,7 @@ govukApplications:
             name: signon-app-asset-manager
             key: oauth_secret
       - name: GOVUK_ASSET_ROOT  # testing in isolation
-        value: https://asset-manager.eks.integration.govuk.digital
+        value: https://assets-origin.eks.integration.govuk.digital
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -23,6 +23,7 @@ govukApplications:
       enabled: true
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: asset-manager
+        alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
       hosts:
       - name: asset-manager.eks.integration.govuk.digital
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital


### PR DESCRIPTION
This renames the dns hostname, ingress and able to assets-origin as they will be shared resources to route requests to both Whitehall (for CSV previews) and asset manager.

(This also enables ALB logging with the same conventions we use for www-origin ALB)