### PR TITLE
Add preStop hook wait for ALB to drain connections

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -124,6 +124,10 @@ spec:
             # Asset Manager shares an NFS volume with its EC2 counterpart.
             runAsUser: *old-ec2-deploy-uid
             runAsGroup: *old-ec2-deploy-uid
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
@@ -157,3 +161,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -126,6 +126,10 @@ spec:
             {{- with .Values.appExtraVolumeMounts }}
               {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}
@@ -164,4 +168,8 @@ spec:
             {{- with .Values.nginxExtraVolumeMounts }}
               {{ . | toYaml | trim | nindent 12 }}
             {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
 {{- end }}


### PR DESCRIPTION
We have a race condition during a rollout between a pod being terminated and the ALB deregistering it. Currently these process happen independently and frequently the pods terminate before ALB deregistration which cause traffic to be sent to a terminating pod. This causes a few 502/504s to be served until deregistration is complete. Until we have a better fix, adding a delay until pod termination makes this senario less likely. However, it would be ideal if we had proper fix whereby pods are only terminated after it's known that they've be successfully deregistered from the ALB.