### PR TITLE
Fix Smokey Plek configuration for domain suffixes.

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -57,17 +57,17 @@ spec:
             - name: GOVUK_APP_DOMAIN
               value: ""
             - name: GOVUK_APP_DOMAIN_EXTERNAL
-              value: eks.{{ .Values.govukEnvironment }}.govuk.digital
+              value: {{ .Values.k8sPublishingDomainSuffix }}
             - name: GOVUK_ASSET_ROOT
-              value: https://assets-eks.{{ .Values.govukEnvironment }}.publishing.service.gov.uk
+              value: https://{{ .Values.k8sAssetsDomain }}
             - name: GOVUK_WEBSITE_ROOT
-              value: https://www.eks.{{ .Values.govukEnvironment }}.govuk.digital
+              value: https://www.{{ .Values.k8sExternalDomainSuffix }}
             - name: PLEK_SERVICE_ASSETS_URI
-              value: https://assets-eks.{{ .Values.govukEnvironment }}.publishing.service.gov.uk
+              value: https://{{ .Values.k8sAssetsDomain }}
             - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
-              value: https://assets-origin.eks.{{ .Values.govukEnvironment }}.govuk.digital
+              value: https://assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
-              value: https://content-data.eks.{{ .Values.govukEnvironment }}.govuk.digital
+              value: https://content-data.{{ .Values.k8sExternalDomainSuffix }}
             - name: PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS
               value: "1"
             - name: SIGNON_EMAIL

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -31,15 +31,17 @@ spec:
           - name: GOVUK_APP_DOMAIN
             value: ""
           - name: GOVUK_APP_DOMAIN_EXTERNAL
-            value: eks.{{ .Values.govukEnvironment }}.govuk.digital
+            value: {{ .Values.k8sPublishingDomainSuffix }}
           - name: GOVUK_ASSET_ROOT
-            value: https://assets-eks.{{ .Values.govukEnvironment }}.publishing.service.gov.uk
+            value: https://{{ .Values.k8sAssetsDomain }}
           - name: GOVUK_WEBSITE_ROOT
-            value: https://www.eks.{{ .Values.govukEnvironment }}.govuk.digital
+            value: https://www.{{ .Values.k8sExternalDomainSuffix }}
           - name: PLEK_SERVICE_ASSETS_URI
-            value: https://assets-eks.{{ .Values.govukEnvironment }}.publishing.service.gov.uk
+            value: https://{{ .Values.k8sAssetsDomain }}
           - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
-            value: https://assets-origin.eks.{{ .Values.govukEnvironment }}.govuk.digital
+            value: https://assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
+            value: https://content-data.{{ .Values.k8sExternalDomainSuffix }}
           - name: PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS
             value: "1"
           - name: SIGNON_EMAIL

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -1,4 +1,7 @@
 govukEnvironment: test
+k8sExternalDomainSuffix: eks.test.govuk.digital
+k8sPublishingDomainSuffix: test.publishing.service.gov.uk
+k8sAssetsDomain: assets-eks.test.publishing.service.gov.uk
 
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey


### PR DESCRIPTION
This makes Smokey's Plek configuration consistent with the applications being probed (apart from the workaround for the content-data-admin vs. content-data alias, which we still need).

Tested on the (not-yet-live) prod cluster.