### PR TITLE
Set Rails SECRET_KEY_BASE for workers too.

### DIFF
--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -54,6 +54,13 @@ spec:
             - configMapRef:
                 name: govuk-apps-env
           env:
+            {{- if $.Values.rails.enabled }}
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.repoName }}-rails-secret-key-base
+                  key: secret-key-base
+            {{- end }}
             {{- if $.Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:


### PR DESCRIPTION
content-publisher-worker was failing without SECRET_KEY_BASE.

We effectively stopped defining SECRET_KEY_BASE for workers in #920, but it's needed in at least some cases and it always would have been defined for workers in the old EC2/Puppet setup.

Tested:

```
helm install chris-content-pub ../generic-govuk-app --values <(
    helm template . --values values-integration.yaml |
    yq e '.|select(.metadata.name=="content-publisher").spec.source.helm.values'
  ) --set sentry.enabled=false --set rails.createKeyBaseSecret=false
k get all -l'app in (content-publisher,content-publisher-worker)'
...
helm uninstall chris-content-pub
```