### PR TITLE
Improve names of Signon cronjobs + dither timings.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2104,17 +2104,17 @@ govukApplications:
       hosts:
         - name: signon.{{ .Values.publishingDomainSuffix }}
     cronTasks:
-      - name: "kubernetes-sync-app-secrets"
+      - name: sync-app-secrets-to-k8s
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
-        schedule: "5 1 * * *"
+        schedule: "6 1 * * *"
         serviceAccount: signon
-      - name: "kubernetes-sync-token-secrets"
+      - name: sync-token-secrets-to-k8s
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
-        schedule: "5 1 * * *"
+        schedule: "7 1 * * *"
         serviceAccount: signon
-      - name: "delete-logs-older-than-two-years"
+      - name: delete-logs-older-than-two-years
         task: "event_log:delete_logs_older_than_two_years"
-        schedule: "15 1 * * *"
+        schedule: "16 1 * * *"
         serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2147,17 +2147,17 @@ govukApplications:
       hosts:
         - name: signon.{{ .Values.publishingDomainSuffix }}
     cronTasks:
-      - name: "kubernetes-sync-app-secrets"
+      - name: sync-app-secrets-to-k8s
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
-        schedule: "5 1 * * *"
+        schedule: "8 1 * * *"
         serviceAccount: signon
-      - name: "kubernetes-sync-token-secrets"
+      - name: sync-token-secrets-to-k8s
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
-        schedule: "5 1 * * *"
+        schedule: "9 1 * * *"
         serviceAccount: signon
-      - name: "delete-logs-older-than-two-years"
+      - name: delete-logs-older-than-two-years
         task: "event_log:delete_logs_older_than_two_years"
-        schedule: "15 1 * * *"
+        schedule: "17 1 * * *"
         serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2154,17 +2154,17 @@ govukApplications:
       hosts:
         - name: signon.{{ .Values.publishingDomainSuffix }}
     cronTasks:
-      - name: "kubernetes-sync-app-secrets"
+      - name: sync-app-secrets-to-k8s
         task: "kubernetes:sync_app_secrets[signon-secrets-sync-conf]"
-        schedule: "5 1 * * *"
+        schedule: "11 1 * * *"
         serviceAccount: signon
-      - name: "kubernetes-sync-token-secrets"
+      - name: sync-token-secrets-to-k8s
         task: "kubernetes:sync_token_secrets[signon-secrets-sync-conf]"
-        schedule: "5 1 * * *"
+        schedule: "12 1 * * *"
         serviceAccount: signon
-      - name: "delete-logs-older-than-two-years"
+      - name: delete-logs-older-than-two-years
         task: "event_log:delete_logs_older_than_two_years"
-        schedule: "15 1 * * *"
+        schedule: "18 1 * * *"
         serviceAccount: signon
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID


### PR DESCRIPTION
- Make it clearer that the "sync" jobs are syncing secrets from Signon into k8s.
- The CronJob names no longer match the Rake task names as closely, but that's fine; the contexts are different so e.g. the `kubernetes-` prefix makes sense in the Rake task but not so much in the name of the k8s cronjob.
- Also dither the timings a bit to smooth out the resource usage (i.e. reduce the chance of simultaneous cronjobs causing cluster scale-up).