### PR TITLE
Requeue scheduled publications after DB restore.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1477,12 +1477,15 @@ govukApplications:
     dbMigrationEnabled: true
     workerEnabled: true
     cronTasks:
-      - name: reports-generate
-        task: "reports:generate"
-        schedule: "0 * * * *"
       - name: mail-fetcher
         command: "script/mail_fetcher"
         schedule: "*/5 * * * *"
+      - name: reports-generate
+        task: "reports:generate"
+        schedule: "0 * * * *"
+      - name: reschedule-pubs-after-db-restore  # non-prod only
+        task: "editions:requeue_scheduled_for_publishing"
+        schedule: "38 7 * * 1-5"
     ingress:
       enabled: true
       annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1519,12 +1519,15 @@ govukApplications:
     dbMigrationEnabled: true
     workerEnabled: true
     cronTasks:
-      - name: reports-generate
-        task: "reports:generate"
-        schedule: "0 * * * *"
       - name: mail-fetcher
         command: "script/mail_fetcher"
         schedule: "*/5 * * * *"
+      - name: reports-generate
+        task: "reports:generate"
+        schedule: "0 * * * *"
+      - name: reschedule-pubs-after-db-restore  # non-prod only
+        task: "editions:requeue_scheduled_for_publishing"
+        schedule: "47 7 * * 1-5"
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
There was a Jenkins cronjob in the [staging](https://github.com/alphagov/govuk-puppet/blob/c61e9cf/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb) and [integration](https://github.com/alphagov/govuk-puppet/blob/c61e9cf/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb) environments that ran `rake editions:requeue_scheduled_for_publishing` each morning so that any new scheduled publications would be inserted as tasks in the Sidekiq queue after the nightly database restore (also known as the environment sync).

The other commands in those Jenkins jobs are either no longer necessary (e.g. [`router-api routes:reload`](https://github.com/alphagov/router-api/pull/550)) or we'll deal with them without the need for more batch jobs (e.g. we can now set `SIGNON_APPS_URI_SUB_PATTERN` instead of patching the database).