### PR TITLE
Bump the number of search api workers in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1936,6 +1936,7 @@ govukApplications:
     uploadAssets:
       enabled: false
     workerEnabled: true
+    workerReplicaCount: 3
     cronTasks:
       - name: generate-sitemap
         task: "sitemap:generate_and_upload"


### PR DESCRIPTION
After an issue with search api struggling to cope with the jobs in integration we are bumping the number of workers from the default 1 up to 3 to help handle the queue more quickly.