### PR TITLE
Add bulk migrate confirmation email account env var for email-alert-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -830,6 +830,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-email-alert-api-account-api
             key: bearer_token
+      - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
+        value: email-alert-api-integration@digital.cabinet-office.gov.uk
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -840,6 +840,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-email-alert-api-account-api
             key: bearer_token
+      - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
+        value: email-alert-api-bulk-migrate@digital.cabinet-office.gov.uk
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -847,6 +847,8 @@ govukApplications:
           secretKeyRef:
             name: signon-token-email-alert-api-account-api
             key: bearer_token
+      - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
+        value: email-alert-api-staging@digital.cabinet-office.gov.uk
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Part of configuring an email group to send a confirmation to when we complete a bulk migration of email subscriptions, as part of retiring specialist topics.

Trello: https://trello.com/c/xERWHGe7/1831-configure-bulk-migrate-email-confirmation-m