### PR TITLE
Explicitly specify TLS cert for Signon ingress (staging).

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2125,6 +2125,8 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-backend-waf-ruleset
+        # TODO: remove certificate-arn annotation once ambiguous certs are removed from Cert Manager.
+        alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-1:696911096973:certificate/ea990af0-b7b7-4ce0-8145-56d639d54cde
         external-dns.alpha.kubernetes.io/hostname: signon.{{ .Values.k8sExternalDomainSuffix }}
       hosts:
         - name: signon.{{ .Values.publishingDomainSuffix }}


### PR DESCRIPTION
This is a temporary workaround until we can remove the old certs from Certificate Manager. Right now, there are multiple certs that match `*.staging.publishing.service.gov.uk` and we can't fix that until we've fully decommissioned the old EC2 stuff.