### PR TITLE
Hostname for content-data-admin is `content-data`.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -225,7 +225,7 @@ govukApplications:
       annotations:
         alb.ingress.kubernetes.io/load-balancer-name: content-data-admin
       hosts:
-        - name: content-data-admin.eks.integration.govuk.digital
+        - name: content-data.eks.integration.govuk.digital
     uploadAssets:
       path: /app/public/assets
     workerEnabled: true


### PR DESCRIPTION
E.g. https://content-data.integration.publishing.service.gov.uk/

I didn't spot this in #831.