### PR TITLE
Revert "Swap in draft-content-store-proxy for draft-content-store via service app selector"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -708,7 +708,7 @@ govukApplications:
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
 
-- name: draft-content-store-mongo-main
+- name: draft-content-store
   repoName: content-store
   helmValues:
     <<: *content-store
@@ -792,10 +792,9 @@ govukApplications:
       enabled: false
     extraEnv:
       - name: PRIMARY_UPSTREAM
-        value: "http://draft-content-store-mongo-main/"
+        value: "http://draft-content-store/"
       - name: SECONDARY_UPSTREAM
         value: "http://draft-content-store-postgresql-branch/"
-    serviceSelector: draft-content-store
 
 - name: content-tagger
   helmValues:

--- a/charts/generic-govuk-app/templates/service.yaml
+++ b/charts/generic-govuk-app/templates/service.yaml
@@ -20,4 +20,4 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
   selector:
-    app: {{ .Values.serviceSelector | default ($fullName) }}
+    app: {{ $fullName }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -5,9 +5,6 @@ service:
   annotations: {}
   port: 80
 
-# which app hostname this service will respond to
-serviceSelector:
-
 ingress:
   enabled: false
 


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#1188

2 of the 3 changes worked (the draft-content-store-proxy service now has the updated Selector, and draft-content-store is now named draft-content-store-mongo-main) but the all-important 3rd (http://draft-content-store/ should resolve to draft-content-store-proxy now ) doesn't.

```
kubectl describe service -n apps draft-content-store-proxy 
Name:                     draft-content-store-proxy
Namespace:                apps
Labels:                   app=draft-content-store-proxy
                          app.kubernetes.io/component=app
                          app.kubernetes.io/name=draft-content-store-proxy
                          argocd.argoproj.io/instance=draft-content-store-proxy
Annotations:              <none>
Selector:                 app=draft-content-store
```

but from a bash prompt on a running container:
```
app@draft-content-store-mongo-main-55fff44d9c-lcgtk:~$ curl http://draft-content-store/api/content
curl: (6) Could not resolve host: draft-content-store
```
