### PR TITLE
Corrected path for mount location of transition-config.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2533,7 +2533,7 @@ govukApplications:
           path: /transition
     appExtraVolumeMounts:
       - name: transition-config-efs
-        mountPath: /app/data/transition-config
+        mountPath: /app/data
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/generic-govuk-app/templates/transition-config-cron.yaml
+++ b/charts/generic-govuk-app/templates/transition-config-cron.yaml
@@ -85,7 +85,7 @@ spec:
                 - name: tmp
                   mountPath: /tmp
                 - name: transition-config-efs
-                  mountPath: /app/data/transition-config
+                  mountPath: /app/data
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
It should look like:
/app/data/transition-config

Its currently looking like this:
/app/data/transition-config/transition-config