### PR TITLE
Add SENTRY_CURRENT_ENV for Smokey

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -80,6 +80,8 @@ spec:
                 secretKeyRef:
                   key: password
                   name: smokey-signon-account
+            - name: SENTRY_CURRENT_ENV
+              value: {{ .Values.govukEnvironment }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
We want to populate the Sentry `environment` tag.
Without specifying it, all errors are tagged as "production"