### PR TITLE
Increase some resources limits/requests in prod.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -4,13 +4,6 @@ govukEnvironment: production
 externalDomainSuffix: gov.uk
 publishingServiceDomainSuffix: publishing.service.gov.uk
 assetsDomain: assets.publishing.service.gov.uk
-appResources:
-  limits:
-    cpu: 1
-    memory: 1500Mi
-  requests:
-    cpu: 0.1
-    memory: 800Mi
 replicaCount: 3
 
 # Individual apps to be deployed by ArgoCD, and any values specific to those
@@ -85,6 +78,14 @@ govukApplications:
     enableWebhookIngress: true
 - name: collections
   helmValues:
+    replicaCount: 4
+    appResources:
+      limits:
+        cpu: 2
+        memory: 1500Mi
+      requests:
+        cpu: 1
+        memory: 1Gi
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:
@@ -185,14 +186,14 @@ govukApplications:
       - name: registries-refresh
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
+    replicaCount: 4
     appResources:
       limits:
         cpu: 4
-        memory: 1Gi
+        memory: 1500Mi
       requests:
         cpu: 2
-        memory: 512Mi
-    replicaCount: 3
+        memory: 1Gi
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:
@@ -210,13 +211,14 @@ govukApplications:
         value: '4'
 - name: frontend
   helmValues:
+    replicaCount: 4
     appResources:
       limits:
         cpu: 4
-        memory: 1Gi
+        memory: 1500Mi
       requests:
         cpu: 2
-        memory: 512Mi
+        memory: 1Gi
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: cb633abc-6ae6-4843-ae6f-82ca500b6de2
@@ -256,13 +258,14 @@ govukApplications:
             key: SECRET_KEY_BASE
 - name: government-frontend
   helmValues:
+    replicaCount: 6
     appResources:
       limits:
         cpu: 2
-        memory: 1Gi
+        memory: 1500Mi
       requests:
         cpu: 1
-        memory: 512Mi
+        memory: 1Gi
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -65,10 +65,10 @@ nginxDenyCrawlers: false
 appResources:
   limits:
     cpu: 1
-    memory: 1Gi
+    memory: 1500Mi
   requests:
     cpu: 500m
-    memory: 512Mi
+    memory: 800Mi
 
 workerResources:
   limits:


### PR DESCRIPTION
RAM figures are based on recent data from staging (traffic replay) e.g. https://grafana.eks.staging.govuk.digital/goto/Dj9SxiK4z

Also slightly increase the replica count for the [more popular frontends](https://graphite.production.govuk.digital/S/a), so we have a bit more headroom.

We can always tune these back down later if it turns out our utilisation was low.

Invariant: this shouldn't reduce any resource allocations, limits or replica counts anywhere at all. If it does, then that's a bug and please shout about it!