### PR TITLE
Configuration fixes for local-links-manager in integration.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1218,8 +1218,6 @@ govukApplications:
         task: "export:google_analytics:bad_links"
         schedule: "0 6 * * *"
     dbMigrationEnabled: true
-    uploadAssets:
-      path: /app/public/assets
     extraEnv:
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1214,8 +1214,8 @@ govukApplications:
       - name: import-ga
         task: "import:google_analytics"
         schedule: "0 5 * * *"
-      - name: import-ga-bad-links
-        task: "import:google_analytics:bad_links"
+      - name: export-ga-bad-links
+        task: "export:google_analytics:bad_links"
         schedule: "0 6 * * *"
     dbMigrationEnabled: true
     uploadAssets:


### PR DESCRIPTION
- Fix a cronjob that specified the wrong name for the Rake task that it was trying to run.
- Fix the Rails assets path (https://github.com/alphagov/local-links-manager/pull/1027)

Tested: works in the integration cluster.