### PR TITLE
Fix wrong security group on account-api ingress LB.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -58,7 +58,6 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-www-waf-ruleset
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "account-api.{{ .Values.publishingDomainSuffix }}"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -55,7 +55,6 @@ govukApplications:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-www-waf-ruleset
         alb.ingress.kubernetes.io/load-balancer-name: account-api
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "account-api.{{ .Values.publishingDomainSuffix }}"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -61,7 +61,6 @@ govukApplications:
       annotations:
         <<: *default-alb-ingress-annotations
         <<: *alb-ingress-www-waf-ruleset
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "account-api.{{ .Values.publishingDomainSuffix }}"


### PR DESCRIPTION
This was open to Internet traffic on the old EC2 setup but accidentally firewalled off because of a copy-pasto in #949 (by me). Presumably didn't spot the problem because I happened to be connected to the office VPN when I tested the fix :(

This allows traffic to account-api.publishing.service.gov.uk from the public again, like it was before we switched to Kubernetes.

Verified that the old SG rules allowed this traffic by checking the in the AWS web console. In prod, rule `sgr-09af9510f487c75ee` was allowing TCP 443 inbound from `0.0.0.0/0` on `govuk_account_elb_external_access` (`sg-07787b07d2928de53`).

Kudos to @theseanything for finding this bug.