### PR TITLE
Enable Rails to serve /public files in Static

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2211,6 +2211,8 @@ govukApplications:
     extraEnv:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
+      - name: RAILS_SERVE_STATIC_FILES
+        value: "true"
       - name: GA_UNIVERSAL_ID
         value: &ga-universal-id UA-26179049-22
       - name: GOOGLE_TAG_MANAGER_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2259,6 +2259,8 @@ govukApplications:
     extraEnv:
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
+      - name: RAILS_SERVE_STATIC_FILES
+        value: "true"
       - name: GA_UNIVERSAL_ID
         value: &ga-universal-id UA-26179049-20
       - name: GOOGLE_TAG_MANAGER_ID


### PR DESCRIPTION
Static has a few static files stored under the [/public directory](https://github.com/alphagov/static/tree/main/public) (e.g. humans.txt, google-verification.html) that need to be available under the root path (e.g. gov.uk/humans.txt). There are [special routes published](https://github.com/alphagov/static/blob/main/lib/tasks/publishing_api.rake) so that router sends these requests to Static. Previously, Nginx served these public files as[ it's root directive was set to the /public folder](https://github.com/alphagov/govuk-puppet/blob/24aee1852dc429fb1152c8f06955799cf58e7883/modules/nginx/templates/proxy-vhost.conf#L150). However in Kubernetes, the Nginx and Rails container don't share the same file system. This sets the [RAILS_SERVE_STATIC_FILES env var](https://github.com/alphagov/static/blob/642861593b2e1f7fe25a8bf02360ab666b4846bc/config/environments/production.rb#L25) to enable Rails to serve those files. Ideally, we should probably upload these static files to S3 and serve them via Nginx - however this is more complicated as they don't share a common path prefix, which makes it difficult to know which requests are the static files.

This is testing this in integration and staging first.