### PR TITLE
Add Google site verification to nginx

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2238,6 +2238,10 @@ govukApplications:
           absolute_redirect off;
           return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
         }
+        # Google site verification
+        location = /googlec908b3bc32386239.html {
+          return 200 'google-site-verification: googlec908b3bc32386239.html';
+        }
 
 - name: draft-static
   repoName: static

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -655,6 +655,10 @@ govukApplications:
           absolute_redirect off;
           return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
         }
+        # Google site verification
+        location = /googlec908b3bc32386239.html {
+          return 200 'google-site-verification: googlec908b3bc32386239.html';
+        }
 
 - name: whitehall-frontend
   repoName: whitehall

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -655,6 +655,10 @@ govukApplications:
           absolute_redirect off;
           return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
         }
+        # Google site verification
+        location = /googlec908b3bc32386239.html {
+          return 200 'google-site-verification: googlec908b3bc32386239.html';
+        }
 
 - name: whitehall-frontend
   repoName: whitehall

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -248,10 +248,5 @@ data:
         location = /readyz {
           return 200 'ok\n';
         }
-
-        # Google site verification
-        location /googlec908b3bc32386239.html {
-          return 200 'google-site-verification: googlec908b3bc32386239.html';
-        }
       }
     }


### PR DESCRIPTION
Removed config from asset-manager nginx and added to static only for all envs, tested and working in integration