### PR TITLE
Rightsize resource requests for Release app.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1686,6 +1686,24 @@ govukApplications:
       hosts:
         - name: release.{{ .Values.k8sExternalDomainSuffix }}
     workerEnabled: true
+    replicaCount: 2
+    workerReplicaCount: 2
+    podDisruptionBudget:
+      minAvailable: 1
+    appResources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 400Mi
+    workerResources:
+      limits:
+        cpu: 250m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 400Mi
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1690,6 +1690,23 @@ govukApplications:
       hosts:
         - name: release.{{ .Values.k8sExternalDomainSuffix }}
     workerEnabled: true
+    workerReplicaCount: 1
+    podDisruptionBudget:
+      minAvailable: 1
+    appResources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 400Mi
+    workerResources:
+      limits:
+        cpu: 250m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 400Mi
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
WSS has never gone above 200 MiB and CPU usage is tiny.

Also reduce server replica count to 2 (since this is an internal dashboard with a very low request rate) and worker count to 1 (since all the worker does is forward messages to Slack, so if it gets reschedule then it'll just add a few seconds of delay to an already not-guaranteed message).

This offsets the extra cost of the recently-added worker deployment.