### PR TITLE
Set USE_TMPDIR_PAGE_CACHE on static in staging and prod.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -465,6 +465,8 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+      - name: USE_TMPDIR_PAGE_CACHE
+        value: "true"
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -469,6 +469,8 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+      - name: USE_TMPDIR_PAGE_CACHE
+        value: "true"
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:


### PR DESCRIPTION
It needs this flag in order to work with `readOnlyRootFilesystem`.

Tested: installed via `helm install`