### PR TITLE
Add chart for Elasticsearch index copy cronjobs.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2140,6 +2140,11 @@ govukApplications:
       - name: TENSORFLOW_SAGEMAKER_ENDPOINT
         value: govuk-integration-search-ltr-endpoint
 
+- name: search-index-env-sync
+  # See ../charts/search-index-env-sync/values.yaml for job configuration.
+  chartPath: charts/search-index-env-sync
+  postSyncWorkflowEnabled: "false"
+
 - name: service-manual-publisher
   helmValues:
     dbMigrationEnabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2184,6 +2184,11 @@ govukApplications:
       - name: TENSORFLOW_SAGEMAKER_ENDPOINT
         value: govuk-production-search-ltr-endpoint
 
+- name: search-index-env-sync
+  # See ../charts/search-index-env-sync/values.yaml for job configuration.
+  chartPath: charts/search-index-env-sync
+  postSyncWorkflowEnabled: "false"
+
 - name: service-manual-publisher
   helmValues:
     dbMigrationEnabled: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2154,6 +2154,11 @@ govukApplications:
       - name: TENSORFLOW_SAGEMAKER_ENDPOINT
         value: govuk-staging-search-ltr-endpoint
 
+- name: search-index-env-sync
+  # See ../charts/search-index-env-sync/values.yaml for job configuration.
+  chartPath: charts/search-index-env-sync
+  postSyncWorkflowEnabled: "false"
+
 - name: service-manual-publisher
   helmValues:
     dbMigrationEnabled: true

--- a/charts/search-index-env-sync/Chart.yaml
+++ b/charts/search-index-env-sync/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: search-index-env-sync
+description: Cronjobs for copying Elasticsearch indices from prod to non-prod
+type: application
+version: 1.0.0

--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -102,7 +102,7 @@ fi
 : "${ES_URL:?required}"
 : "${SNAPSHOT_REPO:?required}"
 : "${SNAPSHOTS_TO_KEEP:=1}"
-: "${REQUEST_DEADLINE_SECONDS:=300}"  # Keep this > ES's 30s timeout to preserve error messages.
+: "${REQUEST_DEADLINE_SECONDS:=900}"  # Keep this > ES's 30s timeout to preserve error messages.
 readonly GOVUK_ENVIRONMENT ES_URL SNAPSHOTS_TO_KEEP REQUEST_DEADLINE_SECONDS
 
 curl="curl -Ssfm$REQUEST_DEADLINE_SECONDS"

--- a/charts/search-index-env-sync/templates/_helpers.tpl
+++ b/charts/search-index-env-sync/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "search-index-env-sync.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "search-index-env-sync.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "search-index-env-sync.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "search-index-env-sync.labels" -}}
+helm.sh/chart: {{ include "search-index-env-sync.chart" . }}
+{{ include "search-index-env-sync.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "search-index-env-sync.selectorLabels" -}}
+app: {{ include "search-index-env-sync.name" . }}
+app.kubernetes.io/name: {{ include "search-index-env-sync.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/search-index-env-sync/templates/configmap.yaml
+++ b/charts/search-index-env-sync/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "search-index-env-sync.fullname" . }}
+  labels:
+    {{- include "search-index-env-sync.labels" . | nindent 4 }}
+data:
+  snapshot: |
+    {{- $.Files.Get "snapshot.sh" | trim | nindent 4 }}

--- a/charts/search-index-env-sync/templates/cronjob.yaml
+++ b/charts/search-index-env-sync/templates/cronjob.yaml
@@ -1,0 +1,72 @@
+{{- $_ := .Values.govukEnvironment | required "govukEnvironment is required" }}
+{{- $fullName := include "search-index-env-sync.fullname" . }}
+{{- range get .Values.cronjobs .Values.govukEnvironment }}
+  {{- $jobName := printf "%s-%s" $fullName .name }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $jobName }}
+  labels:
+    {{- include "search-index-env-sync.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+  annotations:
+    kubernetes.io/description: >
+      The {{ $fullName }}-* jobs copy Elasticsearch indices between environments
+      via Elasticsearch snapshots, so that the website search feature works in
+      staging and integration.
+
+      Elasticsearch handles the actual transfer of the index shards to/from the
+      snapshot repositories in S3. This job just makes HTTP requests to
+      Elasticsearch to initiate the snapshot and restore.
+
+      These jobs are not involved in making backups for disaster recovery
+      purposes; those are handled separately within AWS Managed Elasticsearch.
+spec:
+  schedule: {{ .schedule | quote }}
+  jobTemplate:
+    metadata:
+      name: {{ $jobName }}
+      labels:
+        {{- include "search-index-env-sync.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: {{ $jobName }}
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          name: {{ $jobName }}
+          labels:
+            {{- include "search-index-env-sync.selectorLabels" $ | nindent 12 }}
+            app.kubernetes.io/component: {{ $jobName }}
+        spec:
+          enableServiceLinks: false
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          restartPolicy: Never
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ $fullName }}
+                defaultMode: 0555  # world-executable
+          containers:
+            - name: main
+              image: {{ $.Values.imageRef | quote }}
+              command:
+                - /opt/bin/snapshot
+              args:
+                {{- toYaml .args | nindent 16 }}
+              env:
+                - name: GOVUK_ENVIRONMENT
+                  value: {{ $.Values.govukEnvironment | required "govukEnvironment is required" }}
+                - name: VERBOSE
+                  value: "1"
+                {{- with .extraEnv }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
+              resources:
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /opt/bin
+{{- end }}

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -4,25 +4,28 @@ nameOverride: ""
 fullnameOverride: ""
 imageRef: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli"
 
+# govukEnvironment determines which set of cronjobs to use from `cronjobs`
+# below. When running under Argo CD, the ../app-config chart passes the
+# appropriate value for govukEnvironment by default.
 govukEnvironment: staging
 
 cronjobs:
   production:
-    - name: take-snapshot
+    - name: snapshot
       schedule: "21 1 * * *"
       args: [create_and_clean_up]
   staging:
-    - name: restore-from-prod
+    - name: copy-from-prod  # These names have to be fairly short :(
       schedule: "37 1 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO
           value: govuk-production
-    - name: take-snapshot
+    - name: snapshot
       schedule: "37 2 * * *"
       args: [create_and_clean_up]
   integration:
-    - name: restore-from-staging
+    - name: copy-from-stag
       schedule: "53 2 * * *"
       args: [restore_latest]
       extraEnv:

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -1,0 +1,52 @@
+# Default values for search-index-env-sync.
+
+nameOverride: ""
+fullnameOverride: ""
+imageRef: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli"
+
+govukEnvironment: staging
+
+cronjobs:
+  production:
+    - name: take-snapshot
+      schedule: "21 1 * * *"
+      args: [create_and_clean_up]
+  staging:
+    - name: restore-from-prod
+      schedule: "37 1 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-production
+    - name: take-snapshot
+      schedule: "37 2 * * *"
+      args: [create_and_clean_up]
+  integration:
+    - name: restore-from-staging
+      schedule: "53 2 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-staging
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi


### PR DESCRIPTION
This replaces the Puppet-managed cronjobs for copying Elasticsearch indices from production to staging (and staging to integration).

(Neither this nor its predecessor is in involved in production backups/DR; backups are handled entirely within AWS Managed Elasticsearch.)

For now, this is its own separate Helm chart. It might become a subchart of a wider "environment sync" chart later, or fit into some other structure; we'll see what fits.

I've tried to keep this chart close enough to the standard `helm create` starter chart (minus the templates that we definitely won't use in the foreseeable future and some that can be trivially back added in if we want them, like serviceaccount) that it shouldn't be too difficult to fit it into whatever structure we end up with re what jobs go in what charts. I.e. it's intended to be composable while avoiding unnecessary complexity or esotericism.

[Puppet-managed cronjobs]:
https://github.com/alphagov/govuk-puppet/blob/603dc08/hieradata_aws/class/staging/search.yaml#L4

https://trello.com/c/Nq4oZAOE

Tested:

* installed chart via plain old `helm install $USER-test-search-index-env-sync .` in staging, successfully ran some test snapshot/restore jobs via `k create job --from cronjob/...`
* installs cleanly in integration with `env=integration chart=search-index-env-sync && helm install $USER-$chart ../$chart --values <(
  helm template . --values values-$env.yaml |
  yq e '.|select(.metadata.name=="'$chart'").spec.source.helm.values'
)` (i.e. with the values that ArgoCD will pass in from the app-config chart).