### PR TITLE
Revert "Permit ingress to asset metadata routes for Asset Manager in integration"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -139,20 +139,16 @@ govukApplications:
       hosts:
         - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
           paths:
-            - path: /assets/  # Integration only
             - path: /government/uploads/
             - path: /government/assets/
             - path: /media/
             - path: /auth/gds  # Viewing draft assets requires user auth.
-            - path: /whitehall_assets/  # Integration only
         - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
           paths:
-            - path: /assets/  # Integration only
             - path: /government/uploads/
             - path: /government/assets/
             - path: /media/
             - path: /auth/gds  # Viewing draft assets requires user auth.
-            - path: /whitehall_assets/  # Integration only
     assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
     nginxConfigMap:
       create: false


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#1136.

The development of CSV Previews in the Frontend application is complete, so we no longer need to permit ingress to these endpoints from local developer machines.

This change had a side effect of blocking the loading of all CSS and JavaScript on the preview pages (as they existed under the `/assets` path), so should be reverted to allow these pages to render correctly.