### PR TITLE
Set the max body size for Content Store request

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -640,6 +640,7 @@ govukApplications:
 
 - name: content-store
   helmValues: &content-store
+    nginxClientMaxBodySize: 20M
     cronTasks:
       - name: report-delays
         task: "publishing_delay_report:report_delays"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -638,6 +638,7 @@ govukApplications:
 
 - name: content-store
   helmValues: &content-store
+    nginxClientMaxBodySize: 20M
     # TODO(chris.banks): tune these once we have some real-world usage data.
     replicaCount: 6
     appResources:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -651,6 +651,7 @@ govukApplications:
 
 - name: content-store
   helmValues: &content-store
+    nginxClientMaxBodySize: 20M
     replicaCount: 6
     cronTasks:
       - name: report-delays


### PR DESCRIPTION
Requests coming from the Publishing API can be larger than the default, this increase the max body size to prevent those request being rejected. Fixes an issue publishing organisation pages in Whitehall.