### PR TITLE
Fix template error in Ingress spec for Maslow.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1236,7 +1236,7 @@ govukApplications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: maslow
       hosts:
-      - maslow.eks.integration.govuk.digital
+        - name: maslow.eks.integration.govuk.digital
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
Took me ages to spot what was wrong here 😅 Missed this in #744.

Tested: `helm template ../generic-govuk-app --values <(helm template . --values values-integration.yaml |yq e '.|select(.metadata.name=="maslow").spec.source.helm.values')`