### PR TITLE
Remove source IP filter from integration Signon ingress.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2024,7 +2024,6 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-backend-waf-ruleset
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "signon.{{ .Values.publishingDomainSuffix }}"


### PR DESCRIPTION
See 3575661. Needed in integration because of the dual-usage of integration by other gov departments to train users of the publishing apps. (We can keep the IP ACL in staging though.)