### PR TITLE
Create Sentry DSN secret for Whitehall

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2696,8 +2696,6 @@ govukApplications:
 - name: whitehall-admin
   repoName: whitehall
   helmValues:
-    sentry:
-      createSecret: false  # Sentry DSNs are per repo.
     securityContext:
       # Use the same uid/gid for NFS permissions as the old stack, so that
       # files uploaded by whitehall-admin on k8s can be processed by


### PR DESCRIPTION
At least one of the Whitehall apps needs to create the Sentry DSN secret. It used to by the draft-whitehall-frontend app, but thats been removed.