### PR TITLE
Add draft-whitehall-frontend service

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2818,6 +2818,8 @@ govukApplications:
           [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.testAssetsDomain }}"]}}]
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
+    extraServices:
+      - name: draft-whitehall-frontend
     extraEnv:
       - name: JWT_AUTH_SECRET
         valueFrom:

--- a/charts/generic-govuk-app/templates/extra-services.yaml
+++ b/charts/generic-govuk-app/templates/extra-services.yaml
@@ -1,0 +1,23 @@
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+{{- range .Values.extraServices }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ $fullName }}
+{{ if $.Values.service.annotations }}
+  annotations:
+    {{- range $key, $value := $.Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ $.Values.service.type }}
+  ports:
+    - name: app
+      port: {{ $.Values.service.port }}
+      targetPort: {{ $.Values.nginxPort }}
+  selector:
+    app: {{ $fullName }}
+{{- end }}


### PR DESCRIPTION
This adds a template to the govuk-generic-app chart to allow the creation of additional service for the same application pod. This is then used by Whitehall frontend to add a draft-whitehall-frontend service, to make the page available on the draft domain without running a separate instance of Whitehall (as pages rendered by Whitehall don't support draft versions).