### PR TITLE
Remove Signon IP ACL in staging.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2083,7 +2083,6 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-backend-waf-ruleset
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "signon.{{ .Values.publishingDomainSuffix }}"


### PR DESCRIPTION
People are using this for testing :(

We should nuke the signon.*.govuk.digital host rules to make this permanently ok.