### PR TITLE
Update path to content schemas for Pub API

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1353,7 +1353,7 @@ govukApplications:
       - name: EVENT_LOG_AWS_USERNAME
         value: govuk-publishing-api-event-log_user
       - name: GOVUK_CONTENT_SCHEMAS_PATH
-        value: /govuk-content-schemas
+        value: /app/content_schemas
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
The content schemas have been merged into the same repository as the Publishing API, so should be accessible within the app.


https://github.com/alphagov/publishing-api/pull/2184