### PR TITLE
Reduce log verbosity for search-api.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2184,6 +2184,8 @@ govukApplications:
         value: *elasticsearch-uri
       - name: ENABLE_LTR
         value: "true"
+      - name: LOG_LEVEL
+        value: warn
       - name: SEARCH_INDEX
         value: all
       - name: GDS_SSO_OAUTH_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2186,6 +2186,8 @@ govukApplications:
         value: *elasticsearch-uri
       - name: ENABLE_LTR
         value: "true"
+      - name: LOG_LEVEL
+        value: warn
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2156,6 +2156,8 @@ govukApplications:
         value: *elasticsearch-uri
       - name: ENABLE_LTR
         value: "true"
+      - name: LOG_LEVEL
+        value: warn
       - name: GDS_SSO_OAUTH_ID
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
The Elasticsearch client in Search API produces a *lot* of info logs by default and they're not very useful. The log lines look like this:

```
 INFO  Services : GET https://vpc-blue-elasticsearch6-domain-xxxxxxxxxxxxxxxxxxxxxxxxxx.eu-west-1.es.amazonaws.com:443/govuk/_alias [status:200, request:0.005s, query:n/a]
 INFO  Services : GET https://vpc-blue-elasticsearch6-domain-xxxxxxxxxxxxxxxxxxxxxxxxxx.eu-west-1.es.amazonaws.com:443/metasearch/_analyze?index=metasearch [status:200, request:0.010s, query:n/a]
 INFO  Services : GET https://vpc-blue-elasticsearch6-domain-xxxxxxxxxxxxxxxxxxxxxxxxxx.eu-west-1.es.amazonaws.com:443/govuk/_alias [status:200, request:0.004s, query:n/a]
 INFO  Services : GET https://vpc-blue-elasticsearch6-domain-xxxxxxxxxxxxxxxxxxxxxxxxxx.eu-west-1.es.amazonaws.com:443/metasearch/generic-document/_search [status:200, request:0.013s, query:0.001s]
 INFO  Services : GET https://vpc-blue-elasticsearch6-domain-xxxxxxxxxxxxxxxxxxxxxxxxxx.eu-west-1.es.amazonaws.com:443/govuk/_alias [status:200, request:0.004s, query:n/a]
 INFO  Services : GET https://vpc-blue-elasticsearch6-domain-xxxxxxxxxxxxxxxxxxxxxxxxxx.eu-west-1.es.amazonaws.com:443/detailed,government,govuk/generic-document/_search [status:200, request:0.016s, query:0.006s]
```

i.e. they don't tell us anything much that we can't more easily get from counters.

I estimate this specific pattern of log message alone is costing us over GBP 1000 / month in Logit quota.

We'll still log warnings and errors, so I think this is highly unlikely to get in the way of any potential troubleshooting. It's also trivial to turn the verbosity back up if/when necessary.

Related: https://github.com/alphagov/search-api/pull/2637