### PR TITLE
Enable Rails database migrations for imminence.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1142,6 +1142,7 @@ govukApplications:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
     nginxClientMaxBodySize: &max-upload-size 500M
     nginxProxyReadTimeout: 60s
+    dbMigrationEnabled: true
     workerEnabled: true
     extraEnv:
       - name: DATABASE_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1185,6 +1185,7 @@ govukApplications:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
     nginxClientMaxBodySize: &max-upload-size 500M
     nginxProxyReadTimeout: 60s
+    dbMigrationEnabled: true
     workerEnabled: true
     extraEnv:
       - name: DATABASE_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1183,6 +1183,7 @@ govukApplications:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
     nginxClientMaxBodySize: &max-upload-size 500M
     nginxProxyReadTimeout: 60s
+    dbMigrationEnabled: true
     workerEnabled: true
     extraEnv:
       - name: DATABASE_URL


### PR DESCRIPTION
We weren't running Rails database migrations (aka schema changes) on rollout for this app. Looks like we just forgot to set the flag in the Helm values. Probably a copy-pasto.

Thanks @kludgekml for spotting this!