### PR TITLE
Make PodMonitors etc. optional.

### DIFF
--- a/charts/app-config/templates/monitoring-application.yaml
+++ b/charts/app-config/templates/monitoring-application.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -22,3 +23,4 @@ spec:
       selfHeal: true
     syncOptions:
     - ApplyOutOfSyncOnly=true
+{{- end }}

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -20,3 +20,6 @@ publishingServiceDomainSuffix: test.publishing.service.gov.uk
 
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+
+monitoring:
+  enabled: true

--- a/charts/generic-govuk-app/templates/podmonitor.yaml
+++ b/charts/generic-govuk-app/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -11,3 +12,4 @@ spec:
       app: {{ .Release.Name }}
   podMetricsEndpoints:
   - port: metrics
+{{- end }}

--- a/charts/generic-govuk-app/templates/worker-podmonitor.yaml
+++ b/charts/generic-govuk-app/templates/worker-podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.workerEnabled -}}
+{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -12,4 +13,5 @@ spec:
       app: {{ .Release.Name }}-worker
   podMetricsEndpoints:
   - port: metrics
+{{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -112,6 +112,10 @@ uploadAssets:
   enabled: true
 
 metricsPort: 9394
+monitoring:
+  # monitoring.enabled determines whether PodMonitor and other Prometheus
+  # Operator custom resources are to be created or not.
+  enabled: false
 
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
This allows installing the charts without Prometheus Operator, which is helpful when testing.

Defaults are chosen such that there should be no change to what we're deploying via ArgoCD.