### PR TITLE
Revert the dbmigration-job command to `db:migrate`.

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -36,8 +36,8 @@ spec:
       containers:
         - name: dbmigrate
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-          command: ["rails"]
-          args: ["db:prepare"]
+          command:
+            {{- .Values.dbMigrationCommand | toYaml | nindent 12 }}
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
           envFrom:
             - configMapRef:

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -30,6 +30,7 @@ appEnabled: true
 
 # dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
 dbMigrationEnabled: false
+dbMigrationCommand: ["rails", "db:migrate"]
 
 # extraVolumes defines Volumes on the app Pods (in both deployment.yaml and
 # worker-deployment.yaml).


### PR DESCRIPTION
Turns out we can't use `db:prepare` everywhere as in #817 / b3f805c, because only ActiveRecord implements it at the moment yet there are other ORM libraries (like [mongoid](https://github.com/mongodb/mongoid/blob/master/lib/mongoid/railties/database.rake)) in use which implement `db:migrate` but not `db:prepare`. Sigh.

Switch back to `db:migrate` as the default but make it configurable.

Tested: inspected template output via
```sh
helm template content-store ../generic-govuk-app --values
  <(helm template . --values values-integration.yaml \
    | yq e '.|select(.metadata.name=="content-store").spec.source.helm.values' \
  ) --set dbMigrationEnabled=true
```

Kudos to @sihugh for helping me track down the missing implementation of `db:prepare`.