### PR TITLE
Reduce default CPU resource request for nginx.

### DIFF
--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -88,7 +88,7 @@ nginxResources:
     cpu: 1
     memory: 1Gi
   requests:
-    cpu: 500m
+    cpu: 50m
     memory: 512Mi
 
 # dnsConfig is passed directly into the pod specs in the app and worker


### PR DESCRIPTION
The previous 500m was very underutilised. Even on relatively busy apps it's typically using 10m. Our overall CPU utilisation is around 10%, cluster-wide. This should go some way to improving that.