### PR TITLE
Add new app draft-content-store-postgresql-branch in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -773,7 +773,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: draft-content-store-postgres
+            name: content-store-postgres
             key: DATABASE_URL
       - name: DISABLE_ROUTER_API
         value: "true"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -707,6 +707,7 @@ govukApplications:
           mongo-1.integration.govuk-internal.digital,\
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
+
 - name: draft-content-store
   repoName: content-store
   helmValues:
@@ -740,6 +741,42 @@ govukApplications:
           mongo-3.integration.govuk-internal.digital/draft_content_store_production"
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
+
+  - name: draft-content-store-postgresql-branch
+      repoName: content-store-postgresql-branch
+      helmValues:
+        <<: *content-store
+        rails:
+          createKeyBaseSecret: false
+        sentry:
+          createSecret: false  # Sentry DSNs are per repo.
+        extraEnv:
+          - name: ROUTER_API_BEARER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: signon-token-draft-content-store-draft-router-api
+                key: bearer_token
+          - name: GDS_SSO_OAUTH_ID
+            valueFrom:
+              secretKeyRef:
+                name: signon-app-draft-content-store
+                key: oauth_id
+          - name: GDS_SSO_OAUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: signon-app-draft-content-store
+                key: oauth_secret
+          - name: DEFAULT_TTL
+            value: "1"
+          - name: PLEK_HOSTNAME_PREFIX
+            value: draft-
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: draft-content-store-postgres
+                key: DATABASE_URL
+          - name: DISABLE_ROUTER_API
+            value: "true"
 
 - name: content-tagger
   helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -742,41 +742,41 @@ govukApplications:
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
 
-  - name: draft-content-store-postgresql-branch
-      repoName: content-store-postgresql-branch
-      helmValues:
-        <<: *content-store
-        rails:
-          createKeyBaseSecret: false
-        sentry:
-          createSecret: false  # Sentry DSNs are per repo.
-        extraEnv:
-          - name: ROUTER_API_BEARER_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: signon-token-draft-content-store-draft-router-api
-                key: bearer_token
-          - name: GDS_SSO_OAUTH_ID
-            valueFrom:
-              secretKeyRef:
-                name: signon-app-draft-content-store
-                key: oauth_id
-          - name: GDS_SSO_OAUTH_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: signon-app-draft-content-store
-                key: oauth_secret
-          - name: DEFAULT_TTL
-            value: "1"
-          - name: PLEK_HOSTNAME_PREFIX
-            value: draft-
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: draft-content-store-postgres
-                key: DATABASE_URL
-          - name: DISABLE_ROUTER_API
-            value: "true"
+- name: draft-content-store-postgresql-branch
+  repoName: content-store-postgresql-branch
+  helmValues:
+    <<: *content-store
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    extraEnv:
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-draft-content-store-draft-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-content-store
+            key: oauth_secret
+      - name: DEFAULT_TTL
+        value: "1"
+      - name: PLEK_HOSTNAME_PREFIX
+        value: draft-
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: draft-content-store-postgres
+            key: DATABASE_URL
+      - name: DISABLE_ROUTER_API
+        value: "true"
 
 - name: content-tagger
   helmValues:

--- a/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: draft-content-store-postgres
+  name: content-store-postgres
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: draft-content-store-postgres
+    name: content-store-postgres
     template:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/postpsql-conn-string.tpl" | trim }}/draft-content-store_production'

--- a/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: draft-content-store-postgres
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for draft-content-store's Postgres DB hosted in RDS.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: draft-content-store-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/postpsql-conn-string.tpl" | trim }}/draft-content-store_production'
+  dataFrom:
+    - extract:
+        key: govuk/draft-content-store/postgres


### PR DESCRIPTION
This new application is built from the `content-store-postgresql-branch` ECR repo, and will be dual-running alongside the existing draft content-store. A subsequent PR will deal with deploying a proxy in front of both of them, and the hostname-switching needed so that we can smoothly route requests to the proxy. 

Part of [this Trello card](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-on-postgresql-in-integration-for-the-draft-content-store), which is part of the overall epic [Plan for migrating content-store off MongoDB](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)