### PR TITLE
Add new app router-api-postgres on integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1800,6 +1800,31 @@ govukApplications:
           router-backend-2,\
           router-backend-3/draft_router"
 
+- name: draft-router-api-postgres
+  repoName: router-api-postgres
+  helmValues:
+    <<: *router-api
+    rails:
+      createKeyBaseSecret: false
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+    extraEnv:
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-router-api
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-draft-router-api
+            key: oauth_secret
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: router-api-postgres
+            key: DATABASE_URL
+
 - name: router
   helmValues:
     rails:

--- a/charts/external-secrets/templates/draft-router-api-postgres/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-router-api-postgres/postgresql.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: draft-router-api-postgres
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for router-api's Postgres DB hosted in RDS.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: draft-router-api-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/router-api_production'
+  dataFrom:
+    - extract:
+        key: govuk/router-api/postgres


### PR DESCRIPTION
This new app is a fork of Router API but it uses Postgres instead of Mongo.

Trello card: https://trello.com/c/dOXADTQP/1802-spin-up-a-separate-stack-of-router-api-l