### PR TITLE
Turn CSP report only off for Feedback, Finder-Frontend and Smart Answers

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -17,7 +17,9 @@ data:
   GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.publishingDomainSuffix }}
   GOVUK_ASSET_ROOT: https://{{ .Values.assetsDomain }}
-  GOVUK_CSP_REPORT_ONLY: {{ .Values.cspReportOnly | quote }}
+  {{- if .Values.cspReportOnly }}
+  GOVUK_CSP_REPORT_ONLY: "true"
+  {{- end }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -980,6 +980,7 @@ govukApplications:
 
 - name: feedback
   helmValues:
+    cspReportOnly: false
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: 93109fea-34d9-4c38-ac7e-1ebc75e7416b
@@ -1029,6 +1030,7 @@ govukApplications:
 
 - name: finder-frontend
   helmValues:
+    cspReportOnly: false
     cronTasks:
       - name: registries-refresh
         task: "registries:cache_refresh"
@@ -2296,6 +2298,7 @@ govukApplications:
       # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
+    cspReportOnly: false
     extraEnv:
       - name: EXPOSE_GOVSPEAK
         value: "1"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -978,6 +978,7 @@ govukApplications:
 
 - name: feedback
   helmValues:
+    cspReportOnly: false
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: b5baae45-0a68-4b63-91a1-66b05640d27e
@@ -1035,6 +1036,7 @@ govukApplications:
       requests:
         cpu: 2
         memory: 2000Mi
+    cspReportOnly: false
     cronTasks:
       - name: registries-refresh
         task: "registries:cache_refresh"
@@ -2347,6 +2349,7 @@ govukApplications:
       requests:
         memory: 1Gi
         cpu: "2"
+    cspReportOnly: false
     extraEnv:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -951,6 +951,7 @@ govukApplications:
 
 - name: feedback
   helmValues:
+    cspReportOnly: false
     extraEnv:
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: d33f7857-7514-4458-81b9-0995f48e2ac5
@@ -1007,6 +1008,7 @@ govukApplications:
       requests:
         cpu: 2
         memory: 2000Mi
+    cspReportOnly: false
     cronTasks:
       - name: registries-refresh
         task: "registries:cache_refresh"
@@ -2298,6 +2300,7 @@ govukApplications:
       # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
+    cspReportOnly: false
     extraEnv:
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:


### PR DESCRIPTION
This is a draft because I don't want this applied until Tuesday morning.

This PR turns off Content Security Policy (CSP) report only mode for the applications owned by the User Experience Measurement (UXM) team. Turning report only mode off makes the CSP actually apply restrictions, whereas previously it would report and not block.

This is the first time I've created a PR for this repo so I've got a couple of questions:

1. Is the approach I've used to configuring the variables going to work, I'm assuming a variable set in`charts/app-config/values-integration.yaml` overrides something set in `charts/app-config/values.yaml`?
2. Have I got the conditional correct?
3. I'm assuming that once merged this just applies automatically to each environment and doesn't need any extra deploy steps, is that correct?