### PR TITLE
Prevent tracing healthcheck endpoints

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -46,6 +46,7 @@ data:
   # Jaeger not implemented.
   {{- if eq .Values.govukEnvironment "integration" }}
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://grafana-tempo.monitoring.svc.cluster.local:4318"
+  OTEL_RUBY_INSTRUMENTATION_RACK_CONFIG_OPTS: "untraced_endpoints=/healthcheck/live"
   ENABLE_OPEN_TELEMETRY: "true"
   {{- end }}
 


### PR DESCRIPTION
This disable tracing request to the healthcheck endpoint used by kubernetes to see pod status. We want to filter these out as they add a lot of noise and aren't particularly useful as traces.