### PR TITLE
Change asset domain to public facing domain

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3,7 +3,7 @@
 govukEnvironment: integration
 externalDomainSuffix: eks.integration.govuk.digital
 publishingServiceDomainSuffix: integration.publishing.service.gov.uk
-assetsDomain: assets-eks.integration.publishing.service.gov.uk
+assetsDomain: assets.integration.publishing.service.gov.uk
 workerReplicaCount: 1
 appResources:
   limits:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3,7 +3,7 @@
 govukEnvironment: production
 externalDomainSuffix: gov.uk
 publishingServiceDomainSuffix: publishing.service.gov.uk
-assetsDomain: assets-eks.publishing.service.gov.uk
+assetsDomain: assets.publishing.service.gov.uk
 appResources:
   limits:
     cpu: 1

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3,7 +3,7 @@
 govukEnvironment: staging
 externalDomainSuffix: eks.staging.govuk.digital
 publishingServiceDomainSuffix: staging.publishing.service.gov.uk
-assetsDomain: assets-eks.staging.publishing.service.gov.uk
+assetsDomain: assets.staging.publishing.service.gov.uk
 appResources:
   limits:
     cpu: 1


### PR DESCRIPTION
This updates the assets domain from the test domain for EKS to the real asset domain. This is needed for the live traffic experiment where we'll be splitting a proportion of the traffic for the public facing domain to the EKS cluster.