### PR TITLE
Fix ComparisonError when syncing draft-content-store-postgresql-branch 

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -754,11 +754,6 @@ govukApplications:
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
     extraEnv:
-      - name: SENTRY_DSN
-        valueFrom:
-          secretKeyRef:
-            name: content-store-sentry
-            key: dsn
       - name: SENTRY_ENVIRONMENT
         value: "postgresql-draft-integration"
       - name: ROUTER_API_BEARER_TOKEN


### PR DESCRIPTION
Overriding an env var with the same value as is already defined in the overridden instance seems to cause a [sync error](https://argo.eks.integration.govuk.digital/applications/draft-content-store-postgresql-branch?orphaned=false&resource=&operation=true) of the form: 
```
ComparisonError: The order in patch list: [...] doesn't match $setElementOrder list: [...]
``` 
This PR removes the redundant re-definition of `SENTRY_DSN` from `draft-content-store-postgresql-branch` which fixes the problem (tested out-of-argo with `helm install`).