### PR TITLE
Remove dashboard refresh intervals < sampling interval.

### DIFF
--- a/charts/monitoring-config/apps-dashboard.json
+++ b/charts/monitoring-config/apps-dashboard.json
@@ -488,8 +488,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "10s",
-      "30s",
       "1m",
       "5m",
       "15m",
@@ -499,7 +497,6 @@
       "1d"
     ],
     "time_options": [
-      "5m",
       "15m",
       "1h",
       "6h",

--- a/charts/monitoring-config/router-dashboard.json
+++ b/charts/monitoring-config/router-dashboard.json
@@ -461,8 +461,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "10s",
-      "30s",
       "1m",
       "5m",
       "15m",
@@ -472,7 +470,6 @@
       "1d"
     ],
     "time_options": [
-      "5m",
       "15m",
       "1h",
       "6h",

--- a/charts/monitoring-config/sidekiq-dashboard.json
+++ b/charts/monitoring-config/sidekiq-dashboard.json
@@ -319,8 +319,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "10s",
-      "30s",
       "1m",
       "5m",
       "15m",
@@ -330,7 +328,6 @@
       "1d"
     ],
     "time_options": [
-      "5m",
       "15m",
       "1h",
       "6h",


### PR DESCRIPTION
Having dashboards defaulting to auto-refresh every 10s when the sampling interval is 60s isn't the most helpful. Also helps keep the resource usage under control on the backend.

Also get rid of the shortcut for 5m time window, since that's not going to be used very frequently when all the metrics are at 1m resolution.