### PR TITLE
Avoid duplicating response headers in nginx.

### DIFF
--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -60,15 +60,17 @@ data:
         }
       ';
 
-      # This map creates a $sts_default variable for later use.
-      # If this header is already set by upstream, then $sts_default will
-      # be an empty string, which will later lead to:
-      #    add_header Strict-Transport-Security ''
-      # which will be ignored according to http://serverfault.com/a/598106
-      # If the header is not set by upstream, then $sts_default will be set
-      # and later uses in add_header will be effective.
-      map $upstream_http_strict_transport_security $sts_default {
-       '' "max-age=31536000; preload";
+      # Default values for response headers. These values are used when the
+      # header is not already set on the incoming response.
+      # https://serverfault.com/a/598106
+      map $upstream_http_strict_transport_security $strict_transport_security {
+        "" "max-age=31536000; preload";
+      }
+      map $upstream_http_permissions_policy $permissions_policy {
+        "" "interest-cohort=()";
+      }
+      map $upstream_http_x_content_type_options $x_content_type_options {
+        "" "nosniff";
       }
 
       log_format json_event '{ "@timestamp": "$time_iso8601", '
@@ -117,9 +119,11 @@ data:
         access_log /dev/stdout json_event;
         error_log /dev/stderr;
 
-        add_header Strict-Transport-Security $sts_default;
-        add_header Permissions-Policy interest-cohort=();
-        add_header X-Content-Type-Options "nosniff" always;
+        # Where the response header is already set on the incoming response,
+        # these are no-ops. https://serverfault.com/a/598106
+        add_header Strict-Transport-Security $strict_transport_security;
+        add_header Permissions-Policy $permissions_policy;
+        add_header X-Content-Type-Options $x_content_type_options always;
 
         {{- if ( or (ne .Values.govukEnvironment "production") (eq .Values.nginxDenyCrawlers true ) ) }}
         add_header X-Robots-Tag "noindex";


### PR DESCRIPTION
nginx's configuration interface for setting and manipulating headers (`add_header`) makes it very difficult to comply with the [HTTP spec with regard to duplicate headers](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2).

In order to achieve useful semantics like "set this response header if it isn't already set" (or even just "override this header", for that matter) rather than nginx's "add this header regardless of whether there's already one there with the same key, even if that violates the HTTP spec", we have to implement some logic that ought to be basic functionality of the webserver itself, using some rather unintuitive syntax and splitting the logic between two different places :(

Rollout: requires a `k rollout restart deploy` in each environment (hence doing just the one PR for the sake of expedience rather than adding environment guards and 3 separate PRs)

Tested: [minimal example in nginx playground](https://nginx-playground.wizardzines.com/#eyJuZ2lueF9jb25maWciOiJldmVudHMge31cbmh0dHAge1xuICAjIFRoZXNlIGhlYWRlcnMgYXJlbid0IHNldCBieSB0aGUgdXBzdHJlYW0gYXBwIGluIHRoaXMgdGVzdCBzYW5kYm94LlxuICBtYXAgJHVwc3RyZWFtX2h0dHBfc3RyaWN0X3RyYW5zcG9ydF9zZWN1cml0eSAkc3RyaWN0X3RyYW5zcG9ydF9zZWN1cml0eSB7XG4gICAgXCJcIiBcIm1heC1hZ2U9MzE1MzYwMDA7IHByZWxvYWRcIjtcbiAgfVxuICBtYXAgJHVwc3RyZWFtX2h0dHBfcGVybWlzc2lvbnNfcG9saWN5ICRwZXJtaXNzaW9uc19wb2xpY3kge1xuICAgIFwiXCIgXCJpbnRlcmVzdC1jb2hvcnQ9KClcIjtcbiAgfVxuICBtYXAgJHVwc3RyZWFtX2h0dHBfeF9jb250ZW50X3R5cGVfb3B0aW9ucyAkeF9jb250ZW50X3R5cGVfb3B0aW9ucyB7XG4gICAgXCJcIiBcIm5vc25pZmZcIjtcbiAgfVxuXG4gICMgRXhhbXBsZSBvZiBhIHJlc3BvbnNlIGhlYWRlciB0aGF0J3MgYWxyZWFkeSBzZXQgYnkgdGhlIHVwc3RyZWFtXG4gICMgYXBwIGluIHRoZSB0ZXN0IHNhbmRib3gsIHNvIHdlIGNhbiBjaGVjayB0aGF0IG91ciBjb25maWcgZG9lc24ndFxuICAjIG92ZXJyaWRlIGl0IG9yIHJlbW92ZSBpdCBvciBhZGQgYSBkdXBsaWNhdGUuXG4gIG1hcCAkdXBzdHJlYW1faHR0cF9hY2Nlc3NfY29udHJvbF9hbGxvd19vcmlnaW4gJGFjY2Vzc19jb250cm9sX2FsbG93X29yaWdpbiB7XG4gICAgXCJcIiBcInRoaXMgc3RyaW5nIHNob3VsZCBub3QgYXBwZWFyIGluIHRoZSByZXNwb25zZSBoZWFkZXJzXCI7XG4gIH1cblxuICBzZXJ2ZXIge1xuICAgIGxpc3RlbiA4MDtcbiAgICBzZXJ2ZXJfbmFtZSBodHRwLmJpbjtcbiAgICBhY2Nlc3NfbG9nIC9kZXYvbnVsbDtcblxuICAgIGxvY2F0aW9uIC8ge1xuICAgICAgIyBDaGVjayB0aGF0IHdlJ3JlIGFmZmVjdGluZyB0aGUgcmVzcG9uc2UgaGVhZGVycyBhdCBhbGwhXG4gICAgICBhZGRfaGVhZGVyIFgtU2hvdWxkLUFkZGVkLUJ5LU5naW54IFwiZm9vXCI7XG5cbiAgICAgICMgVGhpcyBzaG91bGQgbm90IGFmZmVjdCB0aGUgcmVzcG9uc2UgaGVhZGVycywgYmVjYXVzZSB0aGVcbiAgICAgICMgdXBzdHJlYW0gYXBwIGFscmVhZHkgc2V0cyBpdC5cbiAgICAgIGFkZF9oZWFkZXIgQWNjZXNzLUNvbnRyb2wtQWxsb3ctT3JpZ2luICRhY2Nlc3NfY29udHJvbF9hbGxvd19vcmlnaW47XG5cbiAgICAgICMgVGhlc2Ugc2hvdWxkIGNvbWUgb3V0IGFzIHRoZSBkZWZhdWx0IHZhbHVlcyBhYm92ZSBiZWNhdXNlXG4gICAgICAjIHRoZSB1cHN0cmVhbSBhcHAgZG9lc24ndCBzZW5kIHRoZW0uXG4gICAgICBhZGRfaGVhZGVyIFN0cmljdC1UcmFuc3BvcnQtU2VjdXJpdHkgJHN0cmljdF90cmFuc3BvcnRfc2VjdXJpdHk7XG4gICAgICBhZGRfaGVhZGVyIFBlcm1pc3Npb25zLVBvbGljeSAkcGVybWlzc2lvbnNfcG9saWN5O1xuICAgICAgYWRkX2hlYWRlciBYLUNvbnRlbnQtVHlwZS1PcHRpb25zICR4X2NvbnRlbnRfdHlwZV9vcHRpb25zIGFsd2F5cztcbiAgICAgIHByb3h5X3Bhc3MgaHR0cDovL2xvY2FsaG9zdDo3Nzc3O1xuICAgIH1cbiAgfVxufSIsImN1cmxfY29tbWFuZCI6ImN1cmwgLXZzIGh0dHA6Ly9sb2NhbGhvc3QvZ2V0In0=)