### PR TITLE
Add missing AWS_REGION env var for Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1559,6 +1559,8 @@ govukApplications:
         value: *publishing-notify-template
       - name: REPORTS_S3_BUCKET_NAME
         value: govuk-integration-publisher-csvs
+      - name: AWS_REGION
+        value: eu-west-1
 
 - name: publishing-api
   helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1594,6 +1594,8 @@ govukApplications:
         value: *publishing-notify-template
       - name: REPORTS_S3_BUCKET_NAME
         value: govuk-production-publisher-csvs
+      - name: AWS_REGION
+        value: eu-west-1
 
 - name: publishing-api
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1601,6 +1601,8 @@ govukApplications:
         value: *publishing-notify-template
       - name: REPORTS_S3_BUCKET_NAME
         value: govuk-staging-publisher-csvs
+      - name: AWS_REGION
+        value: eu-west-1
 
 - name: publishing-api
   helmValues:


### PR DESCRIPTION
This is needed by the AWS SDK used for uploading reports to S3.