### PR TITLE
Set max upload size for Imminence.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1099,6 +1099,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
+    nginxClientMaxBodySize: &max-upload-size 500M
     nginxProxyReadTimeout: 60s
     workerEnabled: true
     extraEnv:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1136,6 +1136,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
+    nginxClientMaxBodySize: &max-upload-size 500M
     nginxProxyReadTimeout: 60s
     workerEnabled: true
     extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1140,6 +1140,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
+    nginxClientMaxBodySize: &max-upload-size 500M
     nginxProxyReadTimeout: 60s
     workerEnabled: true
     extraEnv:


### PR DESCRIPTION
Looks like we missed this. Users definitely need to be able to upload large (at least > 5 MiB) objects to Imminence.

https://trello.com/c/vTe1fLR2
https://govuk.zendesk.com/agent/tickets/5271205