### PR TITLE
Fix post sync smokey env vars

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -16,7 +16,7 @@ data:
   BOOTSNAP_READONLY: "1"
   GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.testPublishingDomainSuffix }}
-  GOVUK_ASSET_ROOT: https://assets.{{ .Values.publishingDomainSuffix }}
+  GOVUK_ASSET_ROOT: https://{{ .Values.testAssetsDomain }}
   GOVUK_CSP_REPORT_ONLY: {{ .Values.cspReportOnly | quote }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -29,6 +29,11 @@ spec:
             configMapKeyRef:
               name: govuk-apps-env
               key: GOVUK_APP_DOMAIN
+        - name: GOVUK_APP_DOMAIN_EXTERNAL
+          valueFrom:
+            configMapKeyRef:
+              name: govuk-apps-env
+              key: GOVUK_APP_DOMAIN_EXTERNAL
         - name: GOVUK_ASSET_ROOT
           valueFrom:
             configMapKeyRef:
@@ -39,11 +44,18 @@ spec:
             configMapKeyRef:
               name: govuk-apps-env
               key: GOVUK_WEBSITE_ROOT
-        - name: GOVUK_APP_DOMAIN_EXTERNAL
+        - name: PLEK_SERVICE_ASSETS_URI
           valueFrom:
             configMapKeyRef:
               name: govuk-apps-env
-              key: GOVUK_APP_DOMAIN_EXTERNAL
+              key: PLEK_SERVICE_ASSETS_URI
+        - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
+          valueFrom:
+            configMapKeyRef:
+              name: govuk-apps-env
+              key: PLEK_SERVICE_DRAFT_ASSETS_URI
+        - name: PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS
+          value: "1"
         - name: SIGNON_EMAIL
           valueFrom:
             secretKeyRef:
@@ -59,9 +71,3 @@ spec:
             secretKeyRef:
               name: signon-token-smokey-asset-manager
               key: bearer_token
-        - name: PLEK_SERVICE_ASSET_MANAGER_URI
-          value: http://asset-manager.{{ .Values.internalDomainSuffix }}
-        - name: PLEK_SERVICE_ASSETS_URI
-          value: https://assets.{{ .Values.publishingDomainSuffix }}
-        - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
-          value: https://assets-origin.{{ .Values.publishingDomainSuffix }}


### PR DESCRIPTION
This adds the missing PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS and points to the eks test domains for assets.

It also:
- reorders the env vars to group similar ones
- uses the testAssetDomain helm value in the govuk-app-env config map (doesn't change the end result)