### PR TITLE
Fix config for upload size limits on publisher apps.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -123,7 +123,6 @@ govukApplications:
 - name: asset-manager
   chartPath: charts/asset-manager
   helmValues:
-    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1139,7 +1139,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
-    nginxClientMaxBodySize: &max-upload-size 500M
+    nginxClientMaxBodySize: *max-upload-size
     nginxProxyReadTimeout: 60s
     dbMigrationEnabled: true
     workerEnabled: true
@@ -2650,7 +2650,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
-    nginxClientMaxBodySize: 3M
+    nginxClientMaxBodySize: *max-upload-size
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1182,7 +1182,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
-    nginxClientMaxBodySize: &max-upload-size 500M
+    nginxClientMaxBodySize: *max-upload-size
     nginxProxyReadTimeout: 60s
     dbMigrationEnabled: true
     workerEnabled: true
@@ -2678,7 +2678,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
-    nginxClientMaxBodySize: 3M
+    nginxClientMaxBodySize: *max-upload-size
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -120,7 +120,6 @@ govukApplications:
 - name: asset-manager
   chartPath: charts/asset-manager
   helmValues:
-    nginxClientMaxBodySize: 3M
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1180,7 +1180,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
-    nginxClientMaxBodySize: &max-upload-size 500M
+    nginxClientMaxBodySize: *max-upload-size
     nginxProxyReadTimeout: 60s
     dbMigrationEnabled: true
     workerEnabled: true
@@ -2668,7 +2668,7 @@ govukApplications:
 
 - name: travel-advice-publisher
   helmValues:
-    nginxClientMaxBodySize: 3M
+    nginxClientMaxBodySize: *max-upload-size
     workerEnabled: true
     ingress:
       enabled: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -125,7 +125,6 @@ govukApplications:
 
 - name: asset-manager
   chartPath: charts/asset-manager
-  nginxClientMaxBodySize: 3M
   helmValues:
     workerEnabled: true
     ingress:

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -146,7 +146,7 @@ data:
           proxy_pass http://{{ $fullName }};
         }
 
-        client_max_body_size 500m;
+        client_max_body_size 500M;
 
         # Store values from Rails response headers for use in the
         # cloud-storage-proxy location block below.


### PR DESCRIPTION
- Remove a [no-op Helm value](https://github.com/alphagov/govuk-helm-charts/pull/1108) for asset-manager.
- Apply the 500 MB upload size limit to travel-advice-publisher (same as the others).

Bit more detail in the commit messages.