### PR TITLE
Add CronJob to export content-store data from MongoDB to PostgreSQL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -788,11 +788,9 @@ govukApplications:
   chartPath: charts/content-store-mongo-postgres-cron
   helmValues:
     mongoExport:
-      # {{.Values.images.DraftContentStore.extraEnv.MONGODB_URI}}
-      mongoDbUri: "blah"
+      mongoDbUri: "{{.Values.images.DraftContentStore.extraEnv.MONGODB_URI}}"
     postgresImport:
-      # {{.Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL}}
-      databaseUrl: "blah"
+      databaseUrl: "{{.Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL}}"
 
 - name: content-tagger
   helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -788,9 +788,9 @@ govukApplications:
   chartPath: charts/content-store-mongo-postgres-cron
   helmValues:
     mongoExport:
-      mongoDbUri: "{{.Values.images.DraftContentStore.extraEnv.MONGODB_URI}}"
+      mongoDbUri: "{{ .Values.images.DraftContentStore.extraEnv.MONGODB_URI }}"
     postgresImport:
-      databaseUrl: "{{.Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL}}"
+      databaseUrl: "{{ .Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL }}"
 
 - name: content-tagger
   helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -788,9 +788,11 @@ govukApplications:
   chartPath: charts/content-store-mongo-postgres-cron
   helmValues:
     mongoExport:
-      mongoDbUri: "blah" # {{.Values.images.DraftContentStore.extraEnv.MONGODB_URI}}
+      # {{.Values.images.DraftContentStore.extraEnv.MONGODB_URI}}
+      mongoDbUri: "blah"
     postgresImport:
-      databaseUrl: "blah" # {{.Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL}}
+      # {{.Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL}}
+      databaseUrl: "blah"
 
 - name: content-tagger
   helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -784,6 +784,14 @@ govukApplications:
       - name: DISABLE_ROUTER_API
         value: "true"
 
+- name: draft-content-store-mongo-postgres-cron
+  chartPath: charts/content-store-mongo-postgres-cron
+  helmValues:
+    mongoExport:
+      mongoDbUri: "blah" # {{.Values.images.DraftContentStore.extraEnv.MONGODB_URI}}
+    postgresImport:
+      databaseUrl: "blah" # {{.Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL}}
+
 - name: content-tagger
   helmValues:
     dbMigrationEnabled: true

--- a/charts/content-store-mongo-postgres-cron/Chart.yaml
+++ b/charts/content-store-mongo-postgres-cron/Chart.yaml
@@ -1,5 +1,0 @@
-apiVersion: v2
-name: content-store-mongo-postgres-cron
-description: Cronjobs for copying (draft-)content-store data from Mongo to PostgreSQL
-type: application
-version: 1.0.0

--- a/charts/content-store-mongo-postgres-cron/Chart.yaml
+++ b/charts/content-store-mongo-postgres-cron/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: content-store-mongo-postgres-cron
+description: Cronjobs for copying (draft-)content-store data from Mongo to PostgreSQL
+type: application
+version: 1.0.0

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -38,7 +38,8 @@ spec:
               image: "content-store:release"
               imagePullPolicy: "Always"
               command: ["rake"]
-              args: ["mongo:export:all[/mongo-export/]"]
+              args:
+                - "mongo:export:all[/mongo-export/]"
               env:
                 - name: MONGODB_URI
                   value: "{{ .Values.contentStoreMongoPostgresCron.mongoExport.mongoDbUri }}"
@@ -52,7 +53,7 @@ spec:
             - name: import-mongo-data-to-postgresql
               image: "content-store-postgresql-branch:release"
               imagePullPolicy: "Always"
-              command: ["bundle exec rake"]
+              command: ["rake"]
               args:
                 - "import:all[/mongo-export/]"
               env:

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "content-store-mongo-to-postgres-cron"
+  labels:
+    app: "content-store-mongo-to-postgres-cron"
+    app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+spec:
+  schedule: "15 5 * * *"  
+  jobTemplate:
+    metadata:
+      name: "content-store-mongo-to-postgres-cron"
+      labels:
+        app: "content-store-mongo-to-postgres-cron"
+        app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          name: "content-store-mongo-to-postgres-cron"
+          labels:
+            app: "content-store-mongo-to-postgres-cron"
+            app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+        spec:
+          enableServiceLinks: false
+          securityContext:
+            fsGroup: {{ .Values.securityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+          restartPolicy: Never
+          volumes:
+            - name: mongo-export
+              emptyDir: {}
+          initContainers:
+            - name: export-mongo-data
+              image: "content-store:release"
+              imagePullPolicy: "Always"
+              command: ["rake"]
+              args: ["mongo:export:all[/mongo-export/]"]
+              env:
+                - name: MONGODB_URI
+                  value: "{{.Values.mongoExport.mongoDbUri }}"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: mongo-export
+                  mountPath: /mongo-export
+          containers:
+            - name: import-mongo-data-to-postgresql
+              image: "content-store-postgresql-branch:release"
+              imagePullPolicy: "Always"
+              command: ["bundle exec rake"]
+              args:
+                - "import:all[/mongo-export/]"
+              env:
+                - name: DATABASE_URL
+                  value: "{{ .Values.postgresImport.image.databaseUrl }}"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: mongo-export
+                  mountPath: /mongo-export

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "content-store-mongo-to-postgres-cron"
     app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
 spec:
-  schedule: "15 5 * * *"  
+  schedule: "{{.Values.contentStoreMongoPostgresCron.schedule}}"  
   jobTemplate:
     metadata:
       name: "content-store-mongo-to-postgres-cron"

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "content-store-mongo-to-postgres-cron"
     app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
 spec:
-  schedule: "{{.Values.contentStoreMongoPostgresCron.schedule}}"  
+  schedule: "{{ .Values.contentStoreMongoPostgresCron.schedule }}"  
   jobTemplate:
     metadata:
       name: "content-store-mongo-to-postgres-cron"

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
               args: ["mongo:export:all[/mongo-export/]"]
               env:
                 - name: MONGODB_URI
-                  value: "{{.Values.mongoExport.mongoDbUri }}"
+                  value: "{{ .Values.contentStoreMongoPostgresCron.mongoExport.mongoDbUri }}"
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -57,7 +57,7 @@ spec:
                 - "import:all[/mongo-export/]"
               env:
                 - name: DATABASE_URL
-                  value: "{{ .Values.postgresImport.image.databaseUrl }}"
+                  value: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrl }}"
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -32,3 +32,9 @@ learnToRank:
   sageMakerImage: ""
   sagemakerIamRole: ""
   serviceAccountIamRole: ""
+
+content-store-mongo-postgres-cron:
+  mongoExport:
+    mongoDbUri: ""
+  postgresImport:
+    databaseUrl: ""

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -34,6 +34,7 @@ learnToRank:
   serviceAccountIamRole: ""
 
 contentStoreMongoPostgresCron:
+  schedule: "15 5 * * *"
   mongoExport:
     mongoDbUri: ""
   postgresImport:

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -33,7 +33,7 @@ learnToRank:
   sagemakerIamRole: ""
   serviceAccountIamRole: ""
 
-content-store-mongo-postgres-cron:
+contentStoreMongoPostgresCron:
   mongoExport:
     mongoDbUri: ""
   postgresImport:


### PR DESCRIPTION
Add a CronJob to  import JSON files to the PostgreSQL (draft-)content-store
Uses an `initContainer` to do the initial export of JSON from the MongoDB (draft-)content-store 

The job is templated so that it can be scheduled against the draft- and live content-stores without unnecessary duplication, but this PR only schedules it against the draft-content-store. Once we've seen this working successfully in integration, I'll add a subsequent PR to schedule it againt the live content-store.

[Trello card](https://trello.com/c/GMoOthyj/671-add-step-to-overnight-environment-sync-job-to-export-mongodb-to-json-and-import-to-postgresql), part of rolling out the [content-store Mongo -> PostgreSQL migration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb) on [integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-postgresql-branch-in-integration-for-the-draft-content-store)