### PR TITLE
Add back a couple more missing `SECRET_KEY_BASE`.

### DIFF
--- a/charts/asset-manager/templates/rails-secret-key-base-external-secret.yaml
+++ b/charts/asset-manager/templates/rails-secret-key-base-external-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rails.createKeyBaseSecret }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -20,3 +21,4 @@ spec:
       remoteRef:
         key: govuk/common/rails-secret-key-base
         property: asset-manager
+{{- end }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -81,6 +81,11 @@ spec:
               value: *uploads-path
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.repoName }}-rails-secret-key-base
+                  key: secret-key-base
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -103,3 +103,6 @@ monitoring:
 sentry:
   enabled: true
   createSecret: true
+
+rails:
+  createKeyBaseSecret: true

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -49,6 +49,13 @@ spec:
           env:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            {{- if .Values.rails.enabled }}
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.repoName }}-rails-secret-key-base
+                  key: secret-key-base
+            {{- end }}
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
There were a couple more places where we unintentionally removed SECRET_KEY_BASE in #920.

Looked around more thoroughly this time and I think that's the last of them.

Tested with the usual `helm install` (see previous PRs for examples). We really must improve that chart validation pre-merge sometime soon 😅 (easier said than done though, suspect it would need to be able to talk to a real apiserver)