### PR TITLE
Set Sentry environment names back to normal

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -35,7 +35,7 @@ data:
   PLEK_UNPREFIXABLE_HOSTS: account-api,feedback,imminence,info-frontend,licensify,local-links-manager,locations-api,search-api,signon
   PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   RAILS_LOG_TO_STDOUT: "true"
-  SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}-eks
+  SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}
 
   # Data sync period used by sentry to ignore application errors during that time. Only relevant to integration and staging.
   {{- if ne .Values.govukEnvironment "production" }}


### PR DESCRIPTION
removal of the eks suffix from env

https://trello.com/c/65hnxqmM/1169-set-sentry-environment-names-back-to-normal-lose-the-eks-suffix-so-that-teams-sentry-alert-rules-work-again