### PR TITLE
Swap in draft content store proxy via service app selector

### DIFF
--- a/charts/app-config/templates/draft-content-store-proxy-service.yaml
+++ b/charts/app-config/templates/draft-content-store-proxy-service.yaml
@@ -5,10 +5,6 @@ kind: Service
 metadata:
   name: draft-content-store
 spec:
-  ports:
-    - name: app
-      port: 80
-      targetPort: 8080
-  selector:
-    app: draft-content-store-proxy
+  type: ExternalName
+  externalName: draft-content-store-proxy
 {{- end }}

--- a/charts/app-config/templates/draft-content-store-proxy-service.yaml
+++ b/charts/app-config/templates/draft-content-store-proxy-service.yaml
@@ -6,5 +6,5 @@ metadata:
   name: draft-content-store
 spec:
   type: ExternalName
-  externalName: draft-content-store-proxy
+  externalName: draft-content-store-proxy.apps.svc.cluster.local
 {{- end }}

--- a/charts/app-config/templates/draft-content-store-proxy-service.yaml
+++ b/charts/app-config/templates/draft-content-store-proxy-service.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.enableDraftContentStoreProxy }}
+# route all requests for draft-content-store via draft-content-store-proxy
+apiVersion: v1
+kind: Service
+metadata:
+  name: draft-content-store
+spec:
+  ports:
+    - name: app
+      port: 80
+      targetPort: 8080
+  selector:
+    app: draft-content-store-proxy
+{{- end }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -38,6 +38,8 @@ alb-ingress-backend-waf-ruleset: &alb-ingress-backend-waf-ruleset
   alb.ingress.kubernetes.io/wafv2-acl-arn: >-
     arn:aws:wafv2:eu-west-1:210287912431:regional/webacl/backend_public_web_acl/b5f616fd-699e-4b44-8ea2-7afd6626aa98
 
+# Route all requests for draft-content-store via draft-content-store-proxy
+enableDraftContentStoreProxy: true
 
 # Individual apps to be deployed by ArgoCD, and any values specific to those
 # apps.

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -710,7 +710,7 @@ govukApplications:
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
 
-- name: draft-content-store
+- name: draft-content-store-mongo-main
   repoName: content-store
   helmValues:
     <<: *content-store
@@ -794,9 +794,10 @@ govukApplications:
       enabled: false
     extraEnv:
       - name: PRIMARY_UPSTREAM
-        value: "http://draft-content-store/"
+        value: "http://draft-content-store-mongo-main/"
       - name: SECONDARY_UPSTREAM
         value: "http://draft-content-store-postgresql-branch/"
+    serviceSelector: draft-content-store
 
 - name: content-tagger
   helmValues:

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -22,3 +22,5 @@ cspReportURI: ""
 
 monitoring:
   enabled: true
+
+enableDraftContentStoreProxy: false

--- a/charts/generic-govuk-app/templates/service.yaml
+++ b/charts/generic-govuk-app/templates/service.yaml
@@ -20,4 +20,4 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
   selector:
-    app: {{ $fullName }}
+    app: {{ .Values.serviceSelector | default ($fullName) }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -5,6 +5,9 @@ service:
   annotations: {}
   port: 80
 
+# which app hostname this service will respond to
+serviceSelector:
+
 ingress:
   enabled: false
 


### PR DESCRIPTION
Second attempt at swapping-in `draft-content-store-proxy` as per the previous attempt in #1188  - this time with an additional Service that should route http://draft-content-store/ to the draft-content-store-proxy pods. 


[Trello card](https://trello.com/c/xeJcwf6w/707-deploy-content-store-proxy-in-integration-for-the-draft-content-store), part of rolling out the [content-store mongo->postgresql migration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)  on [integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-postgresql-branch-in-integration-for-the-draft-content-store)