### PR TITLE
Fix configuration for Transition in integration.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2313,8 +2313,6 @@ govukApplications:
         task: "import:hits:refresh_materialized"
         schedule: "30 0,12 * * *"
     dbMigrationEnabled: true
-    uploadAssets:
-      path: /app/public/assets
     workerEnabled: true
     extraEnv:
       - name: GDS_SSO_OAUTH_ID

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2330,16 +2330,6 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: transition-aws
-            key: access_key
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: transition-aws
-            key: secret_key
       - name: AWS_REGION
         value: eu-west-1
       - name: BASIC_AUTH_PASSWORD

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2293,6 +2293,12 @@ govukApplications:
             key: DATABASE_URL
 - name: transition
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: transition
+      hosts:
+        - name: transition.eks.integration.govuk.digital
     cronTasks:
       - name: import-dns
         task: "import:dns_details"


### PR DESCRIPTION
- Add missing ingress.
- Fix assets upload path (now that it's the standard one as of https://github.com/alphagov/transition/pull/1272)
- Remove long-lived AWS credentials for accessing S3.

Tested: works on the integration cluster