### PR TITLE
Permit ingress to frontend assets directory

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1022,6 +1022,8 @@ govukApplications:
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
           pathType: ImplementationSpecific
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template


### PR DESCRIPTION
This will allow the assets (e.g. CSS) to be retrieved for CSV Previews.

The rule was missed in https://github.com/alphagov/govuk-helm-charts/pull/1169.

[Trello card](https://trello.com/c/a67EW0uB)