### PR TITLE
Remove some unnecessary hardcoding of namespaces.

### DIFF
--- a/charts/app-config/templates/signon-secrets-sync-configmap.yaml
+++ b/charts/app-config/templates/signon-secrets-sync-configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: signon-secrets-sync-conf
-  namespace: apps
 data:
   app_names: |
     [

--- a/charts/app-config/templates/signon-service-account.yaml
+++ b/charts/app-config/templates/signon-service-account.yaml
@@ -2,12 +2,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: signon
-  namespace: apps
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: apps
   name: signon-secret-manager
 rules:
 - apiGroups: [""]
@@ -22,7 +20,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: signon-secret-manager-binding
-  namespace: apps
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
This shouldn't change where these resources are installed via Argo, but makes it easier to install locally via `helm install`.