### PR TITLE
Clean up `PLEK_*` env vars for draft-content-store.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -480,20 +480,8 @@ govukApplications:
           mongo-3.integration.govuk-internal.digital/draft_content_store_production"
       - name: NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH
         value: "1"
-      # Draft apps use draft backends by default so that any misconfiguration
-      # leads to obvious errors rather than draft content being unknowingly
-      # made public.
-      # TODO: fix Plek so that we don't need all this error-prone config for
-      # each draft app.
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
-      # https://github.com/alphagov/govuk-puppet/pull/10316/commits/899ac50
-      - name: PLEK_SERVICE_SIGNON_URI
-        value: https://signon.{{ .Values.externalDomainSuffix }}
-      - name: PLEK_SERVICE_FEEDBACK_URI
-        value: http://feedback
-      - name: PLEK_SERVICE_INFO_FRONTEND_URI
-        value: http://support
 - name: draft-router
   repoName: router
   helmValues:


### PR DESCRIPTION
Since #602 / 865b118, we no longer need to set `PLEK_SERVICE_*_PREFIX` on draft apps for every backend service which doesn't have a `draft-` flavour, because [`PLEK_UNPREFIXABLE_HOSTS`] takes care of that for us.

[`PLEK_UNPREFIXABLE_HOSTS`]: https://github.com/alphagov/plek/blob/main/CHANGELOG.md#410

Tested:
- `helm install chris-draft-content-store ../generic-govuk-app --values <(helm template . --values values-integration.yaml |yq e '.|select(.metadata.name=="draft-content-store").spec.source.helm.values')`
- `k get deploy/chris-draft-content-store`
- `k logs !$`
- `helm uninstall chris-draft-content-store`