### PR TITLE
added link to playbook for router alert

### DIFF
--- a/charts/monitoring-config/rules/router.yaml
+++ b/charts/monitoring-config/rules/router.yaml
@@ -27,6 +27,7 @@ groups:
         for: 10m
         labels:
           severity: page
+          playbook: 'https://docs.publishing.service.gov.uk/manual/alerts/{{ .Labels.alertname }}.html'
         annotations:
           summary: Router error ratio too high
-          description: More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.
+          description: 'More than 10% of HTTP responses from Router were 500-series errors for 10 minutes. [link]: {{ .Labels.playbook }}'


### PR DESCRIPTION
Added playbook link to router alert.
https://github.com/alphagov/govuk-developer-docs/pull/3964