### PR TITLE
Omit `bundle exec` from worker commands.

### DIFF
--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -57,8 +57,7 @@ spec:
         - name: app
           image: "{{ required "appImage.repository is required" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
-          command: ["bundle"]
-          args: ["exec", "sidekiq", "-C", "config/sidekiq.yml"]
+          command: ["sidekiq", "-C", "config/sidekiq.yml"]
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 2
 workerEnabled: false
 workerReplicaCount: 2
 workers:
-- command: ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]
+- command: ["sidekiq", "-C", "config/sidekiq.yml"]
   name: worker
 # appEnabled determines if web app should run.
 appEnabled: true


### PR DESCRIPTION
`bundle exec` is no longer necessary with recent govuk-ruby-images.

Tested: inspected template output

```sh
helm template publisher ../generic-govuk-app --values
  <(helm template . --values values-integration.yaml \
    | yq e '.|select(.metadata.name=="publisher").spec.source.helm.values' \
  ) 
```

```sh
helm template asset-manager ../asset-manager --values
  <(helm template . --values values-integration.yaml \
    | yq e '.|select(.metadata.name=="asset-manager").spec.source.helm.values' \
  )
```