### PR TITLE
Add SSO_PUSH_USER_EMAIL env var to signon staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2291,6 +2291,8 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+      - name: SSO_PUSH_USER_EMAIL
+        value: signon+permissions@alphagov.co.uk
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2281,6 +2281,8 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+      - name: SSO_PUSH_USER_EMAIL
+        value: signon+permissions@alphagov.co.uk
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This is used to sync new user permissions with applications. This env var was previously set in the old infrastructure, but not copied over.

This was previously set for integration, now setting it in all envs as we have confirmed this fixes the issues we were seeing.

As per @sengi's comment on the integration PR, it probably doesn't make sense to have this as a configurable value. Fixing for now as is, but will pass over to the signon team to consider.