### PR TITLE
Export, compress & upload the draft-content-store-postgresql-branch DB to S3

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -142,7 +142,6 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
-          containers:
             - name: import-mongo-data-to-postgresql
               image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
               imagePullPolicy: "Always"
@@ -167,3 +166,103 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
+                - name: pg-dump
+                  mountPath: /pg-dump
+            - name: dump-postgresql
+              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
+              imagePullPolicy: "Always"
+              command: ["pg_dump"]
+              args:
+                - "-F c"
+                - "-f /pg-dump/content_store_production"
+                - "${DATABASE_URL}"
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
+                      key: DATABASE_URL
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: app-tmp
+                  mountPath: /tmp
+                - name: pg-dump
+                  mountPath: /pg-dump
+            - name: compress-pg-dump
+              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
+              imagePullPolicy: "Always"
+              command: ["tar"]
+              args:
+                - "--create"
+                - "--gzip"
+                - "--force-local"
+                - "-f /pg-dump/content_store_production.gz"
+                - /pg-dump/content_store_production
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.draftContentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
+                      key: DATABASE_URL
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: pg-dump
+                  mountPath: /pg-dump
+                - name: app-tmp
+                  mountPath: /tmp
+            - name: timestamp-pg-dump
+              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
+              imagePullPolicy: "Always"
+              command: ["mv"]
+              args:
+                - /pg-dump/content_store_production.gz
+                - "/pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production.gz"
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.draftContentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
+                      key: DATABASE_URL
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: pg-dump
+                  mountPath: /pg-dump
+                - name: app-tmp
+                  mountPath: /tmp
+          containers:
+            - name: upload-to-s3
+              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+              command:
+                - aws
+                - s3
+                - sync
+                - /pg-dump
+                - s3://govuk-integration-database-backups/draft-content-store/
+              {{- with .Values.jobResources }}
+              resources:
+                {{- . | toYaml | trim | nindent 12 }}
+              {{- end }}
+              volumeMounts:
+                - name: pg-dump
+                  mountPath: /pg-dump
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -169,12 +169,11 @@ spec:
                 - name: pg-dump
                   mountPath: /pg-dump
             - name: dump-postgresql
-              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
-              imagePullPolicy: "Always"
+              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
               command: ["pg_dump"]
               args:
                 - "-F c"
-                - "-f /pg-dump/content_store_production"
+                - "-f /pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production"
                 - "${DATABASE_URL}"
               env:
                 - name: DATABASE_URL
@@ -194,59 +193,6 @@ spec:
                   mountPath: /tmp
                 - name: pg-dump
                   mountPath: /pg-dump
-            - name: compress-pg-dump
-              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
-              imagePullPolicy: "Always"
-              command: ["tar"]
-              args:
-                - "--create"
-                - "--gzip"
-                - "--force-local"
-                - "-f /pg-dump/content_store_production.gz"
-                - /pg-dump/content_store_production
-              env:
-                - name: DATABASE_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: "{{ .Values.draftContentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
-                      key: DATABASE_URL
-              {{- with .Values.resources }}
-              resources:
-                {{- . | toYaml | trim | nindent 16 }}
-              {{- end }}
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-              volumeMounts:
-                - name: pg-dump
-                  mountPath: /pg-dump
-                - name: app-tmp
-                  mountPath: /tmp
-            - name: timestamp-pg-dump
-              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
-              imagePullPolicy: "Always"
-              command: ["mv"]
-              args:
-                - /pg-dump/content_store_production.gz
-                - "/pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production.gz"
-              env:
-                - name: DATABASE_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: "{{ .Values.draftContentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
-                      key: DATABASE_URL
-              {{- with .Values.resources }}
-              resources:
-                {{- . | toYaml | trim | nindent 16 }}
-              {{- end }}
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-              volumeMounts:
-                - name: pg-dump
-                  mountPath: /pg-dump
-                - name: app-tmp
-                  mountPath: /tmp
           containers:
             - name: upload-to-s3
               image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest


### PR DESCRIPTION
Export, compress, and upload-to-s3, the newly-import PostgreSQL database at the end of the mongo-to-postgres cronjob for `draft-content-store-postgresql-branch` in integration. This is needed so that the downstream consumers of the mongo database (Data Services, content-data app etc) can update their import scripts to import PostgreSQL rather than Mongo. 

[Trello card](https://trello.com/c/RxgagJzD/737-add-overnight-pgdump-of-content-store-postgresql-rds-instance-to-s3), part of the [overall epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)

I don't know how well this is going to work until I try it, this solution is quite verbose and could probably be DRY-ed up quite a lot. There are also a couple of questions outstanding:

- would we want to do this as part of _this_ job (makes sense to do it as soon as the import is finished), or as part of a separate port of the `govuk_env_sync` job [from govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/782ae60e32118bdd50e3d4856d6bfd65ef010eaa/modules/govuk_env_sync/files/govuk_env_sync.sh)? 
- It also doesn't _need_ to all be run on the app images, there are probably simpler trusted images we could use (a postgres one for the first, maybe just a generic ubuntu one for all the other steps except the last s3 one ?)