### PR TITLE
Add content-store-proxy app in integration only

### DIFF
--- a/charts/app-config/image-tags/integration/content-store-proxy
+++ b/charts/app-config/image-tags/integration/content-store-proxy
@@ -1,0 +1,3 @@
+image_tag: 
+automatic_deploys_enabled: true
+promote_deployment: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -784,6 +784,18 @@ govukApplications:
       - name: DISABLE_ROUTER_API
         value: "true"
 
+- name: draft-content-store-proxy
+  repoName: content-store-proxy
+  helmValues:
+    nginxClientMaxBodySize: 20M
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: PRIMARY_UPSTREAM
+        value: "http://draft-content-store/"
+      - name: SECONDARY_UPSTREAM
+        value: "http://draft-content-store-postgresql-branch/"
+
 - name: content-tagger
   helmValues:
     dbMigrationEnabled: true


### PR DESCRIPTION
… but don't switch the hostnames to have it proxy `content-store` requests yet - we'll do that in a separate PR, so that that's the smallest revertable change to rollback if there are any issues

[Trello card](https://trello.com/c/xeJcwf6w/707-deploy-content-store-proxy-in-integration-for-the-draft-content-store), part of [rolling out the content-store Mongo migration in integration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)