### PR TITLE
Set nginx timeouts to match EC2/Puppet + tune healthcheck probes.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -400,6 +400,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: content-data.{{ .Values.testExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
     workerEnabled: true
     extraEnv:
       - name: CONTENT_DATA_API_BEARER_TOKEN
@@ -459,6 +460,7 @@ govukApplications:
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
+    nginxProxyReadTimeout: 60s
     workerEnabled: true
     workers:
       - command: ["sidekiq", "-C", "config/sidekiq.yml"]
@@ -1034,6 +1036,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.testExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
     workerEnabled: true
     extraEnv:
       - name: DATABASE_URL
@@ -2236,6 +2239,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: specialist-publisher.{{ .Values.testExternalDomainSuffix }}
+    nginxProxyReadTimeout: 30s
     extraEnv:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -101,24 +101,21 @@ spec:
           {{- with .Values.appProbes }}
             {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
-          startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
+          livenessProbe: &app-probe
             httpGet:
               path: /healthcheck/live
               port: http
-            failureThreshold: 10
-            periodSeconds: 3
-            timeoutSeconds: 15
-          livenessProbe:
-            <<: *app-probe
             failureThreshold: 3
             periodSeconds: 5
+            timeoutSeconds: 30
           readinessProbe:
-            <<: *app-probe
-            httpGet:
-              path: /healthcheck/live  # TODO: fix readiness check so that we can use it here.
-              port: http
+            <<: *app-probe  # Intentionally same path as liveness.
             failureThreshold: 2
-            periodSeconds: 5
+          startupProbe:
+            <<: *app-probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
@@ -135,7 +132,7 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.nginxPort }}
-          livenessProbe:
+          livenessProbe: &nginx-probe
             httpGet:
               path: /readyz
               port: http
@@ -144,12 +141,8 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 20
           readinessProbe:
-            httpGet:
-              path: /readyz
-              port: http
-            initialDelaySeconds: 2
+            <<: *nginx-probe  # Intentionally same path as liveness.
             failureThreshold: 2
-            periodSeconds: 5
             timeoutSeconds: 15
           {{- with .Values.nginxResources }}
           resources:


### PR DESCRIPTION
- Set nginx `proxy_read_timeout` the same as EC2/Puppet for a few apps where it was different.
- Apply the 30s liveness/readiness/startup probe timeout (up from 15s) to all apps rather than just Whitehall, since it's simpler and probably slightly safer. Saves Whitehall being a special-case.

Bit more detail in the commit messages.