### PR TITLE
Disable Open Telemetry for db migrations

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -49,6 +49,8 @@ spec:
           env:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            - name: ENABLE_OPEN_TELEMETRY
+              value: "false"
             {{- if .Values.rails.enabled }}
             - name: SECRET_KEY_BASE
               value: unused_for_dbmigrate_but_still_required


### PR DESCRIPTION
There is an issue that prevents db migrations from successfully running when open telemetry instrumentation is enabled.