### PR TITLE
Reinstate long-lived creds for support->S3.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2384,10 +2384,20 @@ govukApplications:
       path: /app/public/assets/support
     workerEnabled: true
     extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: access_key
       - name: AWS_REGION
         value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-integration-support-api-csvs
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: secret_key
       - name: EMERGENCY_CONTACT_DETAILS
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2414,10 +2414,20 @@ govukApplications:
       path: /app/public/assets/support
     workerEnabled: true
     extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: access_key
       - name: AWS_REGION
         value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-production-support-api-csvs
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: secret_key
       - name: EMERGENCY_CONTACT_DETAILS
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2423,10 +2423,20 @@ govukApplications:
       path: /app/public/assets/support
     workerEnabled: true
     extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: access_key
       - name: AWS_REGION
         value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-staging-support-api-csvs
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: support-aws
+            key: secret_key
       - name: EMERGENCY_CONTACT_DETAILS
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This is just a short-term measure while we figure out why the Fog library isn't able to use the instance profile creds properly.

https://trello.com/c/WDltvCoF