### PR TITLE
Allow requests from assets domain in assets ALB rules

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3,6 +3,7 @@
 govukEnvironment: integration
 externalDomainSuffix: eks.integration.govuk.digital
 publishingServiceDomainSuffix: integration.publishing.service.gov.uk
+assetsDomain: assets-eks.integration.publishing.service.gov.uk
 workerReplicaCount: 1
 appResources:
   limits:
@@ -26,6 +27,8 @@ govukApplications:
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '10'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
       hosts:
       - name: assets-origin.eks.integration.govuk.digital
         path: /government/uploads/
@@ -1791,6 +1794,8 @@ govukApplications:
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '30'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
     extraEnv:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
@@ -2231,6 +2236,8 @@ govukApplications:
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
     uploadAssets: *whitehall-upload-assets

--- a/charts/asset-manager/templates/ingress.yaml
+++ b/charts/asset-manager/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- (tpl (toYaml .Values.ingress.annotations) .) | trim | nindent 4 }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/generic-govuk-app/templates/ingress.yaml
+++ b/charts/generic-govuk-app/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- (tpl (toYaml .Values.ingress.annotations) .) | trim | nindent 4 }}
     {{- if .Values.ingress.hosts }}
     external-dns.alpha.kubernetes.io/hostname: {{ join "," .Values.ingress.hosts }}
     {{- end }}


### PR DESCRIPTION
This adds a condition the ALB rules for asset-origin to allow requests from the public facing asset domain. This is because request are being forwarded from Fastly, where the Host header is set as the original asset domain (not the domain of the alb). This is done by adding an annotation to the ingress resources that is used to AWS ALB ingress controller. T

See: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#conditions

The annotation are put through the template function as the key and value require a Helm value to be rendered.

This has been tested with helm install.