### PR TITLE
Turn CSP report only off for Feedback, Finder-Frontend and Smart Answers

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -17,7 +17,6 @@ data:
   GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.publishingDomainSuffix }}
   GOVUK_ASSET_ROOT: https://{{ .Values.assetsDomain }}
-  GOVUK_CSP_REPORT_ONLY: {{ .Values.cspReportOnly | quote }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1035,8 +1035,6 @@ govukApplications:
 - name: feedback
   helmValues:
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: 93109fea-34d9-4c38-ac7e-1ebc75e7416b
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
@@ -1090,8 +1088,6 @@ govukApplications:
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
       - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -2415,8 +2411,6 @@ govukApplications:
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: EXPOSE_GOVSPEAK
         value: "1"
       - name: LINK_CHECKER_API_BEARER_TOKEN

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -300,6 +300,8 @@ govukApplications:
 - name: collections
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
       - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -318,6 +320,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -933,6 +937,8 @@ govukApplications:
 - name: email-alert-frontend
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: SUBSCRIPTION_MANAGEMENT_ENABLED
         value: "yes"
       - name: REDIS_URL
@@ -1029,6 +1035,8 @@ govukApplications:
 - name: feedback
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: 93109fea-34d9-4c38-ac7e-1ebc75e7416b
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
@@ -1082,6 +1090,8 @@ govukApplications:
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
       - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -1112,6 +1122,8 @@ govukApplications:
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           path: /assets/frontend/
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
       - name: MEMCACHE_SERVERS
@@ -1174,6 +1186,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
       - name: PLEK_HOSTNAME_PREFIX
@@ -1207,6 +1221,8 @@ govukApplications:
 - name: government-frontend
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
 
@@ -1220,6 +1236,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
 
@@ -1330,6 +1348,10 @@ govukApplications:
         value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 
 - name: info-frontend
+  helmValues:
+    extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
 
 - name: licencefinder
   repoName: licence-finder
@@ -1339,6 +1361,8 @@ govukApplications:
       path: /app/public/assets/licencefinder
       s3Directory: "licencefinder"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
       - name: ELASTICSEARCH_URI
@@ -2339,6 +2363,8 @@ govukApplications:
         schedule: "7 1 * * *"
         serviceAccount: signon
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
       - name: GOVUK_NOTIFY_API_KEY
@@ -2389,6 +2415,8 @@ govukApplications:
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: EXPOSE_GOVSPEAK
         value: "1"
       - name: LINK_CHECKER_API_BEARER_TOKEN

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -278,6 +278,8 @@ govukApplications:
         cpu: 1
         memory: 1Gi
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.production.govuk-internal.digital
       - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -296,6 +298,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -885,6 +889,8 @@ govukApplications:
 - name: email-alert-frontend
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: SUBSCRIPTION_MANAGEMENT_ENABLED
         value: "yes"
       - name: REDIS_URL
@@ -979,6 +985,8 @@ govukApplications:
 - name: feedback
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: b5baae45-0a68-4b63-91a1-66b05640d27e
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
@@ -1040,6 +1048,8 @@ govukApplications:
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -1077,6 +1087,8 @@ govukApplications:
         cpu: 2
         memory: 1Gi
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
       - name: MEMCACHE_SERVERS
@@ -1140,6 +1152,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
       - name: PLEK_HOSTNAME_PREFIX
@@ -1181,6 +1195,8 @@ govukApplications:
         cpu: 1
         memory: 1500Mi
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.production.govuk-internal.digital
 
@@ -1194,6 +1210,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
 
@@ -1294,6 +1312,10 @@ govukApplications:
         value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
 
 - name: info-frontend
+  helmValues:
+    extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
 
 - name: licencefinder
   repoName: licence-finder
@@ -1303,6 +1325,8 @@ govukApplications:
       path: /app/public/assets/licencefinder
       s3Directory: "licencefinder"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
       - name: ELASTICSEARCH_URI
@@ -2323,6 +2347,8 @@ govukApplications:
         schedule: "9 1 * * *"
         serviceAccount: signon
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
       - name: GOVUK_NOTIFY_API_KEY
@@ -2380,6 +2406,8 @@ govukApplications:
         memory: 1Gi
         cpu: "2"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -985,8 +985,6 @@ govukApplications:
 - name: feedback
   helmValues:
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: b5baae45-0a68-4b63-91a1-66b05640d27e
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
@@ -1048,8 +1046,6 @@ govukApplications:
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -2406,8 +2402,6 @@ govukApplications:
         memory: 1Gi
         cpu: "2"
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -283,6 +283,8 @@ govukApplications:
         cpu: 1
         memory: 1Gi
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
       - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -301,6 +303,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -892,6 +896,8 @@ govukApplications:
 - name: email-alert-frontend
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: SUBSCRIPTION_MANAGEMENT_ENABLED
         value: "yes"
       - name: REDIS_URL
@@ -952,6 +958,8 @@ govukApplications:
 - name: feedback
   helmValues:
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: d33f7857-7514-4458-81b9-0995f48e2ac5
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
@@ -1012,6 +1020,8 @@ govukApplications:
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -1049,6 +1059,8 @@ govukApplications:
         cpu: 2
         memory: 1Gi
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
       - name: MEMCACHE_SERVERS
@@ -1113,6 +1125,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *frontend-notify-template
       - name: PLEK_HOSTNAME_PREFIX
@@ -1153,6 +1167,8 @@ govukApplications:
         cpu: 1
         memory: 1500Mi
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: MEMCACHE_SERVERS
         value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
 
@@ -1166,6 +1182,8 @@ govukApplications:
     uploadAssets:
       enabled: false
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: PLEK_HOSTNAME_PREFIX
         value: draft-
 
@@ -1266,6 +1284,10 @@ govukApplications:
         value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
 - name: info-frontend
+  helmValues:
+    extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
 
 - name: licencefinder
   repoName: licence-finder
@@ -1275,6 +1297,8 @@ govukApplications:
       path: /app/public/assets/licencefinder
       s3Directory: "licencefinder"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
       # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
       # TODO: Change this when copying from staging to production.
@@ -2283,6 +2307,8 @@ govukApplications:
         schedule: "12 1 * * *"
         serviceAccount: signon
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: GOVUK_NOTIFY_TEMPLATE_ID
         value: *publishing-notify-template
       - name: GOVUK_NOTIFY_API_KEY
@@ -2333,6 +2359,8 @@ govukApplications:
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
     extraEnv:
+      - name: GOVUK_CSP_REPORT_ONLY
+        value: "true"
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -958,8 +958,6 @@ govukApplications:
 - name: feedback
   helmValues:
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
         value: d33f7857-7514-4458-81b9-0995f48e2ac5
       - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
@@ -1020,8 +1018,6 @@ govukApplications:
         task: "registries:cache_refresh"
         schedule: "15 * * * *"
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: EMAIL_ALERT_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:
@@ -2359,8 +2355,6 @@ govukApplications:
       path: /app/public/assets/smartanswers
       s3Directory: "smartanswers"
     extraEnv:
-      - name: GOVUK_CSP_REPORT_ONLY
-        value: "true"
       - name: LINK_CHECKER_API_BEARER_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -18,7 +18,6 @@ ec2InternalDomainSuffix: govuk-internal.digital
 externalDomainSuffix: eks.test.govuk.digital
 publishingDomainSuffix: test.publishing.service.gov.uk
 
-cspReportOnly: true
 cspReportURI: ""
 
 monitoring:


### PR DESCRIPTION
This PR follows on from: https://github.com/alphagov/govuk-helm-charts/pull/1181 but takes a different approach. It's left as a draft as it'll not be ready to merge until Tuesday morning

This PR first changes how we manage the GOVUK_CSP_REPORT_ONLY environment variable to use individual application environment variables rather than a global one. We have only configured the GOV.UK CSP on a few apps so we don't actually need to apply this env var to many places.

It then removes this env var for Feedback, Finder Frontend and Smart Answers so that those apps will no longer have the env var and will have their CSP on.

As I understand roll out wise (typing this out so it can be sense checked): Once this is merged these environment variables will be automatically rolled out to apps, but they won't have any effect as the configmap one is still there. Once I run `kubectl rollout restart` in each environment this will remove the configmap env var and will remove this env var from apps that don't have it individually configured.