### PR TITLE
Swap in draft-content-store-proxy by switching app names with draft-content-store

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -708,7 +708,7 @@ govukApplications:
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
 
-- name: draft-content-store
+- name: draft-content-store-mongo-main
   repoName: content-store
   helmValues:
     <<: *content-store
@@ -784,7 +784,7 @@ govukApplications:
       - name: DISABLE_ROUTER_API
         value: "true"
 
-- name: draft-content-store-proxy
+- name: draft-content-store
   repoName: content-store-proxy
   helmValues:
     nginxClientMaxBodySize: 20M
@@ -792,7 +792,7 @@ govukApplications:
       enabled: false
     extraEnv:
       - name: PRIMARY_UPSTREAM
-        value: "http://draft-content-store/"
+        value: "http://draft-content-store-mongo-main/"
       - name: SECONDARY_UPSTREAM
         value: "http://draft-content-store-postgresql-branch/"
 


### PR DESCRIPTION
Having previously attempted more subtle methods (#1191 and #1188) to route all requests for `draft-content-store` via the `draft-content-store-proxy`,  this latest version simply swaps the app names of the two apps.

[Trello card](https://trello.com/c/xeJcwf6w/707-deploy-content-store-proxy-in-integration-for-the-draft-content-store), part of rolling out the [content-store mongo->postgresql migration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)  on [integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-postgresql-branch-in-integration-for-the-draft-content-store)