### PR TITLE
Disable time limit for Clamd scans for testing.

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -25,7 +25,7 @@ data:
     # (as opposed to UNIX socket).
     MaxFileSize 500M
     MaxScanSize 1200M
-    MaxScanTime 240000
+    MaxScanTime 0
     MaxThreads 20
     SelfCheck 900
     StreamMaxLength 500M


### PR DESCRIPTION
Applying to Integration only for now.

Removing limit to test actual time it takes to scan certain files.
Will use the data from this exercise to set an somewhat accurate value here.