### PR TITLE
Use seperate IAM roles for sagemaker and the service account

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1119,7 +1119,8 @@ govukApplications:
         type: ml.t2.medium
         count: '2'
       sageMakerImage: 210287912431.dkr.ecr.eu-west-1.amazonaws.com/search
-      iamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
+      sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
+      serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
 
 - name: hmrc-manuals-api
   helmValues:

--- a/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
+++ b/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
@@ -76,7 +76,7 @@ spec:
                 - name: AWS_S3_RELEVANCY_BUCKET_NAME
                   value: "govuk-{{ .Values.govukEnvironment }}-search-relevancy"
                 - name: ROLE_ARN
-                  value: {{ .Values.learnToRank.iamRole }}
+                  value: {{ .Values.learnToRank.sagemakerIamRole }}
                 - name: AWS_DEFAULT_REGION
                   value: eu-west-1
                 - name: IMAGE

--- a/charts/govuk-jobs/templates/search-api-ltr-service-account.yaml
+++ b/charts/govuk-jobs/templates/search-api-ltr-service-account.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   name: search-api-learn-to-rank
   annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.learnToRank.iamRole }}
+    eks.amazonaws.com/role-arn: {{ .Values.learnToRank.serviceAccountIamRole }}

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -29,5 +29,6 @@ learnToRank:
   deployInstance:
     type: ""
     count: '1'
-  iamRole: ""
   sageMakerImage: ""
+  sagemakerIamRole: ""
+  serviceAccountIamRole: ""


### PR DESCRIPTION
This passes the arn for the seperate IAM roles used by sagemaker itself to train the learn to rank model and the service account used by the k8s job.