### PR TITLE
Add draft asset hostname to asset manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -122,11 +122,10 @@ govukApplications:
           [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.testAssetsDomain }}"]}}]
       hosts:
       - name: assets-origin.eks.integration.govuk.digital
-        path: /government/uploads/
-      - name: assets-origin.eks.integration.govuk.digital
-        path: /government/assets/
-      - name: assets-origin.eks.integration.govuk.digital
-        path: /media/
+        paths:
+          - path: /government/uploads/
+          - path: /government/assets/
+          - path: /media/
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -131,6 +131,7 @@ govukApplications:
           - path: /government/uploads/
           - path: /government/assets/
           - path: /media/
+          - path: /auth/gds
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -126,6 +126,11 @@ govukApplications:
           - path: /government/uploads/
           - path: /government/assets/
           - path: /media/
+      - name: draft-assets.eks.integration.govuk.digital
+        paths:
+          - path: /government/uploads/
+          - path: /government/assets/
+          - path: /media/
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false

--- a/charts/asset-manager/templates/ingress.yaml
+++ b/charts/asset-manager/templates/ingress.yaml
@@ -15,13 +15,10 @@ metadata:
 spec:
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
+        {{- range .Values.ingress.tls }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/asset-manager/templates/ingress.yaml
+++ b/charts/asset-manager/templates/ingress.yaml
@@ -25,6 +25,7 @@ spec:
     - host: {{ .name }}
       http:
         paths:
+        {{- range .paths }}
           - path: {{ default "/" .path }}
             pathType: {{ default "Prefix" .pathType }}
             backend:
@@ -32,5 +33,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -15,8 +15,9 @@ ingress:
     alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
   hosts:
   - name:
-    path: /
-    pathType: Prefix
+    paths:
+      - path: /
+        pathType: Prefix
 
 replicaCount: 1
 


### PR DESCRIPTION
This enable the draft asset domain on EKS, these request go directly to the live version of asset manager (i.e there's no draft version of asset manager). Authentication for access to drafts is done by asset manager, rather than auth proxy.