### PR TITLE
Reverting  'update an application’s environment configuration tutorial'

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2641,8 +2641,6 @@ govukApplications:
         value: message_by_maisy
       - name: ENV_MESSAGE_OTHER
         value: message_by_other
-      - name: ENV_MESSAGE_ALEX
-        value: message_by_alex
 
 - name: whitehall-admin
   repoName: whitehall


### PR DESCRIPTION
Reverting this [PR](https://github.com/alphagov/govuk-helm-charts/pull/966). As laid out in the tutorial outlined[ here ](https://govuk-k8s-user-docs.publishing.service.gov.uk/get-started/tutorials/app-config-deploy-helm-chart/)