### PR TITLE
Integration cutover: make Signon use the publishing domains.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -47,7 +47,9 @@ data:
 
   # Override to force publishing applications to use EKS version of Signon
   # TODO: remove once publishing apps have migrated
+  {{- if ne .Values.govukEnvironment "integration" }}
   PLEK_SERVICE_SIGNON_URI: https://signon.{{ .Values.k8sPublishingDomainSuffix }}
+  {{- end }}
 
   # Services which remain in EC2 for a while after "MVP launch".
   PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2085,10 +2085,6 @@ govukApplications:
         value: "1"
       - name: MANDATE_2SV_FOR_ORGANISATION
         value: "1"
-      - name: SIGNON_APPS_URI_SUB_PATTERN
-        value: integration.publishing.service.gov.uk
-      - name: SIGNON_APPS_URI_SUB_REPLACEMENT
-        value: eks.integration.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
- Remove the `s/integration.publishing.service.gov.uk/eks.integration.govuk.digital/` substitution.
- Remove the Plek override.