### PR TITLE
Change Smokey schedule in integration and staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2254,6 +2254,8 @@ govukApplications:
 
 - name: smokey
   chartPath: charts/smokey
+  helmValues:
+    cronSchedule: "*/10 7-19 * * 1-5"
 
 - name: static
   helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2301,6 +2301,8 @@ govukApplications:
 
 - name: smokey
   chartPath: charts/smokey
+  helmValues:
+    cronSchedule: "*/10 7-19 * * 1-5"
 
 - name: static
   helmValues:

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -6,7 +6,7 @@ spec:
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 3
   successfulJobsHistoryLimit: 3
-  schedule: "*/10 * * * *"
+  schedule: {{ .Values.cronSchedule | quote }}
   jobTemplate:
     metadata:
       name: smokey

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -2,6 +2,7 @@ govukEnvironment: test
 externalDomainSuffix: www.test.publishing.service.gov.uk
 publishingDomainSuffix: test.publishing.service.gov.uk
 assetsDomain: assets.test.publishing.service.gov.uk
+cronSchedule: "*/10 * * * *"
 
 k8sExternalDomainSuffix: eks.test.govuk.digital
 k8sPublishingDomainSuffix: test.publishing.service.gov.uk


### PR DESCRIPTION
We don't need Smokey to run 24/7 in these environments.

The nightly data sync means a lot Smokey jobs fail and there's a lot of noise in Sentry.