### PR TITLE
Swap in draft-content-store-proxy for draft-content-store via service app selector

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -708,7 +708,7 @@ govukApplications:
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
 
-- name: draft-content-store
+- name: draft-content-store-mongo-main
   repoName: content-store
   helmValues:
     <<: *content-store
@@ -792,9 +792,12 @@ govukApplications:
       enabled: false
     extraEnv:
       - name: PRIMARY_UPSTREAM
-        value: "http://draft-content-store/"
+        value: "http://draft-content-store-mongo-main/"
       - name: SECONDARY_UPSTREAM
         value: "http://draft-content-store-postgresql-branch/"
+    service:
+      selector:
+        app: draft-content-store
 
 - name: content-tagger
   helmValues:

--- a/charts/generic-govuk-app/templates/service.yaml
+++ b/charts/generic-govuk-app/templates/service.yaml
@@ -20,4 +20,5 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
   selector:
-    app: {{ $fullName }}
+    # app: {{ $fullName }}
+    app: {{ .Values.service.selector.app | default ($fullName) }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -4,6 +4,8 @@ service:
   type: NodePort
   annotations: {}
   port: 80
+  selector:
+    app:
 
 ingress:
   enabled: false


### PR DESCRIPTION
We have the draft-[content-store-proxy](https://github.com/alphagov/content-store-proxy) up and running on integration, now we need to manipulate the cluster DNS-resolution into making http://draft-content-store/ resolve to the proxy (as per [this doc](https://docs.google.com/document/d/1pg2woRhCTWOoq18RyswkPVAz2LgCwjhjugFvwyGdMvg/edit?pli=1))

This PR:

* allows an app to override the `service -> selector -> app` value 
* makes the `draft-content-store-proxy` provide a selector of `draft-content-store`
* renames the `draft-content-store` app to `draft-content-store-mongo-main`
* alters the `PRIMARY_UPSTREAM` env var for the proxy to `http://draft-content-store-mongo-main/`

*Note* - I'm _hoping_ that this will achieve the desired result, but beyond linting correctly I can't really test this locally (unless I install kubernetes and replicate the cluster setup on my laptop, etc etc  which would be a big job). I'm totally open to alternative ways of achieving the result.

[Trello card](https://trello.com/c/xeJcwf6w/707-deploy-content-store-proxy-in-integration-for-the-draft-content-store), part of rolling out the [content-store mongo->postgresql migration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)  on [integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-postgresql-branch-in-integration-for-the-draft-content-store)