### PR TITLE
Send deployment information to Release

### DIFF
--- a/charts/app-config/templates/signon-secrets-sync-configmap.yaml
+++ b/charts/app-config/templates/signon-secrets-sync-configmap.yaml
@@ -42,6 +42,7 @@ data:
     ]
   api_user_emails: |
     [
+      "argo-workflows@alphagov.co.uk",
       "govuk-accounts-developers+account-api@digital.cabinet-office.gov.uk",
       "collections@alphagov.co.uk",
       "collections-publisher@alphagov.co.uk",

--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -42,6 +42,18 @@ spec:
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
                 - name: newTag
                   value: "deployed-to-{{"{{workflow.parameters.environment}}"}}"
+          - name: record-deployment-in-release
+            templateRef:
+              name: notify-release
+              template: notify-release
+            arguments:
+              parameters:
+                - name: environment
+                  value: "{{"{{workflow.parameters.environment}}"}}"
+                - name: repositoryName
+                  value: "{{"{{workflow.parameters.repoName}}"}}"
+                - name: commitSha
+                  value: "{{"{{= sprig.trimPrefix('release-', workflow.parameters.imageTag) }}"}}"
 
     - name: exit-handler
       steps:

--- a/charts/argo-services/templates/workflows/notify-release/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-release/workflow.yaml
@@ -21,7 +21,7 @@ spec:
         command:
           - sh
         source: >
-          curl https://release.publishing.service.gov.uk/deployments \
+          curl http://release/deployments \
            -H "Authorization: Bearer ${RELEASE_API_TOKEN}" \
            --json '{
               "repo": "alphagov/{{"{{inputs.parameters.repositoryName}}"}}",

--- a/charts/argo-services/templates/workflows/notify-release/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-release/workflow.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: notify-release
+spec:
+  entrypoint: notify-release
+  arguments:
+    parameters:
+      - name: repositoryName
+      - name: commitSha
+      - name: environment
+  templates:
+    - name: notify-release
+      inputs:
+        parameters:
+        - name: repositoryName
+        - name: commitSha
+        - name: environment
+      script:
+        image: curlimages/curl
+        command:
+          - sh
+        source: >
+          curl https://release.publishing.service.gov.uk/deployments \
+           -H "Authorization: Bearer ${RELEASE_API_TOKEN}" \
+           --json '{
+              "repo": "alphagov/{{"{{inputs.parameters.repositoryName}}"}}",
+              "deployment": {
+                "environment": "{{"{{inputs.parameters.environment}}"}} EKS",
+                "deployed_sha": "{{"{{inputs.parameters.commitSha}}"}}",
+                "version": "{{"{{inputs.parameters.commitSha}}"}}"
+              }
+            }'
+        env:
+          - name: RELEASE_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: signon-token-argo-workflows-release
+                key: bearer_token


### PR DESCRIPTION
This adds an Argo Workflow to send deployment information to the Release App. This is a very MVP version of getting deployment information to display in Release. This using the existing Deployment API to notify Release of deployments, however it might be better in future if Release could get deployment information directly from Kubernetes or Prometheus.

Another downside of this implementation, is that it records a deployment when the image tag is updated in the GitHub repo. This does not necessarily guarantee that the new image was deployed to K8s correctly. 

At least this give more visibility into deployment in EKS compared to the old infra.

Note: more work needs to be in Release to support showing deployments based on commit SHA instead of tags. (As we don't have git tag information in EKS)