### PR TITLE
Prevent post sync workflow from trigging deployment promotion

### DIFF
--- a/charts/argo-services/scripts/update-image-tag.sh
+++ b/charts/argo-services/scripts/update-image-tag.sh
@@ -10,6 +10,7 @@ change_image_tag() {
   git checkout -b "${BRANCH}"
 
   yq -i '.image_tag = env(IMAGE_TAG)' "${FILE}"
+  yq -i '.promote_deployment = env(PROMOTE_DEPLOYMENT)' "${FILE}"
 
   git add "${FILE}"
   git commit -m "Update ${REPO_NAME} image tag to ${IMAGE_TAG} for ${ENVIRONMENT}"

--- a/charts/argo-services/templates/events/update-image-tag-sensor.yaml
+++ b/charts/argo-services/templates/events/update-image-tag-sensor.yaml
@@ -35,6 +35,10 @@ spec:
             src:
               dependencyName: update-image-tag
               dataKey: body.manualDeploy
+          - dest: spec.arguments.parameters.4.value
+            src:
+              dependencyName: update-image-tag
+              dataKey: body.promoteDeployment
           - dest: metadata.generateName
             src:
               dependencyName: update-image-tag
@@ -59,5 +63,6 @@ spec:
                   - name: repoName
                   - name: imageTag
                   - name: manualDeploy
+                  - name: promoteDeployment
               workflowTemplateRef:
                 name: deploy-image

--- a/charts/argo-services/templates/executor-default-rolebinding.yaml
+++ b/charts/argo-services/templates/executor-default-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: executor-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: executor
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/charts/argo-services/templates/executor-role.yaml
+++ b/charts/argo-services/templates/executor-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: executor
+  annotations:
+    workflows.argoproj.io/description: |
+      Recomended minimum permissions for the `emissary` executor.
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - create
+      - patch

--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -11,6 +11,7 @@ spec:
       - name: repoName
       - name: imageTag
       - name: manualDeploy
+      - name: promoteDeployment
   templates:
     - name: deploy-image
       steps:
@@ -28,6 +29,8 @@ spec:
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
                 - name: manualDeploy
                   value: "{{"{{workflow.parameters.manualDeploy}}"}}"
+                - name: promoteDeployment
+                  value: "{{"{{workflow.parameters.promoteDeployment}}"}}"
         - - name: add-deployed-to-tag
             templateRef:
               name: add-tag-to-image

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -29,9 +29,19 @@ spec:
                 - name: extra-args
                   value: "{{"@app-{{workflow.parameters.application}}"}}"
     {{ if .Values.nextEnvironment }}
-          - name: promote-release
+          - name: check-for-promotion
             depends: smoke-test.Succeeded
             when: "{{"'{{workflow.parameters.application}}' !~ '^draft-'"}}"
+            template: check-for-promotion
+            arguments:
+              parameters:
+                - name: environment
+                  value: "{{ .Values.govukEnvironment }}"
+                - name: repoName
+                  value: "{{"{{workflow.parameters.repoName}}"}}"
+          - name: promote-release
+            depends: check-for-promotion.Succeeded
+            when: "{{"'{{tasks.check-for-promotion.outputs.result}}' !~ '^true'"}}"
             template: send-webhook
             arguments:
               parameters:
@@ -45,6 +55,24 @@ spec:
                   value: "false"
                 - name: promoteDeployment
                   value: "true"
+
+    - name: check-for-promotion
+      inputs:
+        parameters:
+        - name: environment
+        - name: repoName
+      script:
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+        command: [/bin/bash]
+        env:
+          - name: ENVIRONMENT
+            value: "{{"{{inputs.parameters.environment}}"}}"
+          - name: REPO_NAME
+            value: "{{"{{inputs.parameters.repoName}}"}}"
+        source: >
+          export DEPLOYMENT_CONFIG_URL="https://raw.githubusercontent.com/alphagov/govuk-helm-charts/main/charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}"
+
+          curl -Ls $DEPLOYMENT_CONFIG_URL | yq ".promote_deployment" -
 
     - name: send-webhook
       inputs:

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -43,6 +43,8 @@ spec:
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
                 - name: manualDeploy
                   value: "false"
+                - name: promoteDeployment
+                  value: "true"
 
     - name: send-webhook
       inputs:
@@ -51,6 +53,7 @@ spec:
         - name: repoName
         - name: imageTag
         - name: manualDeploy
+        - name: promoteDeployment
       script:
         image: curlimages/curl
         command:
@@ -62,7 +65,8 @@ spec:
               "environment": "{{"{{inputs.parameters.environment}}"}}",
               "repoName": "{{"{{inputs.parameters.repoName}}"}}",
               "imageTag": "{{"{{inputs.parameters.imageTag}}"}}",
-              "manualDeploy": "{{"{{inputs.parameters.manualDeploy}}"}}"
+              "manualDeploy": "{{"{{inputs.parameters.manualDeploy}}"}}",
+              "promoteDeployment": "{{"{{inputs.parameters.promoteDeployment}}"}}"
             }'
         env:
           - name: WEBHOOK_TOKEN

--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -10,6 +10,7 @@ spec:
       - name: repoName
       - name: imageTag
       - name: manualDeploy
+      - name: promoteDeployment
   templates:
     - name: update-image-tag
       inputs:
@@ -18,6 +19,8 @@ spec:
           - name: repoName
           - name: imageTag
           - name: manualDeploy
+            default: "false"
+          - name: promoteDeployment
             default: "false"
       script:
         image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
@@ -41,6 +44,8 @@ spec:
             value: "{{"{{inputs.parameters.repoName}}"}}"
           - name: MANUAL_DEPLOY
             value: "{{"{{inputs.parameters.manualDeploy}}"}}"
+          - name: PROMOTE_DEPLOYMENT
+            value: "{{"{{inputs.parameters.promoteDeployment}}"}}"
         source: |
           {{- .Files.Get "scripts/update-image-tag.sh" | nindent 14 }}
   podSpecPatch: |


### PR DESCRIPTION
This adds a check to prevent the post sync workflow from trigging the deploy image workflow in the promotion environment. Previously this was normal behaviour as the deploy image workflow had a check prevent deployments that shouldn't be promoted. However, this mean that other steps (including notifying the release app of deployment) in the workflow continued to execute.

We now explicitly state whether a deployment should be promoted in the image tag file. This states is used by the post sync workflow to decide whether to trigger a promotion.

This simplifies the mental model, and remove the confusion around deploy image workflow always running even when a deployment isn't being promoted.

This check relies on workflow step outputs, which required the correct service account permissions - that had not been previously set up.

We continue to have the manual_deploy flag set - but will remove in future PRs, as should be no longer needed.

(Tested in integration)