### PR TITLE
Add Catalina's test message for tutorial

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2235,6 +2235,8 @@ govukApplications:
         value: message_by_example
       - name: ENV_MESSAGE_OTHER
         value: message_by_other
+      - name: ENV_MESSAGE_CATALINA
+        value: Catalina's test message
 - name: whitehall-admin
   repoName: whitehall
   helmValues:


### PR DESCRIPTION
Members of Platform Reliability are carrying out the [Kubernetes tutorials](https://govuk-k8s-user-docs.publishing.service.gov.uk/get-started/tutorials/app-config-deploy-helm-chart/#update-an-application-39-s-environment-configuration)