### PR TITLE
Fix Init:ImagePullBackoff in content-store-mongo-to-postgres-cronjob

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1162,7 +1162,7 @@ govukApplications:
       sageMakerImage: 210287912431.dkr.ecr.eu-west-1.amazonaws.com/search
       sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
       serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
-    contentStoreMongoPostgresCron:
+    draftContentStoreMongoPostgresCron:
       mongoExport:
         mongoDbUri: "mongodb://\
           mongo-1.integration.govuk-internal.digital,\

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1164,7 +1164,10 @@ govukApplications:
       serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
     contentStoreMongoPostgresCron:
       mongoExport:
-        mongoDbUri: "{{ .Values.images.DraftContentStore.extraEnv.MONGODB_URI }}"
+        mongoDbUri: "mongodb://\
+          mongo-1.integration.govuk-internal.digital,\
+          mongo-2.integration.govuk-internal.digital,\
+          mongo-3.integration.govuk-internal.digital/draft_content_store_production"
       postgresImport:
         databaseUrlSecretName: "draft-content-store-postgres"
 

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -790,7 +790,7 @@ govukApplications:
     mongoExport:
       mongoDbUri: "{{ .Values.images.DraftContentStore.extraEnv.MONGODB_URI }}"
     postgresImport:
-      databaseUrl: "{{ .Values.images.DraftContentStorePostgresqlBranch.extraEnv.DATABASE_URL }}"
+      databaseUrlSecretName: "draft-content-store-postgres"
 
 - name: content-tagger
   helmValues:
@@ -1153,6 +1153,8 @@ govukApplications:
   chartPath: charts/govuk-jobs
   postSyncWorkflowEnabled: "false"
   imageValues:
+    - "content-store"
+    - "content-store-postgresql-branch"
     - "govuk-dependency-checker"
     - "search-api"
     - "search-api-learn-to-rank"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -784,14 +784,6 @@ govukApplications:
       - name: DISABLE_ROUTER_API
         value: "true"
 
-- name: draft-content-store-mongo-postgres-cron
-  chartPath: charts/content-store-mongo-postgres-cron
-  helmValues:
-    mongoExport:
-      mongoDbUri: "{{ .Values.images.DraftContentStore.extraEnv.MONGODB_URI }}"
-    postgresImport:
-      databaseUrlSecretName: "draft-content-store-postgres"
-
 - name: content-tagger
   helmValues:
     dbMigrationEnabled: true
@@ -1170,6 +1162,11 @@ govukApplications:
       sageMakerImage: 210287912431.dkr.ecr.eu-west-1.amazonaws.com/search
       sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
       serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
+    contentStoreMongoPostgresCron:
+      mongoExport:
+        mongoDbUri: "{{ .Values.images.DraftContentStore.extraEnv.MONGODB_URI }}"
+      postgresImport:
+        databaseUrlSecretName: "draft-content-store-postgres"
 
 - name: hmrc-manuals-api
   helmValues:

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -43,6 +43,10 @@ spec:
               env:
                 - name: MONGODB_URI
                   value: "{{ .Values.contentStoreMongoPostgresCron.mongoExport.mongoDbUri }}"
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -59,6 +63,10 @@ spec:
               env:
                 - name: DATABASE_URL
                   value: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrl }}"
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
               emptyDir: {}
           initContainers:
             - name: export-mongo-data
-              image: "content-store:release"
+              image: "{{ .Values.images.DraftContentStore.repository }}:{{ .Values.images.DraftContentStore.tag }}"
               imagePullPolicy: "Always"
               command: ["rake"]
               args:
@@ -51,7 +51,7 @@ spec:
                   mountPath: /mongo-export
           containers:
             - name: import-mongo-data-to-postgresql
-              image: "content-store-postgresql-branch:release"
+              image: "{{ .Values.images.DraftContentStorePostgresqlBranch.repository }}:{{ .Values.images.DraftContentStorePostgresqlBranch.tag }}"
               imagePullPolicy: "Always"
               command: ["rake"]
               args:

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -55,7 +55,7 @@ spec:
                   mountPath: /mongo-export
           containers:
             - name: import-mongo-data-to-postgresql
-              image: "{{ .Values.images.DraftContentStorePostgresqlBranch.repository }}:{{ .Values.images.DraftContentStorePostgresqlBranch.tag }}"
+              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
               imagePullPolicy: "Always"
               command: ["rake"]
               args:

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -2,26 +2,26 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "content-store-mongo-to-postgres-cron"
+  name: "draft-content-store-mongo-to-postgres-cron"
   labels:
-    app: "content-store-mongo-to-postgres-cron"
-    app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+    app: "draft-content-store-mongo-to-postgres-cron"
+    app.kubernetes.io/component: "draft-content-store-mongo-to-postgres-cron"
 spec:
-  schedule: "{{ .Values.contentStoreMongoPostgresCron.schedule }}"  
+  schedule: "{{ .Values.draftContentStoreMongoPostgresCron.schedule }}"  
   jobTemplate:
     metadata:
-      name: "content-store-mongo-to-postgres-cron"
+      name: "draft-content-store-mongo-to-postgres-cron"
       labels:
-        app: "content-store-mongo-to-postgres-cron"
-        app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+        app: "draft-content-store-mongo-to-postgres-cron"
+        app.kubernetes.io/component: "draft-content-store-mongo-to-postgres-cron"
     spec:
       backoffLimit: 0
       template:
         metadata:
-          name: "content-store-mongo-to-postgres-cron"
+          name: "draft-content-store-mongo-to-postgres-cron"
           labels:
-            app: "content-store-mongo-to-postgres-cron"
-            app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+            app: "draft-content-store-mongo-to-postgres-cron"
+            app.kubernetes.io/component: "draft-content-store-mongo-to-postgres-cron"
         spec:
           enableServiceLinks: false
           securityContext:
@@ -42,7 +42,7 @@ spec:
                 - "mongo:export:all[/mongo-export/]"
               env:
                 - name: MONGODB_URI
-                  value: "{{ .Values.contentStoreMongoPostgresCron.mongoExport.mongoDbUri }}"
+                  value: "{{ .Values.draftContentStoreMongoPostgresCron.mongoExport.mongoDbUri }}"
               {{- with .Values.resources }}
               resources:
                 {{- . | toYaml | trim | nindent 16 }}
@@ -64,7 +64,7 @@ spec:
                 - name: DATABASE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
+                      name: "{{ .Values.draftContentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
                       key: DATABASE_URL
               {{- with .Values.resources }}
               resources:

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
               emptyDir: {}
           initContainers:
             - name: export-mongo-data
-              image: "{{ .Values.images.DraftContentStore.repository }}:{{ .Values.images.DraftContentStore.tag }}"
+              image: "{{ .Values.images.ContentStore.repository }}:{{ .Values.images.ContentStore.tag }}"
               imagePullPolicy: "Always"
               command: ["rake"]
               args:

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -62,7 +62,10 @@ spec:
                 - "import:all[/mongo-export/]"
               env:
                 - name: DATABASE_URL
-                  value: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrl }}"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
+                      key: DATABASE_URL
               {{- with .Values.resources }}
               resources:
                 {{- . | toYaml | trim | nindent 16 }}

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -44,4 +44,4 @@ contentStoreMongoPostgresCron:
   mongoExport:
     mongoDbUri: ""
   postgresImport:
-    databaseUrl: ""
+    databaseUrlSecretName: "draft-content-store-postgres"

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -11,10 +11,10 @@ resources:
     cpu: 0.1
     memory: 800Mi
 images:
-  DraftContentStore:
+  ContentStore:
     repository: "content-store"
     tag: "release"
-  DraftContentStorePostgresqlBranch:
+  ContentStorePostgresqlBranch:
     repository: "content-store-postgresql-branch"
     tag: "release"
   GovukDependencyChecker:

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -39,7 +39,7 @@ learnToRank:
   sagemakerIamRole: ""
   serviceAccountIamRole: ""
 
-contentStoreMongoPostgresCron:
+draftContentStoreMongoPostgresCron:
   schedule: "15 5 * * *"
   mongoExport:
     mongoDbUri: ""

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -11,6 +11,12 @@ resources:
     cpu: 0.1
     memory: 800Mi
 images:
+  DraftContentStore:
+    repository: "content-store"
+    tag: "release"
+  DraftContentStorePostgresqlBranch:
+    repository: "content-store-postgresql-branch"
+    tag: "release"
   GovukDependencyChecker:
     repository: "govuk-dependency-checker"
     tag: "release"


### PR DESCRIPTION
The CronJob `content-store-mongo-to-postgres-cronjob` added in #1166 was scheduled and tried to execute for the first time this morning, but failed with an `Init:ImagePullBackoff` error.

This usually implies an incorrect container image name/tag (or repo), so I've parameterized the previously hard-coded repo names/tags.

This probably won't fix the issue by itself, but makes them more consistent with the other CronJobs and means I can adjust the values passed in without affecting the job definition. I've also added the `resource` lines from the other jobs while I was at it.

[Trello card](https://trello.com/c/GMoOthyj/671-add-step-to-overnight-environment-sync-job-to-export-mongodb-to-json-and-import-to-postgresql) part of the overall [content-store migration epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb) on [integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-postgresql-branch-in-integration-for-the-draft-content-store)

### Update

On further investigation, I _think_ the issue(s) might have been that 

1. I was passing the parameters in the wrong place (should have been in the `govuk-jobs` block, and
2. I also needed to add the container-names into the `imageValues` block

I've made those changes in #[d5a3563](https://github.com/alphagov/govuk-helm-charts/pull/1167/commits/d5a3563c684979ac8803f9c0e0abaaeac90d2d79)
