### PR TITLE
Pass govuk-dependency-checker image tag from the image-tag files

### DIFF
--- a/charts/app-config/image-tags/production/govuk-dependency-checker
+++ b/charts/app-config/image-tags/production/govuk-dependency-checker
@@ -1,0 +1,1 @@
+image_tag: release-bbba41106c8e5c0377dc6fa6815d1ee1d9dd1ed8

--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -31,10 +31,21 @@ spec:
       values: |
         {{- toYaml (omit $.Values "govukApplications") | nindent 8 }}
         repoName: {{ $reponame }}
+        {{- if .imageValues }}
+        images:
+        {{ range .imageValues }}
+          {{- $imageTagConfig := $.Files.Get (printf "image-tags/%s/%s" $.Values.govukEnvironment . ) | fromYaml }}
+          {{- $imageTag := $imageTagConfig.image_tag }}
+          {{ camelcase . }}:
+            repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/{{ . }}
+            tag: {{ $imageTag }}
+        {{- end }}
+        {{- else }}
         appImage:
           repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/{{ $reponame }}
           tag: {{ $imageTag }}
           pullPolicy: {{ .appImagePullPolicy | default "IfNotPresent" }}
+        {{- end }}
         {{- with .helmValues }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1126,6 +1126,8 @@ govukApplications:
 - name: govuk-jobs
   chartPath: charts/govuk-jobs
   postSyncWorkflowEnabled: "false"
+  imageValues:
+    - "govuk-dependency-checker"
 
 - name: hmrc-manuals-api
   helmValues:

--- a/charts/govuk-jobs/templates/dependabot-metrics-cronjob.yaml
+++ b/charts/govuk-jobs/templates/dependabot-metrics-cronjob.yaml
@@ -32,7 +32,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: main
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              image: "{{ .Values.images.GovukDependencyChecker.repository }}:{{ .Values.images.GovukDependencyChecker.tag }}"
               imagePullPolicy: "Always"
               command: ["./dependabot_time_to_merge"]
               args: ["--days-range", "7", "--output-format", "prometheus"]

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -10,6 +10,7 @@ resources:
   requests:
     cpu: 0.1
     memory: 800Mi
-image:
-  repository: "govuk-dependency-checker"
-  tag: "release"
+images:
+  GovukDependencyChecker:
+    repository: "govuk-dependency-checker"
+    tag: "release"


### PR DESCRIPTION
This enable continuous deployment for the govuk-dependency-checker job. This a the ability for a chart to be passed multiple image tags as Helm Values instead only the one that corresponded with app or repo name.