### PR TITLE
Serve static files from S3 for local links manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1346,6 +1346,21 @@ govukApplications:
           secretKeyRef:
             name: local-links-manager-postgres
             key: DATABASE_URL
+    nginxConfigMap:
+      extraConf: |
+        location /data {
+          proxy_set_header   Authorization "";
+          proxy_set_header   Connection "";
+          proxy_set_header   X-Real-IP $remote_addr;  # TODO: pass the actual end-client address
+          proxy_hide_header  x-amz-id-2;
+          proxy_hide_header  x-amz-meta-server-side-encryption;
+          proxy_hide_header  x-amz-request-id;
+          proxy_hide_header  x-amz-server-side-encryption;
+          proxy_hide_header  x-amz-version-id;
+          add_header         Cache-Control "public, max-age=3600";
+          proxy_intercept_errors on;
+          proxy_pass         https://govuk-app-assets-integration.s3.eu-west-1.amazonaws.com/data/local-links-manager;
+        }
 - name: locations-api
   helmValues:
     uploadAssets:


### PR DESCRIPTION
This adds Nginx config to serve static files in the `/data` path from S3 (separate from application assets). This is required to serve a local authorities links CSV file which is generated daily by a cron task. Cache needs to be less than a day, as this file is regenerated every day.