### PR TITLE
Set ENABLE_OPEN_TELEMETRY to true in integration

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -46,6 +46,7 @@ data:
   # Jaeger not implemented.
   {{- if eq .Values.govukEnvironment "integration" }}
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger-collector.monitoring.svc.cluster.local:4318"
+  ENABLE_OPEN_TELEMETRY: "true"
   {{- end }}
 
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}


### PR DESCRIPTION
This enable Open Telementry intrumentation for all Rails applications in integration that use govuk_app_config v8.1.0 or greater.