### PR TITLE
Add Open Telemetry exporter endpoint

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -41,6 +41,13 @@ data:
   GOVUK_DATA_SYNC_PERIOD: "22:0-8:0"
   {{- end }}
 
+  # Endpoint used to export Open Telemetry data. Only set for integration as
+  # being used to demo Jaeger as part of GIFT week. Should be removed if not
+  # Jaeger not implemented.
+  {{- if eq .Values.govukEnvironment "integration" }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger-collector.monitoring.svc.cluster.local:4318"
+  {{- end }}
+
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}
   PLEK_SERVICE_DRAFT_ASSETS_URI: https://draft-assets.{{ .Values.publishingDomainSuffix }}
 


### PR DESCRIPTION
This adds a env var that can be used be Open Telemetry SDKs to export data to Jaeger (distributive tracing tooling). This env var is only enabled in integration as part of a demo of Jaeger and shouldn't affect other environments.

---
This work is being done as part of GIFT week, and should be removed if not implemented fully.