### PR TITLE
Add initial image-tag file for content-store-postgresql-branch

### DIFF
--- a/charts/app-config/image-tags/integration/content-store-postgresql-branch
+++ b/charts/app-config/image-tags/integration/content-store-postgresql-branch
@@ -1,0 +1,3 @@
+image_tag: release-bce1edc3f48e6699a284dca5dec3d331ef05e1e2
+automatic_deploys_enabled: true
+promote_deployment: false


### PR DESCRIPTION
This should allow the C.I. process to automatically deploy the `draft-content-store-postgresql-branch` to integration only