### PR TITLE
Remove alb.ingress.kubernetes.io/security-groups from frontend and draft frontend

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1060,7 +1060,6 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '15'
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
       hosts:
@@ -1126,7 +1125,6 @@ govukApplications:
         alb.ingress.kubernetes.io/load-balancer-name: assets-origin
         alb.ingress.kubernetes.io/group.name: assets-origin
         alb.ingress.kubernetes.io/group.order: '16'
-        alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
         alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
         alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
       hosts:


### PR DESCRIPTION
We've got an ongoing issue where draft asset manger is not working in production. We've received many Zendesk tickets stating people can't see draft PDFs

We were pointed to a similar incident which was resolves via these PRs:

https://github.com/alphagov/govuk-helm-charts/pull/1024
https://github.com/alphagov/govuk-helm-charts/pull/1025

So we're going to remove the same lines from the recent [PR](https://github.com/alphagov/govuk-helm-charts/pull/1174) that was merged for CSV rendering that includes the same.