### PR TITLE
Allow Argo CD to create ClusterExternalSecret.

### DIFF
--- a/charts/argo-bootstrap/templates/argocd/govuk-project.yaml
+++ b/charts/argo-bootstrap/templates/argocd/govuk-project.yaml
@@ -12,12 +12,16 @@ spec:
   - '*'
 
   # Deny all cluster-scoped resources from being created, except for Namespace
+  # and (for argocd-notifications-secret) external-secrets.io:ClusterExternalSecret.
+  # See argo-services/templates/notifications/secret.yaml.
   clusterResourceWhitelist:
   - group: ''
     kind: Namespace
+  - group: external-secrets.io
+    kind: ClusterExternalSecret
 
   destinations:
-  - namespace: "*"
+  - namespace: '*'
     server: https://kubernetes.default.svc
 
   orphanedResources:

--- a/charts/argo-services/templates/notifications/secret.yaml
+++ b/charts/argo-services/templates/notifications/secret.yaml
@@ -1,5 +1,7 @@
-# NOTE: This assumes that an AWS SecretsManager secret `govuk/slack-webhook-url`
-# exists with key `url`.
+# TODO: do we even still need to create secret/argocd-notifications-secret in
+# both namespaces? If not, get rid of this and remove ClusterExternalSecret
+# from the list of allowed resource types in
+# charts/argo-bootstrap/templates/argocd/govuk-project.yaml
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterExternalSecret
 metadata:


### PR DESCRIPTION
It looks like we moved a ClusterExternalSecret (`argo-notifications-secret`) into an ArgoCD-managed chart (`argo-services`) but never gave Argo CD permission to create it. This only showed up when deleting everything out of the staging cluster and checking whether Argo CD could re-create it all.

Alternatively, we could move this ClusterExternalSecret to the `argo-bootstrap` chart if we wanted to keep the permissions the same. I don't think this permissions change represents an actual widening of access in practice though, as far as I can tell (but happy to be told otherwise).

Should fix `resource external-secrets.io:ClusterExternalSecret is not permitted in project govuk` failure when syncing `charts/argo-services`.