### PR TITLE
Update max body size for publishing api and hmrc manuals in prod and staging

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1099,6 +1099,7 @@ govukApplications:
 
 - name: hmrc-manuals-api
   helmValues:
+    nginxClientMaxBodySize: 2M
     ingress:
       enabled: true
       annotations:
@@ -1571,6 +1572,7 @@ govukApplications:
 
 - name: publishing-api
   helmValues:
+    nginxClientMaxBodySize: 2M
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1103,6 +1103,7 @@ govukApplications:
 
 - name: hmrc-manuals-api
   helmValues:
+    nginxClientMaxBodySize: 2M
     ingress:
       enabled: true
       annotations:
@@ -1578,6 +1579,7 @@ govukApplications:
 
 - name: publishing-api
   helmValues:
+    nginxClientMaxBodySize: 2M
     dbMigrationEnabled: true
     uploadAssets:
       enabled: false


### PR DESCRIPTION
This fixes an issue where a manual was being rejected by nginx for being too big. We've confirmed that the equivalent changes have worked in integration.

[Zendesk](https://govuk.zendesk.com/agent/tickets/5281642)