### PR TITLE
Post about out-of-sync deploys earlier

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1758,7 +1758,7 @@ govukApplications:
     cronTasks:
       - name: post-out-of-sync-deploys
         task: "post_out_of_sync_deploys"
-        schedule: "0 9 * * 1-5"
+        schedule: "30 7 * * 1-5"
     extraEnv:
       - name: GDS_SSO_OAUTH_ID
         valueFrom:


### PR DESCRIPTION
The task was scheduled at 10:00 BST (9:00 GMT). However if a developer is doing a dependabot update at just before 10, the lag badger warns about it because the environments are out of sync for 15 minutes.

There are currently 2 other messages being posted every morning:
  - 8:30 BST (7:30 GMT) Seal
  - 9:00 BST (9:00 GMT) Dependapanda

Hence, it makes sense to post about undeployed apps before the Dependapanda. Decided to schedule it at the same time as Seal to try reduce the possible distraction of bots posting say every ~15 mins in the morning.