### PR TITLE
Collections publisher needs Ingress

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -147,6 +147,12 @@ govukApplications:
     uploadAssets:
       path: /app/public/assets
     workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: collections-publisher
+      hosts:
+        - name: collections-publisher.eks.integration.govuk.digital
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
Adding Ingress host: `collections-publisher.eks.integration.govuk.digital`

Currently we use `collections-publisher.integration.publishing.service.gov.uk` in Integration hosted on EC2