### PR TITLE
Bump max client body size for asset manager and travel advice publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -123,6 +123,7 @@ govukApplications:
 - name: asset-manager
   chartPath: charts/asset-manager
   helmValues:
+    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true
@@ -2649,6 +2650,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
+    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -120,6 +120,7 @@ govukApplications:
 - name: asset-manager
   chartPath: charts/asset-manager
   helmValues:
+    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true
@@ -2677,6 +2678,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
+    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -125,6 +125,7 @@ govukApplications:
 
 - name: asset-manager
   chartPath: charts/asset-manager
+  nginxClientMaxBodySize: 3M
   helmValues:
     workerEnabled: true
     ingress:
@@ -2667,6 +2668,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
+    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true


### PR DESCRIPTION
We've had a [zendesk ticket](https://govuk.zendesk.com/agent/tickets/5315094) from someone trying to upload a 2.1MB PDF via travel advice publisher, so bumping these limits to allow for this. We'll need both a bump to travel advice and to asset manager since this is an asset.

Questions I have:
* Is arbitrary 3MB OK? Any reason to pick any other number?
* I'm somewhat surprised asset manager didn't already have a higher limit than the default, although maybe mostly what we've been contending with has been large content items rather than large assets. But wanted to double check that there's definitely nowhere else this could be set for asset manager that I'm not overriding

