### PR TITLE
Fix assets upload path for support

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2270,7 +2270,7 @@ govukApplications:
 - name: support
   helmValues:
     uploadAssets:
-      path: /app/public/assets
+      path: /app/public/assets/support
     workerEnabled: true
     extraEnv:
       - name: PUBLISHING_API_BEARER_TOKEN


### PR DESCRIPTION
This will prevent it from uploading a directory called `support` to the assets bucket

https://trello.com/c/VuxjcRPI/1096-user-journey-make-a-support-request