### PR TITLE
Use uncached endpoint for deployment config for promotion checks

### DIFF
--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Fetch the YAML configuration
-CONFIG_URL="https://raw.githubusercontent.com/alphagov/govuk-helm-charts/main/charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}"
-CONFIG_CONTENT=$(curl -Ls "${CONFIG_URL}")
+CONFIG_URL="/repos/alphagov/govuk-helm-charts/contents/charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}?ref=main"
+CONFIG_CONTENT=$(gh api --cache 0 "${CONFIG_URL}" -q '.content' | base64 --decode)
 
 # Extract the values of automatic_deploys_enabled and promote_deployment
 automatic_deploys_enabled=$(echo "${CONFIG_CONTENT}" | yq '.automatic_deploys_enabled' -)

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -69,6 +69,11 @@ spec:
             value: "{{"{{inputs.parameters.environment}}"}}"
           - name: REPO_NAME
             value: "{{"{{inputs.parameters.repoName}}"}}"
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: govuk-ci-github-creds
+                key: token
         source: |
           {{- .Files.Get "scripts/check-for-promotion.sh" | nindent 14 }}
     - name: send-webhook


### PR DESCRIPTION
This fixes an issue whereby deployments less than 5 mins apart can cause the later deployment to download an old deployment config due to caching implemented on the "raw.githubusercontent.com" endpoint. This switched the curl command to retireve the file using the GitHub API which should be uncached.