### PR TITLE
Add email alert monitoring

### DIFF
--- a/charts/app-config/image-tags/integration/email-alert-monitoring
+++ b/charts/app-config/image-tags/integration/email-alert-monitoring
@@ -1,3 +1,1 @@
-image_tag: release-2532625527a6ba455e543a56cefcd82d814f9cd8
 automatic_deploys_enabled: true
-promote_deployment: true

--- a/charts/app-config/image-tags/integration/email-alert-monitoring
+++ b/charts/app-config/image-tags/integration/email-alert-monitoring
@@ -1,0 +1,3 @@
+image_tag: release-2532625527a6ba455e543a56cefcd82d814f9cd8
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/image-tags/production/email-alert-monitoring
+++ b/charts/app-config/image-tags/production/email-alert-monitoring
@@ -1,0 +1,1 @@
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/email-alert-monitoring
+++ b/charts/app-config/image-tags/staging/email-alert-monitoring
@@ -1,0 +1,1 @@
+automatic_deploys_enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -917,6 +917,38 @@ govukApplications:
             name: email-alert-auth
             key: token
 
+- name: email-alert-monitoring
+  helmValues:
+    appEnabled: false
+    uploadAssets:
+      enabled: false
+    rails:
+      enabled: false
+    cronTasks:
+      - name: run_medical_alerts
+        task: "run_medical_alerts"
+        schedule: "21,51 * * * *"
+      - name: run_travel_alerts
+        task: "run_travel_alerts"
+        schedule: "*/15 * * * *"
+    workerEnabled: false
+    extraEnv:
+      - name: GOOGLE_OAUTH_CREDENTIALS
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-monitoring-google
+            key: oauth_credentials
+      - name: GOOGLE_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-monitoring-google
+            key: client_id
+      - name: GOOGLE_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-monitoring-google
+            key: client_secret
+
 - name: email-alert-service
   helmValues:
     appEnabled: false

--- a/charts/external-secrets/templates/email-alert-monitoring/google.yaml
+++ b/charts/external-secrets/templates/email-alert-monitoring/google.yaml
@@ -17,4 +17,4 @@ spec:
     name: email-alert-monitoring-google
   dataFrom:
     - extract:
-        key: govuk/email-alert-montioring/google
+        key: govuk/email-alert-monitoring/google

--- a/charts/external-secrets/templates/email-alert-monitoring/google.yaml
+++ b/charts/external-secrets/templates/email-alert-monitoring/google.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: email-alert-monitoring-google
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Google secrets used by email alert monitoring.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: email-alert-monitoring-google
+  dataFrom:
+    - extract:
+        key: govuk/email-alert-montioring/google


### PR DESCRIPTION
Currently runs on jenkins and is being migrated over to EKS - this only needs to be run in Production.
https://deploy.blue.production.govuk.digital/job/medical-safety-email-alert-check/configure

Jenkins job currently runs to Rake commands on a cron:
bundle exec rake run_medical_alerts @ 21:51 daily.
bundle exec rake run_travel_alerts @ every 15th minute.

Purposely not added to Integration and Staging, though i have added Image tags in all environments incase we may want to deploy in other environments if testing.

https://trello.com/c/qBfopr21/1184-medicalsafetyemailalertcheck-traveladviceemailalertcheck-jenkins-job-move-to-eks