### PR TITLE
Add conjobs to update popularity on search indexes

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1950,6 +1950,34 @@ govukApplications:
       - name: generate-sitemap
         task: "sitemap:generate_and_upload"
         schedule: "50 2 * * *"
+      - name: load-page-traffic
+        command: "./bin/load_page_traffic.sh"
+        schedule: "32 4 * * *"
+        env:
+        - name: AWS_SEARCH_ANALYTICS_BUCKET
+          value: govuk-search-analytics-integration
+      - name: update-detailed-index-popularity
+        task: "search:update_popularity"
+        schedule: "42 4 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: detailed
+        - name: PROCESS_ALL_DATA
+          value: "true"
+      - name: update-government-index-popularity
+        task: "search:update_popularity"
+        schedule: "12 5 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: government
+        - name: PROCESS_ALL_DATA
+          value: "true"
+      - name: update-govuk-index-popularity
+        task: "search:update_popularity"
+        schedule: "42 5 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: govuk
     workers:
       - command: ["sidekiq", "-C", "config/sidekiq.yml"]
         name: worker

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1996,6 +1996,34 @@ govukApplications:
       - name: generate-sitemap
         task: "sitemap:generate_and_upload"
         schedule: "50 2 * * *"
+      - name: load-page-traffic
+        command: "./bin/load_page_traffic.sh"
+        schedule: "32 4 * * *"
+        env:
+        - name: AWS_SEARCH_ANALYTICS_BUCKET
+          value: govuk-search-analytics-integration
+      - name: update-detailed-index-popularity
+        task: "search:update_popularity"
+        schedule: "42 4 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: detailed
+        - name: PROCESS_ALL_DATA
+          value: "true"
+      - name: update-government-index-popularity
+        task: "search:update_popularity"
+        schedule: "12 5 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: government
+        - name: PROCESS_ALL_DATA
+          value: "true"
+      - name: update-govuk-index-popularity
+        task: "search:update_popularity"
+        schedule: "42 5 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: govuk
     workers:
       - command: ["sidekiq", "-C", "config/sidekiq.yml"]
         name: worker

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1996,6 +1996,34 @@ govukApplications:
       - name: generate-sitemap
         task: "sitemap:generate_and_upload"
         schedule: "50 2 * * *"
+      - name: load-page-traffic
+        command: "./bin/load_page_traffic.sh"
+        schedule: "32 4 * * *"
+        env:
+        - name: AWS_SEARCH_ANALYTICS_BUCKET
+          value: govuk-search-analytics-integration
+      - name: update-detailed-index-popularity
+        task: "search:update_popularity"
+        schedule: "42 4 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: detailed
+        - name: PROCESS_ALL_DATA
+          value: "true"
+      - name: update-government-index-popularity
+        task: "search:update_popularity"
+        schedule: "12 5 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: government
+        - name: PROCESS_ALL_DATA
+          value: "true"
+      - name: update-govuk-index-popularity
+        task: "search:update_popularity"
+        schedule: "42 5 * * *"
+        env:
+        - name: SEARCH_INDEX
+          value: govuk
     workers:
       - command: ["sidekiq", "-C", "config/sidekiq.yml"]
         name: worker

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -66,6 +66,9 @@ spec:
                 {{- with $.Values.extraEnv }}
                   {{- . | toYaml | trim | nindent 16 }}
                 {{- end }}
+                {{- with .env }}
+                  {{- . | toYaml | trim | nindent 16 }}
+                {{- end }}
               {{- with $.Values.appResources }}
               resources:
                 {{- . | toYaml | trim | nindent 16 }}


### PR DESCRIPTION
This replaces function of the search-api-fetch-analytics-data Jenkins job and [nightly-run.sh in search-analytics repo](https://github.com/alphagov/search-analytics/blob/d124229da53d9664512a74b47ded8dd50c27e8dc/nightly-run.sh).

The update popularity rake tasks are spaced out over 40 min intervals to avoid overwhelming Redis.