### PR TITLE
Force publishing apps to use EKS Signon

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -45,5 +45,9 @@ data:
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}
   PLEK_SERVICE_DRAFT_ASSETS_URI: https://draft-assets.{{ .Values.publishingDomainSuffix }}
 
+  # Override to force publishing applications to use EKS version of Signon
+  # TODO: remove once publishing apps have migrated
+  PLEK_SERVICE_SIGNON_URI: https://signon.{{ .Values.k8sPublishingDomainSuffix }}
+
   # Services which remain in EC2 for a while after "MVP launch".
   PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}


### PR DESCRIPTION
To switch frontend applications to the live external domain (i.e. publishing.service.gov.uk) we had to update the
GOVUK_APP_DOMAIN_EXTERNAL. This meant that publishing application try to authenticate with the old version of Signon (as that has not yet been migrated).