### PR TITLE
Remove `signon.eks.staging.govuk.digital` from ingress rules.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2125,12 +2125,9 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-backend-waf-ruleset
-        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-          [{"field": "host-header", "hostHeaderConfig": { "values": [
-              "signon.{{ .Values.publishingDomainSuffix }}"
-          ]}}]
+        external-dns.alpha.kubernetes.io/hostname: signon.{{ .Values.k8sExternalDomainSuffix }}
       hosts:
-        - name: signon.{{ .Values.k8sExternalDomainSuffix }}
+        - name: signon.{{ .Values.publishingDomainSuffix }}
     cronTasks:
       - name: "kubernetes-sync-app-secrets"
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"


### PR DESCRIPTION
We don't want to serve Signon on any URL that's not a gov.uk domain. (People have reported `signon.*.govuk.digital` as phishing in the past, which led to the domain being added to some widely-shared blocklists with ensuing chaos.)

We still need `signon.eks.*.govuk.digital` to exist in DNS and point at the application, but we don't want the application to actually serve Signon pages unless `host` header in the request is a `gov.uk` domain.

We achieve this by telling external-dns to create the DNS record but making the LB rules match only the `gov.uk` domain (`publishingDomainSuffix`).

Staging-only first, to check whether this approach actually works.