### PR TITLE
Remove IP source address filter on prod Signon.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2066,7 +2066,6 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-backend-waf-ruleset
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "signon.{{ .Values.publishingDomainSuffix }}"


### PR DESCRIPTION
When we launch the publisher apps on Kubernetes, other gov departments etc. will need to be able to make requests to Signon via its ingress.

Ideally we don't want to be serving Signon on the govuk.digital domain, but we can solve this after launch. Probably the way to solve it is to put Signon behind Fastly and re-apply the origin ACL to the ingress (i.e. revert this PR once Signon is behind Fastly). That'd also give us DoS protection.