### PR TITLE
Configure short-url-manager in integration.

### DIFF
--- a/charts/app-config/image-tags/integration/short-url-manager
+++ b/charts/app-config/image-tags/integration/short-url-manager
@@ -1,0 +1,1 @@
+image_tag: release-b5af983f3d58af9faf22c433751daf44c7a5be5b

--- a/charts/app-config/image-tags/production/short-url-manager
+++ b/charts/app-config/image-tags/production/short-url-manager
@@ -1,0 +1,1 @@
+image_tag: latest

--- a/charts/app-config/image-tags/staging/short-url-manager
+++ b/charts/app-config/image-tags/staging/short-url-manager
@@ -1,0 +1,1 @@
+image_tag: latest

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2123,6 +2123,51 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
+- name: short-url-manager
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: short-url-manager
+      hosts:
+        - name: short-url-manager.eks.integration.govuk.digital
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-short-url-manager
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-short-url-manager
+            key: oauth_secret
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: short-url-manager-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 759acac6-da53-4a19-b591-b7538c7c39de
+      - name: INSTANCE_NAME
+        value: integration
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: short-url-manager-docdb
+            key: MONGODB_URI
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-short-url-manager-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: SECRET_KEY_BASE
+        valueFrom:
+          secretKeyRef:
+            name: rails-secret-key-base
+            key: SECRET_KEY_BASE
 - name: specialist-publisher
   helmValues:
     nginxClientMaxBodySize: *max-upload-size

--- a/charts/external-secrets/templates/short-url-manager/docdb.yaml
+++ b/charts/external-secrets/templates/short-url-manager/docdb.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: short-url-manager-docdb
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Short URL Manager to connect to DocumentDB (MongoDB).
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: short-url-manager-docdb
+    template:
+      data:
+        MONGODB_URI: '{{ $.Files.Get "externalsecrets-templates/mongo-conn-string.tpl" | trim }}/short_url_manager_production'
+  dataFrom:
+    - extract:
+        key: govuk/common/shared-documentdb

--- a/charts/external-secrets/templates/short-url-manager/notify.yaml
+++ b/charts/external-secrets/templates/short-url-manager/notify.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: short-url-manager-notify
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      The GOV.UK Notify API key belonging to Short URL Manager.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: short-url-manager-notify
+  dataFrom:
+    - extract:
+        key: govuk/short-url-manager/notify


### PR DESCRIPTION
Puppet config for reference: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/short_url_manager.pp

Tested: works in the integration cluster.

Rollout: I've already added the field for the app's Sentry project to the Secrets Manager secret in all three accounts.