### PR TITLE
Fix the draft asset domain to point to EKS

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -44,7 +44,7 @@ data:
 
   # TODO: change testAssetsDomain to assetsDomain before launch.
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.testAssetsDomain }}
-  PLEK_SERVICE_DRAFT_ASSETS_URI: https://draft-assets.{{ .Values.publishingDomainSuffix }}
+  PLEK_SERVICE_DRAFT_ASSETS_URI: https://draft-assets.{{ .Values.testPublishingDomainSuffix }}
 
   # Services which remain in EC2 for a while after "MVP launch".
   PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}


### PR DESCRIPTION
This makes sure redirects from Asset Manager to the draft stack stay within in EKS.