### PR TITLE
Honour `appImage.pullPolicy` on hook Jobs and CronJobs.

### DIFF
--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -25,6 +25,7 @@ spec:
       initContainers:
         - name: copy-assets-for-upload
           image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
           command:
             - sh
             - -c

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -43,9 +43,10 @@ spec:
           containers:
             - name: cron-task
               image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
+              imagePullPolicy: {{ $.Values.appImage.pullPolicy | default "Always" }}
               {{- if .task }}
-              command: ["bundle"]
-              args: ["exec", "rails", "{{ .task }}"]
+              command: ["rails"]
+              args: ["{{ .task }}"]
               {{- else if .command }}
               command: ["/bin/bash"]
               args: ["-c", "{{ .command }}"]

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -38,6 +38,7 @@ spec:
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           command: ["rails"]
           args: ["db:prepare"]
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
           envFrom:
             - configMapRef:
                 name: govuk-apps-env


### PR DESCRIPTION
This allows these jobs to run on Docker Desktop's built-in cluster. Previously this value was being ignored for these jobs and the default `pullPolicy: Always` (when testing with `:latest`) would defeat the redirection to Docker Desktop's image cache via dockershim and the jobs would fail with `ErrImagePull`.