### PR TITLE
Prevent draft apps from promoting a deployment

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -31,6 +31,7 @@ spec:
           {{ if .Values.nextEnvironment }}
           - name: promote-release
             depends: smoke-test.Succeeded
+            when: "{{"'{{workflow.parameters.application}}' !~ '^draft-'"}}"
             template: send-webhook
             arguments:
               parameters:


### PR DESCRIPTION
This adds a check in the promotion step to check if the app is a draft app - we need to only promote an app if the non-draft version has passed the smokey tests.