### PR TITLE
Remove unused/disused image tag files.

### DIFF
--- a/charts/app-config/image-tags/staging/draft-router
+++ b/charts/app-config/image-tags/staging/draft-router
@@ -1,2 +1,0 @@
-image_tag: a5c4f8814fa556a4461ae0b87751652cdbe86a30
-automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/draft-whitehall-frontend
+++ b/charts/app-config/image-tags/staging/draft-whitehall-frontend
@@ -1,2 +1,0 @@
-image_tag: 340353d4f9ed595a6a898613acfae811ccf38f91
-automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/smartanswers
+++ b/charts/app-config/image-tags/staging/smartanswers
@@ -1,2 +1,0 @@
-image_tag: 64438bd21054add4c5e1de574757c565a3c4e979
-automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/whitehall-admin
+++ b/charts/app-config/image-tags/staging/whitehall-admin
@@ -1,2 +1,0 @@
-image_tag: 56978fdcc6f02fe9e55c40bfa2e0c844befc6002
-automatic_deploys_enabled: true


### PR DESCRIPTION
This is functionally a no-op, just cleans up some unused files that could otherwise cause confusion.

Tested: works on the integration cluster.