### PR TITLE
Fix ownership of whitehall-rails-secret-key-base.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2710,6 +2710,8 @@ govukApplications:
         - name: assets-origin.{{ .Values.testExternalDomainSuffix }}
           path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
           pathType: ImplementationSpecific
+    rails:
+      createKeyBaseSecret: false
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
     extraEnv:


### PR DESCRIPTION
The `app/whitehall-admin` and `app/whitehall-frontend` ArgoCD apps were fighting over `externalsecret/whitehall-rails-secret-key-base`.