### PR TITLE
add Sentry config in integration for draft-content-store-postgresql-branch

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -754,6 +754,13 @@ govukApplications:
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
     extraEnv:
+      - name: SENTRY_DSN
+        valueFrom:
+          secretKeyRef:
+            name: content-store-sentry
+            key: dsn
+      - name: SENTRY_ENVIRONMENT
+        value: "postgresql-draft-integration"
       - name: ROUTER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Set up to let it use the existing Sentry DSN while still allowing us to differentiate between the versions through the supplied environment label