### PR TITLE
Add `asset-manager` to unprefixable hosts list

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -31,7 +31,7 @@ data:
   {{- end }}
   GOVUK_SIDEKIQ_JSON_LOGGING: "1"
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
-  PLEK_UNPREFIXABLE_HOSTS: account-api,feedback,imminence,info-frontend,licensify,local-links-manager,locations-api,search-api,signon
+  PLEK_UNPREFIXABLE_HOSTS: account-api,asset-manager,feedback,imminence,info-frontend,licensify,local-links-manager,locations-api,search-api,signon
   PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   RAILS_LOG_TO_STDOUT: "true"
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}


### PR DESCRIPTION
There is no draft version of Asset Manager, so we don't want to prefix the route with `draft-` when in the draft stack.

Therefore adding it to the list of unprefixable hosts.

This is used by Plek to determine whether to add the `draft-` prefix (https://github.com/alphagov/plek/blob/a13aa51efebc8084a0a68bbbd93fae2a14d25b01/lib/plek.rb#L42C38-L42C61).

[Trello card](https://trello.com/c/y2vagYMl)

Resolves [Sentry error](https://govuk.sentry.io/issues/4265119919/?project=202225&query=is%3Aunresolved&referrer=issue-stream&stream_index=3).