### PR TITLE
Permit ingress to asset metadata routes for Asset Manager in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -143,16 +143,20 @@ govukApplications:
       hosts:
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           paths:
+            - path: /assets/  # Integration only
             - path: /government/uploads/
             - path: /government/assets/
             - path: /media/
             - path: /auth/gds  # Viewing draft assets requires user auth.
+            - path: /whitehall_assets/  # Integration only
         - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
           paths:
+            - path: /assets/  # Integration only
             - path: /government/uploads/
             - path: /government/assets/
             - path: /media/
             - path: /auth/gds  # Viewing draft assets requires user auth.
+            - path: /whitehall_assets/  # Integration only
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false


### PR DESCRIPTION
We would like to use the integration asset manager to allow development of new features locally, without needing to replicate the entirety of Asset Manager's database and assets.

This will permit ingress to the relevant routes and allow us to obtain that metadata.

The Asset Manager application [requires a user to be authenticated](https://github.com/alphagov/asset-manager/blob/7cf2e0c88f130285a9beb7fed02d0cc648ccda03/app/controllers/application_controller.rb#L8) to access this path, so it will only be available to those with a relevant Signon account or bearer token.

[Trello card](https://trello.com/c/hn6IpttC/545-create-route-controller-basic-view-and-presenter-for-csv-preview-in-frontend)