### PR TITLE
Add environment variable to Specialist Finder

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2421,6 +2421,8 @@ govukApplications:
         value: *publishing-notify-template
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: PUBLISH_PRE_PRODUCTION_FINDERS
+        value: "yes"
 
 - name: support
   helmValues:


### PR DESCRIPTION
This commit adds the environment variable `PUBLISH_PRE_PRODUCTION_FINDERS` to the Specialist Publisher app in integration, so that finders can be published and tested by end users.

This environment variable was present in the previous hosting infrastructure, but was not migrated over to the new EKS hosting platform.

It should only be present in integration. It's been deliberately omitted from the staging and production environments.