### PR TITLE
Fix the logic of when to promote deployment

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -41,7 +41,7 @@ spec:
                   value: "{{"{{workflow.parameters.repoName}}"}}"
           - name: promote-release
             depends: check-for-promotion.Succeeded
-            when: "{{"'{{tasks.check-for-promotion.outputs.result}}' !~ '^true'"}}"
+            when: "{{"'{{tasks.check-for-promotion.outputs.result}}' == 'true'"}}"
             template: send-webhook
             arguments:
               parameters:


### PR DESCRIPTION
We want to promote when promote_deployment is true. Missed this fix commit in the previous PR.