### PR TITLE
Increase RAM request and limit for government-frontend in prod.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -262,10 +262,10 @@ govukApplications:
     appResources:
       limits:
         cpu: 2
-        memory: 1500Mi
+        memory: 2Gi
       requests:
         cpu: 1
-        memory: 1Gi
+        memory: 1500Mi
     extraEnv:
       - name: SECRET_KEY_BASE
         valueFrom:


### PR DESCRIPTION
Based on utilisation during the prod traffic split.

https://grafana.eks.production.govuk.digital/goto/epTvbGKVz

Pretty much the same as we did for finder-frontend in #760.