### PR TITLE
Simplify promotion checks

### DIFF
--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the YAML configuration
+CONFIG_URL="https://raw.githubusercontent.com/alphagov/govuk-helm-charts/main/charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}"
+CONFIG_CONTENT=$(curl -Ls "${CONFIG_URL}")
+
+# Extract the values of automatic_deploys_enabled and promote_deployment
+automatic_deploys_enabled=$(echo "${CONFIG_CONTENT}" | yq '.automatic_deploys_enabled' -)
+promote_deployment=$(echo "${CONFIG_CONTENT}" | yq '.promote_deployment' -)
+
+# Check if both values are true
+if [ "${automatic_deploys_enabled,,}" == "true" ] && [ "${promote_deployment,,}" == "true" ]; then
+  echo "true"
+else
+  echo "false"
+fi

--- a/charts/argo-services/scripts/update-image-tag.sh
+++ b/charts/argo-services/scripts/update-image-tag.sh
@@ -3,19 +3,6 @@ set -euo pipefail
 
 BRANCH="update-image-tag/${REPO_NAME}/${ENVIRONMENT}/${IMAGE_TAG}"
 FILE="charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}"
-CHANGED=false
-
-change_image_tag() {
-  git checkout -b "${BRANCH}"
-
-  yq -i '.image_tag = env(IMAGE_TAG)' "${FILE}"
-  yq -i '.promote_deployment = env(PROMOTE_DEPLOYMENT)' "${FILE}"
-
-  git add "${FILE}"
-  git commit -m "Update ${REPO_NAME} image tag to ${IMAGE_TAG} for ${ENVIRONMENT}"
-
-  CHANGED=true
-}
 
 git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
 git config --global user.name "${GIT_NAME}"
@@ -30,14 +17,19 @@ current_image_tag="$(yq '.image_tag' "${FILE}")"
 # Ignore if image tag already set
 if [[ "${current_image_tag}" = "${IMAGE_TAG}" ]]; then
   echo "Image tag already set as ${IMAGE_TAG}"
-else
-  change_image_tag
+  exit 0
 fi
 
-if [[ "${CHANGED}" = true ]]; then
-  git push -u origin "${BRANCH}"
-  gh api repos/alphagov/govuk-helm-charts/merges -f head="${BRANCH}" -f base=main
-  git push origin --delete "${BRANCH}"
+git checkout -b "${BRANCH}"
 
-  echo "Pushed changes to GitHub"
-fi
+yq -i '.image_tag = env(IMAGE_TAG)' "${FILE}"
+yq -i '.promote_deployment = env(PROMOTE_DEPLOYMENT)' "${FILE}"
+
+git add "${FILE}"
+git commit -m "Update ${REPO_NAME} image tag to ${IMAGE_TAG} for ${ENVIRONMENT}"
+
+git push -u origin "${BRANCH}"
+gh api repos/alphagov/govuk-helm-charts/merges -f head="${BRANCH}" -f base=main
+git push origin --delete "${BRANCH}"
+
+echo "Pushed changes to GitHub"

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -69,11 +69,8 @@ spec:
             value: "{{"{{inputs.parameters.environment}}"}}"
           - name: REPO_NAME
             value: "{{"{{inputs.parameters.repoName}}"}}"
-        source: >
-          export DEPLOYMENT_CONFIG_URL="https://raw.githubusercontent.com/alphagov/govuk-helm-charts/main/charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}"
-
-          curl -Ls $DEPLOYMENT_CONFIG_URL | yq ".promote_deployment" -
-
+        source: |
+          {{- .Files.Get "scripts/check-for-promotion.sh" | nindent 14 }}
     - name: send-webhook
       inputs:
         parameters:


### PR DESCRIPTION
This moves the checks for whether an application deployment should be promoted into the post-sync workflow. Previously checks were done in the update-image-tag script, which was confusing as it looked like a deployment, however the workflow was just checking whether a deployment should occur. This improves the separation of concerns between the two workflows.

This also fixes a bug whereby we'd notify the release application of deployment, even though the update-image-tag didn't actually make a change (because the deployment wasn't promoted).

(Tested in integration)