### PR TITLE
Set `BOOTSNAP_READONLY` everywhere.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -13,6 +13,7 @@ metadata:
     kubernetes.io/description: >
       Environment variables applied to every GOV.UK app.
 data:
+  BOOTSNAP_READONLY: "1"
   GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.externalDomainSuffix }}
   GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingServiceDomainSuffix }}


### PR DESCRIPTION
Set [Bootsnap read-only mode](https://www.github.com/Shopify/bootsnap/commit/b51397f) everywhere. This isn't strictly necessary, but it's a good idea for robustness.

The reason for setting this here rather than in the container images (which would otherwise be slightly preferable) is:

- Our builder image inherits from our base image (which is fine).
- Bootsnap doesn't look at the value of `BOOTSNAP_READONLY`; it just checks for the presence of the key (also fine).
- Dockerfile doesn't provide a way to unset an environment variable inherited from a base image. \sad_trombone

Rollout: requires a k8s rollout for deployments to pick up the configmap change.