### PR TITLE
Refactor Router alert and add recording rules.

### DIFF
--- a/charts/monitoring-config/rules/README.md
+++ b/charts/monitoring-config/rules/README.md
@@ -1,4 +1,9 @@
 ## Run Prometheus alert tests
 
 - Install `promtool` on your machine: `brew install prometheus`
-- Run `promtool test rules *_tests.yaml`.
+- Run the following command
+
+    ```sh
+    (GLOBIGNORE='*_tests.*' && promtool check rules *.yaml) &&
+      promtool test rules *_tests.yaml
+    ```

--- a/charts/monitoring-config/rules/router.yaml
+++ b/charts/monitoring-config/rules/router.yaml
@@ -1,12 +1,15 @@
 groups:
-- name: RouterAlerts
-  rules:
-  - alert: RouterBackendHandlerResponse5xxErrorRate
-    expr: sum(rate(router_backend_handler_response_duration_seconds_count{response_code=~"^5..", namespace="apps", job="router"}[5m])) / sum(rate(router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}[5m])) > 0.1
-    for: 10m
-    labels:
-        severity: page
-        job: router
-    annotations:
-        summary: "High 5xx error rate for router"
-        description: "router has high 5xx error rate for more than 10 minutes."
+  - name: RouterAlerts
+    rules:
+      - alert: RouterBackendHandlerResponse5xxErrorRate
+        expr: >
+          sum(rate(router_backend_handler_response_duration_seconds_count{response_code=~"^5..", namespace="apps", job="router"}[5m]))
+            /
+          sum(rate(router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: page
+          job: router
+        annotations:
+          summary: "High 5xx error rate for router"
+          description: "router has high 5xx error rate for more than 10 minutes."

--- a/charts/monitoring-config/rules/router.yaml
+++ b/charts/monitoring-config/rules/router.yaml
@@ -6,6 +6,7 @@ groups:
     for: 10m
     labels:
         severity: page
+        job: router
     annotations:
         summary: "High 5xx error rate for router"
         description: "router has high 5xx error rate for more than 10 minutes."

--- a/charts/monitoring-config/rules/router.yaml
+++ b/charts/monitoring-config/rules/router.yaml
@@ -1,15 +1,32 @@
 groups:
   - name: RouterAlerts
     rules:
-      - alert: RouterBackendHandlerResponse5xxErrorRate
-        expr: >
-          sum(rate(router_backend_handler_response_duration_seconds_count{response_code=~"^5..", namespace="apps", job="router"}[5m]))
-            /
-          sum(rate(router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}[5m])) > 0.1
+      - record: global:router_requests:rate5m
+        expr: |
+          sum by (job, backend_id, response_code) (
+            rate(router_backend_handler_response_duration_seconds_count{namespace="apps"}[5m])
+          )
+
+      - record: global:router_5xx_responses_per_request_by_backend:ratio_rate5m
+        expr: |2
+            sum without (response_code) (global:router_requests:rate5m{response_code=~"5.."})
+          /
+            sum without (response_code) (global:router_requests:rate5m)
+
+      - record: global:router_5xx_responses_per_request:ratio_rate5m
+        expr: |2
+            sum without (backend_id, response_code) (global:router_requests:rate5m{response_code=~"5.."})
+          /
+            sum without (backend_id, response_code) (global:router_requests:rate5m)
+
+      - alert: RouterErrorRatioTooHigh
+        expr: |2
+            global:router_5xx_responses_per_request:ratio_rate5m{job="router"} > 0.1
+          and
+            sum without (backend_id, response_code) (global:router_requests:rate5m{job="router"}) > 1
         for: 10m
         labels:
           severity: page
-          job: router
         annotations:
-          summary: "High 5xx error rate for router"
-          description: "router has high 5xx error rate for more than 10 minutes."
+          summary: Router error ratio too high
+          description: More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.

--- a/charts/monitoring-config/rules/router_tests.yaml
+++ b/charts/monitoring-config/rules/router_tests.yaml
@@ -1,42 +1,36 @@
 rule_files:
-    - router.yaml
+  - router.yaml
 
 evaluation_interval: 1m
 
 tests:
-    # Test that alerts will be triggered.
-    - interval: 1m
-      input_series:
-          - series: 'router_backend_handler_response_duration_seconds_count{response_code="500", namespace="apps", job="router"}'
-            values: '0 2+1x6 8x4' # 0 3 4 5 6 7 8 8 8 8 8
-          - series: 'router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}'
-            values: '0+1x11' # 1 2 3 4 5 6 7 8 9 10 11
+  # Alert fires when threshold exceeded for too long.
+  - interval: 1m
+    input_series:
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="500", namespace="apps", job="router"}'
+        values: '0 2+1x6 8x4'
+      - series: 'router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}'
+        values: '0+1x11'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: RouterBackendHandlerResponse5xxErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              job: router
+            exp_annotations:
+              summary: High 5xx error rate for router
+              description: router has high 5xx error rate for more than 10 minutes.
 
-      # Unit test for alerting rules.
-      alert_rule_test:
-          - eval_time: 11m
-            alertname: RouterBackendHandlerResponse5xxErrorRate
-            exp_alerts:
-                # This alert will trigger when the apps/router error ratio is >0.1 for more than 10 minutes.
-                - exp_labels:
-                      severity: page
-                      job: router
-                  exp_annotations:
-                      summary: High 5xx error rate for router
-                      description: router has high 5xx error rate for more than 10 minutes.
-
-    # Control test, should pass without any alerts triggered.
-    - interval: 1m
-      input_series:
-          - series: 'router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}'
-            values: '0+1x11' # 1 2 3 4 5 6 7 8 9 10 11
-          - series: 'router_backend_handler_response_duration_seconds_count{response_code="500", namespace="apps", job="router"}'
-            # No alert triggered as only increase in router errors for 4 minutes
-            values: '0 2+1x4 6x6' # 0 3 4 5 6 6 6 6 6 6 6
-
-      # Unit test for alerting rules.
-      alert_rule_test:
-          - eval_time: 11m
-            alertname: RouterBackendHandlerResponse5xxErrorRate
-            exp_alerts:
-                # No alerts triggered.
+  # Alert does not fire when threshold not exceeded for long enough.
+  - interval: 1m
+    input_series:
+      - series: 'router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}'
+        values: '0+1x11'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="500", namespace="apps", job="router"}'
+        # No alert triggered as only increase in router errors for 4 minutes
+        values: '0 2+1x4 6x6'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: RouterBackendHandlerResponse5xxErrorRate
+        exp_alerts: []

--- a/charts/monitoring-config/rules/router_tests.yaml
+++ b/charts/monitoring-config/rules/router_tests.yaml
@@ -21,6 +21,9 @@ tests:
                 - exp_labels:
                       severity: page
                       job: router
+                  exp_annotations:
+                      summary: High 5xx error rate for router
+                      description: router has high 5xx error rate for more than 10 minutes.
 
     # Control test, should pass without any alerts triggered.
     - interval: 1m

--- a/charts/monitoring-config/rules/router_tests.yaml
+++ b/charts/monitoring-config/rules/router_tests.yaml
@@ -7,30 +7,59 @@ tests:
   # Alert fires when threshold exceeded for too long.
   - interval: 1m
     input_series:
-      - series: 'router_backend_handler_response_duration_seconds_count{response_code="500", namespace="apps", job="router"}'
-        values: '0 2+1x6 8x4'
-      - series: 'router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}'
-        values: '0+1x11'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="200", namespace="apps", job="router", backend_id="foo"}'
+        values: '0+89x15'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="502", namespace="apps", job="router", backend_id="foo"}'
+        values: '0+5x15'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="503", namespace="apps", job="router", backend_id="bar"}'
+        values: '0+6x15'
+    promql_expr_test:
+      - expr: 'round(sum by (job) (global:router_requests:rate5m{job="router", response_code=~"5.."}), 1E-4)'
+        eval_time: 15m
+        exp_samples:
+          - labels: '{job="router"}'
+            value: 0.1833
+      - expr: 'round(sum by (job) (global:router_requests:rate5m{job="router"}), 1E-4)'
+        eval_time: 15m
+        exp_samples:
+          - labels: '{job="router"}'
+            value: 1.6667
+      - expr: 'round(sum by (job) (global:router_5xx_responses_per_request:ratio_rate5m{job="router"}), 1E-4)'
+        eval_time: 15m
+        exp_samples:
+          - labels: '{job="router"}'
+            value: 0.1100
     alert_rule_test:
-      - eval_time: 11m
-        alertname: RouterBackendHandlerResponse5xxErrorRate
+      - eval_time: 15m
+        alertname: RouterErrorRatioTooHigh
         exp_alerts:
           - exp_labels:
               severity: page
               job: router
             exp_annotations:
-              summary: High 5xx error rate for router
-              description: router has high 5xx error rate for more than 10 minutes.
+              summary: Router error ratio too high
+              description: More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.
 
   # Alert does not fire when threshold not exceeded for long enough.
   - interval: 1m
     input_series:
-      - series: 'router_backend_handler_response_duration_seconds_count{namespace="apps", job="router"}'
-        values: '0+1x11'
-      - series: 'router_backend_handler_response_duration_seconds_count{response_code="500", namespace="apps", job="router"}'
-        # No alert triggered as only increase in router errors for 4 minutes
-        values: '0 2+1x4 6x6'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="200", namespace="apps", job="router"}'
+        values: '0+60x15'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="503", namespace="apps", job="router"}'
+        values: '0+12x8 0x7'
     alert_rule_test:
-      - eval_time: 11m
-        alertname: RouterBackendHandlerResponse5xxErrorRate
+      - eval_time: 15m
+        alertname: RouterErrorRatioTooHigh
+        exp_alerts: []
+
+  # Alert does not fire when min QPS threshold is not met.
+  - interval: 1m
+    input_series:
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="200", namespace="apps", job="router"}'
+        values: '0+30x15'
+      - series: 'router_backend_handler_response_duration_seconds_count{response_code="503", namespace="apps", job="router"}'
+        values: '0+20x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RouterErrorRatioTooHigh
         exp_alerts: []

--- a/schemas/prometheusrule_v1.json
+++ b/schemas/prometheusrule_v1.json
@@ -1,123 +1,111 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "object",
-    "definitions": {
-      "duration": {
-        "type": ["string", "null"],
-        "pattern": "^([0-9]+y)?([0-9]+w)?([0-9]+d)?([0-9]+h)?([0-9]+m)?([0-9]+s)?([0-9]+ms)?$",
-        "minLength": 1
-      }
+  "description": "PrometheusRule defines recording and alerting rules for a Prometheus instance",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
     },
-    "required": [
-      "apiVersion",
-      "kind",
-      "metadata",
-      "spec"
-    ],
-    "properties": {
-      "apiVersion": {
-        "type": "string"
-      },
-      "kind": {
-        "type": "string"
-      },
-      "metadata": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "namespace": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "namespace"
-        ]
-      },
-      "spec": {
-        "type": "object",
-        "properties": {
-          "groups": {
-            "type": "array",
-            "items": [
-              {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "rules": {
-                    "type": "array",
-                    "items": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "alert": {
-                            "description": "The name of the alert. Must be a valid metric name.",
-                            "type": "string"
-                          },
-                          "expr": {
-                            "description": "The PromQL expression to evaluate. Every evaluation cycle this is evaluated at the current time, and all resultant time series become pending/firing alerts.",
-                            "type": "string"
-                          },
-                          "for": {
-                            "description": "Alerts are considered firing once they have been returned for this long. Alerts which have not yet fired for long enough are considered pending.",
-                            "$ref": "#/definitions/duration"
-                          },
-                          "labels": {
-                            "type": "object",
-                            "description": "Labels to add or overwrite for each alert.",
-                            "properties": {
-                              "severity": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "severity"
-                            ]
-                          },
-                          "annotations": {
-                            "type": "object",
-                            "description": "Annotations to add to each alert.",
-                            "properties": {
-                              "summary": {
-                                "type": "string"
-                              },
-                              "description": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "summary",
-                              "description"
-                            ]
-                          }
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired alerting rule definitions for Prometheus.",
+      "properties": {
+        "groups": {
+          "description": "Content of Prometheus rule file",
+          "items": {
+            "description": "RuleGroup is a list of sequentially evaluated recording and alerting rules.",
+            "properties": {
+              "interval": {
+                "description": "Interval determines how often rules in the group are evaluated.",
+                "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the rule group.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "partial_response_strategy": {
+                "description": "PartialResponseStrategy is only used by ThanosRuler and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response",
+                "pattern": "^(?i)(abort|warn)?$",
+                "type": "string"
+              },
+              "rules": {
+                "description": "List of alerting and recording rules.",
+                "items": {
+                  "description": "Rule describes an alerting or recording rule See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules) rule",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert. Must be a valid label value. Only one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations to add to each alert. Only valid for alerting rules.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
                         },
-                        "required": [
-                          "alert",
-                          "expr",
-                          "for",
-                          "labels",
-                          "annotations"
-                        ]
-                      }
-                    ]
-                  }
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "PromQL expression to evaluate.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "for": {
+                      "description": "Alerts are considered firing once they have been returned for this long.",
+                      "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels to add or overwrite.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Name of the time series to output to. Must be a valid metric name. Only one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object"
                 },
-                "required": [
-                  "name",
-                  "rules"
-                ]
+                "type": "array"
               }
-            ]
-          }
-        },
-        "required": [
-          "groups"
-        ]
-      }
+            },
+            "required": [
+              "name",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object"
     }
-  }
-  
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
- Add some recording rules for Router metrics and use these in the alert.
- Simplify the name of the alert.
- Add a minimum RPS threshold so it doesn't fire on statistically insignificant input. 
- Fix a failing alert test.
- Improve the messages on test failure and make the tests more self-documenting by adding some assertions on intermediate values.
- Clean up formatting.

Still to do in a later PR: actually run the tests pre-merge instead of them being manual 😅 