### PR TITLE
Add extra nginx conf for Static

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1823,6 +1823,13 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+    nginxConfigMap:
+      extraConf: |
+        # 1stline use this URL in their zendesk template
+        location = /static/gov.uk_logotype_crown.png {
+          absolute_redirect off;
+          return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
+        }
 - name: draft-static
   repoName: static
   helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -541,6 +541,13 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+    nginxConfigMap:
+      extraConf: |
+        # 1stline use this URL in their zendesk template
+        location = /static/gov.uk_logotype_crown.png {
+          absolute_redirect off;
+          return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
+        }
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -542,6 +542,13 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+    nginxConfigMap:
+      extraConf: |
+        # 1stline use this URL in their zendesk template
+        location = /static/gov.uk_logotype_crown.png {
+          absolute_redirect off;
+          return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
+        }
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -168,6 +168,9 @@ data:
         location = /readyz {
           return 200 'ok\n';
         }
+        {{- if .Values.nginxConfigMap.extraConf }}
+        {{ .Values.nginxConfigMap.extraConf | nindent 8 }}
+        {{- end }}
       }
     }
 {{- end }}


### PR DESCRIPTION
This adds extra nginx configuration for static to set up a redirect for the crown logo and robots.txt. These rules are used by the asset domain.