### PR TITLE
fixing workflows error as job names are too long

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2423,7 +2423,7 @@ govukApplications:
       enabled: false
     workerEnabled: true
     cronTasks:
-      - name: anonymous-feedback-deduplication-nightly
+      - name: feedback-deduplication-nightly
         task: "anonymous_feedback_deduplication:nightly"
         schedule: "10 0 * * *"
       - name: import-organisations
@@ -2432,7 +2432,7 @@ govukApplications:
       - name: service-feedback-aggregation
         task: "service_feedback_aggregation:daily"
         schedule: "30 0 * * *"
-      - name: anonymous-feedback-deduplication-recent
+      - name: feedback-deduplication-recent
         task: "anonymous_feedback_deduplication:recent"
         schedule: "*/5 * * * *"
     extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2468,7 +2468,7 @@ govukApplications:
       enabled: false
     workerEnabled: true
     cronTasks:
-      - name: anonymous-feedback-deduplication-nightly
+      - name: -feedback-deduplication-nightly
         task: "anonymous_feedback_deduplication:nightly"
         schedule: "10 0 * * *"
       - name: import-organisations
@@ -2477,7 +2477,7 @@ govukApplications:
       - name: service-feedback-aggregation
         task: "service_feedback_aggregation:daily"
         schedule: "30 0 * * *"
-      - name: anonymous-feedback-deduplication-recent
+      - name: feedback-deduplication-recent
         task: "anonymous_feedback_deduplication:recent"
         schedule: "*/5 * * * *"
     extraEnv:


### PR DESCRIPTION
Cronjob names must be no more than 52 characters. Appears to be a limitation in helm https://github.com/helm/monocular/issues/566