### PR TITLE
Fix aws-lb-controller Ingress annotations for Bouncer.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -19,6 +19,13 @@ appResources:
     cpu: 0.1
     memory: 800Mi
 
+default-alb-ingress-annotations: &default-alb-ingress-annotations
+  alb.ingress.kubernetes.io/scheme: internet-facing
+  alb.ingress.kubernetes.io/target-type: ip
+  alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+  alb.ingress.kubernetes.io/ssl-redirect: "443"
+  alb.ingress.kubernetes.io/healthcheck-path: /readyz
+
 # Individual apps to be deployed by ArgoCD, and any values specific to those
 # apps.
 govukApplications:
@@ -90,6 +97,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
@@ -153,6 +161,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: draft-origin
       hosts:
         - name: draft-origin.eks.integration.govuk.digital
@@ -236,6 +245,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: collections-publisher
       hosts:
         - name: collections-publisher.eks.integration.govuk.digital
@@ -291,6 +301,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: contacts-admin
       hosts:
         - name: contacts-admin.eks.integration.govuk.digital
@@ -331,6 +342,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: content-data-admin
       hosts:
         - name: content-data.eks.integration.govuk.digital
@@ -472,6 +484,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: content-publisher
       hosts:
         - name: content-publisher.eks.integration.govuk.digital
@@ -585,6 +598,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: content-tagger
       hosts:
         - name: content-tagger.eks.integration.govuk.digital
@@ -1113,6 +1127,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: hmrc-manuals-api
       hosts:
       - name: hmrc-manuals-api.eks.integration.govuk.digital
@@ -1144,6 +1159,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: imminence
       hosts:
         - name: imminence.eks.integration.govuk.digital
@@ -1252,6 +1268,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: local-links-manager
       hosts:
         - name: local-links-manager.eks.integration.govuk.digital
@@ -1384,6 +1401,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: manuals-publisher
       hosts:
         - name: manuals-publisher.eks.integration.govuk.digital
@@ -1440,6 +1458,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: maslow
       hosts:
         - name: maslow.eks.integration.govuk.digital
@@ -1483,6 +1502,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: publisher
       hosts:
         - name: publisher.eks.integration.govuk.digital
@@ -1691,9 +1711,9 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
-        alb.ingress.kubernetes.io/healthcheck-path: /readyz
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-integration-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.publishingServiceDomainSuffix }}", "{{ .Values.wwwTestDomain }}"]}}]
@@ -1762,6 +1782,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: search-admin
       hosts:
         - name: search-admin.eks.integration.govuk.digital
@@ -1914,6 +1935,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: service-manual-publisher
       hosts:
         - name: service-manual-publisher.eks.integration.govuk.digital
@@ -1972,6 +1994,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: signon
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
       hosts:
@@ -2085,6 +2108,7 @@ govukApplications:
           path: /
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '30'
@@ -2162,6 +2186,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: short-url-manager
       hosts:
         - name: short-url-manager.eks.integration.govuk.digital
@@ -2209,6 +2234,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: specialist-publisher
       hosts:
         - name: specialist-publisher.eks.integration.govuk.digital
@@ -2276,6 +2302,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: support
       hosts:
         - name: support.eks.integration.govuk.digital
@@ -2407,6 +2434,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: transition
       hosts:
         - name: transition.eks.integration.govuk.digital
@@ -2466,6 +2494,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: travel-advice-publisher
       hosts:
         - name: travel-advice-publisher.eks.integration.govuk.digital
@@ -2526,6 +2555,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: govuk-replatform-test-app
       hosts:
         - name: govuk-replatform-test-app.eks.integration.govuk.digital
@@ -2559,6 +2589,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: whitehall-admin
       hosts:
         - name: whitehall-admin.eks.integration.govuk.digital
@@ -2588,6 +2619,7 @@ govukApplications:
           pathType: ImplementationSpecific
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '10'

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -204,7 +204,12 @@ govukApplications:
       enabled: false
     ingress:
       enabled: true
+      tls: {}
       annotations:
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+        alb.ingress.kubernetes.io/healthcheck-path: /readyz
         alb.ingress.kubernetes.io/load-balancer-name: bouncer
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
       rules:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -12,6 +12,13 @@ cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
 
 replicaCount: 3
 
+default-alb-ingress-annotations: &default-alb-ingress-annotations
+  alb.ingress.kubernetes.io/scheme: internet-facing
+  alb.ingress.kubernetes.io/target-type: ip
+  alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+  alb.ingress.kubernetes.io/ssl-redirect: "443"
+  alb.ingress.kubernetes.io/healthcheck-path: /readyz
+
 # Individual apps to be deployed by ArgoCD, and any values specific to those
 # apps.
 govukApplications:
@@ -23,6 +30,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
@@ -326,6 +334,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
@@ -421,6 +430,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: signon
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:eu-west-1:172025368201:regional/webacl/backend-temp/335a5c5d-ef97-44b3-8cdf-5cedae034a74
@@ -537,6 +547,7 @@ govukApplications:
           path: /
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '30'
@@ -584,6 +595,7 @@ govukApplications:
           pathType: ImplementationSpecific
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '10'

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -18,6 +18,13 @@ appResources:
     cpu: 0.1
     memory: 800Mi
 
+default-alb-ingress-annotations: &default-alb-ingress-annotations
+  alb.ingress.kubernetes.io/scheme: internet-facing
+  alb.ingress.kubernetes.io/target-type: ip
+  alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+  alb.ingress.kubernetes.io/ssl-redirect: "443"
+  alb.ingress.kubernetes.io/healthcheck-path: /readyz
+
 # Individual apps to be deployed by ArgoCD, and any values specific to those
 # apps.
 govukApplications:
@@ -28,6 +35,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
@@ -321,6 +329,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-staging-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
@@ -415,6 +424,7 @@ govukApplications:
     ingress:
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: signon
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
       hosts:
@@ -530,6 +540,7 @@ govukApplications:
           path: /
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '30'
@@ -582,6 +593,7 @@ govukApplications:
           pathType: ImplementationSpecific
       enabled: true
       annotations:
+        <<: *default-alb-ingress-annotations
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '10'

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -7,20 +7,6 @@ service:
 
 ingress:
   enabled: false
-  # ingress.annotations defines the base set of annotations for an app's Ingress.
-  #
-  # When deployed via ArgoCD using ../charts/app-config, these annotations are
-  # merged with the ones from the app's config in
-  # ../charts/app-config/values-$env.yaml.
-  #
-  # TODO: this feels a bit messy and unintuitive; move these into app-config
-  # and make it less surprising.
-  annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
-    alb.ingress.kubernetes.io/healthcheck-path: /readyz
 
 replicaCount: 2
 


### PR DESCRIPTION
Bouncer can't inherit our default set of aws-load-balancer-controller Ingress annotations because it doesn't serve TLS. (TLS is terminated at Fastly for a few transitioned sites where it's been enabled.)

Tested: installed Bouncer and Publisher (as an example of an app whose ingress should stay the same) via `helm install` and checked that the ingresses were created and reconciled successfully.