### PR TITLE
Fix smokey domains for Integration

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -56,6 +56,20 @@ spec:
               value: {{ .Values.govukEnvironment }}
             - name: GOVUK_APP_DOMAIN
               value: ""
+            {{- if eq .Values.govukEnvironment "integration" }}
+            - name: GOVUK_APP_DOMAIN_EXTERNAL
+              value: {{ .Values.publishingDomainSuffix }}
+            - name: GOVUK_ASSET_ROOT
+              value: https://{{ .Values.assetsDomain }}
+            - name: GOVUK_WEBSITE_ROOT
+              value: https://www.{{ .Values.externalDomainSuffix }}
+            - name: PLEK_SERVICE_ASSETS_URI
+              value: https://{{ .Values.assetsDomain }}
+            - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
+              value: https://assets-origin.{{ .Values.externalDomainSuffix }}
+            - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
+              value: https://content-data.{{ .Values.externalDomainSuffix }}
+            {{- else }}
             - name: GOVUK_APP_DOMAIN_EXTERNAL
               value: {{ .Values.k8sPublishingDomainSuffix }}
             - name: GOVUK_ASSET_ROOT
@@ -68,6 +82,7 @@ spec:
               value: https://assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
               value: https://content-data.{{ .Values.k8sExternalDomainSuffix }}
+            {{- end }}
             - name: PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS
               value: "1"
             - name: SIGNON_EMAIL

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -30,6 +30,20 @@ spec:
             value: {{ .Values.govukEnvironment }}
           - name: GOVUK_APP_DOMAIN
             value: ""
+          {{- if eq .Values.govukEnvironment "integration" }}
+          - name: GOVUK_APP_DOMAIN_EXTERNAL
+            value: {{ .Values.publishingDomainSuffix }}
+          - name: GOVUK_ASSET_ROOT
+            value: https://{{ .Values.assetsDomain }}
+          - name: GOVUK_WEBSITE_ROOT
+            value: https://www.{{ .Values.externalDomainSuffix }}
+          - name: PLEK_SERVICE_ASSETS_URI
+            value: https://{{ .Values.assetsDomain }}
+          - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
+            value: https://assets-origin.{{ .Values.externalDomainSuffix }}
+          - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
+            value: https://content-data.{{ .Values.externalDomainSuffix }}
+          {{- else }}
           - name: GOVUK_APP_DOMAIN_EXTERNAL
             value: {{ .Values.k8sPublishingDomainSuffix }}
           - name: GOVUK_ASSET_ROOT
@@ -42,6 +56,7 @@ spec:
             value: https://assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
             value: https://content-data.{{ .Values.k8sExternalDomainSuffix }}
+          {{- end }}
           - name: PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS
             value: "1"
           - name: SIGNON_EMAIL


### PR DESCRIPTION
As we've switched over domains in Integration, smokey needs to use them instead of the internal domains as Signon will not authenticate causing test failures.