### PR TITLE
Remove obsolete mongo config for imminence

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1041,9 +1041,6 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.testExternalDomainSuffix }}
-    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-      searches:
-        - blue.integration.govuk-internal.digital
     workerEnabled: true
     extraEnv:
       - name: DATABASE_URL
@@ -1063,8 +1060,6 @@ govukApplications:
             key: oauth_secret
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-      - name: MONGODB_URI
-        value: "mongodb://mongo-1,mongo-2,mongo-3/imminence_production"
 
 - name: licencefinder
   repoName: licence-finder


### PR DESCRIPTION
Imminence has been running on Postgres in both the old estate and EKS for a few months now, so remove redundant config.