### PR TITLE
Add environment variables to enable new 2SV features in Signon

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2173,6 +2173,10 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: PERMIT_2SV_EXEMPTION
+        value: "1"
+      - name: MANDATE_2SV_FOR_ORGANISATION
+        value: "1"
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This applies the feature flags to switch on new 2SV features in Signon.

In a later PR, we will remove the feature flags and these environment variables will be deleted.

This is the same as we did in staging as part of https://github.com/alphagov/govuk-helm-charts/pull/1053.

[Trello card](https://trello.com/c/MgDSImHc)