### PR TITLE
Add CronJob to export live (integration) content-store from mongo to postgres

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1314,7 +1314,14 @@ govukApplications:
           mongo-3.integration.govuk-internal.digital/draft_content_store_production"
       postgresImport:
         databaseUrlSecretName: "draft-content-store-postgres"
-
+    contentStoreMongoPostgresCron:
+      mongoExport:
+        mongoDbUri: "mongodb://\
+          mongo-1.integration.govuk-internal.digital,\
+          mongo-2.integration.govuk-internal.digital,\
+          mongo-3.integration.govuk-internal.digital/content_store_production"
+      postgresImport:
+        databaseUrlSecretName: "content-store-postgres"
 - name: hmrc-manuals-api
   helmValues:
     nginxClientMaxBodySize: 2M

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -82,3 +82,88 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "content-store-mongo-to-postgres-cron"
+  labels:
+    app: "content-store-mongo-to-postgres-cron"
+    app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+spec:
+  schedule: "{{ .Values.draftContentStoreMongoPostgresCron.schedule }}"  
+  jobTemplate:
+    metadata:
+      name: "content-store-mongo-to-postgres-cron"
+      labels:
+        app: "content-store-mongo-to-postgres-cron"
+        app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          name: "content-store-mongo-to-postgres-cron"
+          labels:
+            app: "content-store-mongo-to-postgres-cron"
+            app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
+        spec:
+          enableServiceLinks: false
+          securityContext:
+            fsGroup: {{ .Values.securityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+          restartPolicy: Never
+          volumes:
+            - name: mongo-export
+              emptyDir: {}
+            - name: app-tmp
+              emptyDir: {}
+          initContainers:
+            - name: export-mongo-data
+              image: "{{ .Values.images.ContentStore.repository }}:{{ .Values.images.ContentStore.tag }}"
+              imagePullPolicy: "Always"
+              command: ["rake"]
+              args:
+                - "mongo:export:all[/mongo-export/]"
+              env:
+                - name: MONGODB_URI
+                  value: "{{ .Values.contentStoreMongoPostgresCron.mongoExport.mongoDbUri }}"
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: mongo-export
+                  mountPath: /mongo-export
+                - name: app-tmp
+                  mountPath: /tmp
+          containers:
+            - name: import-mongo-data-to-postgresql
+              image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
+              imagePullPolicy: "Always"
+              command: ["rake"]
+              args:
+                - "import:all[/mongo-export/]"
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
+                      key: DATABASE_URL
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: mongo-export
+                  mountPath: /mongo-export
+                - name: app-tmp
+                  mountPath: /tmp

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -45,3 +45,10 @@ draftContentStoreMongoPostgresCron:
     mongoDbUri: ""
   postgresImport:
     databaseUrlSecretName: "draft-content-store-postgres"
+
+contentStoreMongoPostgresCron:
+  schedule: "15 5 * * *"
+  mongoExport:
+    mongoDbUri: ""
+  postgresImport:
+    databaseUrlSecretName: "content-store-postgres"

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -40,7 +40,7 @@ learnToRank:
   serviceAccountIamRole: ""
 
 draftContentStoreMongoPostgresCron:
-  schedule: "15 5 * * *"
+  schedule: "30 6 * * *"
   mongoExport:
     mongoDbUri: ""
   postgresImport:


### PR DESCRIPTION
essentially duplicating the existing job which does the same for draft-content-store.

There's very probably a much more elegant way of doing this which avoids the duplication, but my helm-fu is not yet up to the task, sorry. 