### PR TITLE
Add Transition hits import cron + dither timings.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2568,16 +2568,19 @@ govukApplications:
     cronTasks:
       - name: import-dns
         task: "import:dns_details"
-        schedule: "0 07-19 * * 1-5"
+        schedule: "3 07-19 * * 1-5"
+      - name: import-hits-from-cdn-logs
+        task: "import:all:hits[govuk-integration-transition-fastly-logs]"
+        schedule: "22 3 * * *"
       - name: clear-expired-sessions
         task: "clear_expired_sessions"
-        schedule: "0 3 * * *"
+        schedule: "58 3 * * *"
       - name: clear-old-mappings
         task: "clear_old_mappings_batches"
-        schedule: "0 3 * * *"
-      - name: refresh-materialized
+        schedule: "52 3 * * *"
+      - name: refresh-materialized-hits
         task: "import:hits:refresh_materialized"
-        schedule: "30 0,12 * * *"
+        schedule: "38 0,12 * * *"
     extraVolumes:
       - name: transition-config-efs
         nfs:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2604,6 +2604,22 @@ govukApplications:
     dbMigrationEnabled: true
     workerEnabled: true
     transitionConfigEnabled: true
+    cronTasks:
+      - name: import-dns
+        task: "import:dns_details"
+        schedule: "4 07-19 * * 1-5"
+      - name: import-hits-from-cdn-logs
+        task: "import:all:hits[govuk-production-transition-fastly-logs]"
+        schedule: "39 3 * * *"
+      - name: clear-expired-sessions
+        task: "clear_expired_sessions"
+        schedule: "29 3 * * *"
+      - name: clear-old-mappings
+        task: "clear_old_mappings_batches"
+        schedule: "31 3 * * *"
+      - name: refresh-materialized-hits
+        task: "import:hits:refresh_materialized"
+        schedule: "28 0,12 * * *"
     extraVolumes:
       - name: transition-config-efs
         nfs:
@@ -2612,19 +2628,6 @@ govukApplications:
     appExtraVolumeMounts:
       - name: transition-config-efs
         mountPath: /app/data/transition-config
-    cronTasks:
-      - name: import-dns
-        task: "import:dns_details"
-        schedule: "0 07-19 * * 1-5"
-      - name: clear-expired-sessions
-        task: "clear_expired_sessions"
-        schedule: "0 3 * * *"
-      - name: clear-old-mappings
-        task: "clear_old_mappings_batches"
-        schedule: "0 3 * * *"
-      - name: refresh-materialized
-        task: "import:hits:refresh_materialized"
-        schedule: "30 0,12 * * *"
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2611,8 +2611,24 @@ govukApplications:
       hosts:
         - name: transition.{{ .Values.k8sExternalDomainSuffix }}
     dbMigrationEnabled: true
-    workerEnabled: false
+    workerEnabled: true
     transitionConfigEnabled: true
+    cronTasks:
+      - name: import-dns
+        task: "import:dns_details"
+        schedule: "24 07-19 * * 1-5"
+      - name: import-hits-from-cdn-logs
+        task: "import:all:hits[govuk-staging-transition-fastly-logs]"
+        schedule: "9 3 * * *"
+      - name: clear-expired-sessions
+        task: "clear_expired_sessions"
+        schedule: "18 3 * * *"
+      - name: clear-old-mappings
+        task: "clear_old_mappings_batches"
+        schedule: "8 3 * * *"
+      - name: refresh-materialized-hits
+        task: "import:hits:refresh_materialized"
+        schedule: "4 0,12 * * *"
     extraVolumes:
       - name: transition-config-efs
         nfs:
@@ -2621,19 +2637,6 @@ govukApplications:
     appExtraVolumeMounts:
       - name: transition-config-efs
         mountPath: /app/data/transition-config
-    cronTasks:
-      - name: import-dns
-        task: "import:dns_details"
-        schedule: "0 07-19 * * 1-5"
-      - name: clear-expired-sessions
-        task: "clear_expired_sessions"
-        schedule: "0 3 * * *"
-      - name: clear-old-mappings
-        task: "clear_old_mappings_batches"
-        schedule: "0 3 * * *"
-      - name: refresh-materialized
-        task: "import:hits:refresh_materialized"
-        schedule: "30 0,12 * * *"
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
- Add the `import:all:hits` cronjob, which replaces the `Transition: daily hits import` Jenkins cronjob.
- Dither the timings of the existing cronjobs to smooth out the load. The old Jenkins jobs already had this but in k8s we have to do the randomisation ourselves.
- Rename `refresh-materialized` to `refresh-materialized-hits`.
- Put Transition's YAML config in the same order in the integration/staging/production values files so that it's easier to compare them.

Tested: 

<details>
<summary>checked that <tt>rake import:all:hits[govuk-integration-transition-fastly-logs]</tt> works, via <tt>kubectl exec</tt></summary>

```
int GDS10889:app-config chrisbanks$ k exec -it deploy/transition -- bash
Defaulted container "app" out of: app, nginx
app@transition-86c964ddc7-ljtws:~$ rake import:all:hits[govuk-integration-transition-fastly-logs]
INFO: with_tmpdir_for_ruby: execing rake with TMPDIR=/tmp/ruby-app-2dkrazB3
Refreshing daily hit totals from hits ... done
Refreshing host paths ... done
Adding missing mapping_id/canonical_path to host paths ... #<HostPath:0x00007fe5b6d92968> not associated with a site
#<HostPath:0x00007fe5b4cdbc38> not associated with a site
done
Updating hits from host paths ... done
Precomputing mapping hit counts ... done
app@transition-86c964ddc7-ljtws:~$ 
```
</details>