### PR TITLE
Add ingress for account-api.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -48,6 +48,23 @@ govukApplications:
       enabled: false
     dbMigrationEnabled: true
     workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: account-api
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-integration-aws-logging,
+          access_logs.s3.prefix=elb/asset-manager-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &assets-lb-conditions >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "account-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: account-api.{{ .Values.k8sExternalDomainSuffix }}
     extraEnv:
       - name: DATABASE_URL
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -49,6 +49,23 @@ govukApplications:
       enabled: false
     dbMigrationEnabled: true
     workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: account-api
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
+          access_logs.s3.prefix=elb/asset-manager-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &assets-lb-conditions >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "account-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: account-api.{{ .Values.k8sExternalDomainSuffix }}
     extraEnv:
       - name: DATABASE_URL
         valueFrom:
@@ -115,7 +132,7 @@ govukApplications:
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
           access_logs.s3.enabled=true,
-          access_logs.s3.bucket=govuk-staging-aws-logging,
+          access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
           access_logs.s3.prefix=elb/assets-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &assets-lb-conditions >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
@@ -1694,7 +1711,7 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
         alb.ingress.kubernetes.io/load-balancer-attributes: >
           access_logs.s3.enabled=true,
-          access_logs.s3.bucket=govuk-staging-aws-logging,
+          access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
           access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [


### PR DESCRIPTION
Apparently Account API serves requests directly to the general public as well as being an internal API.

It'd be nice to have clear separation between the internal and public API surfaces, but there isn't any such separation in the existing EC2/Puppet/Terraform deployment so 🤷