### PR TITLE
Rename Search-api bearer token to Rummager bearer-token

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1862,7 +1862,7 @@ govukApplications:
           secretKeyRef:
             name: signon-token-search-admin-publishing-api
             key: bearer_token
-      - name: SEARCH_API_BEARER_TOKEN
+      - name: RUMMAGER_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
             name: signon-token-search-admin-search-api


### PR DESCRIPTION
https://github.com/alphagov/govuk-puppet/blob/1c137dc22ae91f57e21901112868d705250cda27/modules/govuk/manifests/apps/search_admin.pp#L136