### PR TITLE
Add a retry for smokey tests in post sync workflow

### DIFF
--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -12,6 +12,8 @@ spec:
       inputs:
         parameters:
           - name: extra-args
+      retryStrategy:
+        limit: "2"
       container:
         image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
         command:


### PR DESCRIPTION
Due to race conditions between pod termination and ALB connection draining, we sometimes serve 502/504s intermittently during a rollout. As post sync run directly after a rollout, sometimes the smokey tests fail due to these errors. This prevents the post sync workflow promoting the release. Ultimately we should fix the issue with the race condition.