### PR TITLE
Add extra nginx conf for Static

### DIFF
--- a/charts/app-config/templates/static-nginx-configmap.yaml
+++ b/charts/app-config/templates/static-nginx-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-extra-nginx-conf
+  labels:
+    {{- include "app-config.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  extra-nginx.conf: |-
+    # 1stline use this URL in their zendesk template
+    location = /static/gov.uk_logotype_crown.png {
+      absolute_redirect off;
+      return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
+    }
+
+    location /robots.txt {
+      expires 1w;
+    }

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1821,6 +1821,16 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+    nginxConfigMap:
+      extraConf: true
+    nginxExtraVolumeMounts:
+      - name: static-extra-nginx-conf
+        mountPath: /etc/nginx/extra-nginx.conf
+        subPath: extra-nginx.conf
+    extraVolumes:
+      - name: static-extra-nginx-conf
+        configMap:
+          name: static-extra-nginx-conf
 - name: draft-static
   repoName: static
   helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -541,6 +541,16 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+    nginxConfigMap:
+      extraConf: true
+    nginxExtraVolumeMounts:
+      - name: static-extra-nginx-conf
+        mountPath: /etc/nginx/extra-nginx.conf
+        subPath: extra-nginx.conf
+    extraVolumes:
+      - name: static-extra-nginx-conf
+        configMap:
+          name: static-extra-nginx-conf
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -542,6 +542,16 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+    nginxConfigMap:
+      extraConf: true
+    nginxExtraVolumeMounts:
+      - name: static-extra-nginx-conf
+        mountPath: /etc/nginx/extra-nginx.conf
+        subPath: extra-nginx.conf
+    extraVolumes:
+      - name: static-extra-nginx-conf
+        configMap:
+          name: static-extra-nginx-conf
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -168,6 +168,11 @@ data:
         location = /readyz {
           return 200 'ok\n';
         }
+
+
+        {{- if .Values.nginxConfigMap.extraConf }}
+        include       /etc/nginx/extra-nginx.conf;
+        {{- end }}
       }
     }
 {{- end }}


### PR DESCRIPTION
This adds extra nginx configuration for static to set up a redirect for the crown logo and robots.txt. These rules are used by the asset domain. The configuration has been copied from [govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/templates/static_extra_nginx_config.conf.erb).