### PR TITLE
Add content-store-postgresql-branch and content-store-proxy apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -696,6 +696,60 @@ govukApplications:
           mongo-2.integration.govuk-internal.digital,\
           mongo-3.integration.govuk-internal.digital/content_store_production"
 
+- name: content-store-postgresql-branch
+  repoName: content-store-postgresql-branch
+  helmValues:
+    <<: *content-store
+    rails:
+      createKeyBaseSecret: false
+      # use the same secret as the mongo content-store, it will make the
+      # eventual switchover easier and reduce toil
+      secretKeyBaseName: content-store-rails-secret-key-base
+    sentry:
+      createSecret: false  # Sentry DSNs are per repo.
+      dsnSecretName: content-store-sentry
+    extraEnv:
+      - name: SENTRY_ENVIRONMENT
+        value: "postgresql-integration"
+      - name: ROUTER_API_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: signon-token-content-store-router-api
+            key: bearer_token
+      - name: GDS_SSO_OAUTH_ID
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_id
+      - name: GDS_SSO_OAUTH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: signon-app-content-store
+            key: oauth_secret
+      - name: DEFAULT_TTL
+        value: "1"
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: content-store-postgres
+            key: DATABASE_URL
+      - name: DISABLE_ROUTER_API
+        value: "true"
+
+- name: content-store-proxy
+  repoName: content-store-proxy
+  helmValues:
+    rails:
+      enabled: false
+    nginxClientMaxBodySize: 20M
+    uploadAssets:
+      enabled: false
+    extraEnv:
+      - name: PRIMARY_UPSTREAM
+        value: "http://content-store/"
+      - name: SECONDARY_UPSTREAM
+        value: "http://content-store-postgresql-branch/"
+
 - name: draft-content-store-mongo-main
   repoName: content-store
   helmValues:


### PR DESCRIPTION
...but do not swap in the proxy yet. That will be done in a separate PR, to allow for the smallest possible reversion in case of any issues.

Trello cards: [sub-epic](https://trello.com/c/HMibQBll/735-roll-out-content-store-proxy-postgresql-app-for-live-content-store-in-integration) and [overall epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)