### PR TITLE
Create separate Whitehall db secrets

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2770,7 +2770,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: whitehall-mysql
+            name: whitehall-frontend-mysql
             key: DATABASE_URL
     appResources:
       limits:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2711,7 +2711,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: whitehall-mysql
+            name: whitehall-admin-mysql
             key: DATABASE_URL
     extraVolumes:
       - name: asset-uploads-efs

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2795,5 +2795,5 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: whitehall-mysql
+            name: whitehall-frontend-mysql
             key: DATABASE_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2728,7 +2728,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: whitehall-mysql
+            name: whitehall-admin-mysql
             key: DATABASE_URL
     extraVolumes:
       - name: asset-uploads-efs

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2733,7 +2733,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: whitehall-mysql
+            name: whitehall-admin-mysql
             key: DATABASE_URL
     extraVolumes:
       - name: asset-uploads-efs

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2793,7 +2793,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: whitehall-mysql
+            name: whitehall-frontend-mysql
             key: DATABASE_URL
     appResources:
       limits:

--- a/charts/external-secrets/templates/whitehall/whitehall-admin-mysql.yaml
+++ b/charts/external-secrets/templates/whitehall/whitehall-admin-mysql.yaml
@@ -1,12 +1,12 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: whitehall-mysql
+  name: whitehall-admin-mysql
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      Credentials for Whitehall to connect to MYSQL.
+      Credentials for Whitehall Admin to connect to MYSQL.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -14,10 +14,10 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: whitehall-mysql
+    name: whitehall-admin-mysql
     template:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/whitehall_production'
   dataFrom:
     - extract:
-        key: govuk/whitehall/mysql-primary
+        key: govuk/whitehall-admin/mysql

--- a/charts/external-secrets/templates/whitehall/whitehall-frontend-mysql.yaml
+++ b/charts/external-secrets/templates/whitehall/whitehall-frontend-mysql.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: whitehall-frontend-mysql
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Whitehall Frontend to connect to MYSQL.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: whitehall-frontend-mysql
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/whitehall_production'
+  dataFrom:
+    - extract:
+        key: govuk/whitehall-frontend/mysql


### PR DESCRIPTION
This separates the Whitehall frontend and admin database secrets, as frontend only has read-only permissions.