### PR TITLE
Add separate Bigquery secret for Search API Learn to Rank 

### DIFF
--- a/charts/external-secrets/templates/search-api/ltr-bigquery.yaml
+++ b/charts/external-secrets/templates/search-api/ltr-bigquery.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: search-api-ltr-bigquery
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials used by search-api learn to rank process to access Google Bigquery
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-api-ltr-bigquery
+  dataFrom:
+    - extract:
+        key: govuk/search-api/ltr-bigquery

--- a/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
+++ b/charts/govuk-jobs/templates/search-api-ltr-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
                 - name: BIGQUERY_CREDENTIALS
                   valueFrom:
                     secretKeyRef:
-                      name: search-api-google-bigquery
+                      name: search-api-ltr-bigquery
                       key: credentials
                 - name: ELASTICSEARCH_URI
                   value: {{ .Values.learnToRank.elasticsearchUri }}


### PR DESCRIPTION
Turns out we can't re-use the existing credentials for Bigquery used by Search API application. This creates a separate secrets for the credentials to be used by the Learn to rank process.