### PR TITLE
Add EMAIL_ADDRESS_OVERRIDE env var to Whitehall

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -806,6 +806,8 @@ govukApplications:
             key: bearer_token
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 759acac6-da53-4a19-b591-b7538c7c39de
+      - name: EMAIL_ADDRESS_OVERRIDE
+        value: whitehall-emails-integration@digital.cabinet-office.gov.uk
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       - name: MEMCACHE_SERVERS

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -674,6 +674,8 @@ govukApplications:
         value: govuk-staging-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 112842bb-d8a4-4511-90de-57dc5c8f27ec
+      - name: EMAIL_ADDRESS_OVERRIDE
+        value: whitehall-emails-staging@digital.cabinet-office.gov.uk
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       - name: MEMCACHE_SERVERS


### PR DESCRIPTION
To mirror the changes made in alphagov/govuk-puppet#11964