### PR TITLE
Sync Signon feature flags from EC2.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2092,6 +2092,10 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: PERMIT_2SV_EXEMPTION
+        value: "1"
+      - name: MANDATE_2SV_FOR_ORGANISATION
+        value: "1"
       - name: SIGNON_APPS_URI_SUB_PATTERN
         value: integration.publishing.service.gov.uk
       - name: SIGNON_APPS_URI_SUB_REPLACEMENT


### PR DESCRIPTION
See https://github.com/alphagov/govuk-puppet/pull/11999

These flags haven't been flipped in staging and prod yet, so this brings us up to date.