### PR TITLE
Actually set worker replicas to 1 for Release.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1687,7 +1687,7 @@ govukApplications:
         - name: release.{{ .Values.k8sExternalDomainSuffix }}
     workerEnabled: true
     replicaCount: 2
-    workerReplicaCount: 2
+    workerReplicaCount: 1
     podDisruptionBudget:
       minAvailable: 1
     appResources:


### PR DESCRIPTION
Whoops, sorry for the extra noise. Fixes typo in 682df2f7.