### PR TITLE
Use `db:prepare` instead of `db:migrate`.

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -35,8 +35,8 @@ spec:
       containers:
         - name: dbmigrate
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-          command: ["bundle"]
-          args: ["exec", "rails", "db:migrate"]
+          command: ["rails"]
+          args: ["db:prepare"]
           envFrom:
             - configMapRef:
                 name: govuk-apps-env


### PR DESCRIPTION
[`db:prepare`](https://www.github.com/rails/rails/pull/35768) is equivalent to `db:migrate` where there's an existing database, but if the database hasn't been created yet then it'll run `db:setup` to create the schema and insert any initial records.

This facilitates testing the system without having to dump/load datasets out of the integration environment.

`db:prepare` was added in Rails 6 and all of our apps are now on Rails 7, so I'm not expecting any compatibility issues here.

Also omit `bundle exec` from the command since it's no longer required.

Tested: inspected template output

    helm template content-store ../generic-govuk-app --values \
      <(helm template . --values values-integration.yaml \
        | yq e '.|select(.metadata.name=="content-store").spec.source.helm.values' \
      ) --set dbMigrationEnabled=true