### PR TITLE
Set max request body size for file uploads.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1681,6 +1681,7 @@ govukApplications:
             key: DATABASE_URL
 - name: search-api
   helmValues:
+    nginxClientMaxBodySize: 20M
     uploadAssets:
       enabled: false
     workerEnabled: true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -363,6 +363,7 @@ govukApplications:
 - name: content-publisher
   helmValues:
     dbMigrationEnabled: true
+    nginxClientMaxBodySize: &max-upload-size 500M
     workerEnabled: true
     ingress:
       enabled: true
@@ -1261,6 +1262,7 @@ govukApplications:
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 - name: manuals-publisher
   helmValues:
+    nginxClientMaxBodySize: &max-upload-size
     workerEnabled: true
     ingress:
       enabled: true
@@ -2035,6 +2037,7 @@ govukApplications:
         value: "true"
 - name: specialist-publisher
   helmValues:
+    nginxClientMaxBodySize: &max-upload-size
     workerEnabled: true
     ingress:
       enabled: true
@@ -2385,6 +2388,7 @@ govukApplications:
     dbMigrationEnabled: true
     workerEnabled: true
     uploadAssets: *whitehall-upload-assets
+    nginxClientMaxBodySize: &max-upload-size
     nginxDenyCrawlers: true
     ingress:
       enabled: true

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -125,6 +125,7 @@ data:
           proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://{{ $fullName }};
           proxy_redirect     off;
+          client_max_body_size {{ .Values.nginxClientMaxBodySize }};
         }
 
 {{- if .Values.serveRailsAssetsFromFilesystem }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -58,6 +58,7 @@ nginxImage:
 nginxPort: 8080
 nginxProxyConnectTimeout: 1s
 nginxProxyReadTimeout: 15s
+nginxClientMaxBodySize: 1M
 nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []


### PR DESCRIPTION
This matches the 500 MB limit that we currently set for these via govuk-puppet. It fixes things like image uploads on content-publisher.

nginx's default is 1M, which should be plenty, so keep that for everything else.

In govuk-puppet this is set to 20M for all the other apps (i.e. apps that don't handle file uploads), but I intentionally haven't set that here because there should be no legit reason for those apps to receive such huge request bodies; it's just a (small but unnecessary) resource-exhaustion attack risk. I couldn't find any justification in the govuk-puppet commit history as to why it was set so large.

Similarly, I couldn't find any explanation as to why search-api had this set to 500 MB so I'm leaving that at the default 1M too.

### Testing

Inspected `helm template` output for an app with/without an override of the new value:

```sh
helm template content-publisher ../generic-govuk-app --values <(
  helm template . --values values-integration.yaml |
    yq e '.|select(.metadata.name=="content-publisher").spec.source.helm.values'
)
```

```sh
helm template frontend ../generic-govuk-app --values <(
  helm template . --values values-integration.yaml |
    yq e '.|select(.metadata.name=="frontend").spec.source.helm.values'
)
```