### PR TITLE
Adding ingress to search-admin and removing custom asset path

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1728,9 +1728,13 @@ govukApplications:
 - name: search-admin
   helmValues:
     dbMigrationEnabled: true
-    uploadAssets:
-      path: /app/public/assets
     workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        alb.ingress.kubernetes.io/load-balancer-name: search-admin
+      hosts:
+        - name: search-admin.eks.integration.govuk.digital
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
Search-admin needs an ingress.

This will add ingres to search admin.

Also removing custom asset path:
https://github.com/alphagov/search-admin/pull/904
