### PR TITLE
Use separate dedicated DB credential secret for draft-content-store-postgresql-branch

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -783,7 +783,7 @@ govukApplications:
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: content-store-postgres
+            name: draft-content-store-postgres
             key: DATABASE_URL
       - name: DISABLE_ROUTER_API
         value: "true"

--- a/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
@@ -17,7 +17,7 @@ spec:
     name: draft-content-store-postgres
     template:
       data:
-        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/postpsql-conn-string.tpl" | trim }}/draft-content-store_production'
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/draft-content-store_production'
   dataFrom:
     - extract:
         key: govuk/draft-content-store/postgres

--- a/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: content-store-postgres
+  name: draft-content-store-postgres
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: content-store-postgres
+    name: draft-content-store-postgres
     template:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/postpsql-conn-string.tpl" | trim }}/draft-content-store_production'


### PR DESCRIPTION
In the old system, with mongo credentials managed by puppet, it made sense to minimise toil by sharing credentials between draft and live content stores. 

In the new platform, (and in this [migration project](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-on-postgresql-in-integration-for-the-draft-content-store)) where DB credentials are secrets are managed by AWS, and the databases will be RDS PostgreSQL, it makes more sense to have separate credentials for each.  

This PR changes the name of the secret for the `draft-content-store-postgresql-branch` app to draft-content-store-postgres, in line with other postgresql-related secrets in the charts