### PR TITLE
Change rendering application of CSV previews in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1007,6 +1007,21 @@ govukApplications:
 
 - name: frontend
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '15'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
@@ -2894,9 +2909,6 @@ govukApplications:
           path: /government/placeholder/
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /assets/whitehall/
-        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-          pathType: ImplementationSpecific
     rails:
       createKeyBaseSecret: false
     sentry:


### PR DESCRIPTION
CSV Previews are currently being rendered by Whitehall Frontend. This is being changed to Frontend.

This makes that change in integration only (we will switch the remaining environments in a later PR).

[Trello card](https://trello.com/c/a67EW0uB)