### PR TITLE
Add service account for search api ltr job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1118,8 +1118,8 @@ govukApplications:
       deployInstance:
         type: ml.t2.medium
         count: '2'
-      iamRole: arn:aws:iam::210287912431:role/govuk-integration-search-learntorank-role
       sageMakerImage: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/search
+      iamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
 
 - name: hmrc-manuals-api
   helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1118,7 +1118,7 @@ govukApplications:
       deployInstance:
         type: ml.t2.medium
         count: '2'
-      sageMakerImage: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/search
+      sageMakerImage: 210287912431.dkr.ecr.eu-west-1.amazonaws.com/search
       iamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
 
 - name: hmrc-manuals-api

--- a/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
+++ b/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
@@ -24,6 +24,7 @@ spec:
             app.kubernetes.io/component: "search-api-ltr"
         spec:
           enableServiceLinks: false
+          serviceAccountName: search-api-learn-to-rank
           securityContext:
             fsGroup: {{ .Values.securityContext.runAsGroup }}
             runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}

--- a/charts/govuk-jobs/templates/search-api-ltr-service-account.yaml
+++ b/charts/govuk-jobs/templates/search-api-ltr-service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: search-api-learn-to-rank
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.learnToRank.iamRole }}


### PR DESCRIPTION
This provides service account that allows the search-api learn to rank
job assume the correct IAM role.