### PR TITLE
Temporarily Stop Pub API Workers on Staging EKS

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1569,7 +1569,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false
-    workerEnabled: true
+    workerEnabled: false
     cronTasks:
       - name: events-export
         task: "events:export_to_s3"


### PR DESCRIPTION
This stops the Publishing API Workers on Staging EKS for our load testing.

## Related

* https://github.com/alphagov/govuk-helm-charts/pull/1036