### PR TITLE
Add missing bearer token to collections publisher (integration)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -362,6 +362,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-collections-publisher-publishing-api
             key: bearer_token
+      - name: EMAIL_ALERT_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-collections-publisher-email-alert-api
+            key: bearer_token
       - name: JWT_AUTH_SECRET
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
 Email-alert-api bearer token

Adding for integration now, following [adding in staging and production](https://github.com/alphagov/govuk-helm-charts/pull/1124)