### PR TITLE
Switch rendering application for CSV Previews in staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1052,6 +1052,23 @@ govukApplications:
 
 - name: frontend
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '15'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     replicaCount: 4
     appResources:
       limits:
@@ -1101,6 +1118,23 @@ govukApplications:
 - name: draft-frontend
   repoName: frontend
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '16'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     rails:
       createKeyBaseSecret: false
     sentry:
@@ -2971,9 +3005,6 @@ govukApplications:
           path: /government/placeholder/
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /assets/whitehall/
-        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-          pathType: ImplementationSpecific
     rails:
       createKeyBaseSecret: false
     sentry:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1024,6 +1024,23 @@ govukApplications:
 
 - name: frontend
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '15'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
+        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     appResources:
       limits:
         cpu: 4
@@ -1072,6 +1089,23 @@ govukApplications:
 - name: draft-frontend
   repoName: frontend
   helmValues:
+    ingress:
+      enabled: true
+      annotations:
+        <<: *default-alb-ingress-annotations
+        <<: *alb-ingress-www-waf-ruleset
+        alb.ingress.kubernetes.io/load-balancer-name: assets-origin
+        alb.ingress.kubernetes.io/group.name: assets-origin
+        alb.ingress.kubernetes.io/group.order: '16'
+        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+        alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
+      hosts:
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+          pathType: ImplementationSpecific
+        - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+          path: /assets/frontend/
     rails:
       createKeyBaseSecret: false
     sentry:
@@ -2929,9 +2963,6 @@ govukApplications:
           path: /government/placeholder/
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /assets/whitehall/
-        - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-          path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-          pathType: ImplementationSpecific
     rails:
       createKeyBaseSecret: false
     sentry:


### PR DESCRIPTION
This switches the rendering of CSV Previews in staging and production from Whitehall Frontend to Frontend.

[Trello card](https://trello.com/c/a67EW0uB)