### PR TITLE
Mount serviceaccount token when a specific SA is configured.

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -23,7 +23,7 @@ spec:
             {{- include "generic-govuk-app.labels" $ | nindent 12 }}
             app.kubernetes.io/component: app
         spec:
-          automountServiceAccountToken: false
+          automountServiceAccountToken: {{- if .serviceAccount }} true {{- else }} false {{- end }}
           enableServiceLinks: false
           securityContext:
             fsGroup: {{ $.Values.securityContext.runAsGroup }}


### PR DESCRIPTION
This should fix the Signon token sync cronjob.

We still disable automountServiceAccountToken for everything else.