### PR TITLE
Add nginx redirect for /government/assets/ on asset domain

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -33,6 +33,8 @@ govukApplications:
       - name: assets-origin.eks.integration.govuk.digital
         path: /government/uploads/
       - name: assets-origin.eks.integration.govuk.digital
+        path: /government/assets/
+      - name: assets-origin.eks.integration.govuk.digital
         path: /media/
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -127,6 +127,9 @@ data:
         access_log /dev/stdout json_event;
         error_log /dev/stderr;
 
+        # Add as an ALB rule and direct to whitehall service
+        rewrite ^/government/assets/(.*)$ /assets/whitehall/$1 permanent;
+
         location / {
           proxy_buffer_size 16k;  # Max total size of response headers.
           # n * m = max response size before spooling to disk. p95 response size should


### PR DESCRIPTION
This adds a nginx directive and alb configuration to redirect requests to for /government/assets/ to /government/whitehall/. This is a legacy path, just in case any links still exist.