### PR TITLE
Move Argo Workflows back into the `apps` namespace

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -78,7 +78,6 @@ govukApplications:
         value: govuk-assets-integration
 - name: argo-services
   chartPath: charts/argo-services
-  namespace: cluster-services
   postSyncWorkflowEnabled: "false"
   helmValues:
     nextEnvironment: staging

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -70,7 +70,6 @@ govukApplications:
         value: govuk-assets-production
 - name: argo-services
   chartPath: charts/argo-services
-  namespace: cluster-services
   postSyncWorkflowEnabled: "false"
   # TODO: Handle case where production doesn't promote deployments
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -75,7 +75,6 @@ govukApplications:
         value: govuk-assets-staging
 - name: argo-services
   chartPath: charts/argo-services
-  namespace: cluster-services
   postSyncWorkflowEnabled: "false"
   helmValues:
     nextEnvironment: production

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -8,7 +8,7 @@
 appsNamespace: apps
 argoNamespace: cluster-services
 monitoringNamespace: monitoring
-workflowsNamespace: cluster-services
+workflowsNamespace: apps
 
 slackChannel: govuk-deploy-alerts
 

--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -7,7 +7,7 @@ service.webhook.argo_events: |
     value: "application/json"
   - name: Authorization
     value: Bearer $argo_events_webhook_token
-  url: "http://argo-events-service.cluster-services.svc.cluster.local:12000"
+  url: "http://argo-events-service.apps.svc.cluster.local:12000"
 service.grafana: |
   apiUrl: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local/api
   apiKey: $grafana_api_key

--- a/charts/argo-services/templates/notifications/secret.yaml
+++ b/charts/argo-services/templates/notifications/secret.yaml
@@ -1,43 +1,48 @@
 # NOTE: This assumes that an AWS SecretsManager secret `govuk/slack-webhook-url`
 # exists with key `url`.
 apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
+kind: ClusterExternalSecret
 metadata:
   name: argocd-notifications-secret
-  namespace: "{{ .Values.argoNamespace }}"
   labels:
     argocd.argoproj.io/secret-type: argocd-notifications-secret
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: aws-secretsmanager
-    kind: ClusterSecretStore
-  target:
-    template:
-      metadata:
-        labels:
-          argocd.argoproj.io/secret-type: argocd-notifications-secret
-      data:
-        # Helm and External Secrets use the same template language and conflict
-        slack_url: "{{
-          "{{ .slackUrl | toString}}"
-        }}"
-        argo_events_webhook_token: "{{
-          "{{ .argoEventsWebhookToken | toString}}"
-        }}"
-        grafana_api_key: "{{
-          "{{ .grafanaApiKey | toString}}"
-        }}"
-  data:
-    - secretKey: slackUrl
-      remoteRef:
-        key: govuk/slack-webhook-url
-        property: url
-    - secretKey: argoEventsWebhookToken
-      remoteRef:
-        key: govuk/argo-events-webhook-token
-        property: token
-    - secretKey: grafanaApiKey
-      remoteRef:
-        key: govuk/argo-notifications/grafana
-        property: grafana-api-key
+  externalSecretName: "argocd-notifications-secret"
+  namespaceSelector:
+    matchExpressions:
+      - {key: kubernetes.io/metadata.name, operator: In, values: [apps, cluster-services]}
+  refreshTime: 1h
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: aws-secretsmanager
+      kind: ClusterSecretStore
+    target:
+      template:
+        metadata:
+          labels:
+            argocd.argoproj.io/secret-type: argocd-notifications-secret
+        data:
+          # Helm and External Secrets use the same template language and conflict
+          slack_url: "{{
+            "{{ .slackUrl | toString}}"
+          }}"
+          argo_events_webhook_token: "{{
+            "{{ .argoEventsWebhookToken | toString}}"
+          }}"
+          grafana_api_key: "{{
+            "{{ .grafanaApiKey | toString}}"
+          }}"
+    data:
+      - secretKey: slackUrl
+        remoteRef:
+          key: govuk/slack-webhook-url
+          property: url
+      - secretKey: argoEventsWebhookToken
+        remoteRef:
+          key: govuk/argo-events-webhook-token
+          property: token
+      - secretKey: grafanaApiKey
+        remoteRef:
+          key: govuk/argo-notifications/grafana
+          property: grafana-api-key

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -24,7 +24,6 @@ spec:
             templateRef:
               name: smoke-test
               template: smoke-test
-              clusterScope: true
             arguments:
               parameters:
                 - name: extra-args

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -1,5 +1,5 @@
 apiVersion: argoproj.io/v1alpha1
-kind: ClusterWorkflowTemplate
+kind: WorkflowTemplate
 metadata:
   name: smoke-test
 spec:

--- a/schemas/clusterexternalsecret_v1beta1.json
+++ b/schemas/clusterexternalsecret_v1beta1.json
@@ -1,0 +1,584 @@
+{
+  "description": "ClusterExternalSecret is the Schema for the clusterexternalsecrets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.",
+      "properties": {
+        "externalSecretName": {
+          "description": "The name of the external secrets to be created defaults to the name of the ClusterExternalSecret",
+          "type": "string"
+        },
+        "externalSecretSpec": {
+          "description": "The spec for the ExternalSecrets to be created",
+          "properties": {
+            "data": {
+              "description": "Data defines the connection between the Kubernetes Secret keys and the Provider data",
+              "items": {
+                "description": "ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.",
+                "properties": {
+                  "remoteRef": {
+                    "description": "RemoteRef points to the remote secret and defines which secret (version/property/..) to fetch.",
+                    "properties": {
+                      "conversionStrategy": {
+                        "default": "Default",
+                        "description": "Used to define a conversion Strategy",
+                        "type": "string"
+                      },
+                      "decodingStrategy": {
+                        "default": "None",
+                        "description": "Used to define a decoding Strategy",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the key used in the Provider, mandatory",
+                        "type": "string"
+                      },
+                      "metadataPolicy": {
+                        "description": "Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None",
+                        "type": "string"
+                      },
+                      "property": {
+                        "description": "Used to select a specific property of the Provider value (if a map), if supported",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Used to select a specific version of the Provider value, if supported",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secretKey": {
+                    "description": "SecretKey defines the key in which the controller stores the value. This is the key in the Kind=Secret",
+                    "type": "string"
+                  },
+                  "sourceRef": {
+                    "description": "SourceRef allows you to override the source from which the value will pulled from.",
+                    "maxProperties": 1,
+                    "properties": {
+                      "generatorRef": {
+                        "description": "GeneratorRef points to a generator custom resource in",
+                        "properties": {
+                          "apiVersion": {
+                            "default": "generators.external-secrets.io/v1alpha1",
+                            "description": "Specify the apiVersion of the generator resource",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Specify the name of the generator resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storeRef": {
+                        "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the SecretStore resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "remoteRef",
+                  "secretKey"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "dataFrom": {
+              "description": "DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order",
+              "items": {
+                "properties": {
+                  "extract": {
+                    "description": "Used to extract multiple key/value pairs from one secret Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.",
+                    "properties": {
+                      "conversionStrategy": {
+                        "default": "Default",
+                        "description": "Used to define a conversion Strategy",
+                        "type": "string"
+                      },
+                      "decodingStrategy": {
+                        "default": "None",
+                        "description": "Used to define a decoding Strategy",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the key used in the Provider, mandatory",
+                        "type": "string"
+                      },
+                      "metadataPolicy": {
+                        "description": "Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None",
+                        "type": "string"
+                      },
+                      "property": {
+                        "description": "Used to select a specific property of the Provider value (if a map), if supported",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Used to select a specific version of the Provider value, if supported",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "find": {
+                    "description": "Used to find secrets based on tags or regular expressions Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.",
+                    "properties": {
+                      "conversionStrategy": {
+                        "default": "Default",
+                        "description": "Used to define a conversion Strategy",
+                        "type": "string"
+                      },
+                      "decodingStrategy": {
+                        "default": "None",
+                        "description": "Used to define a decoding Strategy",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Finds secrets based on the name.",
+                        "properties": {
+                          "regexp": {
+                            "description": "Finds secrets base",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "path": {
+                        "description": "A root path to start the find operations.",
+                        "type": "string"
+                      },
+                      "tags": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Find secrets based on tags.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rewrite": {
+                    "description": "Used to rewrite secret Keys after getting them from the secret Provider Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)",
+                    "items": {
+                      "properties": {
+                        "regexp": {
+                          "description": "Used to rewrite with regular expressions. The resulting key will be the output of a regexp.ReplaceAll operation.",
+                          "properties": {
+                            "source": {
+                              "description": "Used to define the regular expression of a re.Compiler.",
+                              "type": "string"
+                            },
+                            "target": {
+                              "description": "Used to define the target pattern of a ReplaceAll operation.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "source",
+                            "target"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "sourceRef": {
+                    "description": "SourceRef points to a store or generator which contains secret values ready to use. Use this in combination with Extract or Find pull values out of a specific SecretStore. When sourceRef points to a generator Extract or Find is not supported. The generator returns a static map of values",
+                    "maxProperties": 1,
+                    "properties": {
+                      "generatorRef": {
+                        "description": "GeneratorRef points to a generator custom resource in",
+                        "properties": {
+                          "apiVersion": {
+                            "default": "generators.external-secrets.io/v1alpha1",
+                            "description": "Specify the apiVersion of the generator resource",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Specify the name of the generator resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storeRef": {
+                        "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the SecretStore resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "refreshInterval": {
+              "default": "1h",
+              "description": "RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are \"ns\", \"us\" (or \"\u00b5s\"), \"ms\", \"s\", \"m\", \"h\" May be set to zero to fetch and create it once. Defaults to 1h.",
+              "type": "string"
+            },
+            "secretStoreRef": {
+              "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+              "properties": {
+                "kind": {
+                  "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the SecretStore resource",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "target": {
+              "default": {
+                "creationPolicy": "Owner",
+                "deletionPolicy": "Retain"
+              },
+              "description": "ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.",
+              "properties": {
+                "creationPolicy": {
+                  "default": "Owner",
+                  "description": "CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'",
+                  "enum": [
+                    "Owner",
+                    "Orphan",
+                    "Merge",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "deletionPolicy": {
+                  "default": "Retain",
+                  "description": "DeletionPolicy defines rules on how to delete the resulting Secret Defaults to 'Retain'",
+                  "enum": [
+                    "Delete",
+                    "Merge",
+                    "Retain"
+                  ],
+                  "type": "string"
+                },
+                "immutable": {
+                  "description": "Immutable defines if the final secret will be immutable",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource",
+                  "type": "string"
+                },
+                "template": {
+                  "description": "Template defines a blueprint for the created Secret resource.",
+                  "properties": {
+                    "data": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "engineVersion": {
+                      "default": "v2",
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "description": "ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "templateFrom": {
+                      "items": {
+                        "maxProperties": 1,
+                        "minProperties": 1,
+                        "properties": {
+                          "configMap": {
+                            "properties": {
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "items",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "items",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespaceSelector": {
+          "description": "The labels to select by to find the Namespaces to create the ExternalSecrets in.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "refreshTime": {
+          "description": "The time in which the controller should reconcile it's objects and recheck namespaces for labels.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalSecretSpec",
+        "namespaceSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failedNamespaces": {
+          "description": "Failed namespaces are the namespaces that failed to apply an ExternalSecret",
+          "items": {
+            "description": "ClusterExternalSecretNamespaceFailure represents a failed namespace deployment and it's reason.",
+            "properties": {
+              "namespace": {
+                "description": "Namespace is the namespace that failed when trying to apply an ExternalSecret",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Reason is why the ExternalSecret failed to apply to the namespace",
+                "type": "string"
+              }
+            },
+            "required": [
+              "namespace"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "provisionedNamespaces": {
+          "description": "ProvisionedNamespaces are the namespaces where the ClusterExternalSecret has secrets",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR moves the relevant components to run our workflows back into the "apps" namespace. This is needed because the post sync workflow cannot trigger the smoke tests because they run in different namespaces. (Smoke tests are configured in a separate helm chart and are dependent on resources in the "apps" namespace).

This was simpler than trying to move smokey test to the cluster-services namespace (due dependent resource) or trying to use a sensor to trigger a workflow across namespace (as they add complexity and potential for breakage).

To move the web hook resources to "apps", we need a copy of the argocd-notifications-secret in both the "apps" and "cluster-services" namespace - as it is also used by the core argo-notification service (which is apart of argocd installed in cluster-services).