### PR TITLE
Change smokey namespace to cluster-services

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1784,6 +1784,7 @@ govukApplications:
             key: password
 - name: smokey
   chartPath: charts/smokey
+  namespace: cluster-services
 - name: static
   helmValues:
     ingress:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -503,6 +503,7 @@ govukApplications:
             key: password
 - name: smokey
   chartPath: charts/smokey
+  namespace: cluster-services
 - name: static
   helmValues:
     ingress:


### PR DESCRIPTION
Post sync workflow are currently failing to trigger smokey because they are in a different namespace. This make smokey and post sync workflows to be in the same namespace.