### PR TITLE
Run the Signon token sync cron nightly instead of hourly.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1668,11 +1668,11 @@ govukApplications:
     cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
-        schedule: "0 */1 * * *"
+        schedule: "5 1 * * *"
         serviceAccount: signon
       - name: "kubernetes-sync-token-secrets"
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
-        schedule: "0 */1 * * *"
+        schedule: "5 1 * * *"
         serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -351,11 +351,11 @@ govukApplications:
     cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
-        schedule: "0 */1 * * *"
+        schedule: "5 1 * * *"
         serviceAccount: signon
       - name: "kubernetes-sync-token-secrets"
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
-        schedule: "0 */1 * * *"
+        schedule: "5 1 * * *"
         serviceAccount: signon
       - name: "delete-event-logs"
         task: "event_log:delete_logs_older_than_two_years"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -350,11 +350,11 @@ govukApplications:
     cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
-        schedule: "0 */1 * * *"
+        schedule: "5 1 * * *"
         serviceAccount: signon
       - name: "kubernetes-sync-token-secrets"
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
-        schedule: "0 */1 * * *"
+        schedule: "5 1 * * *"
         serviceAccount: signon
       - name: "delete-event-logs"
         task: "event_log:delete_logs_older_than_two_years"


### PR DESCRIPTION
I couldn't think of much of an advantage to running it hourly now that the configuration is fairly stable.

When it comes to rotating tokens, we'll still need a transition period where old and new token are both valid (which might as well be a day if it's an hour), and it'd be straightforward for any rotation automation to just start a sync job on demand.