### PR TITLE
Set GOVUK_NOTIFY_RECIPIENTS to * in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -804,7 +804,7 @@ govukApplications:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: &frontend-notify-template cb633abc-6ae6-4843-ae6f-82ca500b6de2
       - name: GOVUK_NOTIFY_RECIPIENTS
-        value: email-alert-api-production@digital.cabinet-office.gov.uk
+        value: '*'
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       - name: WEB_CONCURRENCY


### PR DESCRIPTION
This was understandably missed, because the values in puppet are:

- email-alert-api-integration@digital.cabinet-office.gov.uk (in integration)
- email-alert-api-staging@digital.cabinet-office.gov.uk (in staging)

... so you would naturally assume that the value in production would be email-alert-api-production@digital.cabinet-office.gov.uk.

But it's not. It's *

https://github.com/alphagov/govuk-puppet/blob/main/hieradata_aws/production.yaml#L187

This means that no emails are sent to Notify, because of this method in email-alert-api:

https://github.com/alphagov/email-alert-api/blob/c737f41319241a636c94c9c484c26e223048573c/app/services/send_email_service.rb#L25-L30

Update helm to use *