### PR TITLE
Remove "eks" prefix from Sentry environments for Router

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1769,7 +1769,7 @@ govukApplications:
       - name: GOMAXPROCS
         value: "2"
       - name: SENTRY_ENVIRONMENT
-        value: "integration-eks"
+        value: "integration"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1811,7 +1811,7 @@ govukApplications:
       - name: GOMAXPROCS
         value: "4"  # Keep this similar to the CPU limit (in whole cores).
       - name: SENTRY_ENVIRONMENT
-        value: "production-eks"
+        value: "production"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1818,7 +1818,7 @@ govukApplications:
       - name: GOMAXPROCS
         value: "4"  # Keep this similar to the CPU limit (in whole cores).
       - name: SENTRY_ENVIRONMENT
-        value: "staging-eks"
+        value: "staging"
       - name: ROUTER_PUBADDR
         value: ":3000"
       - name: ROUTER_APIADDR


### PR DESCRIPTION
Router uses a different ENV VAR to set Sentry environment names - these were missed with when dropped the prefix in 1a6c38070e05087099a477ac171939e3cd505b92 - https://github.com/alphagov/govuk-helm-charts/pull/1061