### PR TITLE
Mixed case URL/slugs should not return 404s

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -156,11 +156,6 @@ http {
         rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
       }
 
-      # If slug contains mIxEd CaSe, then return 404.
-      location ~ ^\/(?=.*[A-Z])(?=.*[a-z]).*$ {
-        return 404;
-      }
-
       # If slug has trailing URL, direct after trimming.
       location ~ ^\/(.+)\/$ {
         rewrite ^\/(.+)\/$ $scheme://$host/$1 permanent;


### PR DESCRIPTION
In #286 we added some nginx configuration to make all mixed case URLs 404. The commit message / PR description doesn't make it clear why this was necessary, and there's no linked trello card.

GOV.UK currently has many mixed case URLs which do not 404, for example:

- https://www-origin.publishing.service.gov.uk/AAA-screening-easy-read
- https://www-origin.publishing.service.gov.uk/Brexit
- https://www-origin.publishing.service.gov.uk/CostOfLivingSupport
- https://www-origin.publishing.service.gov.uk/MoD

As there appear to be many legitimate use cases for these URLs, we're removing the clause that 404s them.

We've tried to think of any potential risks of doing this, but we can't think of any.