### PR TITLE
Update otel endpoint to new tempo service name

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -46,7 +46,7 @@ data:
   # being used to demo Jaeger as part of GIFT week. Should be removed if not
   # Jaeger not implemented.
   {{- if eq .Values.govukEnvironment "integration" }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://grafana-tempo.monitoring.svc.cluster.local:4318"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo-distributor.monitoring.svc.cluster.local:4318"
   OTEL_RUBY_INSTRUMENTATION_RACK_CONFIG_OPTS: "untraced_endpoints=/healthcheck/live"
   ENABLE_OPEN_TELEMETRY: "true"
   {{- end }}


### PR DESCRIPTION
As part of trailing the S3 backend for tempo, the service name for the otel endpoint has changed as using the distrubuted version of Tempo.