### PR TITLE
Increment argo-bootstrap version number.

### DIFF
--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps ArgoCD with initial configuration
-version: 0.3.0
+version: 0.3.1


### PR DESCRIPTION
This is one of the few charts where the version number matters, because we're installing it using Terraform and Helm rather than Argo CD. Forgot this in #944. Ugh.