### PR TITLE
Add ALB Rule to allow test domain for assets

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4,6 +4,9 @@ govukEnvironment: integration
 externalDomainSuffix: eks.integration.govuk.digital
 publishingServiceDomainSuffix: integration.publishing.service.gov.uk
 assetsDomain: assets.integration.publishing.service.gov.uk
+# TODO: Remove once fully migrated to EKS
+assetsTestDomain: assets-eks.integration.publishing.service.gov.uk
+
 workerReplicaCount: 1
 appResources:
   limits:
@@ -28,7 +31,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '20'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
       hosts:
       - name: assets-origin.eks.integration.govuk.digital
         path: /government/uploads/
@@ -1796,7 +1799,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '30'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
     extraEnv:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
@@ -2245,7 +2248,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '10'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
     uploadAssets: *whitehall-upload-assets

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -4,6 +4,9 @@ govukEnvironment: production
 externalDomainSuffix: gov.uk
 publishingServiceDomainSuffix: publishing.service.gov.uk
 assetsDomain: assets.publishing.service.gov.uk
+# TODO: Remove once fully migrated to EKS
+assetsTestDomain: assets-eks.production.publishing.service.gov.uk
+
 replicaCount: 3
 
 # Individual apps to be deployed by ArgoCD, and any values specific to those
@@ -22,7 +25,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '20'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
       hosts:
       - name: assets-origin.eks.production.govuk.digital
         path: /government/uploads/
@@ -522,7 +525,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '30'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
     extraEnv:
       # These GA/GTM values are not secrets.
       - name: GA_UNIVERSAL_ID
@@ -569,7 +572,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '10'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
     appResources:
       limits:
         memory: 4Gi

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -4,6 +4,9 @@ govukEnvironment: staging
 externalDomainSuffix: staging.publishing.service.gov.uk
 publishingServiceDomainSuffix: staging.publishing.service.gov.uk
 assetsDomain: assets.staging.publishing.service.gov.uk
+# TODO: Remove once fully migrated to EKS
+assetsTestDomain: assets-eks.staging.publishing.service.gov.uk
+
 appResources:
   limits:
     cpu: 1
@@ -27,7 +30,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '20'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
       hosts:
       - name: assets-origin.eks.staging.govuk.digital
         path: /government/uploads/
@@ -515,7 +518,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '30'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
     extraEnv:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
@@ -567,7 +570,7 @@ govukApplications:
         alb.ingress.kubernetes.io/group.order: '10'
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.assetsTestDomain }}"]}}]
     appResources:
       limits:
         memory: 4Gi


### PR DESCRIPTION
This allows us to access assets via the test domain, whilst still allowing traffic for the live domains (if we do a traffic split). This should be removed once traffic is fully migrated across to use EKS.