### PR TITLE
Add missing app specific Nginx config

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -782,6 +782,17 @@ govukApplications:
             key: SECRET_KEY_BASE
       - name: WEB_CONCURRENCY
         value: '10'
+    nginxConfigMap:
+      extraConf: |
+        location ~ ^/status-updates(/|$) {
+          limit_req zone=email_alert_api_public burst=20 nodelay;
+          proxy_pass http://email-alert-api;
+        }
+
+        location ~ ^/spam-reports(/|$) {
+          limit_req zone=email_alert_api_public burst=20 nodelay;
+          proxy_pass http://email-alert-api;
+        }
 
 - name: email-alert-frontend
   helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2388,6 +2388,15 @@ govukApplications:
         value: 759acac6-da53-4a19-b591-b7538c7c39de
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+    nginxConfigMap:
+      extraConf: |
+        client_max_body_size 500M;
+
+        # Extended timeout to allow the processing of large attachments
+        location ~* attachments {
+          proxy_read_timeout 30s;
+          proxy_pass http://specialist-publisher;
+        }
 
 - name: support
   helmValues:


### PR DESCRIPTION
There specific bits of Nginx config relevant for certain apps - this adds:
- Rate limiting for email-alerts-api's public endpoints
- Increase timeouts and body size to handle large attachments in specialist publisher