### PR TITLE
Add content-data-api ETL cronjob.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -535,6 +535,10 @@ govukApplications:
         name: publishing-api-consumer
       - command: ['rake', 'publishing_api:bulk_import_consumer']
         name: bulk-import-publishing-api-consumer
+    cronTasks:
+      - name: etl
+        task: "etl:main"
+        schedule: "22 13 * * *"
     extraEnv:
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -537,6 +537,10 @@ govukApplications:
         name: publishing-api-consumer
       - command: ['rake', 'publishing_api:bulk_import_consumer']
         name: bulk-import-publishing-api-consumer
+    cronTasks:
+      - name: etl
+        task: "etl:main"
+        schedule: "9 7 * * *"
     extraEnv:
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -546,6 +546,10 @@ govukApplications:
         name: publishing-api-consumer
       - command: ['rake', 'publishing_api:bulk_import_consumer']
         name: bulk-import-publishing-api-consumer
+    cronTasks:
+      - name: etl
+        task: "etl:main"
+        schedule: "15 11 * * *"
     extraEnv:
       - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
         valueFrom:


### PR DESCRIPTION
This used to be run [from Jenkins](https://github.com/alphagov/govuk-puppet/blob/3327d34/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb).

The variations in the minutes field are intentional, for load spreading (since k8s CronJob still doesn't [support fuzzing the start time](https://www.github.com/kubernetes/kubernetes/issues/91652) 😢).

Tested: ran successfully on the integration cluster.

https://trello.com/c/v9XYF5EB

Related: https://github.com/alphagov/content-data-api/pull/1867