### PR TITLE
Add puma timeout for hmrc manuals api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1102,6 +1102,8 @@ govukApplications:
             key: bearer_token
       - name: PUBLISH_TOPICS
         value: "1"
+      - name: PUMA_TIMEOUT
+        value: "300"
 
 - name: imminence
   helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1134,6 +1134,8 @@ govukApplications:
             key: bearer_token
       - name: PUBLISH_TOPICS
         value: "1"
+      - name: PUMA_TIMEOUT
+        value: "300"
 
 - name: imminence
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1138,6 +1138,8 @@ govukApplications:
             key: bearer_token
       - name: PUBLISH_TOPICS
         value: "1"
+      - name: PUMA_TIMEOUT
+        value: "300"
 
 - name: imminence
   helmValues:


### PR DESCRIPTION
This was previously set for our old infrastructure, and is important in order to allow for publishing of large manuals.

See equivalent PR for puppet [here](https://github.com/alphagov/govuk-puppet/pull/11286/files) (note that we already have an `nginxProxyReadTimeout` variable set for hmrc manuals api, so I think we only need the unicorn timeout part of this to be equivalent.

This will not have any effect for hmrc manuals api until the [work](https://github.com/alphagov/govuk_app_config/pull/288) to introduce `PUMA_TIMEOUT` as a configurable variable is released, and hmrc manuals api is switched to using this version of govuk_app_config.

[Zendesk](https://govuk.zendesk.com/agent/tickets/5281642)

[Trello](https://trello.com/c/qtpjC3PB/556-increase-timeout-for-hmrc-manuals-api)