### PR TITLE
Fix missing AWS_REGION for export links cronjob

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1339,6 +1339,8 @@ govukApplications:
         value: "false"
       - name: AWS_S3_ASSET_BUCKET_NAME
         value: "govuk-app-assets-integration"
+      - name: AWS_REGION
+        value: "eu-west-1"
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Missed adding this env var, needed for the AWS client to upload the links csv to S3.