### PR TITLE
Fix wrong name for PLEK_UNPREFIXABLE_HOSTS in global configmap.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -28,7 +28,7 @@ data:
   GOVUK_PERSONALISATION_SECURITY_URI: "https://integration.account.gov.uk?link=security-privacy"
   {{- end }}
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
-  PLEK_UNPREFIXABLE_DOMAINS: account-api,feedback,imminence,info-frontend,licensify,local-links-manager,locations-api,search-api,signon
+  PLEK_UNPREFIXABLE_HOSTS: account-api,feedback,imminence,info-frontend,licensify,local-links-manager,locations-api,search-api,signon
   PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   RAILS_LOG_TO_STDOUT: "true"
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}-eks


### PR DESCRIPTION
It's
[PLEK_UNPREFIXABLE_HOSTS](https://github.com/alphagov/plek/blob/main/CHANGELOG.md#410), not PLEK_UNPREFIXABLE_DOMAINS. D'oh.