### PR TITLE
Add missing email alert api bearer tokens to collections publisher

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -368,6 +368,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-collections-publisher-publishing-api
             key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-email-alert-api
+            key: bearer_token
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -373,6 +373,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-collections-publisher-publishing-api
             key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-email-alert-api
+            key: bearer_token
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Leaving integration value missing for time being to support a bug fix. 

Will add to integration once complete.