### PR TITLE
Clean up Helm values for pre-cutover DNS suffixes.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3,13 +3,9 @@
 
 govukEnvironment: integration
 externalDomainSuffix: integration.publishing.service.gov.uk
+k8sExternalDomainSuffix: eks.integration.govuk.digital
 publishingDomainSuffix: integration.publishing.service.gov.uk
 assetsDomain: assets.integration.publishing.service.gov.uk
-
-k8sAssetsDomain: assets-eks.integration.publishing.service.gov.uk
-k8sExternalDomainSuffix: eks.integration.govuk.digital
-# TODO: Remove once fully migrated to EKS
-k8sPublishingDomainSuffix: eks.integration.govuk.digital
 
 cspReportURI: https://csp-reporter.integration.publishing.service.gov.uk/report
 

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3,13 +3,9 @@
 
 govukEnvironment: production
 externalDomainSuffix: gov.uk
+k8sExternalDomainSuffix: eks.production.govuk.digital
 publishingDomainSuffix: publishing.service.gov.uk
 assetsDomain: assets.publishing.service.gov.uk
-
-k8sAssetsDomain: assets-eks.publishing.service.gov.uk
-k8sExternalDomainSuffix: eks.production.govuk.digital
-# TODO: Remove once fully migrated to EKS
-k8sPublishingDomainSuffix: eks.production.govuk.digital
 
 cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3,13 +3,9 @@
 
 govukEnvironment: staging
 externalDomainSuffix: staging.publishing.service.gov.uk
+k8sExternalDomainSuffix: eks.staging.govuk.digital
 publishingDomainSuffix: staging.publishing.service.gov.uk
 assetsDomain: assets.staging.publishing.service.gov.uk
-
-k8sAssetsDomain: assets-eks.staging.publishing.service.gov.uk
-k8sExternalDomainSuffix: eks.staging.govuk.digital
-# TODO: Remove once fully migrated to EKS
-k8sPublishingDomainSuffix: eks.staging.govuk.digital
 
 cspReportURI: https://csp-reporter.staging.publishing.service.gov.uk/report
 

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -1,12 +1,10 @@
 govukEnvironment: test
 externalDomainSuffix: www.test.publishing.service.gov.uk
+k8sExternalDomainSuffix: eks.test.govuk.digital
 publishingDomainSuffix: test.publishing.service.gov.uk
 assetsDomain: assets.test.publishing.service.gov.uk
-cronSchedule: "*/10 * * * *"
 
-k8sExternalDomainSuffix: eks.test.govuk.digital
-k8sPublishingDomainSuffix: test.publishing.service.gov.uk
-k8sAssetsDomain: assets-eks.test.publishing.service.gov.uk
+cronSchedule: "*/10 * * * *"
 
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey


### PR DESCRIPTION
`k8sAssetsDomain` and `k8sPublishingDomainSuffix` were used in the run up to launching on Kubernetes, but are no longer needed.

There are no longer any references to these values in any of the templates.

https://trello.com/c/iYcNFlgH