### PR TITLE
Remove redundant SSO_PUSH_USER_EMAIL env var for Signon

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2277,8 +2277,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-      - name: SSO_PUSH_USER_EMAIL
-        value: signon+permissions@alphagov.co.uk
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2322,8 +2322,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
-      - name: SSO_PUSH_USER_EMAIL
-        value: signon+permissions@alphagov.co.uk
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2280,8 +2280,6 @@ govukApplications:
             key: DEVISE_SECRET_KEY
       - name: REDIS_URL
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-      - name: SSO_PUSH_USER_EMAIL
-        value: signon+permissions@alphagov.co.uk
       - name: SIGNON_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
This effectively reverts #1129 & #1130 now that the value has been hard-coded in alphagov/signon#2200.