### PR TITLE
Fix broken nginx config for specialist-publisher.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2265,6 +2265,7 @@ govukApplications:
 - name: specialist-publisher
   helmValues:
     nginxClientMaxBodySize: *max-upload-size
+    nginxProxyReadTimeout: 30s
     workerEnabled: true
     ingress:
       enabled: true
@@ -2277,7 +2278,6 @@ govukApplications:
           ]}}]
       hosts:
         - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
-    nginxProxyReadTimeout: 30s
     extraEnv:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
@@ -2332,15 +2332,6 @@ govukApplications:
         value: *publishing-notify-template
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-    nginxConfigMap:
-      extraServerConf: |
-        client_max_body_size 500M;
-
-        # Extended timeout to allow the processing of large attachments
-        location ~* attachments {
-          proxy_read_timeout 30s;
-          proxy_pass http://specialist-publisher;
-        }
 
 - name: support
   helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2304,6 +2304,7 @@ govukApplications:
 - name: specialist-publisher
   helmValues:
     nginxClientMaxBodySize: *max-upload-size
+    nginxProxyReadTimeout: 30s
     workerEnabled: true
     ingress:
       enabled: true
@@ -2316,7 +2317,6 @@ govukApplications:
           ]}}]
       hosts:
         - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
-    nginxProxyReadTimeout: 30s
     extraEnv:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
@@ -2371,15 +2371,6 @@ govukApplications:
         value: *publishing-notify-template
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
-    nginxConfigMap:
-      extraServerConf: |
-        client_max_body_size 500M;
-
-        # Extended timeout to allow the processing of large attachments
-        location ~* attachments {
-          proxy_read_timeout 30s;
-          proxy_pass http://specialist-publisher;
-        }
 
 - name: support
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2311,6 +2311,7 @@ govukApplications:
 - name: specialist-publisher
   helmValues:
     nginxClientMaxBodySize: *max-upload-size
+    nginxProxyReadTimeout: 30s
     workerEnabled: true
     ingress:
       enabled: true
@@ -2323,7 +2324,6 @@ govukApplications:
           ]}}]
       hosts:
         - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
-    nginxProxyReadTimeout: 30s
     extraEnv:
       - name: ASSET_MANAGER_BEARER_TOKEN
         valueFrom:
@@ -2378,15 +2378,6 @@ govukApplications:
         value: *publishing-notify-template
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-    nginxConfigMap:
-      extraServerConf: |
-        client_max_body_size 500M;
-
-        # Extended timeout to allow the processing of large attachments
-        location ~* attachments {
-          proxy_read_timeout 30s;
-          proxy_pass http://specialist-publisher;
-        }
 
 - name: support
   helmValues:


### PR DESCRIPTION
A bunch of nginx `proxy_*` directives are magically reset on entering a `location` scope, so this config was breaking the forwarding of the Host header, which broke the app's redirect to `/auth/gds` by causing it to use the wrong hostname.