### PR TITLE
Fix the default for automatic_deploys_enabled.

### DIFF
--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -6,7 +6,7 @@ CONFIG_URL="https://raw.githubusercontent.com/alphagov/govuk-helm-charts/main/ch
 CONFIG_CONTENT=$(curl -Ls "${CONFIG_URL}")
 
 # Extract the values of automatic_deploys_enabled and promote_deployment
-automatic_deploys_enabled=$(echo "${CONFIG_CONTENT}" | yq '.automatic_deploys_enabled' -)
+automatic_deploys_enabled=$(echo "${CONFIG_CONTENT}" | yq '.automatic_deploys_enabled // true' -)
 promote_deployment=$(echo "${CONFIG_CONTENT}" | yq '.promote_deployment' -)
 
 # Check if both values are true


### PR DESCRIPTION
automatic_deploys_enabled used to default to true but this subtly changed to false in #1057, which broke automatic promotion (push-on-green) from staging to production for apps which didn't have automatic_deploys_enabled explicitly set to true in their image-tags YAML files.