### PR TITLE
Tune some more jobs' backoffLimits.

### DIFF
--- a/charts/asset-manager/templates/freshclam-presync.yaml
+++ b/charts/asset-manager/templates/freshclam-presync.yaml
@@ -10,6 +10,6 @@ metadata:
     app: {{ $fullName }}
     app.kubernetes.io/component: freshclam
 spec:
-  backoffLimit: 2
+  backoffLimit: 1
   template:
     {{- include "asset-manager.freshclam.podspec" . | indent 4 }}

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -13,7 +13,7 @@ metadata:
     argocd.argoproj.io/hook: PreSync
 spec:
   activeDeadlineSeconds: 900
-  backoffLimit: 2
+  backoffLimit: 1
   template:
     spec:
       automountServiceAccountToken: false

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -17,7 +17,7 @@ spec:
         {{- include "generic-govuk-app.labels" $ | nindent 8 }}
         app.kubernetes.io/component: app
     spec:
-      backoffLimit: 1
+      backoffLimit: 0
       template:
         metadata:
           name: "{{ $fullName }}-{{ .name }}-cron-task"

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -11,7 +11,7 @@ metadata:
     argocd.argoproj.io/hook: PreSync
 spec:
   activeDeadlineSeconds: 900
-  backoffLimit: 2
+  backoffLimit: 1
   template:
     metadata:
       name: {{ $fullName }}-dbmigrate

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -14,7 +14,7 @@ metadata:
       ArgoCD runs this job after each deployment of the Static app.
 spec:
   activeDeadlineSeconds: 900
-  backoffLimit: 2
+  backoffLimit: 1
   template:
     spec:
       automountServiceAccountToken: false


### PR DESCRIPTION
We don't want to retry apps' cronjobs by default as most wouldn't have had automatic retries on the old setup and we can't assume idempotence.

Limit presync jobs to 1 retry (2 attempts per sync) since a third attempt is very unlikely to succeed after two failures whereas adding significant delay to every failed rollout has a non-negligible productivity cost. Also it's probably what we intended in the first place what with `backoffLimit` being confusingly named.