### PR TITLE
Use "rake" instead of "rails" command for CronTasks

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -51,7 +51,7 @@ spec:
               image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
               imagePullPolicy: {{ $.Values.appImage.pullPolicy | default "Always" }}
               {{- if .task }}
-              command: ["rails"]
+              command: ["rake"]
               args: ["{{ .task }}"]
               {{- else if .command }}
               command: ["/bin/bash"]


### PR DESCRIPTION
Not all govuk apps are rails apps e.g. search-api is sinatra, however still uses rake tasks. The commands can be used interchangeably for Rails apps.