### PR TITLE
Switch staging back to using test domain

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1,7 +1,7 @@
 # Defaults for all apps in this environment. These can be overridden for
 # individual apps below.
 govukEnvironment: staging
-externalDomainSuffix: staging.publishing.service.gov.uk
+externalDomainSuffix: eks.staging.govuk.digital
 publishingServiceDomainSuffix: staging.publishing.service.gov.uk
 assetsDomain: assets.staging.publishing.service.gov.uk
 # TODO: Remove once fully migrated to EKS
@@ -316,7 +316,7 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "{{ .Values.wwwTestDomain }}"]}}]
+          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.publishingServiceDomainSuffix }}", "{{ .Values.wwwTestDomain }}"]}}]
       hosts:
       - www-origin.eks.staging.govuk.digital
     nginxConfigMap:


### PR DESCRIPTION
Smokey is currently failing as its trying to access to the non-test domain (i.e. old infra). This is blocked due to ACLs, but also means smokey would be testing the wrong infra.