### PR TITLE
[RP-1135] Toggle-on the Publish* Workers

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1471,7 +1471,7 @@ govukApplications:
 - name: publisher
   helmValues:
     dbMigrationEnabled: true
-    workerEnabled: false
+    workerEnabled: true
     cronTasks:
       - name: reports-generate
         task: "reports:generate"
@@ -1570,7 +1570,7 @@ govukApplications:
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false
-    workerEnabled: false
+    workerEnabled: true
     cronTasks:
       - name: events-export
         task: "events:export_to_s3"


### PR DESCRIPTION
## What?
This reverts the previous commits that disabled the workers. We turned them off because we wanted to try and benchmark the publisher workers on legacy infra.

## Reverts
* https://github.com/alphagov/govuk-helm-charts/pull/1036
* https://github.com/alphagov/govuk-helm-charts/pull/1037