### PR TITLE
turn off LTR ranking in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1914,7 +1914,7 @@ govukApplications:
       - name: ELASTICSEARCH_URI
         value: *elasticsearch-uri
       - name: ENABLE_LTR
-        value: "true"
+        value: "false"
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Turn of LTR ranking on search-api in integration to test effect on specialist finder results for licence finder
(temporary, will be reverted after testing)

https://trello.com/c/VSypv1Xp/1889-spike-why-most-relevant-result-for-term-information-appeared-low-in-results-list