### PR TITLE
Add SiteImprove secrets to Content Data Admin in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -444,6 +444,18 @@ govukApplications:
           secretKeyRef:
             name: signon-token-content-data-admin-content-data-api
             key: bearer_token
+      - name: SITE_IMPROVE_API_CLIENT_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: content-data-admin-site-improve-api-client
+            key: username
+      - name: SITE_IMPROVE_API_CLIENT_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: content-data-admin-site-improve-api-client
+            key: password
+      - name: SITE_IMPROVE_SITE_ID
+        value: 27169161461
       # These GA/GTM values are not secrets (not even the the gtm_auth one).
       # https://github.com/alphagov/govuk-puppet/pull/8041
       - name: GOOGLE_TAG_MANAGER_AUTH

--- a/charts/external-secrets/templates/content-data-admin/site-improve.yaml
+++ b/charts/external-secrets/templates/content-data-admin/site-improve.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: content-data-admin-site-improve-api-client
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Site Improve API credentials for content data admin, used for accessibility reports.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: content-data-admin-site-improve-api-client
+  dataFrom:
+    - extract:
+        key: govuk/content-data-admin/site-improve-api-client


### PR DESCRIPTION
Adds SITE_IMPROVE_API_CLIENT_USERNAME, SITE_IMPROVE_API_CLIENT_PASSWORD, served from AWS secrets, plus SITE_IMPROVE_SITE_ID (hardcoded), as values available to content-data-admin app in integration, supporting GIFT week project here:

https://trello.com/b/AO68KGHI/gift-week-summer-2023