### PR TITLE
Sprinkle some deadlines, backoffLimits and common labels.

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -1,4 +1,5 @@
 {{- define "asset-manager.freshclam.podspec" }}
+activeDeadlineSeconds: 1800
 automountServiceAccountToken: false
 enableServiceLinks: false
 securityContext:

--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -1,36 +1,42 @@
 {{- define "asset-manager.freshclam.podspec" }}
-activeDeadlineSeconds: 1800
-automountServiceAccountToken: false
-enableServiceLinks: false
-securityContext:
-  seccompProfile:
-    type: RuntimeDefault
-  runAsUser: 1001
-  runAsGroup: 1001
-containers:
-  - name: freshclam
-    image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-    imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
-    command: ["freshclam"]
-    {{ with .Values.freshclamResources }}
-    resources:
-      {{- . | toYaml | trim | nindent 8 }}
-    {{ end }}
-    volumeMounts:
-      - name: clam-virus-db
-        mountPath: /var/lib/clamav
-      - name: etc-clamav
-        mountPath: /etc/clamav
-    securityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-volumes:
-  - name: clam-virus-db
-    nfs:
-      server: "{{ .Values.assetManagerNFS }}"
-      path: /clamav-db
-  - name: etc-clamav
-    configMap:
-      name: {{ .Release.Name }}-etc-clamav
-restartPolicy: Never
+metadata:
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}
+    app.kubernetes.io/component: freshclam
+spec:
+  activeDeadlineSeconds: 1800
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    runAsUser: 1001
+    runAsGroup: 1001
+  containers:
+    - name: freshclam
+      image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+      imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+      command: ["freshclam"]
+      {{ with .Values.freshclamResources }}
+      resources:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{ end }}
+      volumeMounts:
+        - name: clam-virus-db
+          mountPath: /var/lib/clamav
+        - name: etc-clamav
+          mountPath: /etc/clamav
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+  volumes:
+    - name: clam-virus-db
+      nfs:
+        server: "{{ .Values.assetManagerNFS }}"
+        path: /clamav-db
+    - name: etc-clamav
+      configMap:
+        name: {{ .Release.Name }}-etc-clamav
+  restartPolicy: Never
 {{- end }}

--- a/charts/asset-manager/templates/freshclam-cronjob.yaml
+++ b/charts/asset-manager/templates/freshclam-cronjob.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "19 * * * *"
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           {{- include "asset-manager.freshclam.podspec" . | indent 10 }}

--- a/charts/asset-manager/templates/freshclam-cronjob.yaml
+++ b/charts/asset-manager/templates/freshclam-cronjob.yaml
@@ -2,11 +2,19 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-freshclam
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}
+    app.kubernetes.io/component: freshclam
 spec:
   schedule: "19 * * * *"
   jobTemplate:
+    metadata:
+      labels:
+        {{- include "asset-manager.labels" . | nindent 8 }}
+        app: {{ .Release.Name }}
+        app.kubernetes.io/component: freshclam
     spec:
       backoffLimit: 1
       template:
-        spec:
-          {{- include "asset-manager.freshclam.podspec" . | indent 10 }}
+        {{- include "asset-manager.freshclam.podspec" . | indent 8 }}

--- a/charts/asset-manager/templates/freshclam-presync.yaml
+++ b/charts/asset-manager/templates/freshclam-presync.yaml
@@ -4,8 +4,11 @@ metadata:
   name: {{ .Release.Name }}-update-freshclam
   annotations:
     argocd.argoproj.io/hook: PreSync
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}
+    app.kubernetes.io/component: freshclam
 spec:
   backoffLimit: 2
   template:
-    spec:
-      {{- include "asset-manager.freshclam.podspec" . | indent 6 }}
+    {{- include "asset-manager.freshclam.podspec" . | indent 4 }}

--- a/charts/asset-manager/templates/freshclam-presync.yaml
+++ b/charts/asset-manager/templates/freshclam-presync.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:
+  backoffLimit: 2
   template:
     spec:
       {{- include "asset-manager.freshclam.podspec" . | indent 6 }}

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -5,6 +5,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-upload-assets
+  labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upload-assets
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 2
   template:
     spec:
       automountServiceAccountToken: false

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -9,6 +9,8 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 2
   template:
     metadata:
       name: {{ .Release.Name }}-dbmigrate

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -3,6 +3,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-upload-error-pages
+  labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upload-error-pages
   annotations:
     argocd.argoproj.io/hook: PostSync
     kubernetes.io/description: >

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -9,6 +9,8 @@ metadata:
       Fetch "static" error pages from the Static service and upload them to S3.
       ArgoCD runs this job after each deployment of the Static app.
 spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 2
   template:
     spec:
       automountServiceAccountToken: false


### PR DESCRIPTION
Set deadlines and backoffLimits for pre- and post-sync jobs so that ArgoCD syncs (rollouts) don't get stuck indefinitely. This should help to avoid the situation where a broken pre/post-sync job has since been fixed but Argo is still stuck waiting indefinitely for the broken job to finish and requires someone to go into the UI and manually terminate the sync to unstick it.

Also add the common set of labels to a bunch of objects where they were missing.

Tested: installed asset-manager and collections (generic-govuk-app) using `helm install`, everything still validates, deployments come up healthy, successfully ran the freshclam cronjob using `k create job --from cronjob/...`.