### PR TITLE
Explicitly set automatic deploy enabled values

### DIFF
--- a/charts/app-config/image-tags/staging/account-api
+++ b/charts/app-config/image-tags/staging/account-api
@@ -1,1 +1,2 @@
 image_tag: release-84acfbec78e9a637e287609fd1c0c55d32176ea6
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/bouncer
+++ b/charts/app-config/image-tags/staging/bouncer
@@ -1,2 +1,3 @@
 image_tag: release-53a59335a6824227cd3d72c5165ee6c83f1cee99
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/collections-publisher
+++ b/charts/app-config/image-tags/staging/collections-publisher
@@ -1,2 +1,3 @@
 image_tag: release-d10d60bd14a4e46e17e26e12c46b999ecdc1d716
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/content-data-admin
+++ b/charts/app-config/image-tags/staging/content-data-admin
@@ -1,2 +1,3 @@
 image_tag: release-5ed940a8fd2c7e9bce7e73e01dc0763d5f8e7d1b
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/content-data-api
+++ b/charts/app-config/image-tags/staging/content-data-api
@@ -1,2 +1,3 @@
 image_tag: release-11e153a4319457d6e0c7ab5a03950a191e888e22
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/content-tagger
+++ b/charts/app-config/image-tags/staging/content-tagger
@@ -1,1 +1,2 @@
 image_tag: release-65a21ef0531e7c3472501a04eaf8d96279b0efa1
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/email-alert-api
+++ b/charts/app-config/image-tags/staging/email-alert-api
@@ -1,2 +1,3 @@
 image_tag: release-c95e3c625b53edb82efdf1f330e8d533f04c2f18
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/imminence
+++ b/charts/app-config/image-tags/staging/imminence
@@ -1,1 +1,2 @@
 image_tag: release-e495d1de435ff3278007155f5038b5a2cfc59a63
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/link-checker-api
+++ b/charts/app-config/image-tags/staging/link-checker-api
@@ -1,1 +1,2 @@
 image_tag: release-57f902b16e6c1b4c2cc0c1bcaacd9bebf19173b2
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/local-links-manager
+++ b/charts/app-config/image-tags/staging/local-links-manager
@@ -1,1 +1,2 @@
 image_tag: release-b7e0eb8b20fe56fd86d8611027cc745ad3afbee9
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/locations-api
+++ b/charts/app-config/image-tags/staging/locations-api
@@ -1,1 +1,2 @@
 image_tag: release-769ae4d33e6c315510c91ac51eb7145c152cc8f6
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/manuals-publisher
+++ b/charts/app-config/image-tags/staging/manuals-publisher
@@ -1,2 +1,3 @@
 image_tag: release-d68cbf7a3db7d2dd0284786451049308bc8ac8b0
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/maslow
+++ b/charts/app-config/image-tags/staging/maslow
@@ -1,2 +1,3 @@
 image_tag: release-9bf31a7b01eeb742d74d282008992f5984d9f208
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/router-api
+++ b/charts/app-config/image-tags/staging/router-api
@@ -1,3 +1,3 @@
 image_tag: release-111145e9b2d587d30eee3a15178a379cc530f51e
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false
 promote_deployment: true

--- a/charts/app-config/image-tags/staging/search-admin
+++ b/charts/app-config/image-tags/staging/search-admin
@@ -1,1 +1,2 @@
 image_tag: release-bb53c10190131accbfc162b4e548e4595e84f74a
+automatic_deploys_enabled: false

--- a/charts/app-config/image-tags/staging/search-api
+++ b/charts/app-config/image-tags/staging/search-api
@@ -1,2 +1,2 @@
 image_tag: release-f1be8ff3a5d56582115d87498f065f651ad2bb73
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/app-config/image-tags/staging/service-manual-frontend
+++ b/charts/app-config/image-tags/staging/service-manual-frontend
@@ -1,2 +1,2 @@
 image_tag: release-a7feae52af7311d4eecceaabbbee026157111025
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/app-config/image-tags/staging/service-manual-publisher
+++ b/charts/app-config/image-tags/staging/service-manual-publisher
@@ -1,2 +1,3 @@
 image_tag: release-4bee478c71149ae7731ffd089950a9f993be64d6
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/short-url-manager
+++ b/charts/app-config/image-tags/staging/short-url-manager
@@ -1,2 +1,3 @@
 image_tag: release-fa3d014aae99d60b1743eedb1402faa4a0952d8b
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/signon
+++ b/charts/app-config/image-tags/staging/signon
@@ -1,3 +1,3 @@
 image_tag: release-1f4d3048bbba2eba2765004e1f9543c57c79b89c
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true
 promote_deployment: true

--- a/charts/app-config/image-tags/staging/specialist-publisher
+++ b/charts/app-config/image-tags/staging/specialist-publisher
@@ -1,2 +1,3 @@
 image_tag: release-bb14b95cd70c76fa7041d0088be39aa23d3fce1a
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/support
+++ b/charts/app-config/image-tags/staging/support
@@ -1,2 +1,3 @@
 image_tag: release-93d68491de1cd28c0713b4feff70a726c341e04a
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/support-api
+++ b/charts/app-config/image-tags/staging/support-api
@@ -1,2 +1,3 @@
 image_tag: release-f64b9acb75731a05585f521fb8b4a65fd3f5c649
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/travel-advice-publisher
+++ b/charts/app-config/image-tags/staging/travel-advice-publisher
@@ -1,2 +1,3 @@
 image_tag: release-bb8db07ff88e665323cb541c4457e137372e5563
 promote_deployment: true
+automatic_deploys_enabled: true

--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -6,7 +6,7 @@ CONFIG_URL="https://raw.githubusercontent.com/alphagov/govuk-helm-charts/main/ch
 CONFIG_CONTENT=$(curl -Ls "${CONFIG_URL}")
 
 # Extract the values of automatic_deploys_enabled and promote_deployment
-automatic_deploys_enabled=$(echo "${CONFIG_CONTENT}" | yq '.automatic_deploys_enabled // true' -)
+automatic_deploys_enabled=$(echo "${CONFIG_CONTENT}" | yq '.automatic_deploys_enabled' -)
 promote_deployment=$(echo "${CONFIG_CONTENT}" | yq '.promote_deployment' -)
 
 # Check if both values are true


### PR DESCRIPTION
This reverts the fix in https://github.com/alphagov/govuk-helm-charts/pull/1060 in favour of explicitly setting the `automatic_deploy_enabled` values in the image tag file.

This should minimise implicit behaviour and be less risky for apps that shouldn't be automatically deployed.
