### PR TITLE
Add DISABLE_LTR_ON_PATHS env to finder-frontend in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -954,6 +954,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-finder-frontend-email-alert-api
             key: bearer_token
+      - name: DISABLE_LTR_ON_PATHS
+        value: /find-licences
 
 - name: frontend
   helmValues:


### PR DESCRIPTION
Env var to allow turning off LTR for specific specialist finders (rather than disabling it entirely in search-api)

Handled by finder-frontend code in PR: https://github.com/alphagov/finder-frontend/pull/3028