### PR TITLE
Route draft requests for whitehall frontend to live

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1831,7 +1831,7 @@ govukApplications:
       - name: BACKEND_URL_static
         value: "http://draft-static"
       - name: BACKEND_URL_whitehall-frontend
-        value: "http://draft-whitehall-frontend"
+        value: "http://whitehall-frontend"  # There is no draft version whitehall frontend
       - name: BACKEND_URL_account-api
         value: "http://account-api"
       - name: BACKEND_URL_feedback


### PR DESCRIPTION
This configures draft router to send requests for whitehall frontend to the live version of the app (rather than a draft version). This is becuase whitehall doesn't render pages that can be drafts, yet we still want those pages to be available on the draft domain.