### PR TITLE
Fix bad resource names when installed as dependency.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -964,6 +964,10 @@ govukApplications:
 - name: licencefinder
   repoName: licence-finder
   helmValues:
+    uploadAssets:
+      # https://github.com/alphagov/licence-finder/blob/e60ad6b/config/application.rb#L35
+      path: /app/public/assets/licencefinder
+      s3Directory: "licencefinder"
     extraEnv:
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
@@ -1794,6 +1798,10 @@ govukApplications:
 - name: smartanswers
   repoName: smart-answers
   helmValues:
+    uploadAssets:
+      # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
+      path: /app/public/assets/smartanswers
+      s3Directory: "smartanswers"
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"
@@ -1826,6 +1834,7 @@ govukApplications:
   chartPath: charts/smokey
 - name: static
   helmValues:
+    uploadStaticErrorPagesEnabled: true
     ingress:
       hosts:
         - name: assets-origin.eks.integration.govuk.digital

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -517,6 +517,7 @@ govukApplications:
   chartPath: charts/smokey
 - name: static
   helmValues:
+    uploadStaticErrorPagesEnabled: true
     ingress:
       hosts:
         - name: assets-origin.eks.production.govuk.digital

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -510,6 +510,7 @@ govukApplications:
   chartPath: charts/smokey
 - name: static
   helmValues:
+    uploadStaticErrorPagesEnabled: true
     ingress:
       hosts:
         - name: assets-origin.eks.staging.govuk.digital

--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -1,8 +1,9 @@
 {{- define "asset-manager.freshclam.podspec" }}
+{{- $fullName := include "asset-manager.fullname" . }}
 metadata:
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
     app.kubernetes.io/component: freshclam
 spec:
   activeDeadlineSeconds: 1800
@@ -37,6 +38,6 @@ spec:
         path: /clamav-db
     - name: etc-clamav
       configMap:
-        name: {{ .Release.Name }}-etc-clamav
+        name: {{ $fullName }}-etc-clamav
   restartPolicy: Never
 {{- end }}

--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -1,7 +1,8 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-etc-clamav
+  name: {{ $fullName }}-etc-clamav
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: clamd

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -1,22 +1,23 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $fullName }}
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
     app.kubernetes.io/component: app
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 5
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $fullName }}
   template:
     metadata:
       labels:
         {{- include "asset-manager.labels" . | nindent 8 }}
-        app: {{ .Release.Name }}
+        app: {{ $fullName }}
         app.kubernetes.io/component: app
     spec:
       automountServiceAccountToken: false
@@ -33,9 +34,9 @@ spec:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
       volumes:
-        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
           configMap:
-            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
         - name: app-tmp
           emptyDir: {}
         - name: nginx-tmp
@@ -138,7 +139,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 15
           volumeMounts:
-            - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+            - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
             - name: nginx-tmp

--- a/charts/asset-manager/templates/freshclam-cronjob.yaml
+++ b/charts/asset-manager/templates/freshclam-cronjob.yaml
@@ -1,10 +1,11 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-freshclam
+  name: {{ $fullName }}-freshclam
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
     app.kubernetes.io/component: freshclam
 spec:
   schedule: "19 * * * *"
@@ -12,7 +13,7 @@ spec:
     metadata:
       labels:
         {{- include "asset-manager.labels" . | nindent 8 }}
-        app: {{ .Release.Name }}
+        app: {{ $fullName }}
         app.kubernetes.io/component: freshclam
     spec:
       backoffLimit: 1

--- a/charts/asset-manager/templates/freshclam-presync.yaml
+++ b/charts/asset-manager/templates/freshclam-presync.yaml
@@ -1,12 +1,13 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-update-freshclam
+  name: {{ $fullName }}-update-freshclam
   annotations:
     argocd.argoproj.io/hook: PreSync
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
     app.kubernetes.io/component: freshclam
 spec:
   backoffLimit: 2

--- a/charts/asset-manager/templates/ingress.yaml
+++ b/charts/asset-manager/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := .Release.Name -}}
+{{- $fullName := include "asset-manager.fullname" . }}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Values.ingress.name | default .Release.Name }}
+  name: {{ .Values.ingress.name | default $fullName }}
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -1,7 +1,8 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-nginx-conf
+  name: {{ $fullName }}-nginx-conf
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
@@ -31,7 +32,7 @@ data:
       sendfile        on;
       keepalive_timeout  65;
 
-      upstream {{ .Release.Name }} {
+      upstream {{ $fullName }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }
 
@@ -140,7 +141,7 @@ data:
         }
 
         location @app {
-          proxy_pass http://{{ .Release.Name }};
+          proxy_pass http://{{ $fullName }};
         }
 
         client_max_body_size 500m;

--- a/charts/asset-manager/templates/podMonitor.yaml
+++ b/charts/asset-manager/templates/podMonitor.yaml
@@ -1,15 +1,16 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   labels:
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-  name: {{ .Release.Name }}
+  name: {{ $fullName }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $fullName }}
   podMetricsEndpoints:
   - port: metrics

--- a/charts/asset-manager/templates/service.yaml
+++ b/charts/asset-manager/templates/service.yaml
@@ -1,10 +1,11 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $fullName }}
   labels:
-    app: {{ .Release.Name }}
-{{ if .Values.service.annotations}}
+    app: {{ $fullName }}
+{{ if .Values.service.annotations }}
   annotations:
     {{- range $key, $value := .Values.service.annotations }}
     {{ $key }}: {{ $value }}
@@ -16,4 +17,4 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
   selector:
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -1,22 +1,23 @@
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-worker
+  name: {{ $fullName }}-worker
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}-worker
+    app: {{ $fullName }}-worker
     app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 5
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-worker
+      app: {{ $fullName }}-worker
   template:
     metadata:
       labels:
         {{- include "asset-manager.labels" . | nindent 8 }}
-        app: {{ .Release.Name }}-worker
+        app: {{ $fullName }}-worker
         app.kubernetes.io/component: worker
     spec:
       automountServiceAccountToken: false
@@ -48,7 +49,7 @@ spec:
             readOnly: true
         - name: etc-clamav
           configMap:
-            name: {{ .Release.Name }}-etc-clamav
+            name: {{ $fullName }}-etc-clamav
         {{- with .Values.extraVolumes }}
           {{ . | toYaml | trim | nindent 8 }}
         {{- end }}

--- a/charts/asset-manager/templates/worker-podmonitor.yaml
+++ b/charts/asset-manager/templates/worker-podmonitor.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.workerEnabled -}}
+{{- $fullName := include "asset-manager.fullname" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Release.Name }}-worker
+  name: {{ $fullName }}-worker
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}-worker
+    app: {{ $fullName }}-worker
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-worker
+      app: {{ $fullName }}-worker
   podMetricsEndpoints:
   - port: metrics
 {{- end }}

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.uploadAssets.enabled -}}
-{{- $destDir := .Values.uploadAssets.s3Directory | default .Release.Name }}
-{{- $sourcePath := .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Release.Name) }}
+{{- $destDir := .Values.uploadAssets.s3Directory | default .Values.repoName }}
+{{- $sourcePath := .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Values.repoName) }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-upload-assets
+  name: {{ $fullName }}-upload-assets
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: upload-assets
@@ -22,7 +23,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
       initContainers:
-        - name: {{ .Release.Name }}-copy-assets-for-upload
+        - name: copy-assets-for-upload
           image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
           command:
             - sh
@@ -35,7 +36,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
       containers:
-        - name: {{ .Release.Name }}-upload-assets
+        - name: upload-assets
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
           command:
             - aws

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -1,9 +1,10 @@
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 {{- range .Values.cronTasks }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ $.Release.Name }}-{{ .name }}-cron-task"
+  name: "{{ $fullName }}-{{ .name }}-cron-task"
   labels:
     {{- include "generic-govuk-app.labels" $ | nindent 4 }}
     app.kubernetes.io/component: app
@@ -11,7 +12,7 @@ spec:
   schedule: "{{ .schedule }}"
   jobTemplate:
     metadata:
-      name: "{{ $.Release.Name }}-{{ .name }}-cron-task"
+      name: "{{ $fullName }}-{{ .name }}-cron-task"
       labels:
         {{- include "generic-govuk-app.labels" $ | nindent 8 }}
         app.kubernetes.io/component: app
@@ -19,7 +20,7 @@ spec:
       backoffLimit: 1
       template:
         metadata:
-          name: "{{ $.Release.Name }}-{{ .name }}-cron-task"
+          name: "{{ $fullName }}-{{ .name }}-cron-task"
           labels:
             {{- include "generic-govuk-app.labels" $ | nindent 12 }}
             app.kubernetes.io/component: app

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.dbMigrationEnabled -}}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-dbmigrate
+  name: {{ $fullName }}-dbmigrate
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: dbmigrate
@@ -13,7 +14,7 @@ spec:
   backoffLimit: 2
   template:
     metadata:
-      name: {{ .Release.Name }}-dbmigrate
+      name: {{ $fullName }}-dbmigrate
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
         app.kubernetes.io/component: dbmigrate

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -1,23 +1,24 @@
 {{- if .Values.appEnabled -}}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $fullName }}
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
     app.kubernetes.io/component: app
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 5
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $fullName }}
   template:
     metadata:
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
-        app: {{ .Release.Name }}
+        app: {{ $fullName }}
         app.kubernetes.io/component: app
     spec:
       automountServiceAccountToken: false
@@ -32,9 +33,9 @@ spec:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
       volumes:
-        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+        - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
           configMap:
-            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+            name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
         - name: app-tmp
           emptyDir: {}
         - name: nginx-tmp
@@ -134,7 +135,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" .Release.Name) }}
+            - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
             - name: nginx-tmp

--- a/charts/generic-govuk-app/templates/ingress.yaml
+++ b/charts/generic-govuk-app/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := .Release.Name -}}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Values.ingress.name | default .Release.Name }}
+  name: {{ .Values.ingress.name | default $fullName }}
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.nginxConfigMap.create }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-nginx-conf
+  name: {{ $fullName }}-nginx-conf
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
@@ -98,7 +99,7 @@ data:
                            '"upstream_addr": "$upstream_addr", '
                            '"upstream_response_time": "$upstream_response_time" }';
 
-      upstream {{ .Release.Name }} {
+      upstream {{ $fullName }} {
         server 127.0.0.1:{{ .Values.appPort }};
       }
 
@@ -122,7 +123,7 @@ data:
         location / {
           proxy_set_header   Host $http_host;
           proxy_set_header   X-Real-IP $remote_addr;
-          proxy_pass         http://{{ .Release.Name }};
+          proxy_pass         http://{{ $fullName }};
           proxy_redirect     off;
         }
 
@@ -142,7 +143,7 @@ data:
           location ~ "-[0-9a-f]{32,}\." {
             expires max;
             add_header Cache-Control "public, immutable";
-            add_header Surrogate-Key "assets assets-{{ .Release.Name }}";
+            add_header Surrogate-Key "assets assets-{{ $fullName }}";
             proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
 
             # Set CORS allow origin for fonts only

--- a/charts/generic-govuk-app/templates/podmonitor.yaml
+++ b/charts/generic-govuk-app/templates/podmonitor.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.monitoring.enabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $fullName }}
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $fullName }}
   podMetricsEndpoints:
   - port: metrics
 {{- end }}

--- a/charts/generic-govuk-app/templates/service.yaml
+++ b/charts/generic-govuk-app/templates/service.yaml
@@ -1,10 +1,11 @@
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $fullName }}
   labels:
-    app: {{ .Release.Name }}
-{{ if .Values.service.annotations}}
+    app: {{ $fullName }}
+{{ if .Values.service.annotations }}
   annotations:
     {{- range $key, $value := .Values.service.annotations }}
     {{ $key }}: {{ $value }}
@@ -17,4 +18,4 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
   selector:
-    app: {{ .Release.Name }}
+    app: {{ $fullName }}

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -1,8 +1,9 @@
-{{- if or .Values.uploadStaticErrorPagesEnabled (eq .Release.Name "static") }}
+{{- if .Values.uploadStaticErrorPagesEnabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-upload-error-pages
+  name: {{ $fullName }}-upload-error-pages
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: upload-error-pages
@@ -35,7 +36,7 @@ spec:
             - name: GOVUK_ENVIRONMENT
               value: {{ .Values.govukEnvironment }}
             - name: SERVICE
-              value: {{ .Release.Name }}
+              value: {{ $fullName }}
           command:
             - "/bin/bash"
             - "-c"

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -1,23 +1,24 @@
 {{- if .Values.workerEnabled -}}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-worker
+  name: {{ $fullName }}-worker
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}-worker
+    app: {{ $fullName }}-worker
     app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 5
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-worker
+      app: {{ $fullName }}-worker
   template:
     metadata:
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
-        app: {{ .Release.Name }}-worker
+        app: {{ $fullName }}-worker
         app.kubernetes.io/component: worker
     spec:
       automountServiceAccountToken: false

--- a/charts/generic-govuk-app/templates/worker-podmonitor.yaml
+++ b/charts/generic-govuk-app/templates/worker-podmonitor.yaml
@@ -1,16 +1,17 @@
 {{- if .Values.workerEnabled -}}
 {{- if .Values.monitoring.enabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Release.Name }}-worker
+  name: {{ $fullName }}-worker
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}-worker
+    app: {{ $fullName }}-worker
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-worker
+      app: {{ $fullName }}-worker
   podMetricsEndpoints:
   - port: metrics
 {{- end }}


### PR DESCRIPTION
Use the `fullname` template from the default `_helpers.tpl` instead of referring directly to `.Release.Name`.

Using `.Release.Name` only works as intended when the chart is being installed at the top level. When a chart is installed as a dependency of another chart, `.Release.Name` is the name of the parent chart.

This is one of the problems that Helm's default templates like `fullname` are intended to solve.

We also have to avoid using `.Release.Name` as a default for things like the Rails assets directory name. While we're there, omit the redundant app name prefix from the container names in the upload-assets job. 
    
Tested: no diffs in `helm template` output except for simplifying the container names in the upload-assets job.
