### PR TITLE
Transition cron label fix

### DIFF
--- a/charts/generic-govuk-app/templates/transition-config-cron.yaml
+++ b/charts/generic-govuk-app/templates/transition-config-cron.yaml
@@ -17,7 +17,7 @@ spec:
       name: {{ $fullName }}-config-cron
       labels:
         {{- include "generic-govuk-app.labels" $ | nindent 8 }}
-        app.kubernetes.io/component: "{{ .name }}-config-cron"
+        app.kubernetes.io/component: config-cron
     spec:
       backoffLimit: 0
       template:


### PR DESCRIPTION
Updated label to match other in file such as line 12:
https://github.com/alphagov/govuk-helm-charts/blob/e1c697aa06e01ce2bc69a2f97f7d36ea2642cd1f/charts/generic-govuk-app/templates/transition-config-cron.yaml#L12

