### PR TITLE
Fix missing limit_req_zone/status for email alert api rate limiting

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -786,7 +786,7 @@ govukApplications:
       extraHttpConf: |
         limit_req_zone $binary_remote_addr zone=email_alert_api_public:1M rate=50r/s;
         limit_req_status 429;
-      extraConf: |
+      extraServerConf: |
         location ~ ^/status-updates(/|$) {
           limit_req zone=email_alert_api_public burst=20 nodelay;
           proxy_pass http://email-alert-api;
@@ -1292,7 +1292,7 @@ govukApplications:
             name: local-links-manager-postgres
             key: DATABASE_URL
     nginxConfigMap:
-      extraConf: |
+      extraServerConf: |
         location /data {
           proxy_set_header   Authorization "";
           proxy_set_header   Connection "";
@@ -2235,7 +2235,7 @@ govukApplications:
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
     nginxConfigMap:
-      extraConf: |
+      extraServerConf: |
         # 1stline use this URL in their zendesk template
         location = /static/gov.uk_logotype_crown.png {
           absolute_redirect off;
@@ -2397,7 +2397,7 @@ govukApplications:
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
     nginxConfigMap:
-      extraConf: |
+      extraServerConf: |
         client_max_body_size 500M;
 
         # Extended timeout to allow the processing of large attachments

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -649,7 +649,7 @@ govukApplications:
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
     nginxConfigMap:
-      extraConf: |
+      extraServerConf: |
         # 1stline use this URL in their zendesk template
         location = /static/gov.uk_logotype_crown.png {
           absolute_redirect off;

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -649,7 +649,7 @@ govukApplications:
       - name: USE_TMPDIR_PAGE_CACHE
         value: "true"
     nginxConfigMap:
-      extraConf: |
+      extraServerConf: |
         # 1stline use this URL in their zendesk template
         location = /static/gov.uk_logotype_crown.png {
           absolute_redirect off;

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -176,8 +176,8 @@ data:
         location = /readyz {
           return 200 'ok\n';
         }
-        {{- if .Values.nginxConfigMap.extraConf }}
-        {{ .Values.nginxConfigMap.extraConf | nindent 8 }}
+        {{- if .Values.nginxConfigMap.extraServerConf }}
+        {{ .Values.nginxConfigMap.extraServerConf | nindent 8 }}
         {{- end }}
       }
     }


### PR DESCRIPTION
We were missing Nginx config for email alert api to correctly configure rate limiting. The existing rate limiting rules required the shared memory zone to be declared and we also missed the response status. 

These directives needed to be added into the http context, so I've added a new `extraHttpConfig` value that can be used to add app specific http nginx config. Also renamed the existing value for extraConfig to make it clear that its for the server context. 

(Tested doing helm template)