### PR TITLE
disable rails secret key name generation etc for draft-content-store 

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -763,6 +763,8 @@ govukApplications:
 - name: draft-content-store
   repoName: content-store-proxy
   helmValues:
+    rails:
+      enabled: false
     nginxClientMaxBodySize: 20M
     uploadAssets:
       enabled: false


### PR DESCRIPTION
…(which is actually draft-content-store-proxy)


[Trello card](https://trello.com/c/xeJcwf6w/707-deploy-content-store-proxy-in-integration-for-the-draft-content-store), part of rolling out the [content-store mongo->postgresql migration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)  on [integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-postgresql-branch-in-integration-for-the-draft-content-store)