### PR TITLE
Fix conflict when applying ExternalSecrets templates via ArgoCD.

### DIFF
--- a/charts/asset-manager/templates/rails-secret-key-base-external-secret.yaml
+++ b/charts/asset-manager/templates/rails-secret-key-base-external-secret.yaml
@@ -10,11 +10,12 @@ metadata:
     kubernetes.io/description: >
       The Rails secret key base for the application.
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: asset-manager-rails-secret-key-base
   data:
     - secretKey: secret-key-base

--- a/charts/asset-manager/templates/sentry-external-secret.yaml
+++ b/charts/asset-manager/templates/sentry-external-secret.yaml
@@ -10,11 +10,12 @@ metadata:
     kubernetes.io/description: >
       Client key for the associated Sentry project.
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: {{ .Values.repoName }}-sentry
   data:
     - secretKey: dsn

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -106,3 +106,7 @@ sentry:
 
 rails:
   createKeyBaseSecret: true
+
+externalSecrets:
+  refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+  deletionPolicy: Delete

--- a/charts/external-secrets/templates/account-api/notify.yaml
+++ b/charts/external-secrets/templates/account-api/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: account-api-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/account-api/oauth.yaml
+++ b/charts/external-secrets/templates/account-api/oauth.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: govuk-account-oauth
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/account-api/postgres.yaml
+++ b/charts/external-secrets/templates/account-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: account-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/asset-manager/docdb.yaml
+++ b/charts/external-secrets/templates/asset-manager/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: asset-manager-docdb
     template:
       data:

--- a/charts/external-secrets/templates/authenticating-proxy/jwt-auth-secret.yaml
+++ b/charts/external-secrets/templates/authenticating-proxy/jwt-auth-secret.yaml
@@ -16,6 +16,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: authenticating-proxy-jwt-auth-secret
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/authenticating-proxy/postgres.yaml
+++ b/charts/external-secrets/templates/authenticating-proxy/postgres.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: authenticating-proxy-postgres
     template:
       data:

--- a/charts/external-secrets/templates/basic-auth.yaml
+++ b/charts/external-secrets/templates/basic-auth.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: basic-auth
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/bouncer/postgres.yaml
+++ b/charts/external-secrets/templates/bouncer/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: bouncer-postgres
     template:
       data:

--- a/charts/external-secrets/templates/cache-clearing-service/rabbitmq.yaml
+++ b/charts/external-secrets/templates/cache-clearing-service/rabbitmq.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: cache-clearing-service-rabbitmq
     template:
       data:

--- a/charts/external-secrets/templates/collections-publisher/mysql.yaml
+++ b/charts/external-secrets/templates/collections-publisher/mysql.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: collections-publisher-mysql
     template:
       data:

--- a/charts/external-secrets/templates/collections-publisher/notify.yaml
+++ b/charts/external-secrets/templates/collections-publisher/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: collections-publisher-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/contacts-admin/mysql.yaml
+++ b/charts/external-secrets/templates/contacts-admin/mysql.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: contacts-admin-mysql
     template:
       data:

--- a/charts/external-secrets/templates/content-data-admin/aws.yaml
+++ b/charts/external-secrets/templates/content-data-admin/aws.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-data-admin-aws
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/content-data-admin/notify.yaml
+++ b/charts/external-secrets/templates/content-data-admin/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-data-admin-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/content-data-admin/postgres.yaml
+++ b/charts/external-secrets/templates/content-data-admin/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-data-admin-postgres
     template:
       data:

--- a/charts/external-secrets/templates/content-data-api/google.yaml
+++ b/charts/external-secrets/templates/content-data-api/google.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-data-api-google-analytics
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/content-data-api/postgres.yaml
+++ b/charts/external-secrets/templates/content-data-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-data-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/content-data-api/rabbitmq.yaml
+++ b/charts/external-secrets/templates/content-data-api/rabbitmq.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-data-api-rabbitmq
     template:
       data:

--- a/charts/external-secrets/templates/content-publisher/notify.yaml
+++ b/charts/external-secrets/templates/content-publisher/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-publisher-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/content-publisher/postgres.yaml
+++ b/charts/external-secrets/templates/content-publisher/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-publisher-postgres
     template:
       data:

--- a/charts/external-secrets/templates/content-store/docdb.yaml
+++ b/charts/external-secrets/templates/content-store/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-store-docdb
     template:
       data:

--- a/charts/external-secrets/templates/content-tagger/postgres.yaml
+++ b/charts/external-secrets/templates/content-tagger/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: content-tagger-postgres
     template:
       data:

--- a/charts/external-secrets/templates/email-alert-api/notify.yaml
+++ b/charts/external-secrets/templates/email-alert-api/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: email-alert-api-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/email-alert-api/postgres.yaml
+++ b/charts/external-secrets/templates/email-alert-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: email-alert-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/email-alert-service/rabbitmq.yaml
+++ b/charts/external-secrets/templates/email-alert-service/rabbitmq.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: email-alert-service-rabbitmq
     template:
       data:

--- a/charts/external-secrets/templates/email-alert/auth.yaml
+++ b/charts/external-secrets/templates/email-alert/auth.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: email-alert-auth
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/feedback/assisted-digital-google-sheet.yaml
+++ b/charts/external-secrets/templates/feedback/assisted-digital-google-sheet.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: feedback-assisted-digital-google-sheet
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/feedback/notify.yaml
+++ b/charts/external-secrets/templates/feedback/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: feedback-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/frontend/elections-api.yaml
+++ b/charts/external-secrets/templates/frontend/elections-api.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: frontend-elections-api
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/imminence/postgres.yaml
+++ b/charts/external-secrets/templates/imminence/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: imminence-postgres
     template:
       data:

--- a/charts/external-secrets/templates/link-checker-api/google-api.yaml
+++ b/charts/external-secrets/templates/link-checker-api/google-api.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: link-checker-api-google-api-key
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/link-checker-api/postgres.yaml
+++ b/charts/external-secrets/templates/link-checker-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: link-checker-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/local-links-manager/google.yaml
+++ b/charts/external-secrets/templates/local-links-manager/google.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: local-links-manager-google
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/local-links-manager/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/local-links-manager/link-checker-api-callback-token.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: local-links-manager-link-checker-api-callback-token
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/local-links-manager/postgres.yaml
+++ b/charts/external-secrets/templates/local-links-manager/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: local-links-manager-postgres
     template:
       data:

--- a/charts/external-secrets/templates/locations-api/os-places.yaml
+++ b/charts/external-secrets/templates/locations-api/os-places.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: locations-api-os-places
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/locations-api/postgres.yaml
+++ b/charts/external-secrets/templates/locations-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: locations-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/manuals-publisher/docdb.yaml
+++ b/charts/external-secrets/templates/manuals-publisher/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: manuals-publisher-docdb
     template:
       data:

--- a/charts/external-secrets/templates/manuals-publisher/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/manuals-publisher/link-checker-api-callback-token.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: manuals-publisher-link-checker-api-callback-token
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/maslow/docdb.yaml
+++ b/charts/external-secrets/templates/maslow/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: maslow-docdb
     template:
       data:

--- a/charts/external-secrets/templates/publisher/docdb.yaml
+++ b/charts/external-secrets/templates/publisher/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: publisher-docdb
     template:
       data:

--- a/charts/external-secrets/templates/publisher/fact-check-email-account.yaml
+++ b/charts/external-secrets/templates/publisher/fact-check-email-account.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: publisher-fact-check-email-account
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/publisher/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/publisher/link-checker-api-callback-token.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: publisher-link-checker-api-callback-token
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/publisher/notify.yaml
+++ b/charts/external-secrets/templates/publisher/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: publisher-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/publishing-api/postgres.yaml
+++ b/charts/external-secrets/templates/publishing-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: publishing-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/publishing-api/rabbitmq.yaml
+++ b/charts/external-secrets/templates/publishing-api/rabbitmq.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: publishing-api-rabbitmq
     template:
       data:

--- a/charts/external-secrets/templates/release/github.yaml
+++ b/charts/external-secrets/templates/release/github.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: release-github
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/release/mysql.yaml
+++ b/charts/external-secrets/templates/release/mysql.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: release-mysql
     template:
       data:

--- a/charts/external-secrets/templates/router/nginx-htpasswd.yaml
+++ b/charts/external-secrets/templates/router/nginx-htpasswd.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: router-nginx-htpasswd
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/search-admin/mysql.yaml
+++ b/charts/external-secrets/templates/search-admin/mysql.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: search-admin-mysql
     template:
       data:

--- a/charts/external-secrets/templates/search-admin/notify.yaml
+++ b/charts/external-secrets/templates/search-admin/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: search-admin-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/search-api/google-analytics.yaml
+++ b/charts/external-secrets/templates/search-api/google-analytics.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: search-api-google-analytics
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/search-api/google-bigquery.yaml
+++ b/charts/external-secrets/templates/search-api/google-bigquery.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: search-api-google-bigquery
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/search-api/rabbitmq.yaml
+++ b/charts/external-secrets/templates/search-api/rabbitmq.yaml
@@ -14,6 +14,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: search-api-rabbitmq
     template:
       data:

--- a/charts/external-secrets/templates/service-manual-publisher/notify.yaml
+++ b/charts/external-secrets/templates/service-manual-publisher/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: service-manual-publisher-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/service-manual-publisher/postgres.yaml
+++ b/charts/external-secrets/templates/service-manual-publisher/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: service-manual-publisher-postgres
     template:
       data:

--- a/charts/external-secrets/templates/short-url-manager/docdb.yaml
+++ b/charts/external-secrets/templates/short-url-manager/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: short-url-manager-docdb
     template:
       data:

--- a/charts/external-secrets/templates/short-url-manager/notify.yaml
+++ b/charts/external-secrets/templates/short-url-manager/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: short-url-manager-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/signon/active-record-encryption.yaml
+++ b/charts/external-secrets/templates/signon/active-record-encryption.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: active-record-encryption
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/signon/devise-pepper.yaml
+++ b/charts/external-secrets/templates/signon/devise-pepper.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: signon-devise-pepper
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/signon/devise-secret.yaml
+++ b/charts/external-secrets/templates/signon/devise-secret.yaml
@@ -17,6 +17,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: signon-devise-secret
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/signon/mysql.yaml
+++ b/charts/external-secrets/templates/signon/mysql.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: signon-mysql
     template:
       data:

--- a/charts/external-secrets/templates/smartanswers/zendesk-client.yaml
+++ b/charts/external-secrets/templates/smartanswers/zendesk-client.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: smartanswers-zendesk-client
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/specialist-publisher/aws.yaml
+++ b/charts/external-secrets/templates/specialist-publisher/aws.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: specialist-publisher-aws
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/specialist-publisher/docdb.yaml
+++ b/charts/external-secrets/templates/specialist-publisher/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: specialist-publisher-docdb
     template:
       data:

--- a/charts/external-secrets/templates/specialist-publisher/notify.yaml
+++ b/charts/external-secrets/templates/specialist-publisher/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: specialist-publisher-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/support-api/notify.yaml
+++ b/charts/external-secrets/templates/support-api/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: support-api-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/support-api/postgres.yaml
+++ b/charts/external-secrets/templates/support-api/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: support-api-postgres
     template:
       data:

--- a/charts/external-secrets/templates/support/aws.yaml
+++ b/charts/external-secrets/templates/support/aws.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: support-aws
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/support/emergency-contacts.yaml
+++ b/charts/external-secrets/templates/support/emergency-contacts.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: support-emergency-contacts
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/support/zendesk.yaml
+++ b/charts/external-secrets/templates/support/zendesk.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: support-zendesk
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/transition/aws.yaml
+++ b/charts/external-secrets/templates/transition/aws.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: transition-aws
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/transition/postgres.yaml
+++ b/charts/external-secrets/templates/transition/postgres.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: transition-postgres
     template:
       data:

--- a/charts/external-secrets/templates/travel-advice-publisher/docdb.yaml
+++ b/charts/external-secrets/templates/travel-advice-publisher/docdb.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: travel-advice-publisher-docdb
     template:
       data:

--- a/charts/external-secrets/templates/travel-advice-publisher/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/travel-advice-publisher/link-checker-api-callback-token.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: travel-advice-publisher-link-checker-api-callback-token
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/whitehall/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/whitehall/link-checker-api-callback-token.yaml
@@ -15,6 +15,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: whitehall-link-checker-api-callback-token
   dataFrom:
     - extract:

--- a/charts/external-secrets/templates/whitehall/mysql.yaml
+++ b/charts/external-secrets/templates/whitehall/mysql.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: whitehall-mysql
     template:
       data:

--- a/charts/external-secrets/templates/whitehall/notify.yaml
+++ b/charts/external-secrets/templates/whitehall/notify.yaml
@@ -13,6 +13,7 @@ spec:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: whitehall-notify
   dataFrom:
     - extract:

--- a/charts/external-secrets/values.yaml
+++ b/charts/external-secrets/values.yaml
@@ -1,2 +1,3 @@
 externalSecrets:
+  deletionPolicy: Delete
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.

--- a/charts/generic-govuk-app/templates/rails-secret-key-base-external-secret.yaml
+++ b/charts/generic-govuk-app/templates/rails-secret-key-base-external-secret.yaml
@@ -10,11 +10,12 @@ metadata:
     kubernetes.io/description: >
       The Rails secret key base for the application.
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: {{ .Values.repoName }}-rails-secret-key-base
   data:
     - secretKey: secret-key-base

--- a/charts/generic-govuk-app/templates/sentry-external-secret.yaml
+++ b/charts/generic-govuk-app/templates/sentry-external-secret.yaml
@@ -10,11 +10,12 @@ metadata:
     kubernetes.io/description: >
       Client key for the associated Sentry project.
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: {{ .Values.repoName }}-sentry
   data:
     - secretKey: dsn

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -126,3 +126,7 @@ sentry:
 rails:
   enabled: true
   createKeyBaseSecret: true
+
+externalSecrets:
+  refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+  deletionPolicy: Delete

--- a/charts/smokey/templates/secrets.yaml
+++ b/charts/smokey/templates/secrets.yaml
@@ -8,11 +8,12 @@ metadata:
       Email address and password for the Signon account which Smokey uses when
       testing publisher apps. Field names are `email` and `password`.
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: {{ .Release.Name }}-signon-account
   dataFrom:
     - extract:

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -1,3 +1,7 @@
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey
   tag: latest
+
+externalSecrets:
+  refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+  deletionPolicy: Delete


### PR DESCRIPTION
Set [deletionPolicy=Delete](https://external-secrets.io/v0.7.2/guides/ownership-deletion-policy/) on ExternalSecrets, so that when Argo CD deletes an ExternalSecret and re-creates it with a different uid, the controller deletes Secret that was owned by the old ExternalSecret and is then able to create the new Secret without finding a conflict of ownership.

This hopefully fixes the problem where ExternalSecrets often shows as "degraded" in Argo CD when replacing an Application resource.

Also make refreshInterval configurable consistently. (I've intentionally kept the Helm value names the same throughout, so that things don't break if we move things between charts.)

All the changes except the ones to values.yaml were generated with:

    git grep -l ExternalSecret external-secrets asset-manager generic-govuk-app smokey |
      xargs gsed -i '/  target:/a \ \ \ \ deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}'

    git grep -l ExternalSecret asset-manager generic-govuk-app smokey |
      xargs gsed -i 's/refreshInterval: 1h/refreshInterval: {{ .Values.externalSecrets.refreshInterval }}/'