### PR TITLE
Sync Signon token for Smokey -> Asset Manager.

### DIFF
--- a/charts/app-config/templates/signon-secrets-sync-configmap.yaml
+++ b/charts/app-config/templates/signon-secrets-sync-configmap.yaml
@@ -74,6 +74,7 @@ data:
       "smartanswers@alphagov.co.uk",
       "special-route-publisher@alphagov.co.uk",
       "govuk-dev+specialist-publisher@digital.cabinet-office.gov.uk",
+      "smokey@alphagov.co.uk",
       "static@alphagov.co.uk",
       "support@alphagov.co.uk",
       "travel-advice-publisher@alphagov.co.uk",


### PR DESCRIPTION
Used in [`features/assets.feature:4` "Check assets can be managed via the API"](https://github.com/alphagov/smokey/blob/c08f542/features/assets.feature#L4).