### PR TITLE
Fix allowed host headers for www

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -6,6 +6,7 @@ publishingServiceDomainSuffix: integration.publishing.service.gov.uk
 assetsDomain: assets.integration.publishing.service.gov.uk
 # TODO: Remove once fully migrated to EKS
 assetsTestDomain: assets-eks.integration.publishing.service.gov.uk
+wwwTestDomain: www.eks.integration.govuk.digital
 
 workerReplicaCount: 1
 appResources:
@@ -1436,7 +1437,7 @@ govukApplications:
         alb.ingress.kubernetes.io/healthcheck-path: /readyz
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.publishingServiceDomainSuffix }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.publishingServiceDomainSuffix }}", "{{ .Values.wwwTestDomain }}"]}}]
       hosts:
       - www-origin.eks.integration.govuk.digital
     nginxConfigMap:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -6,6 +6,7 @@ publishingServiceDomainSuffix: publishing.service.gov.uk
 assetsDomain: assets.publishing.service.gov.uk
 # TODO: Remove once fully migrated to EKS
 assetsTestDomain: assets-eks.production.publishing.service.gov.uk
+wwwTestDomain: www.eks.production.govuk.digital
 
 replicaCount: 3
 
@@ -321,7 +322,7 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:eu-west-1:172025368201:regional/webacl/cache_public_web_acl/d9033e40-69e8-4bbc-a61a-cd3c50254d04
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.publishingServiceDomainSuffix }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "{{ .Values.wwwTestDomain }}"]}}]
       hosts:
       - www-origin.eks.production.govuk.digital
     nginxConfigMap:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -6,6 +6,7 @@ publishingServiceDomainSuffix: staging.publishing.service.gov.uk
 assetsDomain: assets.staging.publishing.service.gov.uk
 # TODO: Remove once fully migrated to EKS
 assetsTestDomain: assets-eks.staging.publishing.service.gov.uk
+wwwTestDomain: www.eks.staging.govuk.digital
 
 appResources:
   limits:
@@ -315,7 +316,7 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.publishingServiceDomainSuffix }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "{{ .Values.wwwTestDomain }}"]}}]
       hosts:
       - www-origin.eks.staging.govuk.digital
     nginxConfigMap:


### PR DESCRIPTION
The external domain prefix is the real domain in production vs the test domain in integration and staging. This adds an explicit value for the test domain and adds it to the allowed host headers. Also uses the publishing suffix for integration, as the external domain is currently the test domain.