### PR TITLE
Switch authenticating-proxy from Mongo to Postgres.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -205,12 +205,14 @@ govukApplications:
           ]}}]
       hosts:
         - name: draft-origin.{{ .Values.testExternalDomainSuffix }}
-    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-      searches:
-        - blue.integration.govuk-internal.digital
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-postgres
+            key: DATABASE_URL
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
@@ -228,11 +230,6 @@ govukApplications:
           secretKeyRef:
             name: authenticating-proxy-jwt-auth-secret
             key: JWT_AUTH_SECRET
-      - name: MONGODB_URI  # TODO: this will need to become a secret when moving to DocDB.
-        value: "mongodb://\
-          router-backend-1,\
-          router-backend-2,\
-          router-backend-3/authenticating_proxy_production"
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:

--- a/charts/external-secrets/templates/authenticating-proxy/postgres.yaml
+++ b/charts/external-secrets/templates/authenticating-proxy/postgres.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: authenticating-proxy-postgres
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Connection to Postgres DB hosted in RDS for Authenticating Proxy (aka
+      Content Preview).
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: authenticating-proxy-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/authenticating_proxy_production'
+  dataFrom:
+    - extract:
+        key: govuk/authenticating-proxy/postgres


### PR DESCRIPTION
Reflects https://github.com/alphagov/authenticating-proxy/pull/350.

Rollout: need to add the corresponding Secrets Manager secret in all three accounts.