### PR TITLE
Use dummy `SECRET_KEY_BASE` for the dbmigrate job.

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -51,10 +51,7 @@ spec:
               value: "{{ .Values.appImage.tag }}"
             {{- if .Values.rails.enabled }}
             - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.repoName }}-rails-secret-key-base
-                  key: secret-key-base
+              value: unused_for_dbmigrate_but_still_required
             {{- end }}
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}


### PR DESCRIPTION
It's [difficult](https://www.github.com/argoproj/argo-cd/issues/9891) to run ArgoCD pre-sync jobs that require other resources, such as ExternalSecrets, if those resources are created in the same sync. Since we don't actually need `SECRET_KEY_BASE` in order to run database migrations, the simplest way to avoid this problem is to use a dummy value to keep Rails's validation happy.

### Alternatives considered

I tried using a negative-weighted SyncWave to install the requisite ExternalSecrets before running the dbmigrate job. Couldn't find a way to make that work, because presync hooks run before all SyncWaves.

Also tried making the ExternalSecret a presync hook, so that it gets created in the same pass as the Job that depends on it. This lets the Job succeed, but I couldn't find any combination of options/annotations that would prevent ArgoCD from trying to delete the ExternalSecret again at one stage or another.

I suspect there's some magic formula that I missed here, but even so I concluded that Argo makes this sufficiently unintuitive that the [winning move here is not to play](https://www.imdb.com/title/tt0086567/characters/nm0939795).

Also considered moving the `*-rails-secret-key-base` ExternalSecrets back to their own chart (like they were before #925 / #920), but that's undesirable because they clearly belong with the app chart and splitting apps into separate charts just to work around ArgoCD issues would be a case of [the tail wagging the dog](https://www.collinsdictionary.com/dictionary/english/the-tail-is-wagging-the-dog).