### PR TITLE
Use latest kubeconform for pre-merge checks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: "grep KUBERNETES_VERSION kubernetes_version >> $GITHUB_ENV"
 
       - name: kubeconform
-        uses: docker://ghcr.io/yannh/kubeconform:v0.5.0
+        uses: docker://ghcr.io/yannh/kubeconform:latest-alpine
         with:
           entrypoint: /kubeconform
           args: >


### PR DESCRIPTION
Use `latest` instead of specifying the version, because we don't have an automatic way to keep up to date and there's no security benefit either because image tags on GHCR are mutable.