### PR TITLE
Keep 2 previous replicasets rather than 5.

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: app
 spec:
   replicas: {{ .Values.replicaCount }}
-  revisionHistoryLimit: 5
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ $fullName }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.workerReplicaCount }}
-  revisionHistoryLimit: 5
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ $fullName }}-worker

--- a/charts/fastly-exporter/templates/deployment.yaml
+++ b/charts/fastly-exporter/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "fastly-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  revisionHistoryLimit: 5
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       {{- include "fastly-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: app
 spec:
   replicas: {{ .Values.replicaCount }}
-  revisionHistoryLimit: 5
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ $fullName }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.workerReplicaCount }}
-  revisionHistoryLimit: 5
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ $fullName }}-worker


### PR DESCRIPTION
We don't expect to use `kubectl rollout undo` (since we're using ArgoCD for almost everything and Helm for the rest) and even in the unlikely event that we did want to use it, rolling back more than two revisions is itself unlikely. Having lots of old revisions is therefore not very helpful — it just clutters and slows down the ArgoCD UI and makes unnecessary requests to apiserver and etcd.

This change means we'll see at most 3 ReplicaSets per Deployment rather than 6.