### PR TITLE
Remove send-webhook template when no next environment

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -28,7 +28,7 @@ spec:
               parameters:
                 - name: extra-args
                   value: "{{"@app-{{workflow.parameters.application}}"}}"
-          {{ if .Values.nextEnvironment }}
+    {{ if .Values.nextEnvironment }}
           - name: promote-release
             depends: smoke-test.Succeeded
             when: "{{"'{{workflow.parameters.application}}' !~ '^draft-'"}}"
@@ -43,7 +43,6 @@ spec:
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
                 - name: manualDeploy
                   value: "false"
-          {{- end }}
 
     - name: send-webhook
       inputs:
@@ -76,6 +75,7 @@ spec:
               secretKeyRef:
                 name: deploy-image-webhook-endpoint
                 key: url
+    {{- end }}
 
     - name: exit-handler
       steps:


### PR DESCRIPTION
If there is no next environment, there should no be promotion of deployment. For example, this is the case for production. To make it less confusing we should also remove the send-webhook template, as it's not actually used anywhere.