### PR TITLE
Allowing customisation of the upload asset S3 directory location.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -146,6 +146,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       path: /app/public/assets
+      s3Directory: assets/
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.uploadAssets.enabled -}}
-{{- $destDir := .Values.uploadAssets.s3Directory | default .Release.Name }}
+{{- $destDir := .Values.uploadAssets.s3Directory | default (printf  "assets/%s/" .Release.Name) }}
 {{- $sourcePath := .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Release.Name) }}
 apiVersion: batch/v1
 kind: Job
@@ -42,7 +42,7 @@ spec:
             - s3
             - sync
             - /assets-to-upload
-            - "{{- printf "s3://govuk-app-assets-%s/assets/%s/" .Values.govukEnvironment $destDir }}"
+            - "{{- printf "s3://govuk-app-assets-%s/%s" .Values.govukEnvironment $destDir }}"
           {{- with .Values.jobResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}


### PR DESCRIPTION
Some apps use a different upload aseet path `/app/public/assets/` other then the default `/app/public/assets/.Release.Name`. 
https://github.com/alphagov/govuk-helm-charts/blob/6b57a1c4767de8c4e7d21a06caa0c4a05b05708e/charts/generic-govuk-app/templates/assets-upload-job.yaml#L3

Likewise the need to mirror this in our upload asset to S3 job to: `s3://govuk-app-assets-(GOV ENVIRONMENT)/assets/` and not the default `s3://govuk-app-assets-(GOV ENVIRONMENT)/assets/.Release.Name`. 
https://github.com/alphagov/govuk-helm-charts/blob/6b57a1c4767de8c4e7d21a06caa0c4a05b05708e/charts/generic-govuk-app/templates/assets-upload-job.yaml#L45

Example app using default S3 get:
https://publisher.eks.integration.govuk.digital/assets/publisher/application-fa17b1c2607b4440b2eb5ab6e0cc767862197490e08fc393c19369e6dd1c0e0a.js

Example app using non default s3 get:
https://collections-publisher.eks.integration.govuk.digital/assets/application-787494b18c7a0e7d94b1f285cc27438e8a170040ed3aa8692e469ce4e9c9f81b.css