### PR TITLE
Add missing externalsecret to get Sentry DNS for Smokey

### DIFF
--- a/charts/smokey/templates/sentry-external-secret.yaml
+++ b/charts/smokey/templates/sentry-external-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.repoName }}-sentry
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/description: >
+      Client key for the associated Sentry project.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: {{ .Values.repoName }}-sentry
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: govuk/common/sentry
+        property: {{ .Values.repoName }}-dsn


### PR DESCRIPTION
This is needed to make the k8s secret containing the Sentry DNS that the smokey cronjob uses.