### PR TITLE
Set env variable to enable production-like logs

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -35,6 +35,7 @@ data:
   PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   RAILS_LOG_TO_STDOUT: "true"
   SENTRY_CURRENT_ENV: {{ .Values.govukEnvironment }}
+  GOVUK_RAILS_JSON_LOGGING: "true"
 
   # Data sync period used by sentry to ignore application errors during that time. Only relevant to integration and staging.
   {{- if ne .Values.govukEnvironment "production" }}


### PR DESCRIPTION
We have made changes to `govuk_app_config` and `govuk-docker` to enable allowing production-logs in the development environment. 

The change to consume the variable is made in [this PR](https://github.com/alphagov/govuk_app_config/pull/302)
[Trello card](https://trello.com/c/niLCNflj/117-story-enable-production-like-logging-in-dev-environments)