### PR TITLE
Fix broken reference to a secret in Finder app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1015,7 +1015,7 @@ govukApplications:
         valueFrom:
           secretKeyRef:
             name: signon-token-frontend-asset-manager
-            key: bearer-token
+            key: bearer_token
       - name: ELECTIONS_API_KEY
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1042,7 +1042,7 @@ govukApplications:
         valueFrom:
           secretKeyRef:
             name: signon-token-frontend-asset-manager
-            key: bearer-token
+            key: bearer_token
       - name: ELECTIONS_API_KEY
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1047,7 +1047,7 @@ govukApplications:
         valueFrom:
           secretKeyRef:
             name: signon-token-frontend-asset-manager
-            key: bearer-token
+            key: bearer_token
       - name: ELECTIONS_API_KEY
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
The finder app was failing to start because it couldn't find the referenced key `bearer-token` in the secret store.

It turns out this was a typo in PR #1126 / commit 94f254ca5f527b6e9f7505ed5199c5885cf7909a and the correct key name should be `bearer_token`.