### PR TITLE
Add ALB host header condition for www

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1432,6 +1432,8 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/healthcheck-path: /readyz
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.publishingServiceDomainSuffix }}"]}}]
       hosts:
       - www-origin.eks.integration.govuk.digital
     nginxConfigMap:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -317,6 +317,8 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:eu-west-1:172025368201:regional/webacl/cache_public_web_acl/d9033e40-69e8-4bbc-a61a-cd3c50254d04
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.publishingServiceDomainSuffix }}"]}}]
       hosts:
       - www-origin.eks.production.govuk.digital
     nginxConfigMap:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -311,6 +311,8 @@ govukApplications:
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.publishingServiceDomainSuffix }}"]}}]
       hosts:
       - www-origin.eks.staging.govuk.digital
     nginxConfigMap:


### PR DESCRIPTION
This adds a check that the host header of requests to the Router match GOV.UK domains. This is to add a layer of protection against cache poisoning and leaking internal domains.