### PR TITLE
Reference the correct bigquery creds secret for ltr

### DIFF
--- a/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
+++ b/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
                 - name: BIGQUERY_CREDENTIALS
                   valueFrom:
                     secretKeyRef:
-                      name: search-api-ltr-bigquery
+                      name: search-api-google-bigquery
                       key: credentials
                 - name: ELASTICSEARCH_URI
                   value: {{ .Values.learnToRank.elasticsearchUri }}


### PR DESCRIPTION
Previously the search api ltr job had referenced a manually generated secret that was mistaken not updated to use the existing secret with creds to bigquery.