### PR TITLE
Optionally serve Rails assets from the app pod.

### DIFF
--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -39,9 +39,24 @@ spec:
           emptyDir: {}
         - name: nginx-tmp
           emptyDir: {}
+        {{- if .Values.serveRailsAssetsFromFilesystem }}
+        - name: assets
+          emptyDir: {}
+        {{- end }}
         {{- with .Values.extraVolumes }}
           {{- . | toYaml | trim | nindent 8 }}
         {{- end }}
+      {{- if .Values.serveRailsAssetsFromFilesystem }}
+      initContainers:
+        - name: copy-assets
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+          {{- $sourcePath := .Values.uploadAssets.path | default (printf "/app/public/assets/%s" .Values.repoName) }}
+          command: ["cp", "-R", "{{ $sourcePath }}", "/assets"]
+          volumeMounts:
+            - name: assets
+              mountPath: /assets
+      {{- end }}
       containers:
         - name: app
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -139,6 +154,10 @@ spec:
               subPath: nginx.conf
             - name: nginx-tmp
               mountPath: /tmp
+            {{- if .Values.serveRailsAssetsFromFilesystem }}
+            - name: assets
+              mountPath: /assets
+            {{- end }}
             {{- with .Values.nginxExtraVolumeMounts }}
               {{ . | toYaml | trim | nindent 12 }}
             {{- end }}

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -126,6 +126,12 @@ data:
           proxy_redirect     off;
         }
 
+{{- if .Values.serveRailsAssetsFromFilesystem }}
+        location /assets {
+          alias /assets/;
+          autoindex off;
+        }
+{{- else if .Values.proxyRailsAssetsToS3 }}
         location /assets {
           proxy_set_header   Authorization "";
           proxy_set_header   Connection "";
@@ -154,6 +160,7 @@ data:
             }
           }
         }
+{{- end }}
 
         # Endpoint that isn't cached, which is used to assert that an external
         # service can receive a response from GOV.UK origin on www hostname. It

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -61,6 +61,8 @@ nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []
 nginxDenyCrawlers: false
+proxyRailsAssetsToS3: true
+serveRailsAssetsFromFilesystem: false
 
 appResources:
   limits:


### PR DESCRIPTION
Off by default. This is to facilitate system testing, for now (in a production-like configuration). It could potentially form part of a "serve everything from core" DR fallback strategy in the future, but there are no such plans at the moment.

We could use `RAILS_SERVE_STATIC_FILES`, but the performance characteristics would be undesirable even for testing purposes. For example, it would introduce tail latency issues that would hamper any performance-related tests. It'd also likely serve different cache headers. We'd also still have to introduce nginx config changes anyway in order to have nginx cache Rails's responses, so it wouldn't even be a simpler solution.

Tested: I've been using this with [a chart](https://github.com/alphagov/govuk-helm-charts/compare/sengi/parent-chart) that I've been working on for deploying the whole system. It's a no-diff change for what we're deploying via ArgoCD.