### PR TITLE
GOVUK_WEBSITE_ROOT in prod is just www.gov.uk.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2,7 +2,7 @@
 # individual apps below.
 
 govukEnvironment: production
-externalDomainSuffix: publishing.service.gov.uk
+externalDomainSuffix: gov.uk
 publishingDomainSuffix: publishing.service.gov.uk
 assetsDomain: assets.publishing.service.gov.uk
 


### PR DESCRIPTION
I broke this in #986.