### PR TITLE
Fix assets path on S3 for content-data-admin.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -289,8 +289,6 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: content-data-admin
       hosts:
         - name: content-data.eks.integration.govuk.digital
-    uploadAssets:
-      path: /app/public/assets
     workerEnabled: true
     extraEnv:
       - name: CONTENT_DATA_API_BEARER_TOKEN


### PR DESCRIPTION
This now works the same as the other apps as of https://github.com/alphagov/content-data-admin/pull/1153.