### PR TITLE
Install Argo webhooks into the cluster-services namespace.

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: {{ $.Values.appsNamespace }}
+    namespace: {{ .namespace | default $.Values.appsNamespace }}
   syncPolicy:
     automated:
       prune: true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -68,6 +68,7 @@ govukApplications:
         value: govuk-assets-integration
 - name: argo-services
   chartPath: charts/argo-services
+  namespace: cluster-services
   postSyncWorkflowEnabled: "false"
   helmValues:
     nextEnvironment: staging

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -17,6 +17,7 @@ replicaCount: 3
 govukApplications:
 - name: argo-services
   chartPath: charts/argo-services
+  namespace: cluster-services
   postSyncWorkflowEnabled: "false"
   # TODO: Handle case where production doesn't promote deployments
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -16,6 +16,7 @@ appResources:
 govukApplications:
 - name: argo-services
   chartPath: charts/argo-services
+  namespace: cluster-services
   postSyncWorkflowEnabled: "false"
   helmValues:
     nextEnvironment: production


### PR DESCRIPTION
The webhook servers seem to be failing because they're trying to mount a Secret that's in (presumably correctly) the `cluster-services` namespace but the deployments/pods are being created in the `apps` namespace.

Very much open to alternative fixes here - I don't know whether my proposed fix here is optimal.

Tested: `helm template ../argo-services --values <(helm template . --values values-production.yaml |yq e '. |select(.metadata.name == "argo-services").spec.source.helm.values')` doesn't produce any errors and the output looks plausible.