### PR TITLE
Adding Email alert monitoring to Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -946,6 +946,42 @@ govukApplications:
             name: email-alert-auth
             key: token
 
+- name: email-alert-monitoring
+  helmValues:
+    appEnabled: false
+    sentry:
+      enabled: false
+    uploadAssets:
+      enabled: false
+    rails:
+      enabled: false
+    cronTasks:
+      - name: run-medical-alerts
+        task: "run_medical_alerts"
+        schedule: "21,51 * * * *"
+      - name: run-travel-alerts
+        task: "run_travel_alerts"
+        schedule: "*/15 * * * *"
+    workerEnabled: false
+    extraEnv:
+      - name: GOOGLE_OAUTH_CREDENTIALS
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-monitoring-google
+            key: oauth_credentials
+      - name: GOOGLE_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-monitoring-google
+            key: client_id
+      - name: GOOGLE_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: email-alert-monitoring-google
+            key: client_secret
+      - name: PROMETHEUS_PUSHGATEWAY_URL
+        value: http://prometheus-pushgateway.monitoring.svc.cluster.local:9091
+
 - name: email-alert-service
   helmValues:
     appEnabled: false


### PR DESCRIPTION
This will allows us to run some tests on the service.

In prep for testing push gateway and pager duty alerting on failures.

https://trello.com/c/oOokPLVF/1203-alert-on-email-alert-monitoring-jobs-failures-testng