### PR TITLE
Expose email-alert-api bearer token to content-tagger

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -579,6 +579,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-content-tagger-publishing-api
             key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-tagger-email-alert-api
+            key: bearer_token
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Fixes email subscribers number in taxon view

https://trello.com/c/WCW4v7gA/1080-user-journey-check-taxon-shows-number-of-email-subscribers