### PR TITLE
Set EMAIL_ADDRESS_OVERRIDE for content-publisher in integration.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -447,6 +447,8 @@ govukApplications:
           secretKeyRef:
             name: content-publisher-postgres
             key: DATABASE_URL
+      - name: EMAIL_ADDRESS_OVERRIDE
+        value: content-publisher-notifications-integration@digital.cabinet-office.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Missed this in #834 / dcea95f.

Related: https://github.com/alphagov/content-publisher/pull/2705