### PR TITLE
Adding Search-api bearer token env value in Search-admin app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1862,6 +1862,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-search-admin-publishing-api
             key: bearer_token
+      - name: SEARCH_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-search-admin-search-api
+            key: bearer_token
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
After much troubleshooting i can only come to conclusion that search-api  bearer token needs to be added to container - Signon clearly is aware of a bearer token for Search-api owned by Search-admin. https://signon.integration.publishing.service.gov.uk/api_users/9479/edit

A Kubernetes secret also already exist for Search-api for search-admin. i have ensured it is the same bearer token as stored in Signon. `kubectl get secret signon-token-search-admin-search-api -o jsonpath="{.data.bearer_token}" --namespace apps| base64 --decode`

Saying that i don't see Search_api bearer token declared for this app under puppet. https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/search_admin.pp

**Log extract of the issue i am testing to solve with the change:**

search-admin log for event:
`search-admin app {"request_uri":"http://search-api/v2/metasearch/documents","start_time":1674043920.9410043,"status":401,"end_time":1674043920.9627597,"body":"{\"message\":\"Bearer token does not appear to be valid\`

Search-API log for event on search-admin:
`search-api app {"method":"POST","path":"/unauthenticated","query_string":"","status":401,"duration":25.07,"remote_addr":"127.0.0.1","request":"POST /unauthenticated HTTP/1.0"`

https://trello.com/c/NBxnFniA/1091-user-journey-add-manual-query-result