### PR TITLE
Enable 2sv mandating features in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2181,6 +2181,10 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: PERMIT_2SV_EXEMPTION
+        value: "1"
+      - name: MANDATE_2SV_FOR_ORGANISATION
+        value: "1"
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This forms part of a 'dry run' of 2sv mandating in staging. We've [set them in integration](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-integration.yaml#L2139-L2142), so this change is equivalent for staging.

Once in place, they will enable features that allow admins to exempt individuals from 2 step-verification (2sv), and mandate 2sv at an organisation level.

[Trello](https://trello.com/c/bnFeNsvd/532-dry-run-enable-all-new-2fa-features-on-integration-staging-before-prod-rollout-which-will-happen-in-week-commencing-10-04-2023)