### PR TITLE
Allow apps to set their own Rails secretKeyBaseName

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -748,6 +748,9 @@ govukApplications:
     <<: *content-store
     rails:
       createKeyBaseSecret: false
+      # use the same secret as the mongo draft-content-store, it will make the
+      # eventual switchover easier and reduce toil
+      secretKeyBaseName: content-store-rails-secret-key-base
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
     extraEnv:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.repoName }}-rails-secret-key-base
+                  name: {{ .Values.rails.secretKeyBaseName | default (printf "%s-rails-secret-key-base" .Values.repoName) }}
                   key: secret-key-base
             {{- end }}
             {{- if .Values.sentry.enabled }}


### PR DESCRIPTION
...and do so for `draft-content-store-postgresql-branch`, so that it can use the same secret as the mongo live/draft content stores.

This fixes an issue uncovered while trying to deploy this app, and [getting the error](https://argo.eks.integration.govuk.digital/applications/draft-content-store-postgresql-branch?node=%2FPod%2Fapps%2Fdraft-content-store-postgresql-branch-84c7cdb6bd-xbw6k&orphaned=false&resource=) `secret "content-store-postgresql-branch-rails-secret-key-base" not found`