### PR TITLE
Enable ingress for content-data-api.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -500,10 +500,21 @@ govukApplications:
 
 - name: content-data-api
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "content-data-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: content-data-api.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
-    nginxProxyReadTimeout: 60s
     workerEnabled: true
     workers:
       - command: ["sidekiq", "-C", "config/sidekiq.yml"]

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -497,6 +497,18 @@ govukApplications:
 
 - name: content-data-api
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "content-data-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: content-data-api.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
@@ -508,7 +520,6 @@ govukApplications:
         name: publishing-api-consumer
       - command: ['rake', 'publishing_api:bulk_import_consumer']
         name: bulk-import-publishing-api-consumer
-    nginxProxyReadTimeout: 60s
     extraEnv:
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -506,6 +506,18 @@ govukApplications:
 
 - name: content-data-api
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-backend-waf-ruleset
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "content-data-api.{{ .Values.publishingDomainSuffix }}"
+          ]}}]
+      hosts:
+        - name: content-data-api.{{ .Values.k8sExternalDomainSuffix }}
+    nginxProxyReadTimeout: 60s
     uploadAssets:
       enabled: false
     dbMigrationEnabled: true
@@ -517,7 +529,6 @@ govukApplications:
         name: publishing-api-consumer
       - command: ['rake', 'publishing_api:bulk_import_consumer']
         name: bulk-import-publishing-api-consumer
-    nginxProxyReadTimeout: 60s
     extraEnv:
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:


### PR DESCRIPTION
Missed this one! It's still serving from EC2 right now.

See https://github.com/alphagov/content-data-api/#content-data-api for example URLs that show that this API is indeed meant to be reachable from the Internet (with Signon auth). e.g. https://content-data-api.publishing.service.gov.uk/api/v1/metrics

Tested: applied the Ingress generated from the template in the integration cluster, verified that Signon works and URL above serves the expected response (with /etc/hosts patched to point at the Ingress ALB).

```
helm template content-data-api ../generic-govuk-app --values \
  <(helm template . --values values-integration.yaml |
    yq e '.|select(.metadata.name=="content-data-api").spec.source.helm.values'
   ) \
  --set sentry.enabled=false --set rails.createKeyBaseSecret=false \
  | yq e '.|select(.kind=="Ingress")' \
  | k apply -f -
```