### PR TITLE
Remove signon 2SV-related feature flag env vars

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2151,8 +2151,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-      - name: PERMIT_2SV_EXEMPTION
-        value: "1"
       - name: MANDATE_2SV_FOR_ORGANISATION
         value: "1"
       - name: SIGNON_ADMIN_PASSWORD

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2151,8 +2151,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-      - name: MANDATE_2SV_FOR_ORGANISATION
-        value: "1"
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2194,8 +2194,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
-      - name: MANDATE_2SV_FOR_ORGANISATION
-        value: "1"
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2194,8 +2194,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
-      - name: PERMIT_2SV_EXEMPTION
-        value: "1"
       - name: MANDATE_2SV_FOR_ORGANISATION
         value: "1"
       - name: SIGNON_ADMIN_PASSWORD

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2201,8 +2201,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-      - name: MANDATE_2SV_FOR_ORGANISATION
-        value: "1"
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2201,8 +2201,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-      - name: PERMIT_2SV_EXEMPTION
-        value: "1"
       - name: MANDATE_2SV_FOR_ORGANISATION
         value: "1"
       - name: SIGNON_ADMIN_PASSWORD


### PR DESCRIPTION
Trello: https://trello.com/c/A4DSAq6g

These feature flags have served their purpose and the env var values will become redundant once alphagov/signon#2145 is merged and deployed to all environments.