### PR TITLE
Fix assets paths for smartanswers and licencefinder.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -283,6 +283,10 @@ govukApplications:
 - name: licencefinder
   repoName: licence-finder
   helmValues:
+    uploadAssets:
+      # https://github.com/alphagov/licence-finder/blob/e60ad6b/config/application.rb#L35
+      path: /app/public/assets/licencefinder
+      s3Directory: "licencefinder"
     extraEnv:
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
@@ -490,6 +494,10 @@ govukApplications:
 - name: smartanswers
   repoName: smart-answers
   helmValues:
+    uploadAssets:
+      # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
+      path: /app/public/assets/smartanswers
+      s3Directory: "smartanswers"
     extraEnv:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -278,6 +278,10 @@ govukApplications:
 - name: licencefinder
   repoName: licence-finder
   helmValues:
+    uploadAssets:
+      # https://github.com/alphagov/licence-finder/blob/e60ad6b/config/application.rb#L35
+      path: /app/public/assets/licencefinder
+      s3Directory: "licencefinder"
     extraEnv:
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
@@ -483,6 +487,10 @@ govukApplications:
 - name: smartanswers
   repoName: smart-answers
   helmValues:
+    uploadAssets:
+      # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
+      path: /app/public/assets/smartanswers
+      s3Directory: "smartanswers"
     extraEnv:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:


### PR DESCRIPTION
Forgot to set these for staging and production in #819 / 810f975.