### PR TITLE
Header only appears as "-" in logs on EKS

### DIFF
--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -46,7 +46,7 @@ data:
         sub {
           my $r = shift;
           my $current_header = $r->header_in("GOVUK-Request-Id");
-          if (defined $current_header && $current_header ne "") {
+          if (defined $current_header && $current_header ne "" && $current_header ne "-") {
             return $current_header;
           } else {
             my $pid = $r->variable("pid");

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -46,6 +46,7 @@ data:
         sub {
           my $r = shift;
           my $current_header = $r->header_in("GOVUK-Request-Id");
+          # TODO understand why GOVUK-Request-Id is set to a dash 
           if (defined $current_header && $current_header ne "" && $current_header ne "-") {
             return $current_header;
           } else {


### PR DESCRIPTION
Going through an error to send an email via travel advice publisher and found that the govuk request id is always being set to a dash "-"