### PR TITLE
Multiple workers in generic-govuk-app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -685,8 +685,19 @@ govukApplications:
             key: token
 - name: email-alert-service
   helmValues:
+    appEnabled: false
     uploadAssets:
       enabled: false
+    workerEnabled: true
+    workers:
+      - command: ['rake', 'message_queues:major_change_consumer']
+        name: major-change-consumer
+      - command: ['rake', 'message_queues:subscriber_list_details_update_major_consumer']
+        name: subscriber-list-details-update-major-consumer
+      - command: ['rake', 'message_queues:subscriber_list_details_update_minor_consumer']
+        name: subscriber-list-details-update-minor-consumer
+      - command: ['rake', 'message_queues:unpublishing_consumer']
+        name: unpublishing-consumer
     extraEnv:
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.appEnabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -141,3 +142,4 @@ spec:
             {{- with .Values.nginxExtraVolumeMounts }}
               {{ . | toYaml | trim | nindent 12 }}
             {{- end }}
+{{- end }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -38,41 +38,43 @@ spec:
           {{- . | toYaml | trim | nindent 8 }}
         {{- end }}
       containers:
-        - name: app
-          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
-          command: ["bundle"]
-          args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
+        {{- range .Values.workers }}
+        - name: {{ .name }}
+          image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
+          imagePullPolicy: {{ $.Values.appImage.pullPolicy | default "Always" }}
+          command:
+            {{- .command | toYaml | nindent 12 }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.metricsPort }}
+              containerPort: {{ $.Values.metricsPort }}
           envFrom:
             - configMapRef:
                 name: govuk-apps-env
           env:
-            {{- if .Values.sentry.enabled }}
+            {{- if $.Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.repoName }}-sentry
+                  name: {{ $.Values.repoName }}-sentry
                   key: dsn
             - name: SENTRY_RELEASE
-              value: "{{ .Values.appImage.tag }}"
+              value: "{{ $.Values.appImage.tag }}"
             {{- end }}
-            {{- with .Values.extraEnv }}
+            {{- with $.Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}
-          {{- with .Values.workerResources }}
+          {{- with $.Values.workerResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           securityContext:
-            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp
-            {{- with .Values.appExtraVolumeMounts }}
+            {{- with $.Values.appExtraVolumeMounts }}
               {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
+        {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -22,6 +22,11 @@ replicaCount: 2
 # workerEnabled should be true if the app uses Sidekiq, false otherwise.
 workerEnabled: false
 workerReplicaCount: 2
+workers:
+- command: ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]
+  name: worker
+# appEnabled determines if web app should run.
+appEnabled: true
 
 # dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
 dbMigrationEnabled: false


### PR DESCRIPTION
Changed worker-deployment.yaml to allow for multiple workers to be run
Added flag to enable app deployment.

Tested with  

helm install marc-worker ../generic-govuk-app --values <(helm template . --values values-integration.yaml |yq e '. |select(.metadata.name == "email-alert-service" and .kind == "Application").spec.source.helm.values') --set sentry.createSecret=false