### PR TITLE
Override PROMETHEUS_EXPORTER for email-alert-svc

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -898,6 +898,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-email-alert-service-email-alert-api
             key: bearer_token
+      - name: GOVUK_PROMETHEUS_EXPORTER
+        value: force
       - name: RABBITMQ_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
## What?
The latest version of govuk_app_config (5.1.0) and email-alert-service allows us to forcibly enable the Prometheus Exporter. So let's do it.