### PR TITLE
Explicitly set AWS region for whitehall S3 buckets.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2758,6 +2758,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-search-api
             key: bearer_token
+      - name: AWS_REGION
+        value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-integration-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2762,6 +2762,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-search-api
             key: bearer_token
+      - name: AWS_REGION
+        value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-production-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2775,6 +2775,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-whitehall-search-api
             key: bearer_token
+      - name: AWS_REGION
+        value: eu-west-1
       - name: AWS_S3_BUCKET_NAME
         value: govuk-staging-whitehall-csvs
       - name: GOVUK_NOTIFY_TEMPLATE_ID


### PR DESCRIPTION
Apparently the Fog wrapper lib isn't smart enough to discover the region of a bucket automatically :/