### PR TITLE
Change asset manager Nginx proxy buffer size

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -121,9 +121,10 @@ data:
         error_log /dev/stderr;
 
         location / {
-          proxy_busy_buffers_size 16k;
-          proxy_buffers 8 8k;
-          proxy_buffer_size 8k;
+          proxy_buffer_size 16k;  # Max total size of response headers.
+          # n * m = max response size before spooling to disk. p95 response size should
+          # fit comfortably within this in order to avoid performance issues.
+          proxy_buffers 24 16k;
 
           try_files $uri/index.html $uri.html $uri @app;
         }


### PR DESCRIPTION
This is to make the proxy buffers consistent with the proxy buffer sizes used by other GOV.UK apps. As suggested by @sengi: https://github.com/alphagov/govuk-helm-charts/pull/719/files/dda86934dd46b83e34f1f9566568db8ca39a36b1#r1020280731