### PR TITLE
Increase rate limit to OS Places API.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1337,7 +1337,7 @@ govukApplications:
             name: locations-api-os-places
             key: api-secret
       - name: OS_PLACES_API_POSTCODES_PER_SECOND
-        value: "1"
+        value: "3"
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
 


### PR DESCRIPTION
This makes the locations-api rolling postcode database update run at the same rate in EKS as it used to in EC2.

Rollout: turn off workers in EC2 first.