### PR TITLE
Remove long-lived AWS creds for support-api.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2321,20 +2321,10 @@ govukApplications:
       path: /app/public/assets/support
     workerEnabled: true
     extraEnv:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: support-aws
-            key: access_key
       - name: AWS_REGION
         value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-integration-support-api-csvs
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: support-aws
-            key: secret_key
       - name: EMERGENCY_CONTACT_DETAILS
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
We're using EC2 instance profile creds now (and we might switch to IRSA in future).

See also:
- https://github.com/alphagov/support-api/pull/760
- https://github.com/alphagov/govuk-infrastructure/pull/823