### PR TITLE
Update pre-merge checks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9  # 1.1.0
+      uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0

--- a/kubernetes_version
+++ b/kubernetes_version
@@ -1,3 +1,3 @@
 # Kubernetes version for kubeconform to use when validating helm template
 # output. See .github/workflows/ci.yml.
-KUBERNETES_VERSION=1.23.0
+KUBERNETES_VERSION=1.24.0


### PR DESCRIPTION
- kubeconform to 1.24 schemas.
- shellcheck action from 1.1.0 to [2.0.0](https://github.com/ludeeus/action-shellcheck/releases/tag/2.0.0).