### PR TITLE
Don't auto-refresh dashboards by default.

### DIFF
--- a/charts/monitoring-config/apps-dashboard.json
+++ b/charts/monitoring-config/apps-dashboard.json
@@ -354,7 +354,7 @@
       }
     }
   ],
-  "refresh": "10s",
+  "refresh": "",
   "schemaVersion": 36,
   "style": "dark",
   "tags": [],

--- a/charts/monitoring-config/fastly-dashboard.json
+++ b/charts/monitoring-config/fastly-dashboard.json
@@ -1070,7 +1070,7 @@
       "yBucketBound": "auto"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [
@@ -1200,7 +1200,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",

--- a/charts/monitoring-config/router-dashboard.json
+++ b/charts/monitoring-config/router-dashboard.json
@@ -310,7 +310,7 @@
       "yBucketBound": "auto"
     }
   ],
-  "refresh": "10s",
+  "refresh": "",
   "schemaVersion": 36,
   "style": "dark",
   "tags": [],


### PR DESCRIPTION
It can be frustrating when dashboards refresh unexpectedly, plus it's quite wasteful of resources to leave on by default.

Meant to do this in ad3d030 but hadn't spotted the right field in the JSON.