### PR TITLE
Fix latest image check in update-image-tag script

### DIFF
--- a/charts/argo-services/scripts/update-image-tag.sh
+++ b/charts/argo-services/scripts/update-image-tag.sh
@@ -35,7 +35,7 @@ elif [[ "${MANUAL_DEPLOY}" = true ]]; then
 
 # If automatic deploys, check automatic_deploys_enabled before proceeding.
 # Relies on the assumption the IMAGE_TAG is a commit SHA
-elif [[ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]]; then
+elif [[ "release-${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]]; then
   auto_deploys="$(yq '.automatic_deploys_enabled' "${FILE}")"
   # Auto deploys are enabled unless explicitly set to "false" (case insensitive).
   if [[ "${auto_deploys,,}" != "false" ]]; then


### PR DESCRIPTION
We previously updated image tags to include the prefix of `release-`. However we didn't update the comparision logic to check whether the image tag matches the latest commit sha for the repo. Therefore for non-manual deploys the script failed to update the image tag.