### PR TITLE
Merge staging Helm values into production.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -274,6 +274,7 @@ govukApplications:
 
 - name: collections
   helmValues:
+    replicaCount: 4
     appResources:
       limits:
         cpu: 2
@@ -645,7 +646,15 @@ govukApplications:
 
 - name: content-store
   helmValues: &content-store
+    # TODO(chris.banks): tune these once we have some real-world usage data.
     replicaCount: 6
+    appResources:
+      limits:
+        cpu: 4
+        memory: 2500Mi
+      requests:
+        cpu: 2
+        memory: 2000Mi
     cronTasks:
       - name: report-delays
         task: "publishing_delay_report:report_delays"
@@ -924,6 +933,7 @@ govukApplications:
 
 - name: finder-frontend
   helmValues:
+    replicaCount: 4
     appResources:
       limits:
         cpu: 4
@@ -948,6 +958,7 @@ govukApplications:
 
 - name: frontend
   helmValues:
+    replicaCount: 4
     appResources:
       limits:
         cpu: 4
@@ -1030,6 +1041,7 @@ govukApplications:
 
 - name: government-frontend
   helmValues:
+    replicaCount: 6
     appResources:
       limits:
         cpu: 2
@@ -2145,6 +2157,13 @@ govukApplications:
       # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
+    appResources:
+      limits:
+        memory: 2Gi
+        cpu: "4"
+      requests:
+        memory: 1Gi
+        cpu: "2"
     extraEnv:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
@@ -2743,6 +2762,13 @@ govukApplications:
 - name: whitehall-frontend
   repoName: whitehall
   helmValues:
+    appResources:
+      limits:
+        memory: 4Gi
+        cpu: "2"
+      requests:
+        memory: 2Gi
+        cpu: "1"
     ingress:
       enabled: true
       annotations:
@@ -2791,10 +2817,3 @@ govukApplications:
           secretKeyRef:
             name: whitehall-mysql
             key: DATABASE_URL
-    appResources:
-      limits:
-        memory: 4Gi
-        cpu: "2"
-      requests:
-        memory: 2Gi
-        cpu: "1"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2,16 +2,16 @@
 # individual apps below.
 
 govukEnvironment: production
-externalDomainSuffix: gov.uk
-publishingDomainSuffix: publishing.service.gov.uk
-assetsDomain: assets.publishing.service.gov.uk
+externalDomainSuffix: production.publishing.service.gov.uk
+publishingDomainSuffix: production.publishing.service.gov.uk
+assetsDomain: assets.production.publishing.service.gov.uk
 
-# TODO: Remove once fully migrated to EKS
-k8sExternalDomainSuffix: eks.production.govuk.digital
-k8sPublishingDomainSuffix: eks.production.govuk.digital
 k8sAssetsDomain: assets-eks.production.publishing.service.gov.uk
+k8sExternalDomainSuffix: eks.production.govuk.digital
+# TODO: Remove once fully migrated to EKS
+k8sPublishingDomainSuffix: eks.production.govuk.digital
 
-cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
+cspReportURI: https://csp-reporter.production.publishing.service.gov.uk/report
 
 replicaCount: 3
 workerReplicaCount: 3
@@ -38,11 +38,84 @@ alb-ingress-backend-waf-ruleset: &alb-ingress-backend-waf-ruleset
 # apps.
 
 govukApplications:
+- name: account-api
+  helmValues:
+    uploadAssets:
+      enabled: false
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: account-api
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
+          access_logs.s3.prefix=elb/asset-manager-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &assets-lb-conditions >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "account-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: account-api.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: account-api-postgres
+            key: DATABASE_URL
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-account-api-email-alert-api
+            key: bearer_token
+      - name: GOVUK_ACCOUNT_OAUTH_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: govuk-account-oauth
+            key: GOVUK_ACCOUNT_OAUTH_CLIENT_ID
+      - name: GOVUK_ACCOUNT_OAUTH_PRIVATE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: govuk-account-oauth
+            key: GOVUK_ACCOUNT_OAUTH_PRIVATE_KEY
+      - name: GOVUK_ACCOUNT_OAUTH_PROVIDER_URI
+        valueFrom:
+          secretKeyRef:
+            name: govuk-account-oauth
+            key: GOVUK_ACCOUNT_OAUTH_PROVIDER_URI
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: account-api-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: 6074fdc2-03b3-4bb6-83fe-31220779c13b
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-account-api-publishing-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-account-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-account-api
+            key: oauth_secret
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
 - name: asset-manager
   chartPath: charts/asset-manager
   helmValues:
-    # TODO: Re-enable eventually when we want to support publishing assets in Production.
-    # workerEnabled: true
+    workerEnabled: true
     ingress:
       enabled: true
       annotations:
@@ -51,14 +124,31 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
-        alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
-        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.k8sAssetsDomain }}"]}}]
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
+          access_logs.s3.prefix=elb/assets-origin-eks
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &assets-lb-conditions >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "{{ .Values.assetsDomain }}",
+              "{{ .Values.k8sAssetsDomain }}",
+              "assets-origin.{{ .Values.publishingDomainSuffix }}",
+              "draft-assets.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
       hosts:
-        - name: assets-origin.eks.production.govuk.digital
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           paths:
             - path: /government/uploads/
+            - path: /government/assets/
             - path: /media/
+            - path: /auth/gds  # Viewing assets requires user auth.
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          paths:
+            - path: /government/uploads/
+            - path: /government/assets/
+            - path: /media/
+            - path: /auth/gds  # Viewing assets requires user auth.
     assetManagerNFS: &assets-nfs assets.blue.production.govuk-internal.digital
     nginxConfigMap:
       create: false
@@ -76,8 +166,6 @@ govukApplications:
           secretKeyRef:
             name: signon-app-asset-manager
             key: oauth_secret
-      - name: GOVUK_ASSET_ROOT  # testing in isolation
-        value: https://assets.publishing.service.gov.uk
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:
@@ -98,14 +186,93 @@ govukApplications:
 - name: argo-services
   chartPath: charts/argo-services
   postSyncWorkflowEnabled: "false"
-  # TODO: Handle case where production doesn't promote deployments
   helmValues:
     nextEnvironment: ""
     enableWebhookIngress: true
 
+- name: authenticating-proxy
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: draft-origin
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "draft-origin.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: draft-origin.{{ .Values.k8sExternalDomainSuffix }}
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-postgres
+            key: DATABASE_URL
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-preview
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-preview
+            key: oauth_secret
+      - name: GOVUK_UPSTREAM_URI
+        value: "http://draft-router"
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+
+- name: bouncer
+  helmValues:
+    rails:
+      enabled: false
+    uploadAssets:
+      enabled: false
+    ingress:
+      enabled: true
+      tls: {}
+      annotations:
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+        alb.ingress.kubernetes.io/healthcheck-path: /readyz
+        alb.ingress.kubernetes.io/load-balancer-name: bouncer
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        external-dns.alpha.kubernetes.io/hostname: bouncer.{{ .Values.k8sExternalDomainSuffix }}
+      rules:
+        - http:  # Match all hostnames.
+            paths:
+              - path: "/"
+                pathType: Prefix
+                backend:
+                  service:
+                    name: bouncer
+                    port:
+                      number: 80
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: bouncer-postgres
+            key: DATABASE_URL
+    nginxConfigMap:
+      extraServerConf: |
+        # TODO: Find out which council is using this and ask them to update.
+        location /eff/action/worldPayCallback {
+          proxy_pass https://www.gov.uk/apply-for-a-licence/payment/worldpayCallback;
+        }
+
 - name: collections
   helmValues:
-    replicaCount: 4
     appResources:
       limits:
         cpu: 2
@@ -122,9 +289,537 @@ govukApplications:
             name: signon-token-collections-email-alert-api
             key: bearer_token
 
+- name: draft-collections
+  repoName: collections
+  helmValues:
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-email-alert-api
+            key: bearer_token
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+
+- name: cache-clearing-service
+  helmValues:
+    uploadAssets:
+      enabled: false
+    dbMigrationEnabled: false
+    rails:
+      enabled: false
+    appEnabled: false
+    workerEnabled: true
+    workers:
+      - command: ["rake", "message_queue:consumer", "QUEUE=high"]
+        name: high
+      - command: ["rake", "message_queue:consumer", "QUEUE=medium"]
+        name: medium
+      - command: ["rake", "message_queue:consumer", "QUEUE=low"]
+        name: low
+    extraEnv:
+      - name: RABBITMQ_URL
+        valueFrom:
+          secretKeyRef:
+            name: cache-clearing-service-rabbitmq
+            key: RABBITMQ_URL
+
+- name: collections-publisher
+  helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: collections-publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "collections-publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: collections-publisher.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-collections-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-collections-publisher
+            key: oauth_secret
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-link-checker-api
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-publishing-api
+            key: bearer_token
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: collections-publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: &publishing-notify-template 112842bb-d8a4-4511-90de-57dc5c8f27ec
+      - name: PUBLISH_WITHOUT_2I_EMAIL
+        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: collections-publisher-mysql
+            key: DATABASE_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: contacts-admin
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: contacts-admin
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "contacts-admin.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: contacts-admin.{{ .Values.k8sExternalDomainSuffix }}
+    cronTasks:
+      - name: org-import
+        task: "organisations:import"
+        schedule: "0 3 * * *"
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: contacts-admin-mysql
+            key: DATABASE_URL
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-contacts
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-contacts
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-contacts-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: content-data-admin
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: content-data-admin
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "content-data.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: content-data.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
+    workerEnabled: true
+    extraEnv:
+      - name: CONTENT_DATA_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-data-admin-content-data-api
+            key: bearer_token
+      # These GA/GTM values are not secrets (not even the the gtm_auth one).
+      # https://github.com/alphagov/govuk-puppet/pull/8041
+      - name: GOOGLE_TAG_MANAGER_AUTH
+        value: xcAlGBhKTIeO6y_JhmEapQ
+      - name: GOOGLE_TAG_MANAGER_ID
+        value: GTM-NZG8SF2
+      - name: GOOGLE_TAG_MANAGER_PREVIEW
+        value: env-5
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-data
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-data
+            key: oauth_secret
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: content-data-admin-aws
+            key: access_key
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: content-data-admin-aws
+            key: secret_key
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: AWS_CSV_EXPORT_BUCKET_NAME
+        value: govuk-production-content-data-csvs
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: content-data-admin-postgres
+            key: DATABASE_URL
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: content-data-admin-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: content-data-api
+  helmValues:
+    uploadAssets:
+      enabled: false
+    dbMigrationEnabled: true
+    workerEnabled: true
+    workers:
+      - command: ["sidekiq", "-C", "config/sidekiq.yml"]
+        name: worker
+      - command: ['rake', 'publishing_api:consumer']
+        name: publishing-api-consumer
+      - command: ['rake', 'publishing_api:bulk_import_consumer']
+        name: bulk-import-publishing-api-consumer
+    nginxProxyReadTimeout: 60s
+    extraEnv:
+      - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-google-analytics
+            key: view-id
+      - name: GOOGLE_CLIENT_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-google-analytics
+            key: client-email
+      - name: GOOGLE_PRIVATE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-google-analytics
+            key: private-key
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-data-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-data-api
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-data-api-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-postgres
+            key: DATABASE_URL
+      - name: SUPPORT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-data-api-support-api
+            key: bearer_token
+      - name: RABBITMQ_URL
+        valueFrom:
+          secretKeyRef:
+            name: content-data-api-rabbitmq
+            key: RABBITMQ_URL
+      - name: RABBITMQ_QUEUE
+        value: content_data_api
+      - name: RABBITMQ_QUEUE_BULK
+        value: content_data_api_govuk_importer
+      - name: RABBITMQ_QUEUE_DEAD
+        value: content_data_api_dead_letter_queue
+
+- name: content-publisher
+  helmValues:
+    dbMigrationEnabled: true
+    nginxClientMaxBodySize: &max-upload-size 500M
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: content-publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "content-publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: content-publisher.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: AWS_REGION  # TODO: consider moving this to cm/govuk-apps-env?
+        value: eu-west-1
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-publisher-asset-manager
+            key: bearer_token
+      - name: AWS_S3_BUCKET
+        value: govuk-production-content-publisher-activestorage
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: content-publisher-postgres
+            key: DATABASE_URL
+      - name: EMAIL_ADDRESS_OVERRIDE
+        value: content-publisher-notifications-production@digital.cabinet-office.gov.uk
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-publisher
+            key: oauth_secret
+      # These GTM values are not secrets (not even the the gtm_auth one).
+      # https://github.com/alphagov/govuk-puppet/pull/8041
+      - name: GOOGLE_TAG_MANAGER_ID
+        value: &static-gtm-id GTM-NQXC4TG
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: content-publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-publisher-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: WHITEHALL_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-publisher-whitehall
+            key: bearer_token
+
+- name: content-store
+  helmValues: &content-store
+    replicaCount: 6
+    cronTasks:
+      - name: report-delays
+        task: "publishing_delay_report:report_delays"
+        schedule: "15 2 * * *"
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-store-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_secret
+      - name: DEFAULT_TTL
+        value: "300"
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          mongo-1.production.govuk-internal.digital,\
+          mongo-2.production.govuk-internal.digital,\
+          mongo-3.production.govuk-internal.digital/content_store_production"
+      # TODO: remove this flag and feature after launch (see https://github.com/alphagov/content-store/blob/4c6e16a9/app/models/route_set.rb#L70)
+      - name: NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH
+        value: "1"
+
+- name: draft-content-store
+  repoName: content-store
+  helmValues:
+    <<: *content-store
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    extraEnv:
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-draft-content-store-draft-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-content-store
+            key: oauth_secret
+      - name: DEFAULT_TTL
+        value: "1"
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          mongo-1.production.govuk-internal.digital,\
+          mongo-2.production.govuk-internal.digital,\
+          mongo-3.production.govuk-internal.digital/draft_content_store_production"
+      - name: NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH
+        value: "1"
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+
+- name: content-tagger
+  helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: content-tagger
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "content-tagger.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: content-tagger.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-tagger
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-tagger
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-tagger-publishing-api
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-tagger-email-alert-api
+            key: bearer_token
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: content-tagger-postgres
+            key: DATABASE_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: email-alert-api
+  helmValues:
+    dbMigrationEnabled: true
+    uploadAssets:
+      enabled: false
+    workerEnabled: true
+    extraEnv:
+      - name: ACCOUNT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-email-alert-api-account-api
+            key: bearer_token
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-api-postgres
+            key: DATABASE_URL
+      - name: EMAIL_ALERT_AUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-auth
+            key: token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-email-alert-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-email-alert-api
+            key: oauth_secret
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-api-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: &frontend-notify-template 2844a647-6bf1-4b01-a25c-569d2cc00849
+      - name: GOVUK_NOTIFY_RECIPIENTS
+        value: email-alert-api-production@digital.cabinet-office.gov.uk
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: WEB_CONCURRENCY
+        value: '10'
+    nginxConfigMap:
+      # TODO: consider using WAF for this instead of nginx.
+      extraHttpConf: |
+        limit_req_zone $binary_remote_addr zone=email_alert_api_public:1M rate=50r/s;
+        limit_req_status 429;
+      extraServerConf: |
+        location ~ ^/(status-updates|spam-reports)(/|$) {
+          limit_req zone=email_alert_api_public burst=20 nodelay;
+          proxy_pass http://email-alert-api;
+        }
+
 - name: email-alert-frontend
   helmValues:
     extraEnv:
+      - name: SUBSCRIPTION_MANAGEMENT_ENABLED
+        value: "yes"
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: ACCOUNT_API_BEARER_TOKEN
@@ -148,6 +843,33 @@ govukApplications:
             name: email-alert-auth
             key: token
 
+- name: email-alert-service
+  helmValues:
+    appEnabled: false
+    rails:
+      enabled: false
+    uploadAssets:
+      enabled: false
+    workerEnabled: true
+    workers:
+      - command: ['bin/email-alert-service']
+        name: email-alert-service
+    extraEnv:
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-email-alert-service-email-alert-api
+            key: bearer_token
+      - name: GOVUK_PROMETHEUS_EXPORTER
+        value: force
+      - name: RABBITMQ_URL
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-service-rabbitmq
+            key: RABBITMQ_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
 - name: external-secrets
   chartPath: charts/external-secrets
   postSyncWorkflowEnabled: "false"
@@ -156,13 +878,13 @@ govukApplications:
   helmValues:
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-        value: b5baae45-0a68-4b63-91a1-66b05640d27e
+        value: d33f7857-7514-4458-81b9-0995f48e2ac5
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
-        value: ceefedd7-3214-4774-8b57-f27c89aac90d
+        value: b67971ed-a249-4afa-b05e-9adad9da551a
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
-        value: e8b2d8a6-db5f-4346-9fbd-49b16b531e1c
+        value: d1f54751-80a8-420a-9077-d34c7d6cc734
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
-        value: 54168fa9-3946-4860-a2f8-27ddbb14babe
+        value: 8a8d98c0-42c8-4f56-b61f-77c89417a171
       - name: SUPPORT_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -201,11 +923,6 @@ govukApplications:
 
 - name: finder-frontend
   helmValues:
-    cronTasks:
-      - name: registries-refresh
-        task: "registries:cache_refresh"
-        schedule: "15 * * * *"
-    replicaCount: 4
     appResources:
       limits:
         cpu: 4
@@ -213,20 +930,23 @@ govukApplications:
       requests:
         cpu: 2
         memory: 2000Mi
+    cronTasks:
+      - name: registries-refresh
+        task: "registries:cache_refresh"
+        schedule: "15 * * * *"
     extraEnv:
-      - name: MEMCACHE_SERVERS
-        value: frontend-memcached-govuk.eks.production.govuk-internal.digital
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
             name: signon-token-finder-frontend-email-alert-api
             key: bearer_token
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.production.govuk-internal.digital
       - name: WEB_CONCURRENCY
         value: '4'
 
 - name: frontend
   helmValues:
-    replicaCount: 4
     appResources:
       limits:
         cpu: 4
@@ -236,11 +956,51 @@ govukApplications:
         memory: 1Gi
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
-        value: cb633abc-6ae6-4843-ae6f-82ca500b6de2
+        value: *frontend-notify-template
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+      - name: ACCOUNT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-account-api
+            key: bearer_token
+      - name: ELECTIONS_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: frontend-elections-api
+            key: key
+      - name: ELECTIONS_API_URL
+        valueFrom:
+          secretKeyRef:
+            name: frontend-elections-api
+            key: url
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-email-alert-api
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-publishing-api
+            key: bearer_token
       - name: WEB_CONCURRENCY
         value: '4'
+
+- name: draft-frontend
+  repoName: frontend
+  helmValues:
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *frontend-notify-template
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
       - name: ACCOUNT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -269,7 +1029,6 @@ govukApplications:
 
 - name: government-frontend
   helmValues:
-    replicaCount: 6
     appResources:
       limits:
         cpu: 2
@@ -280,6 +1039,94 @@ govukApplications:
     extraEnv:
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+
+- name: draft-government-frontend
+  repoName: government-frontend
+  helmValues:
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+
+- name: hmrc-manuals-api
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: hmrc-manuals-api
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "hmrc-manuals-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: hmrc-manuals-api.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 300s
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
+        value: "1"
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-hmrc-manuals-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-hmrc-manuals-api
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-hmrc-manuals-api-publishing-api
+            key: bearer_token
+      - name: PUBLISH_TOPICS
+        value: "1"
+
+- name: imminence
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: imminence
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "imminence.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
+    workerEnabled: true
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: imminence-postgres
+            key: DATABASE_URL
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-imminence
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-imminence
+            key: oauth_secret
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: info-frontend
 
 - name: licencefinder
   repoName: licence-finder
@@ -292,7 +1139,7 @@ govukApplications:
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
       - name: ELASTICSEARCH_URI
-        value: "https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com"
+        value: &elasticsearch-uri https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com
       - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
         value: "mongodb://\
           mongo-1.production.govuk-internal.digital,\
@@ -304,6 +1151,441 @@ govukApplications:
             name: signon-token-licence-finder-publishing-api
             key: bearer_token
 
+- name: link-checker-api
+  helmValues:
+    dbMigrationEnabled: true
+    uploadAssets:
+      enabled: false
+    workerEnabled: true
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-link-checker-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-link-checker-api
+            key: oauth_secret
+      - name: GOOGLE_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: link-checker-api-google-api-key
+            key: GOOGLE_API_KEY
+      - name: GOVUK_BASIC_AUTH_CREDENTIALS
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: password
+      - name: GOVUK_USER
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: username
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: link-checker-api-postgres
+            key: DATABASE_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: local-links-manager
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: local-links-manager
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "local-links-manager.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: local-links-manager.{{ .Values.k8sExternalDomainSuffix }}
+    cronTasks:
+      - name: import-interact
+        task: "import:service_interactions:import_all"
+        schedule: "0 1 * * *"
+      - name: check-links
+        task: "check-links"
+        schedule: "0 2 * * *"
+      - name: export-links
+        task: "export:links:s3"
+        schedule: "0 3 * * *"
+      - name: import-ga
+        task: "import:google_analytics"
+        schedule: "0 5 * * *"
+      - name: export-ga-bad-links
+        task: "export:google_analytics:bad_links"
+        schedule: "0 6 * * *"
+    dbMigrationEnabled: true
+    extraEnv:
+      - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-google
+            key: govuk-view-id
+      - name: GOOGLE_CLIENT_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-google
+            key: client-email
+      - name: GOOGLE_EXPORT_ACCOUNT_ID
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-google
+            key: export-account-id
+      - name: GOOGLE_EXPORT_CUSTOM_DATA_IMPORT_SOURCE_ID
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-google
+            key: export-custom-data-import-source-id
+      - name: GOOGLE_EXPORT_TRACKER_ID
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-google
+            key: export-tracker-id
+      - name: GOOGLE_PRIVATE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-google
+            key: private-key
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-local-links-manager
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-local-links-manager
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-local-links-manager-publishing-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-local-links-manager-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: RUN_LINK_GA_EXPORT
+        value: "false"
+      - name: AWS_S3_ASSET_BUCKET_NAME
+        value: "govuk-app-assets-production"
+      - name: AWS_REGION
+        value: "eu-west-1"
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: local-links-manager-postgres
+            key: DATABASE_URL
+    nginxConfigMap:
+      extraServerConf: |
+        location /data {
+          proxy_set_header   Authorization "";
+          proxy_set_header   Connection "";
+          proxy_set_header   X-Real-IP $remote_addr;  # TODO: pass the actual end-client address
+          proxy_hide_header  x-amz-id-2;
+          proxy_hide_header  x-amz-meta-server-side-encryption;
+          proxy_hide_header  x-amz-request-id;
+          proxy_hide_header  x-amz-server-side-encryption;
+          proxy_hide_header  x-amz-version-id;
+          add_header         Cache-Control "public, max-age=3600";
+          proxy_intercept_errors on;
+          proxy_pass         https://govuk-app-assets-production.s3.eu-west-1.amazonaws.com/data/local-links-manager;
+        }
+
+- name: locations-api
+  helmValues:
+    uploadAssets:
+      enabled: false
+    dbMigrationEnabled: true
+    workerEnabled: true
+    extraEnv:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: locations-api-postgres
+            key: DATABASE_URL
+      - name: OS_PLACES_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: locations-api-os-places
+            key: api-key
+      - name: OS_PLACES_API_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: locations-api-os-places
+            key: api-secret
+      - name: OS_PLACES_API_POSTCODES_PER_SECOND
+        value: "1"
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: manuals-publisher
+  helmValues:
+    nginxClientMaxBodySize: *max-upload-size
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: manuals-publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "manuals-publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: manuals-publisher.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-asset-manager
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-email-alert-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-manuals-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-manuals-publisher
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-publishing-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-manuals-publisher-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: manuals-publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: manuals-publisher-docdb
+            key: MONGODB_URI
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: maslow
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: maslow
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "maslow.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: maslow.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-maslow
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-maslow
+            key: oauth_secret
+      - name: MEMCACHE_SERVERS
+        value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-maslow-publishing-api
+            key: bearer_token
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: maslow-docdb
+            key: MONGODB_URI
+
+- name: publisher
+  helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: false
+    cronTasks:
+      - name: reports-generate
+        task: "reports:generate"
+        schedule: "0 * * * *"
+      - name: mail-fetcher
+        command: "script/mail_fetcher"
+        schedule: "*/5 * * * *"
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: publisher.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publisher
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publisher-asset-manager
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publisher-publishing-api
+            key: bearer_token
+      - name: FACT_CHECK_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: publisher-fact-check-email-account
+            key: FACT_CHECK_USERNAME
+      - name: FACT_CHECK_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: publisher-fact-check-email-account
+            key: FACT_CHECK_PASSWORD
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publisher-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: publisher-docdb
+            key: MONGODB_URI
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: EMAIL_GROUP_BUSINESS
+        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_CITIZEN
+        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_DEV
+        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+      - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
+        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+      - name: FACT_CHECK_REPLY_TO_ADDRESS
+        value: govuk-fact-check-production@digital.cabinet-office.gov.uk
+      - name: FACT_CHECK_REPLY_TO_ID
+        value: 88f713ff-7de0-43a6-8221-8721bedd103c
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+
+- name: publishing-api
+  helmValues:
+    dbMigrationEnabled: true
+    uploadAssets:
+      enabled: false
+    workerEnabled: true
+    cronTasks:
+      - name: events-export
+        task: "events:export_to_s3"
+        schedule: "38 5 * * 0"
+      - name: heartbeat
+        task: "heartbeat_messages:send"
+        schedule: "*/4 * * * *"
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publishing-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-publishing-api
+            key: oauth_secret
+      - name: CONTENT_STORE_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-content-store
+            key: bearer_token
+      - name: DRAFT_CONTENT_STORE_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-draft-content-store
+            key: bearer_token
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-publishing-api-router-api
+            key: bearer_token
+      - name: RABBITMQ_URL
+        valueFrom:
+          secretKeyRef:
+            name: publishing-api-rabbitmq
+            key: RABBITMQ_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: EVENT_LOG_AWS_BUCKETNAME
+        value: govuk-publishing-api-event-log-production
+      - name: GOVUK_CONTENT_SCHEMAS_PATH
+        value: /app/content_schemas
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: publishing-api-postgres
+            key: DATABASE_URL
+
 - name: release
   helmValues:
     dbMigrationEnabled: true
@@ -313,8 +1595,12 @@ govukApplications:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-backend-waf-ruleset
         alb.ingress.kubernetes.io/load-balancer-name: release
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "release.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
       hosts:
-        - name: release.eks.production.govuk.digital
+        - name: release.{{ .Values.k8sExternalDomainSuffix }}
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -342,12 +1628,64 @@ govukApplications:
             name: release-github
             key: token
 
+- name: router-api
+  helmValues: &router-api
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.production.govuk-internal.digital
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-router-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-router-api
+            key: oauth_secret
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          router-backend-1,\
+          router-backend-2,\
+          router-backend-3/router"
+
+- name: draft-router-api
+  repoName: router-api
+  helmValues:
+    <<: *router-api
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-router-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-router-api
+            key: oauth_secret
+      - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
+        value: "mongodb://\
+          router-backend-1,\
+          router-backend-2,\
+          router-backend-3/draft_router"
+
 - name: router
   helmValues:
     rails:
       enabled: false
     uploadAssets:
       enabled: false
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.production.govuk-internal.digital
     appResources:
       limits:
         cpu: 3
@@ -355,9 +1693,6 @@ govukApplications:
       requests:
         cpu: 2
         memory: 1Gi
-    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-      searches:
-        - blue.production.govuk-internal.digital
     ingress:
       enabled: true
       annotations:
@@ -365,11 +1700,18 @@ govukApplications:
         <<: *alb-ingress-www-waf-ruleset
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-name: www-origin
-        alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/www-origin-eks
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
+          access_logs.s3.prefix=elb/www-origin-eks
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["www.{{ .Values.externalDomainSuffix }}", "www.{{ .Values.k8sExternalDomainSuffix }}"]}}]
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "www.{{ .Values.externalDomainSuffix }}",
+              "www-origin.{{ .Values.publishingDomainSuffix }}",
+              "www.{{ .Values.k8sExternalDomainSuffix }}"
+          ]}}]
       hosts:
-        - name: www-origin.eks.production.govuk.digital
+        - name: www-origin.{{ .Values.k8sExternalDomainSuffix }}
     nginxConfigMap:
       create: false
       name: live-router-nginx-conf
@@ -377,6 +1719,12 @@ govukApplications:
       - name: live-router-nginx-conf
         mountPath: /usr/share/nginx/html/robots.txt
         subPath: robots.txt
+      - name: router-nginx-htpasswd
+        mountPath: /etc/nginx/htpasswd
+    extraVolumes:
+      - name: router-nginx-htpasswd
+        secret:
+          secretName: router-nginx-htpasswd
     appProbes: &router-app-probes
       startupProbe: &router-probe
         httpGet:
@@ -411,7 +1759,7 @@ govukApplications:
       - name: BACKEND_URL_collections
         value: "http://collections"
       - name: BACKEND_URL_content-store
-        value: "https://content-store.production.govuk-internal.digital"
+        value: "http://content-store"
       - name: BACKEND_URL_email-alert-frontend
         value: "http://email-alert-frontend"
       - name: BACKEND_URL_frontend
@@ -426,9 +1774,8 @@ govukApplications:
         value: "http://static"
       - name: BACKEND_URL_whitehall-frontend
         value: "http://whitehall-frontend"
-        # TODO: switch back to in-cluster account-api once it's fully working (similarly for draft).
       - name: BACKEND_URL_account-api
-        value: "https://account-api.production.govuk-internal.digital"
+        value: "http://account-api"
       - name: BACKEND_URL_feedback
         value: "http://feedback"
       - name: BACKEND_URL_finder-frontend
@@ -439,15 +1786,288 @@ govukApplications:
         value: "http://licencefinder"
       - name: BACKEND_URL_licensify
         value: "https://licensify.production.govuk-internal.digital"
-        # TODO: switch back to in-cluster search-api once it's fully working (similarly for draft).
       - name: BACKEND_URL_search-api
-        value: "https://search-api.production.govuk-internal.digital"
+        value: "http://search-api"
+
+- name: draft-router
+  repoName: router
+  helmValues:
+    rails:
+      enabled: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    uploadAssets:
+      enabled: false
+    dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
+      searches:
+        - blue.production.govuk-internal.digital
+    appProbes: *router-app-probes
+    nginxConfigMap:
+      create: false
+      name: draft-router-nginx-conf
+    extraEnv:
+      - name: ROUTER_PUBADDR
+        value: ":3000"
+      - name: ROUTER_APIADDR
+        value: ":9394"
+      - name: ROUTER_MONGO_URL  # Hostnames should match those shown in MongoDB rs.status().
+        value: *router_mongo_hosts
+      - name: ROUTER_MONGO_DB
+        value: draft_router
+      - name: BACKEND_URL_collections
+        value: "http://draft-collections"
+      - name: BACKEND_URL_content-store
+        value: "http://draft-content-store"
+      - name: BACKEND_URL_email-alert-frontend
+        value: "http://draft-email-alert-frontend"
+      - name: BACKEND_URL_frontend
+        value: "http://draft-frontend"
+      - name: BACKEND_URL_government-frontend
+        value: "http://draft-government-frontend"
+      - name: BACKEND_URL_service-manual-frontend
+        value: "http://draft-service-manual-frontend"
+      - name: BACKEND_URL_smartanswers
+        value: "http://draft-smartanswers"
+      - name: BACKEND_URL_static
+        value: "http://draft-static"
+      - name: BACKEND_URL_whitehall-frontend
+        value: "http://whitehall-frontend"  # There is no draft version whitehall frontend
+      - name: BACKEND_URL_account-api
+        value: "http://account-api"
+      - name: BACKEND_URL_feedback
+        value: "http://feedback"
+      - name: BACKEND_URL_finder-frontend
+        value: "http://finder-frontend"
+      - name: BACKEND_URL_info-frontend
+        value: "http://info-frontend"
+      - name: BACKEND_URL_licencefinder
+        value: "http://licencefinder"
+      - name: BACKEND_URL_licensify
+        value: "https://licensify.production.govuk-internal.digital"
+      - name: BACKEND_URL_search-api
+        value: "http://search-api"
+
+- name: search-admin
+  helmValues:
+    dbMigrationEnabled: true
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: search-admin
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "search-admin.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: search-admin.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-search-admin
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-search-admin
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-search-admin-publishing-api
+            key: bearer_token
+      - name: RUMMAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-search-admin-search-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: search-admin-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: search-admin-mysql
+            key: DATABASE_URL
+
+- name: search-api
+  helmValues:
+    rails:
+      enabled: false
+    nginxClientMaxBodySize: 20M
+    uploadAssets:
+      enabled: false
+    workerEnabled: true
+    cronTasks:
+      - name: generate-sitemap
+        task: "sitemap:generate_and_upload"
+        schedule: "50 2 * * *"
+    workers:
+      - command: ["sidekiq", "-C", "config/sidekiq.yml"]
+        name: worker
+      - command: ['rake', 'message_queue:listen_to_publishing_queue']
+        name: publishing-queue-listener
+      - command: ['rake', 'message_queue:insert_data_into_govuk']
+        name: govuk-index-queue-listener
+      - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
+        name: bulk-reindex-queue-listener
+    extraEnv:
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: AWS_S3_RELEVANCY_BUCKET_NAME
+        value: govuk-production-search-relevancy
+      - name: AWS_S3_SITEMAPS_BUCKET_NAME
+        value: govuk-production-sitemaps
+      - name: ELASTICSEARCH_URI
+        value: *elasticsearch-uri
+      - name: ENABLE_LTR
+        value: "true"
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-search-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-search-api
+            key: oauth_secret
+      - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-analytics
+            key: govuk-view-id
+      - name: GOOGLE_CLIENT_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-analytics
+            key: client-email
+      - name: GOOGLE_EXPORT_ACCOUNT_ID
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-analytics
+            key: export-account-id
+      - name: GOOGLE_EXPORT_CUSTOM_DATA_SOURCE_ID
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-analytics
+            key: export-custom-data-source-id
+      - name: GOOGLE_EXPORT_WEB_PROPERTY_ID
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-analytics
+            key: export-web-property-id
+      - name: GOOGLE_PRIVATE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-analytics
+            key: private-key
+      - name: GOOGLE_BIGQUERY_CREDENTIALS
+        valueFrom:
+          secretKeyRef:
+            name: search-api-google-bigquery
+            key: credentials
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-search-api-publishing-api
+            key: bearer_token
+      - name: RABBITMQ_URL
+        valueFrom:
+          secretKeyRef:
+            name: search-api-rabbitmq
+            key: RABBITMQ_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: TENSORFLOW_SAGEMAKER_ENDPOINT
+        value: govuk-production-search-ltr-endpoint
 
 - name: service-manual-frontend
 
+- name: draft-service-manual-frontend
+  repoName: service-manual-frontend
+  helmValues:
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+
+- name: service-manual-publisher
+  helmValues:
+    dbMigrationEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: service-manual-publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "service-manual-publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: service-manual-publisher.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-service-manual-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-service-manual-publisher
+            key: oauth_secret
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-service-manual-publisher-asset-manager
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-service-manual-publisher-publishing-api
+            key: bearer_token
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: service-manual-publisher-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: service-manual-publisher-postgres
+            key: DATABASE_URL
+      - name: HTTP_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: username
+      - name: HTTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: password
+
 - name: signon
   helmValues:
-    dbMigrationEnabled: false  # TODO: Enable before launch.
+    dbMigrationEnabled: true
     workerEnabled: true
     ingress:
       enabled: true
@@ -456,9 +2076,12 @@ govukApplications:
         <<: *alb-ingress-backend-waf-ruleset
         alb.ingress.kubernetes.io/load-balancer-name: signon
         alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "signon.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
       hosts:
-        - name: signon.eks.production.govuk.digital
-    workerReplicaCount: 1
+        - name: signon.{{ .Values.k8sExternalDomainSuffix }}
     cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
@@ -468,16 +2091,15 @@ govukApplications:
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
         schedule: "5 1 * * *"
         serviceAccount: signon
-      - name: "delete-event-logs"
+      - name: "delete-logs-older-than-two-years"
         task: "event_log:delete_logs_older_than_two_years"
         schedule: "15 1 * * *"
+        serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
-        value: e00e89f5-b622-4dcb-8f30-e6c70231a940
+        value: *publishing-notify-template
       - name: INSTANCE_NAME
         value: production
-      - name: REDIS_URL
-        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
         valueFrom:
           secretKeyRef:
@@ -503,8 +2125,10 @@ govukApplications:
           secretKeyRef:
             name: signon-devise-secret
             key: DEVISE_SECRET_KEY
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: SIGNON_APPS_URI_SUB_PATTERN
-        value: publishing.service.gov.uk
+        value: production.publishing.service.gov.uk
       - name: SIGNON_APPS_URI_SUB_REPLACEMENT
         value: eks.production.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD
@@ -512,8 +2136,6 @@ govukApplications:
           secretKeyRef:
             name: signon-auth-token
             key: token
-
-- name: info-frontend
 
 - name: smartanswers
   repoName: smart-answers
@@ -551,9 +2173,6 @@ govukApplications:
   helmValues:
     uploadStaticErrorPagesEnabled: true
     ingress:
-      hosts:
-        - name: assets-origin.eks.production.govuk.digital
-          path: /
       enabled: true
       annotations:
         <<: *default-alb-ingress-annotations
@@ -561,13 +2180,19 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '30'
-        alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
-        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.k8sAssetsDomain }}"]}}]
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /
     extraEnv:
-      # These GA/GTM values are not secrets.
+      # These GA/GTM values are not secrets (not even the the gtm_auth one).
+      # https://github.com/alphagov/govuk-puppet/pull/8041
       - name: GA_UNIVERSAL_ID
-        value: &ga-universal-id UA-26179049-1
+        value: &ga-universal-id UA-26179049-20
       - name: GOOGLE_TAG_MANAGER_ID
         value: &static-gtm-id GTM-MG7HG5W
       - name: PUBLISHING_API_BEARER_TOKEN
@@ -591,28 +2216,427 @@ govukApplications:
           return 200 'google-site-verification: googlec908b3bc32386239.html';
         }
 
-- name: whitehall-frontend
-  repoName: whitehall
+- name: draft-static
+  repoName: static
+  helmValues:
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: DRAFT_ENVIRONMENT
+        value: "1"
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+      - name: GA_UNIVERSAL_ID
+        value: *ga-universal-id
+      - name: GOOGLE_TAG_MANAGER_ID
+        value: *static-gtm-id
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-static-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: USE_TMPDIR_PAGE_CACHE
+        value: "true"
+
+- name: short-url-manager
   helmValues:
     ingress:
-      hosts:
-        - name: assets-origin.eks.production.govuk.digital
-          path: /government/placeholder/
-        - name: assets-origin.eks.production.govuk.digital
-          path: /assets/whitehall/
-        - name: assets-origin.eks.production.govuk.digital
-          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-          pathType: ImplementationSpecific
       enabled: true
       annotations:
         <<: *default-alb-ingress-annotations
-        <<: *alb-ingress-www-waf-ruleset
-        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
-        alb.ingress.kubernetes.io/group.name: assets-origin
-        alb.ingress.kubernetes.io/group.order: '10'
-        alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-production-aws-logging,access_logs.s3.prefix=elb/assets-origin-eks
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: short-url-manager
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field":"host-header","hostHeaderConfig":{"values":["{{ .Values.assetsDomain }}", "{{ .Values.k8sAssetsDomain }}"]}}]
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "short-url-manager.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: short-url-manager.{{ .Values.k8sExternalDomainSuffix }}
+    cronTasks:
+      - name: organisations-import
+        task: "organisations:import"
+        schedule: "0 4 * * *"
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-short-url-manager
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-short-url-manager
+            key: oauth_secret
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: short-url-manager-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: INSTANCE_NAME
+        value: production
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: short-url-manager-docdb
+            key: MONGODB_URI
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-short-url-manager-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: specialist-publisher
+  helmValues:
+    nginxClientMaxBodySize: *max-upload-size
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: specialist-publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "specialist-publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 30s
+    extraEnv:
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-specialist-publisher-asset-manager
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-specialist-publisher-email-alert-api
+            key: bearer_token
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-specialist-publisher-publishing-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-specialist-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-specialist-publisher
+            key: oauth_secret
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: specialist-publisher-aws
+            key: access_key
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: specialist-publisher-aws
+            key: secret_key
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-production-specialist-publisher-csvs
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: specialist-publisher-docdb
+            key: MONGODB_URI
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: support-api-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+    nginxConfigMap:
+      extraServerConf: |
+        client_max_body_size 500M;
+
+        # Extended timeout to allow the processing of large attachments
+        location ~* attachments {
+          proxy_read_timeout 30s;
+          proxy_pass http://specialist-publisher;
+        }
+
+- name: support
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: support
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "support.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: support.{{ .Values.k8sExternalDomainSuffix }}
+    uploadAssets:
+      path: /app/public/assets/support
+    workerEnabled: true
+    extraEnv:
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-production-support-api-csvs
+      - name: EMERGENCY_CONTACT_DETAILS
+        valueFrom:
+          secretKeyRef:
+            name: support-emergency-contacts
+            key: emergency_contacts
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-support
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-support
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-support-publishing-api
+            key: bearer_token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: SUPPORT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-support-support-api
+            key: bearer_token
+      - name: ZENDESK_CLIENT_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: support-zendesk
+            key: username
+      - name: ZENDESK_CLIENT_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: support-zendesk
+            key: password
+      - name: ZENDESK_ANONYMOUS_TICKET_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: support-zendesk
+            key: ticket_email
+
+- name: support-api
+  helmValues:
+    dbMigrationEnabled: true
+    uploadAssets:
+      enabled: false
+    workerEnabled: true
+    cronTasks:
+      - name: feedback-deduplication-nightly
+        task: "anonymous_feedback_deduplication:nightly"
+        schedule: "10 0 * * *"
+      - name: import-organisations
+        task: "api_sync:import_organisations"
+        schedule: "20 0 * * *"
+      - name: service-feedback-aggregation
+        task: "service_feedback_aggregation:daily"
+        schedule: "30 0 * * *"
+      - name: feedback-deduplication-recent
+        task: "anonymous_feedback_deduplication:recent"
+        schedule: "*/5 * * * *"
+    extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: access_key
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-production-support-api-csvs
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: secret_key
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: support-api-postgres
+            key: DATABASE_URL
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-support-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-support-api
+            key: oauth_secret
+      - name: GOVUK_NOTIFY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: support-api-notify
+            key: GOVUK_NOTIFY_API_KEY
+      - name: GOVUK_NOTIFY_TEMPLATE_ID
+        value: *publishing-notify-template
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: ZENDESK_CLIENT_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: support-zendesk
+            key: username
+      - name: ZENDESK_CLIENT_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: support-zendesk
+            key: password
+      - name: ZENDESK_ANONYMOUS_TICKET_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: support-zendesk
+            key: ticket_email
+
+- name: transition
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: transition
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "transition.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: transition.{{ .Values.k8sExternalDomainSuffix }}
+    cronTasks:
+      - name: import-dns
+        task: "import:dns_details"
+        schedule: "0 07-19 * * 1-5"
+      - name: clear-expired-sessions
+        task: "clear_expired_sessions"
+        schedule: "0 3 * * *"
+      - name: clear-old-mappings
+        task: "clear_old_mappings_batches"
+        schedule: "0 3 * * *"
+      - name: refresh-materialized
+        task: "import:hits:refresh_materialized"
+        schedule: "30 0,12 * * *"
+    dbMigrationEnabled: true
+    workerEnabled: true
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-transition
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-transition
+            key: oauth_secret
+      - name: AWS_REGION
+        value: eu-west-1
+      - name: BASIC_AUTH_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: password
+      - name: BASIC_AUTH_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: basic-auth
+            key: username
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: transition-postgres
+            key: DATABASE_URL
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: travel-advice-publisher
+  helmValues:
+    workerEnabled: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: travel-advice-publisher
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "travel-advice-publisher.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: travel-advice-publisher.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-travel-advice-publisher-asset-manager
+            key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-travel-advice-publisher-email-alert-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-travel-advice-publisher
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-travel-advice-publisher
+            key: oauth_secret
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-travel-advice-publisher-publishing-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-travel-advice-publisher-link-checker-api
+            key: bearer_token
+      - name: LINK_CHECKER_API_SECRET_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: travel-advice-publisher-link-checker-api-callback-token
+            key: LINK_CHECKER_API_SECRET_TOKEN
+      - name: MONGODB_URI
+        valueFrom:
+          secretKeyRef:
+            name: travel-advice-publisher-docdb
+            key: MONGODB_URI
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+
+- name: whitehall-admin
+  repoName: whitehall
+  helmValues:
     appResources:
       limits:
         memory: 4Gi
@@ -620,36 +2644,36 @@ govukApplications:
       requests:
         memory: 2Gi
         cpu: "1"
-    appProbes:
-      startupProbe:
-        failureThreshold: 10
-        httpGet:
-          path: /healthcheck/live
-          port: http
-          scheme: HTTP
-        periodSeconds: 3
-        successThreshold: 1
-        timeoutSeconds: 15
-      livenessProbe:
-        failureThreshold: 3
-        httpGet:
-          path: /healthcheck/live
-          port: http
-          scheme: HTTP
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 30
-      readinessProbe:
-        failureThreshold: 3
-        httpGet:
-          path: /healthcheck/live
-          port: http
-          scheme: HTTP
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 30
-    nginxProxyReadTimeout: 30
-    extraEnv: &whitehall-envs
+    securityContext:
+      # Use the same uid/gid for NFS permissions as the old stack, so that
+      # files uploaded by whitehall-admin on k8s can be processed by
+      # whitehall-admin on EC2 and vice versa. 2899 is the "deploy" user.
+      runAsUser: 2899
+      runAsGroup: 2899
+    cronTasks:
+      - name: index-consultations
+        task: "search:index:consultations"
+        schedule: "0 2-22 * * *"
+      - name: taxonomy-rebuild
+        task: "taxonomy:rebuild_cache"
+        schedule: "*/10 7-20 * * *"
+    dbMigrationEnabled: true
+    workerEnabled: true
+    nginxClientMaxBodySize: *max-upload-size
+    nginxDenyCrawlers: true
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: whitehall-admin
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "whitehall-admin.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: whitehall-admin.{{ .Values.k8sExternalDomainSuffix }}
+    extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
@@ -660,6 +2684,8 @@ govukApplications:
           secretKeyRef:
             name: signon-app-whitehall
             key: oauth_secret
+      - name: GOVUK_UPLOADS_ROOT
+        value: &whitehall-uploads-path /uploads
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -690,10 +2716,71 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-publishing-api
             key: bearer_token
-      - name: AWS_S3_BUCKET_NAME
-        value: govuk-production-whitehall-csvs
+      - name: RUMMAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-search-api
+            key: bearer_token
       - name: GOVUK_NOTIFY_TEMPLATE_ID
-        value: e00e89f5-b622-4dcb-8f30-e6c70231a940
+        value: *publishing-notify-template
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: whitehall-mysql
+            key: DATABASE_URL
+    extraVolumes:
+      - name: asset-uploads-efs
+        nfs:
+          server: *assets-nfs
+          path: /whitehall  # TODO: does this work on an new/empty EFS instance?
+    appExtraVolumeMounts:
+      - name: asset-uploads-efs
+        mountPath: *whitehall-uploads-path
+
+- name: whitehall-frontend
+  repoName: whitehall
+  helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '10'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/placeholder/
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/whitehall/
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    extraEnv:
+      - name: JWT_AUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: authenticating-proxy-jwt-auth-secret
+            key: JWT_AUTH_SECRET
+      - name: PUBLISHING_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-publishing-api
+            key: bearer_token
+      - name: RUMMAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-whitehall-search-api
+            key: bearer_token
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: MEMCACHE_SERVERS
@@ -703,3 +2790,10 @@ govukApplications:
           secretKeyRef:
             name: whitehall-mysql
             key: DATABASE_URL
+    appResources:
+      limits:
+        memory: 4Gi
+        cpu: "2"
+      requests:
+        memory: 2Gi
+        cpu: "1"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -458,11 +458,11 @@ govukApplications:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
       - name: GOOGLE_TAG_MANAGER_AUTH
-        value: xcAlGBhKTIeO6y_JhmEapQ
+        value: sxvBI4QvwgTRX5e76vdIHA
       - name: GOOGLE_TAG_MANAGER_ID
         value: GTM-NZG8SF2
       - name: GOOGLE_TAG_MANAGER_PREVIEW
-        value: env-5
+        value: env-2
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:
@@ -2214,7 +2214,7 @@ govukApplications:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
       - name: GA_UNIVERSAL_ID
-        value: &ga-universal-id UA-26179049-20
+        value: &ga-universal-id UA-26179049-1
       - name: GOOGLE_TAG_MANAGER_ID
         value: &static-gtm-id GTM-MG7HG5W
       - name: PUBLISHING_API_BEARER_TOKEN

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -380,9 +380,9 @@ govukApplications:
             name: collections-publisher-notify
             key: GOVUK_NOTIFY_API_KEY
       - name: GOVUK_NOTIFY_TEMPLATE_ID
-        value: &publishing-notify-template 112842bb-d8a4-4511-90de-57dc5c8f27ec
+        value: &publishing-notify-template e00e89f5-b622-4dcb-8f30-e6c70231a940
       - name: PUBLISH_WITHOUT_2I_EMAIL
-        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+        value: mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
@@ -807,7 +807,7 @@ govukApplications:
             name: email-alert-api-notify
             key: GOVUK_NOTIFY_API_KEY
       - name: GOVUK_NOTIFY_TEMPLATE_ID
-        value: &frontend-notify-template 2844a647-6bf1-4b01-a25c-569d2cc00849
+        value: &frontend-notify-template cb633abc-6ae6-4843-ae6f-82ca500b6de2
       - name: GOVUK_NOTIFY_RECIPIENTS
         value: email-alert-api-production@digital.cabinet-office.gov.uk
       - name: REDIS_URL
@@ -888,13 +888,13 @@ govukApplications:
   helmValues:
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-        value: d33f7857-7514-4458-81b9-0995f48e2ac5
+        value: b5baae45-0a68-4b63-91a1-66b05640d27e
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
-        value: b67971ed-a249-4afa-b05e-9adad9da551a
+        value: ceefedd7-3214-4774-8b57-f27c89aac90d
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
-        value: d1f54751-80a8-420a-9077-d34c7d6cc734
+        value: e8b2d8a6-db5f-4346-9fbd-49b16b531e1c
       - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
-        value: 8a8d98c0-42c8-4f56-b61f-77c89417a171
+        value: 54168fa9-3946-4860-a2f8-27ddbb14babe
       - name: SUPPORT_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -1529,17 +1529,17 @@ govukApplications:
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: EMAIL_GROUP_BUSINESS
-        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+        value: publisher-alerts-business@digital.cabinet-office.gov.uk
       - name: EMAIL_GROUP_CITIZEN
-        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+        value: publisher-alerts-citizen@digital.cabinet-office.gov.uk
       - name: EMAIL_GROUP_DEV
-        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+        value: govuk-dev@digital.cabinet-office.gov.uk
       - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
-        value: mainstream-publisher-notifications-production@digital.cabinet-office.gov.uk
+        value: mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk
       - name: FACT_CHECK_REPLY_TO_ADDRESS
-        value: govuk-fact-check-production@digital.cabinet-office.gov.uk
+        value: govuk-fact-check@digital.cabinet-office.gov.uk
       - name: FACT_CHECK_REPLY_TO_ID
-        value: 88f713ff-7de0-43a6-8221-8721bedd103c
+        value: e739d23a-b761-44af-9a99-a1eba0b75c7e
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
 

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -687,6 +687,8 @@ govukApplications:
       # TODO: remove this flag and feature after launch (see https://github.com/alphagov/content-store/blob/4c6e16a9/app/models/route_set.rb#L70)
       - name: NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH
         value: "1"
+      - name: WEB_CONCURRENCY
+        value: '4'
 
 - name: draft-content-store
   repoName: content-store

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -603,8 +603,6 @@ govukApplications:
           secretKeyRef:
             name: content-publisher-postgres
             key: DATABASE_URL
-      - name: EMAIL_ADDRESS_OVERRIDE
-        value: content-publisher-notifications-production@digital.cabinet-office.gov.uk
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -43,7 +43,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
-    workerEnabled: true
+    # TODO(chris.banks): during launch: global replace s/workerEnabled: false/workerEnabled: true/
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -115,7 +116,7 @@ govukApplications:
 - name: asset-manager
   chartPath: charts/asset-manager
   helmValues:
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -315,7 +316,7 @@ govukApplications:
     rails:
       enabled: false
     appEnabled: false
-    workerEnabled: true
+    workerEnabled: false
     workers:
       - command: ["rake", "message_queue:consumer", "QUEUE=high"]
         name: high
@@ -333,7 +334,7 @@ govukApplications:
 - name: collections-publisher
   helmValues:
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -446,7 +447,7 @@ govukApplications:
       hosts:
         - name: content-data.{{ .Values.k8sExternalDomainSuffix }}
     nginxProxyReadTimeout: 60s
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: CONTENT_DATA_API_BEARER_TOKEN
         valueFrom:
@@ -505,7 +506,7 @@ govukApplications:
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     workers:
       - command: ["sidekiq", "-C", "config/sidekiq.yml"]
         name: worker
@@ -573,7 +574,7 @@ govukApplications:
   helmValues:
     dbMigrationEnabled: true
     nginxClientMaxBodySize: &max-upload-size 500M
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -717,7 +718,7 @@ govukApplications:
 - name: content-tagger
   helmValues:
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -764,7 +765,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: ACCOUNT_API_BEARER_TOKEN
         valueFrom:
@@ -850,7 +851,7 @@ govukApplications:
       enabled: false
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     workers:
       - command: ['bin/email-alert-service']
         name: email-alert-service
@@ -1106,7 +1107,7 @@ govukApplications:
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
     nginxProxyReadTimeout: 60s
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: DATABASE_URL
         valueFrom:
@@ -1156,7 +1157,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -1314,7 +1315,7 @@ govukApplications:
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: DATABASE_URL
         valueFrom:
@@ -1339,7 +1340,7 @@ govukApplications:
 - name: manuals-publisher
   helmValues:
     nginxClientMaxBodySize: *max-upload-size
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -1535,7 +1536,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     cronTasks:
       - name: events-export
         task: "events:export_to_s3"
@@ -1850,7 +1851,7 @@ govukApplications:
 - name: search-admin
   helmValues:
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -1906,7 +1907,7 @@ govukApplications:
     nginxClientMaxBodySize: 20M
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     cronTasks:
       - name: generate-sitemap
         task: "sitemap:generate_and_upload"
@@ -2068,7 +2069,7 @@ govukApplications:
 - name: signon
   helmValues:
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -2298,7 +2299,7 @@ govukApplications:
 - name: specialist-publisher
   helmValues:
     nginxClientMaxBodySize: *max-upload-size
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -2392,7 +2393,7 @@ govukApplications:
         - name: support.{{ .Values.k8sExternalDomainSuffix }}
     uploadAssets:
       path: /app/public/assets/support
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: AWS_REGION
         value: eu-west-1
@@ -2446,7 +2447,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     cronTasks:
       - name: feedback-deduplication-nightly
         task: "anonymous_feedback_deduplication:nightly"
@@ -2543,7 +2544,7 @@ govukApplications:
         task: "import:hits:refresh_materialized"
         schedule: "30 0,12 * * *"
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -2577,7 +2578,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
-    workerEnabled: true
+    workerEnabled: false
     ingress:
       enabled: true
       annotations:
@@ -2658,7 +2659,7 @@ govukApplications:
         task: "taxonomy:rebuild_cache"
         schedule: "*/10 7-20 * * *"
     dbMigrationEnabled: true
-    workerEnabled: true
+    workerEnabled: false
     nginxClientMaxBodySize: *max-upload-size
     nginxDenyCrawlers: true
     ingress:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2,16 +2,16 @@
 # individual apps below.
 
 govukEnvironment: production
-externalDomainSuffix: production.publishing.service.gov.uk
-publishingDomainSuffix: production.publishing.service.gov.uk
-assetsDomain: assets.production.publishing.service.gov.uk
+externalDomainSuffix: publishing.service.gov.uk
+publishingDomainSuffix: publishing.service.gov.uk
+assetsDomain: assets.publishing.service.gov.uk
 
-k8sAssetsDomain: assets-eks.production.publishing.service.gov.uk
+k8sAssetsDomain: assets-eks.publishing.service.gov.uk
 k8sExternalDomainSuffix: eks.production.govuk.digital
 # TODO: Remove once fully migrated to EKS
 k8sPublishingDomainSuffix: eks.production.govuk.digital
 
-cspReportURI: https://csp-reporter.production.publishing.service.gov.uk/report
+cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
 
 replicaCount: 3
 workerReplicaCount: 3
@@ -2143,7 +2143,7 @@ govukApplications:
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: SIGNON_APPS_URI_SUB_PATTERN
-        value: production.publishing.service.gov.uk
+        value: publishing.service.gov.uk
       - name: SIGNON_APPS_URI_SUB_REPLACEMENT
         value: eks.production.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -687,6 +687,8 @@ govukApplications:
       # TODO: remove this flag after launch (see https://github.com/alphagov/content-store/blob/4c6e16a9/app/models/route_set.rb#L70)
       - name: NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH
         value: "1"
+      - name: WEB_CONCURRENCY
+        value: '4'
 
 - name: draft-content-store
   repoName: content-store


### PR DESCRIPTION
This adds the publisher apps and APIs in the production cluster.

Essentially a copy of the staging config with `s/staging/production/` and some other production-specific values changed. See commits for a bit more detail.

Worker deployments are disabled for now, since we don't want workers in k8s pulling work off queues over the weekend.

See #936 for a list of things to consider in review.