### PR TITLE
Add s3 bucket name for whitehall

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2754,6 +2754,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-search-api
             key: bearer_token
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-integration-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
       - name: EMAIL_ADDRESS_OVERRIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2758,6 +2758,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-search-api
             key: bearer_token
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-production-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
       - name: REDIS_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2767,6 +2767,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-search-api
             key: bearer_token
+      - name: AWS_S3_BUCKET_NAME
+        value: govuk-staging-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
       - name: EMAIL_ADDRESS_OVERRIDE  # TODO: remove in production.


### PR DESCRIPTION
These variables were previously defined ([1](https://github.com/alphagov/govuk-puppet/blob/9c3dec9f7b01fbbae6aaf207fc8acd35eaa2cce8/hieradata_aws/production.yaml\#L252), [2](https://github.com/alphagov/govuk-puppet/blob/9c3dec9f7b01fbbae6aaf207fc8acd35eaa2cce8/hieradata_aws/staging.yaml\#L243), [3](https://github.com/alphagov/govuk-puppet/blob/9c3dec9f7b01fbbae6aaf207fc8acd35eaa2cce8/hieradata_aws/integration.yaml\#L109)) in govuk-puppet, and is needed for us to enable csv exports of whitehall data, which publishers use for a varierty of things, including accessibility reports and parliamentary questions. 

We've had several zendesk reports of this issue.
