### PR TITLE
Disable dependency checker job for non-prod envs

### DIFF
--- a/charts/govuk-jobs/templates/dependabot-metrics-cronjob.yaml
+++ b/charts/govuk-jobs/templates/dependabot-metrics-cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.govukEnvironment "production" }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -50,3 +51,4 @@ spec:
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
+{{- end }}


### PR DESCRIPTION
This job only needs to run in Production.