### PR TITLE
Create external DNS name for Bouncer.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -234,6 +234,7 @@ govukApplications:
         alb.ingress.kubernetes.io/healthcheck-path: /readyz
         alb.ingress.kubernetes.io/load-balancer-name: bouncer
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        external-dns.alpha.kubernetes.io/hostname: bouncer.{{ .Values.k8sExternalDomainSuffix }}
       rules:
         - http:  # Match all hostnames.
             paths:


### PR DESCRIPTION
For other services, we're using the hostnames on the Ingress to tell the external-dns controller to create/update the corresponding DNS names. Bouncer has to serve thousands of hostnames, so we have its Ingress rules match any hostname. We therefore configure external-dns for Bouncer explicitly via [an annotation](https://www.github.com/kubernetes-sigs/external-dns/blob/43d29f8/docs/initial-design.md#configuration).