### PR TITLE
Allow apps to define a custom name for their sentry dsn secret

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -753,6 +753,7 @@ govukApplications:
       secretKeyBaseName: content-store-rails-secret-key-base
     sentry:
       createSecret: false  # Sentry DSNs are per repo.
+      dsnSecretName: content-store-sentry
     extraEnv:
       - name: SENTRY_DSN
         valueFrom:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.repoName }}-sentry
+                  name: {{ .Values.sentry.dsnSecretName | default (printf "%s-sentry" .Values.repoName) }}
                   key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"


### PR DESCRIPTION
Uses the same trick as for #1152  to allow draft-content-store-postgresql-branch to use the main content-store dsn secret.

This prevents more toil by allowing the two versions of `draft-content-store` (the original mongoDB version, and the postgreSQL version) to use the existing sentry DSN for the live content-store. Required for this [Trello card](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-on-postgresql-in-integration-for-the-draft-content-store)