### PR TITLE
Add Asset Manager API key to Frontend

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1016,6 +1016,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-frontend-account-api
             key: bearer_token
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-asset-manager
+            key: bearer-token
       - name: ELECTIONS_API_KEY
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1043,6 +1043,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-frontend-account-api
             key: bearer_token
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-asset-manager
+            key: bearer-token
       - name: ELECTIONS_API_KEY
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1048,6 +1048,11 @@ govukApplications:
           secretKeyRef:
             name: signon-token-frontend-account-api
             key: bearer_token
+      - name: ASSET_MANAGER_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-frontend-asset-manager
+            key: bearer-token
       - name: ELECTIONS_API_KEY
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Done as part of the work to migrate CSV Previews from Whitehall to Frontend. 

Trello: https://trello.com/c/7IA3mJD8/544-set-up-communication-between-frontend-and-asset-manager-for-csv-previews