### PR TITLE
Ensure we don't prematurely enable CSP.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -16,6 +16,8 @@ data:
   GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}
+  GOVUK_CSP_REPORT_ONLY: {{ .Values.cspReportOnly | quote }}
+  GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   GOVUK_PROMETHEUS_EXPORTER: "true"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -8,6 +8,8 @@ assetsDomain: assets.integration.publishing.service.gov.uk
 assetsTestDomain: assets-eks.integration.publishing.service.gov.uk
 wwwTestDomain: www.eks.integration.govuk.digital
 
+cspReportURI: https://csp-reporter.integration.publishing.service.gov.uk/report
+
 workerReplicaCount: 1
 appResources:
   limits:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -8,6 +8,8 @@ assetsDomain: assets.publishing.service.gov.uk
 assetsTestDomain: assets-eks.production.publishing.service.gov.uk
 wwwTestDomain: www.eks.production.govuk.digital
 
+cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
+
 replicaCount: 3
 
 # Individual apps to be deployed by ArgoCD, and any values specific to those

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -8,6 +8,8 @@ assetsDomain: assets.staging.publishing.service.gov.uk
 assetsTestDomain: assets-eks.staging.publishing.service.gov.uk
 wwwTestDomain: www.eks.staging.govuk.digital
 
+cspReportURI: https://csp-reporter.staging.publishing.service.gov.uk/report
+
 appResources:
   limits:
     cpu: 1

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -18,5 +18,8 @@ ec2InternalDomainSuffix: govuk-internal.digital
 externalDomainSuffix: eks.test.govuk.digital
 publishingServiceDomainSuffix: test.publishing.service.gov.uk
 
+cspReportOnly: true
+cspReportURI: ""
+
 monitoring:
   enabled: true


### PR DESCRIPTION
Content Security Policy enforcement is behind a feature flag, but that feature flag is inverted in its sense. In other words, we need to set `GOVUK_CSP_REPORT_ONLY` in order to ensure that the feature isn't switched on prematurely.

https://trello.com/c/lxxx5XLZ
https://github.com/alphagov/govuk-puppet/pull/11929

Tested: inspected template output via `helm template . --values values-integration.yaml | yq e '.|select(.metadata.name=="govuk-apps-env")'`

Rollout: requires a k8s rollout of affected Deployments in order to pick up the change. (`k rollout restart deploy && k rollout status deploy` would do in a pinch.)