### PR TITLE
Add SSO_PUSH_USER_EMAIL env var to signon

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2232,6 +2232,8 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+      - name: SSO_PUSH_USER_EMAIL
+        value: signon+permissions@alphagov.co.uk
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This is used to sync new user permissions with applications. This env var was previously set in the old infrastructure, but not copied over.