### PR TITLE
Replace dashes with underscores in draft-content-store-postgresql-branch's DATABASE_URL

### DIFF
--- a/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
@@ -17,7 +17,7 @@ spec:
     name: draft-content-store-postgres
     template:
       data:
-        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/draft-content-store_production'
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/draft_content_store_production'
   dataFrom:
     - extract:
         key: govuk/draft-content-store/postgres


### PR DESCRIPTION
This just makes it more consistent with the rest of the apps, and makes it easier to work with psql commands, as we then don't need to keep quoting the database name.

Part of [this Trello card](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-on-postgresql-in-integration-for-the-draft-content-store), and of the overall [epic to migrate content-store to postgresql](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)