### PR TITLE
Update EventBus to use Jetstream

### DIFF
--- a/charts/argo-services/templates/events/eventbus.yaml
+++ b/charts/argo-services/templates/events/eventbus.yaml
@@ -3,6 +3,5 @@ kind: EventBus
 metadata:
   name: default
 spec:
-  nats:
-    native:
-      auth: token
+  jetstream:
+    version: 2.9.8


### PR DESCRIPTION
Nats streaming server has been deprecated in favor of Jetstream. Also this fixes an issue with creating new EventBus resources, as the don't support the new versions of Nat streaming server.

Requires: https://github.com/alphagov/govuk-infrastructure/pull/794