### PR TITLE
Re-enable auto deploys for {manuals,travel-advice}-publisher.

### DIFF
--- a/charts/app-config/image-tags/integration/manuals-publisher
+++ b/charts/app-config/image-tags/integration/manuals-publisher
@@ -1,2 +1,2 @@
 image_tag: release-f2d6cdf37c44592f867738f221000384ff541ef7
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/integration/travel-advice-publisher
+++ b/charts/app-config/image-tags/integration/travel-advice-publisher
@@ -1,2 +1,2 @@
 image_tag: release-c3d3e600ee3ae57b72e753a39eb75ef3a066bb23
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true


### PR DESCRIPTION
These are the last two left out of sync, as far as I can tell.

licence-finder, router, signon and static are not currently meant to be CDed beyond integration, and publishing-api is pinned to a snowflake build in integration while we wait for content-schemas to move into publishing-api on mainline.