### PR TITLE
Permit access to Frontend for draft CSV previews in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1024,6 +1024,10 @@ govukApplications:
           pathType: ImplementationSpecific
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /assets/frontend/
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template


### PR DESCRIPTION
This adds ingress to Frontend at the draft asset host for CSV previews and the assets needed to render the page.

[Trello card](https://trello.com/c/a67EW0uB)