### PR TITLE
Create long-lived SA tokens for Argo Workflows.

### DIFF
--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps ArgoCD with initial configuration
-version: 0.3.1
+version: 0.3.2

--- a/charts/argo-bootstrap/templates/argo-workflows-rbac/service-account.yaml
+++ b/charts/argo-bootstrap/templates/argo-workflows-rbac/service-account.yaml
@@ -8,6 +8,16 @@ metadata:
     workflows.argoproj.io/rbac-rule-precedence: "1"
 automountServiceAccountToken: false
 ---
+# TODO: switch to TokenRequest instead of legacy long-lived SA tokens. (Or better, drop Argo Workflows and stick with plain Argo CD.)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-workflows-read-only.service-account-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: argo-workflows-read-only
+type: kubernetes.io/service-account-token
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -17,3 +27,12 @@ metadata:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.rbacTeams.read_write }}' in groups"
     workflows.argoproj.io/rbac-rule-precedence: "2"
 automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-workflows-read-write.service-account-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: argo-workflows-read-write
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
Before 1.22, Kubernetes used to create these automatically. They've been deprecated for ages but Argo Workflows [still relies on them](https://www.github.com/argoproj/argo-workflows/pull/9620/commits/8a69080cd58ea9f6a8ccc8c1372e5ee57487fbaf#diff-76961ec9c46eae52804982a6584c81e67658e9f9ae8eceb8525c9b9c085735b1). Not good.

We want to move away from Argo Workflows (i.e. just use Argo CD), but in the meantime, [add these long-lived serviceaccount tokens back in](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount) so that Workflows continues to work when a cluster is installed from scratch.