### PR TITLE
Add external secret for email alert api bulk migrate confirmation email account

### DIFF
--- a/charts/external-secrets/templates/email-alert-api/bulk-migrate-confirmation-email-account.yaml
+++ b/charts/external-secrets/templates/email-alert-api/bulk-migrate-confirmation-email-account.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: email-alert-api-bulk-migrate-confirmation-email-account
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Email address to which confirmations of bulk migrations of email alert subscriptions are sent. Introduced to enable retiring of specialist topics and auto-migration of subscriptions.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: email-alert-api-bulk-migrate-confirmation-email-account
+  dataFrom:
+    - extract:
+        key: govuk/email-alert-api/bulk-migrate-confirmation-email-account


### PR DESCRIPTION
Part of configuring an email group to send a confirmation to when we complete a bulk migration of email subscriptions, as part of retiring specialist topics. 

I've followed the [documentation](https://govuk-k8s-user-docs.publishing.service.gov.uk/manage-app/manage-secrets/#defining-an-externalsecret-in-kubernetes), and the secret is now in aws for each environment.

Trello: [https://trello.com/c/xERWHGe7/1831-configure-bulk-migrate-email-confirmation-m](https://trello.com/c/xERWHGe7/1831-configure-bulk-migrate-email-confirmation-m)
