### PR TITLE
Add REDIS_URL to the Release app and enable worker

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1644,6 +1644,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: release.{{ .Values.k8sExternalDomainSuffix }}
+    workerEnabled: true
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -1670,6 +1671,8 @@ govukApplications:
           secretKeyRef:
             name: release-github
             key: token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 
 - name: router-api
   helmValues: &router-api

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1685,6 +1685,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: release.{{ .Values.k8sExternalDomainSuffix }}
+    workerEnabled: true
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -1711,6 +1712,8 @@ govukApplications:
           secretKeyRef:
             name: release-github
             key: token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
 
 - name: router-api
   helmValues: &router-api

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1686,6 +1686,7 @@ govukApplications:
           ]}}]
       hosts:
         - name: release.{{ .Values.k8sExternalDomainSuffix }}
+    workerEnabled: true
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
@@ -1712,6 +1713,8 @@ govukApplications:
           secretKeyRef:
             name: release-github
             key: token
+      - name: REDIS_URL
+        value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
 - name: router-api
   helmValues: &router-api


### PR DESCRIPTION
We are adding Sidekiq with Redis to the Release app to post Slack messages.

This also enables worker as per https://github.com/alphagov/govuk-helm-charts/blob/d3fc07/charts/generic-govuk-app/values.yaml#L16

[Trello](https://trello.com/c/014hvLkj/3171-add-deploy-out-of-sync-alerting-to-the-release-app-5)