### PR TITLE
Change `draft-assets` routing to use draft-frontend for CSV Previews

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1063,11 +1063,6 @@ govukApplications:
           pathType: ImplementationSpecific
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /assets/frontend/
-        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
-          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-          pathType: ImplementationSpecific
-        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
-          path: /assets/frontend/
     extraEnv:
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
@@ -1107,6 +1102,23 @@ govukApplications:
 - name: draft-frontend
   repoName: frontend
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '16'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     rails:
       createKeyBaseSecret: false
     sentry:


### PR DESCRIPTION
We run two instances of the Frontend application: live and draft.

CSV Previews are currently being routed to the live version for both live and draft assets. This is not correct as the live version of Frontend does not have access to the Draft Content Store.

Therefore updating the routing so draft requests come to the draft frontend instance.

[Trello card](https://trello.com/c/a67EW0uB)