### PR TITLE
Remove Cache Clearing Service from integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -269,30 +269,6 @@ govukApplications:
           proxy_pass https://www.gov.uk/apply-for-a-licence/payment/worldpayCallback;
         }
 
-- name: cache-clearing-service
-  helmValues:
-    uploadAssets:
-      enabled: false
-    dbMigrationEnabled: false
-    rails:
-      enabled: false
-    appEnabled: false
-    podDisruptionBudget: {}
-    workerEnabled: true
-    workers:
-      - command: ["rake", "message_queue:consumer", "QUEUE=high"]
-        name: high
-      - command: ["rake", "message_queue:consumer", "QUEUE=medium"]
-        name: medium
-      - command: ["rake", "message_queue:consumer", "QUEUE=low"]
-        name: low
-    extraEnv:
-      - name: RABBITMQ_URL
-        valueFrom:
-          secretKeyRef:
-            name: cache-clearing-service-rabbitmq
-            key: RABBITMQ_URL
-
 - name: collections
   helmValues:
     extraEnv:


### PR DESCRIPTION
In preparation for a complete removal in https://github.com/alphagov/govuk-helm-charts/pull/1193 we want to first remove it from integration.

[GIFT week summer 2023 card](https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service)
[Tech debt card](https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings)