### PR TITLE
Configure Bouncer in integration.

### DIFF
--- a/charts/app-config/image-tags/integration/bouncer
+++ b/charts/app-config/image-tags/integration/bouncer
@@ -1,0 +1,1 @@
+image_tag: latest

--- a/charts/app-config/image-tags/production/bouncer
+++ b/charts/app-config/image-tags/production/bouncer
@@ -1,0 +1,1 @@
+image_tag: latest

--- a/charts/app-config/image-tags/staging/bouncer
+++ b/charts/app-config/image-tags/staging/bouncer
@@ -1,0 +1,1 @@
+image_tag: latest

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -189,6 +189,31 @@ govukApplications:
           secretKeyRef:
             name: rails-secret-key-base
             key: SECRET_KEY_BASE
+- name: bouncer
+  helmValues:
+    uploadAssets:
+      enabled: false
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: bouncer
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+      rules:
+        - http:  # Match all hostnames.
+            paths:
+              - path: "/"
+                pathType: Prefix
+                backend:
+                  service:
+                    name: bouncer
+                    port:
+                      number: 80
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: bouncer-postgres
+            key: DATABASE_URL
 - name: collections
   helmValues:
     extraEnv:

--- a/charts/external-secrets/templates/bouncer/postgres.yaml
+++ b/charts/external-secrets/templates/bouncer/postgres.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: bouncer-postgres
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Connection to Postgres DB hosted in RDS for Bouncer.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: bouncer-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/transition_production'
+  dataFrom:
+    - extract:
+        key: govuk/bouncer/postgres

--- a/charts/generic-govuk-app/templates/ingress.yaml
+++ b/charts/generic-govuk-app/templates/ingress.yaml
@@ -19,6 +19,9 @@ spec:
         {{- end }}
   {{- end }}
   rules:
+    {{- with .Values.ingress.rules }}
+      {{- . | toYaml | nindent 4 }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .name }}
       http:

--- a/charts/generic-govuk-app/templates/ingress.yaml
+++ b/charts/generic-govuk-app/templates/ingress.yaml
@@ -23,10 +23,10 @@ spec:
       {{- . | toYaml | nindent 4 }}
     {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .name }}
+    - host: {{ .name | quote }}
       http:
         paths:
-          - path: {{ default "/" .path }}
+          - path: {{ .path | default "/" | quote }}
             pathType: {{ default "Prefix" .pathType }}
             backend:
               service:

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -7,15 +7,20 @@ service:
 
 ingress:
   enabled: false
+  # ingress.annotations defines the base set of annotations for an app's Ingress.
+  #
+  # When deployed via ArgoCD using ../charts/app-config, these annotations are
+  # merged with the ones from the app's config in
+  # ../charts/app-config/values-$env.yaml.
+  #
+  # TODO: this feels a bit messy and unintuitive; move these into app-config
+  # and make it less surprising.
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/healthcheck-path: /readyz
-  rules:
-  - path: /
-    pathType: Prefix
 
 replicaCount: 2
 


### PR DESCRIPTION
- Add ArgoCD app config for Bouncer.
- Allow passing arbitrary Ingress rules into generic-govuk-app. (It's not possible to specify `host: '*'`.)
- Fix a quoting issue in the govuk-generic-app Ingress template.

Related: https://github.com/alphagov/bouncer/pull/383

Tested: `helm install bouncer ../generic-govuk-app --values <(helm template . --values values-integration.yaml |yq e '.|select(.metadata.name=="bouncer").spec.source.helm.values')`, app comes up healthy.