### PR TITLE
Work around Ruby `Dir.tmpdir` issue with `readOnlyRootFilesystem` and `emptyDir` on /tmp

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -34,6 +34,7 @@ spec:
         appImage:
           repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/{{ $reponame }}
           tag: {{ $imageTag }}
+          pullPolicy: {{ .appImagePullPolicy | default "IfNotPresent" }}
         {{- with .helmValues }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -3,7 +3,9 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
     app: {{ .Release.Name }}
+    app.kubernetes.io/component: app
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 5
@@ -15,14 +17,45 @@ spec:
       labels:
         {{- include "asset-manager.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
+        app.kubernetes.io/component: app
     spec:
       automountServiceAccountToken: false
+      enableServiceLinks: false
       securityContext:
+        fsGroup: &old-ec2-deploy-uid 2899
         runAsUser: 1001
         runAsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+          configMap:
+            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+        - name: app-tmp
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: asset-manager-efs
+          nfs:
+            server: {{ .Values.assetManagerNFS }}
+            path: /asset-manager
+        {{- with .Values.extraVolumes }}
+          {{ . | toYaml | trim | nindent 8 }}
+        {{- end }}
       containers:
         - name: app
-          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          image: "{{ required "appImage.repository is required" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.appPort }}
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp
@@ -31,11 +64,6 @@ spec:
             {{- with .Values.appExtraVolumeMounts }}
               {{ . | toYaml | trim | nindent 12 }}
             {{- end }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.appPort }}
-            - name: metrics
-              containerPort: {{ .Values.metricsPort }}
           envFrom:
             - configMapRef:
                 name: govuk-apps-env
@@ -85,10 +113,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            # Asset Manager needs to run as 2899 since it shares the same NFS volume with
-            # EC2 counterpart
-            runAsUser: 2899
-            runAsGroup: 2899
+            # Asset Manager shares an NFS volume with its EC2 counterpart.
+            runAsUser: *old-ec2-deploy-uid
+            runAsGroup: *old-ec2-deploy-uid
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
@@ -122,23 +149,3 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
-        {{- . | toYaml | trim | nindent 8 }}
-      {{- end }}
-      enableServiceLinks: false
-      volumes:
-        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-          configMap:
-            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-        - name: app-tmp
-          emptyDir: {}
-        - name: nginx-tmp
-          emptyDir: {}
-        - name: asset-manager-efs
-          nfs:
-            server: {{ .Values.assetManagerNFS }}
-            path: /asset-manager
-        {{- with .Values.extraVolumes }}
-          {{ . | toYaml | trim | nindent 8 }}
-        {{- end }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ .Release.Name }}-worker
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
     app: {{ .Release.Name }}-worker
+    app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 5
@@ -16,18 +16,45 @@ spec:
     metadata:
       labels:
         {{- include "asset-manager.labels" . | nindent 8 }}
-        app.kubernetes.io/component: worker
         app: {{ .Release.Name }}-worker
+        app.kubernetes.io/component: worker
     spec:
       automountServiceAccountToken: false
+      enableServiceLinks: false
       securityContext:
+        fsGroup: &old-ec2-deploy-uid 2899
         runAsUser: 1001
         runAsGroup: 1001
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: app-tmp
+          emptyDir: {}
+        - name: clamd-tmp
+          emptyDir: {}
+        - name: asset-manager-efs
+          nfs:
+            server: "{{ .Values.assetManagerNFS }}"
+            path: /asset-manager
+        - name: clam-virus-db
+          nfs:
+            server: "{{ .Values.assetManagerNFS }}"
+            path: /clamav-db
+            readOnly: true
+        - name: etc-clamav
+          configMap:
+            name: {{ .Release.Name }}-etc-clamav
+        {{- with .Values.extraVolumes }}
+          {{ . | toYaml | trim | nindent 8 }}
+        {{- end }}
       containers:
         - name: app
-          image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          image: "{{ required "appImage.repository is required" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
           command: ["bundle"]
           args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
@@ -62,10 +89,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            # Asset Manager needs to run as 2899 since it shares an NFS volume
-            # with its EC2 counterpart.
-            runAsUser: 2899
-            runAsGroup: 2899
+            # Asset Manager shares an NFS volume with its EC2 counterpart.
+            runAsUser: *old-ec2-deploy-uid
+            runAsGroup: *old-ec2-deploy-uid
         - name: clamd
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
@@ -87,28 +113,3 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
-        {{- . | toYaml | trim | nindent 8 }}
-      {{- end }}
-      enableServiceLinks: false
-      volumes:
-        - name: app-tmp
-          emptyDir: {}
-        - name: clamd-tmp
-          emptyDir: {}
-        - name: asset-manager-efs
-          nfs:
-            server: "{{ .Values.assetManagerNFS }}"
-            path: /asset-manager
-        - name: clam-virus-db
-          nfs:
-            server: "{{ .Values.assetManagerNFS }}"
-            path: /clamav-db
-            readOnly: true
-        - name: etc-clamav
-          configMap:
-            name: {{ .Release.Name }}-etc-clamav
-        {{- with .Values.extraVolumes }}
-          {{ . | toYaml | trim | nindent 8 }}
-        {{- end }}

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -26,6 +26,7 @@ spec:
           automountServiceAccountToken: false
           enableServiceLinks: false
           securityContext:
+            fsGroup: {{ .Values.securityContext.runAsGroup }}
             runAsNonRoot: {{ $.Values.securityContext.runAsNonRoot }}
             runAsUser: {{ $.Values.securityContext.runAsUser }}
             runAsGroup: {{ $.Values.securityContext.runAsGroup }}

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -19,6 +19,7 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -3,7 +3,9 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app: {{ .Release.Name }}
+    app.kubernetes.io/component: app
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 5
@@ -15,12 +17,30 @@ spec:
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
+        app.kubernetes.io/component: app
     spec:
       automountServiceAccountToken: false
+      enableServiceLinks: false
       securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+          configMap:
+            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+        - name: app-tmp
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+          {{- . | toYaml | trim | nindent 8 }}
+        {{- end }}
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -121,19 +141,3 @@ spec:
             {{- with .Values.nginxExtraVolumeMounts }}
               {{ . | toYaml | trim | nindent 12 }}
             {{- end }}
-      enableServiceLinks: false
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
-        {{- . | toYaml | trim | nindent 8 }}
-      {{- end }}
-      volumes:
-        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-          configMap:
-            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
-        - name: app-tmp
-          emptyDir: {}
-        - name: nginx-tmp
-          emptyDir: {}
-        {{- with .Values.extraVolumes }}
-          {{- . | toYaml | trim | nindent 8 }}
-        {{- end }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Release.Name }}-worker
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
     app: {{ .Release.Name }}-worker
+    app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 5
@@ -17,23 +17,35 @@ spec:
     metadata:
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
-        app.kubernetes.io/component: worker
         app: {{ .Release.Name }}-worker
+        app.kubernetes.io/component: worker
     spec:
       automountServiceAccountToken: false
+      enableServiceLinks: false
       securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: app-tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+          {{- . | toYaml | trim | nindent 8 }}
+        {{- end }}
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+          command: ["bundle"]
+          args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}
-          command: ["bundle"]
-          args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
           envFrom:
             - configMapRef:
                 name: govuk-apps-env
@@ -63,15 +75,4 @@ spec:
             {{- with .Values.appExtraVolumeMounts }}
               {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
-      enableServiceLinks: false
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
-        {{- . | toYaml | trim | nindent 8 }}
-      {{- end }}
-      volumes:
-        - name: app-tmp
-          emptyDir: {}
-        {{- with .Values.extraVolumes }}
-          {{- . | toYaml | trim | nindent 8 }}
-        {{- end }}
 {{- end }}


### PR DESCRIPTION
Set `fsGroup` for app containers so that the temp dir we're creating for Ruby ends up with the magic permissions that Ruby [deigns acceptable](https://github.com/ruby/ruby/blob/v2_7_6/lib/tmpdir.rb#L27). See https://github.com/alphagov/govuk-ruby-images/pull/18 and https://github.com/alphagov/govuk-ruby-images/pull/20 for background.

Also:
- Clean up the structure of the Helm templates to make them more consistent so that it's easier to spot inconsistencies and repeated patterns. This should make it easier to factor out repeated components into library charts in future.
- Set a bunch of missing labels which this brought to light.
- Allow kubelet to cache app images by default (`pullPolicy: IfNotPresent`), since they're supposed to be uniquely tagged now.