### PR TITLE
Update externalDomainSuffix in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1,7 +1,7 @@
 # Defaults for all apps in this environment. These can be overridden for
 # individual apps below.
 govukEnvironment: staging
-externalDomainSuffix: eks.staging.govuk.digital
+externalDomainSuffix: staging.publishing.service.gov.uk
 publishingServiceDomainSuffix: staging.publishing.service.gov.uk
 assetsDomain: assets-eks.staging.publishing.service.gov.uk
 appResources:


### PR DESCRIPTION
This changes the externalDomainSuffix for staging to the live domain (i.e. non eks test domains). This is to allow us to test serving traffic from the live domain.