### PR TITLE
Remove IP ACL from assets-origin in int and prod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -133,7 +133,6 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -130,7 +130,6 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '20'
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-attributes: &assets-lb-attributes >
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,


### PR DESCRIPTION
The same LB serves draft assets but these don't go through Fastly, which means non-GDS users need access.

This isn't as bold as it sounds, because nginx handles the bulk of the load and the worst-case end-user impact of an asset-manager outage is just delayed appearance of new assets.

"Proper" long-term solution is to put all of Publishing behind a CDN.