### PR TITLE
Let Release app access the Slack webhook url

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1673,6 +1673,11 @@ govukApplications:
             key: token
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: SLACK_WEBHOOK_URL
+        valueFrom:
+          secretKeyRef:
+            name: slack-webhook-url
+            key: url
 
 - name: router-api
   helmValues: &router-api

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1714,6 +1714,11 @@ govukApplications:
             key: token
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: SLACK_WEBHOOK_URL
+        valueFrom:
+          secretKeyRef:
+            name: slack-webhook-url
+            key: url
 
 - name: router-api
   helmValues: &router-api

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1715,6 +1715,11 @@ govukApplications:
             key: token
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: SLACK_WEBHOOK_URL
+        valueFrom:
+          secretKeyRef:
+            name: slack-webhook-url
+            key: url
 
 - name: router-api
   helmValues: &router-api


### PR DESCRIPTION
This adds SLACK_WEBHOOK_URL as extra variable to the Release app config.

The Slack webhook url is stored in AWS Secrets Manager and already used by Argo:
https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=govuk%2Fslack-webhook-url&region=eu-west-1