### PR TITLE
Fix typo in asset-manager PDB labels.

### DIFF
--- a/charts/asset-manager/templates/pdb.yaml
+++ b/charts/asset-manager/templates/pdb.yaml
@@ -8,11 +8,11 @@ metadata:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app: {{ $fullName }}
     app.kubernetes.io/name: {{ $fullName }}
-    app.kubernetes.io/components: app
+    app.kubernetes.io/component: app
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ $fullName }}
-      app.kubernetes.io/components: app
+      app.kubernetes.io/component: app
   {{- .Values.podDisruptionBudget | toYaml | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Same fix as #1076. That's the last occurrence, based on a quick `git grep`.