### PR TITLE
[RP-1135] Temp Disable Publisher Worker on Staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1448,7 +1448,7 @@ govukApplications:
 - name: publisher
   helmValues:
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     cronTasks:
       - name: reports-generate
         task: "reports:generate"


### PR DESCRIPTION
## What?
This aims to disable the publisher worker in Staging temporarily, so we can load test the worker on legacy EC2 infra without the EKS worker interfering in the results.