### PR TITLE
Add missing search api bearer token for whitehall

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2759,6 +2759,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-publishing-api
             key: bearer_token
+      - name: RUMMAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-search-api
+            key: bearer_token
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: 759acac6-da53-4a19-b591-b7538c7c39de
       - name: EMAIL_ADDRESS_OVERRIDE


### PR DESCRIPTION
This token is used by the `search:index:consultations` rake task triggered by a cronjob.