### PR TITLE
Fix url namespace for argo-events-service

### DIFF
--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -7,7 +7,7 @@ service.webhook.argo_events: |
     value: "application/json"
   - name: Authorization
     value: Bearer $argo_events_webhook_token
-  url: "http://argo-events-service.apps.svc.cluster.local:12000"
+  url: "http://argo-events-service.cluster-services.svc.cluster.local:12000"
 service.grafana: |
   apiUrl: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local/api
   apiKey: $grafana_api_key


### PR DESCRIPTION
Post sync notification were broken since we changed the namespace for the argo workflows. The service is now in the cluster-services namepsaces instead of apps.