### PR TITLE
Add missing config items for contacts-admin.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -274,6 +274,26 @@ govukApplications:
         task: "organisations:import"
         schedule: "0 3 * * *"
     extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: contacts-admin-mysql
+            key: DATABASE_URL
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-contacts
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-contacts
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-contacts-publishing-api
+            key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:

--- a/charts/external-secrets/templates/contacts-admin/mysql.yaml
+++ b/charts/external-secrets/templates/contacts-admin/mysql.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: contacts-admin-mysql
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Contacts Admin (a.k.a. Contacts) to connect to MySQL.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: contacts-admin-mysql
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/contacts_production'
+  dataFrom:
+    - extract:
+        key: govuk/contacts-admin/mysql


### PR DESCRIPTION
Contacts Admin (a.k.a. Contacts) wasn't working because it was missing a bunch of secrets.

Also fixed its API username in integration Signon, which was inconsistent with prod/staging. (This is a database thing that's done via the Signon UI; there's no corresponding code change.)

Puppet config for reference: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/contacts.pp

Tested: installed via Helm, app deployment came up healthy.

Rollout: I've already added the AWS Secrets Manager secret for DATABASE_URL in all three accounts.