### PR TITLE
Remove separate rule Nginx for assets with digest

### DIFF
--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -143,23 +143,18 @@ data:
           proxy_hide_header  x-amz-request-id;
           proxy_hide_header  x-amz-server-side-encryption;
           proxy_hide_header  x-amz-version-id;
-          add_header         Cache-Control max-age=31536000;
+          add_header         Cache-Control "public, max-age=31536000, immutable";
+          add_header         Surrogate-Key "assets assets-{{ $fullName }}";
+
           proxy_intercept_errors on;
           proxy_pass         https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
 
-          location ~ "-[0-9a-f]{32,}\." {
-            expires max;
-            add_header Cache-Control "public, immutable";
-            add_header Surrogate-Key "assets assets-{{ $fullName }}";
+          # Set CORS allow origin for fonts only
+          location ~* \.(eot|otf|ttf|woff|woff2)$ {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Headers "origin, authorization";
             proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
-
-            # Set CORS allow origin for fonts only
-            location ~* \.(eot|otf|ttf|woff|woff2)$ {
-              add_header Access-Control-Allow-Origin "*";
-              add_header Access-Control-Allow-Methods "GET, OPTIONS";
-              add_header Access-Control-Allow-Headers "origin, authorization";
-              proxy_pass https://govuk-app-assets-{{ .Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com;
-            }
           }
         }
 {{- end }}


### PR DESCRIPTION
This separate rules isn't needed as all assets are (/should be) immutable and have unique paths for cache busting. We can make the cache-control header conistent for all requests to assets.