### PR TITLE
Tune Router concurrency limits and CPU limits.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1711,6 +1711,8 @@ govukApplications:
         failureThreshold: 2
         periodSeconds: 5
     extraEnv:
+      - name: GOMAXPROCS
+        value: "2"
       - name: SENTRY_ENVIRONMENT
         value: "integration-eks"
       - name: ROUTER_PUBADDR
@@ -1771,6 +1773,8 @@ govukApplications:
       create: false
       name: draft-router-nginx-conf
     extraEnv:
+      - name: GOMAXPROCS
+        value: "2"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1701,7 +1701,7 @@ govukApplications:
         - blue.production.govuk-internal.digital
     appResources:
       limits:
-        cpu: 3
+        cpu: 4
         memory: 2Gi
       requests:
         cpu: 2
@@ -1758,6 +1758,8 @@ govukApplications:
         failureThreshold: 2
         periodSeconds: 5
     extraEnv:
+      - name: GOMAXPROCS
+        value: "4"  # Keep this similar to the CPU limit (in whole cores).
       - name: SENTRY_ENVIRONMENT
         value: "production-eks"
       - name: ROUTER_PUBADDR
@@ -1819,6 +1821,8 @@ govukApplications:
       create: false
       name: draft-router-nginx-conf
     extraEnv:
+      - name: GOMAXPROCS
+        value: "4"  # Keep this similar to the CPU limit (in whole cores).
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1703,7 +1703,7 @@ govukApplications:
         - blue.staging.govuk-internal.digital
     appResources:
       limits:
-        cpu: 3
+        cpu: 4
         memory: 2Gi
       requests:
         cpu: 2
@@ -1760,6 +1760,8 @@ govukApplications:
         failureThreshold: 2
         periodSeconds: 5
     extraEnv:
+      - name: GOMAXPROCS
+        value: "4"  # Keep this similar to the CPU limit (in whole cores).
       - name: SENTRY_ENVIRONMENT
         value: "staging-eks"
       - name: ROUTER_PUBADDR
@@ -1821,6 +1823,8 @@ govukApplications:
       create: false
       name: draft-router-nginx-conf
     extraEnv:
+      - name: GOMAXPROCS
+        value: "4"  # Keep this similar to the CPU limit (in whole cores).
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR


### PR DESCRIPTION
`GOMAXPROCS` defaults to the number of cores visible on the host machine, which isn't appropriate on Kubernetes.

See e.g. [this hackernews comment](https://news.ycombinator.com/item?id=24355216) for background.

Alternatives considered: might be cleaner to make this zero-config by importing [uber-go/automaxprocs](https://www.github.com/uber-go/automaxprocs/) instead, but we can do that after the launch is out of the way.