### PR TITLE
Updates to Fact check values for Publisher.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1296,14 +1296,12 @@ govukApplications:
         value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
       - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
         value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
-      - name: FACT_CHECK_ADDRESS_FORMAT
-        value: factcheck+integration-{id}@alphagov.co.uk
       - name: FACT_CHECK_SUBJECT_PREFIX
-        value: integration
+        value: dev
       - name: FACT_CHECK_REPLY_TO_ADDRESS
         value: govuk-fact-check-integration@digital.cabinet-office.gov.uk
       - name: FACT_CHECK_REPLY_TO_ID
-        value: govuk-fact-check-integration@digital.cabinet-office.gov.uk
+        value: 6b6ee566-54f2-48f6-98c4-21a373e6dea2
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 759acac6-da53-4a19-b591-b7538c7c39de
 - name: publishing-api


### PR DESCRIPTION
Matching Fact check values to those in Integration EC2.

Removed FACT_CHECK_ADDRESS_FORMAT as its been been removed from code - https://github.com/alphagov/govuk-puppet/commit/83068e0f3f14e2a0d944ad6d02eebdfcfc78a73f

https://trello.com/c/WtN0fz05/1036-journey-test-fact-check-process-for-mainstream-content