### PR TITLE
Update kubeconform validation tests to k8s 1.23.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: "grep KUBERNETES_VERSION kubernetes_version >> $GITHUB_ENV"
 
       - name: kubeconform
-        uses: docker://ghcr.io/yannh/kubeconform:v0.4.13
+        uses: docker://ghcr.io/yannh/kubeconform:v0.5.0
         with:
           entrypoint: /kubeconform
           args: >
@@ -54,6 +54,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9  # 1.1.0

--- a/kubernetes_version
+++ b/kubernetes_version
@@ -1,3 +1,3 @@
 # Kubernetes version for kubeconform to use when validating helm template
 # output. See .github/workflows/ci.yml.
-KUBERNETES_VERSION=1.21.0
+KUBERNETES_VERSION=1.23.0


### PR DESCRIPTION
Now that we're [running Kubernetes 1.23 everywhere](https://github.com/alphagov/govuk-infrastructure/pull/776), run the conformance tests against that version.