### PR TITLE
Staging cutover: reference live domains for Smokey and Signon

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -47,7 +47,7 @@ data:
 
   # Override to force publishing applications to use EKS version of Signon
   # TODO: remove once publishing apps have migrated
-  {{- if ne .Values.govukEnvironment "integration" }}
+  {{- if eq .Values.govukEnvironment "production" }}
   PLEK_SERVICE_SIGNON_URI: https://signon.{{ .Values.k8sPublishingDomainSuffix }}
   {{- end }}
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2128,10 +2128,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-      - name: SIGNON_APPS_URI_SUB_PATTERN
-        value: staging.publishing.service.gov.uk
-      - name: SIGNON_APPS_URI_SUB_REPLACEMENT
-        value: eks.staging.govuk.digital
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -56,7 +56,7 @@ spec:
               value: {{ .Values.govukEnvironment }}
             - name: GOVUK_APP_DOMAIN
               value: ""
-            {{- if eq .Values.govukEnvironment "integration" }}
+            {{- if ne .Values.govukEnvironment "production" }}
             - name: GOVUK_APP_DOMAIN_EXTERNAL
               value: {{ .Values.publishingDomainSuffix }}
             - name: GOVUK_ASSET_ROOT

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -30,7 +30,7 @@ spec:
             value: {{ .Values.govukEnvironment }}
           - name: GOVUK_APP_DOMAIN
             value: ""
-          {{- if eq .Values.govukEnvironment "integration" }}
+          {{- if ne .Values.govukEnvironment "production" }}
           - name: GOVUK_APP_DOMAIN_EXTERNAL
             value: {{ .Values.publishingDomainSuffix }}
           - name: GOVUK_ASSET_ROOT

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -1,4 +1,8 @@
 govukEnvironment: test
+externalDomainSuffix: www.test.publishing.service.gov.uk
+publishingDomainSuffix: test.publishing.service.gov.uk
+assetsDomain: assets.test.publishing.service.gov.uk
+
 k8sExternalDomainSuffix: eks.test.govuk.digital
 k8sPublishingDomainSuffix: test.publishing.service.gov.uk
 k8sAssetsDomain: assets-eks.test.publishing.service.gov.uk


### PR DESCRIPTION
- Remove the `s/staging.publishing.service.gov.uk/eks.staging.govuk.digital/` substitution.
- Remove the Plek override.
- Points smokey at non-internal domains, as Signon will fail otherwise.