### PR TITLE
[BAU] Remove un-needed setup-yq "uses" action...

### DIFF
--- a/.github/workflows/update-image-tag.yml
+++ b/.github/workflows/update-image-tag.yml
@@ -41,8 +41,6 @@ jobs:
       config_file: "charts/app-config/image-tags/${{ env.environment }}/${{ env.repo }}"
       manual_deploy: ${{ github.event.client_payload.manual_deploy || inputs.manual_deploy }}
     steps:
-      - uses: chrisdickinson/setup-yq@latest
-
       - name: Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## What?
This removes the `chrisdickinson/setup-yq@latest` action from our update-image-tag Github job. This workflow doesn't see a lot of use, but the current version of `ubuntu-latest` now includes `yq` out of the box.

The above action was producing deprecation warnings because it is stuck on Node 12.

## More Info

- [How to fix deprecated GitHub Action chrisdickinson/setup-yq](https://ramigs.dev/blog/how-to-fix-deprecated-github-action-chrisdickinson-setup-yq/)