### PR TITLE
Remove old replicaset clutter from Argo WF sensors.

### DIFF
--- a/charts/argo-services/templates/events/update-image-tag-sensor.yaml
+++ b/charts/argo-services/templates/events/update-image-tag-sensor.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     serviceAccountName: operate-workflow-sa
+  revisionHistoryLimit: 1
   dependencies:
   - name: update-image-tag
     eventSourceName: webhook

--- a/charts/argo-services/templates/workflows/post-sync/sensor.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/sensor.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     serviceAccountName: operate-workflow-sa
+  revisionHistoryLimit: 1
   dependencies:
   - name: sync-notification
     eventSourceName: webhook

--- a/charts/argo-services/templates/workflows/set-automatic-deploys/sensor.yaml
+++ b/charts/argo-services/templates/workflows/set-automatic-deploys/sensor.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     serviceAccountName: operate-workflow-sa
+  revisionHistoryLimit: 1
   dependencies:
   - name: set-automatic-deploys-enabled
     eventSourceName: webhook


### PR DESCRIPTION
The default of 10 really clutters up the Argo CD UI.

We don't really need to keep any previous replicasets for these, but let's make it 1 rather than 0 just on the off chance that it comes in handy when debugging one day.

[Schema reference for the field we're setting](https://www.github.com/argoproj/argo-events/blob/c2e63ea/api/jsonschema/schema.json#L3850)