### PR TITLE
Prevent govuk-replatform-test-app deploys to staging

### DIFF
--- a/charts/app-config/image-tags/staging/govuk-replatform-test-app
+++ b/charts/app-config/image-tags/staging/govuk-replatform-test-app
@@ -1,0 +1,2 @@
+image_tag: not-deployed-in-this-environment
+automatic_deploys_enabled: false


### PR DESCRIPTION
This application is not present in our staging environment. This file will prevent the deployment system from trying to automatically deploy the app into the Staging environment, which just results in an error.