### PR TITLE
Swap-in the (live) content-store-proxy on integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -663,7 +663,7 @@ govukApplications:
             name: signon-token-content-publisher-whitehall
             key: bearer_token
 
-- name: content-store
+- name: content-store-mongo-main
   helmValues: &content-store
     nginxClientMaxBodySize: 20M
     cronTasks:
@@ -736,7 +736,7 @@ govukApplications:
       - name: DISABLE_ROUTER_API
         value: "true"
 
-- name: content-store-proxy
+- name: content-store
   repoName: content-store-proxy
   helmValues:
     rails:
@@ -746,7 +746,7 @@ govukApplications:
       enabled: false
     extraEnv:
       - name: PRIMARY_UPSTREAM
-        value: "http://content-store/"
+        value: "http://content-store-mongo-main/"
       - name: SECONDARY_UPSTREAM
         value: "http://content-store-postgresql-branch/"
 


### PR DESCRIPTION
using the same method as for the draft-content-store in #1196 

[Trello card](https://trello.com/c/HMibQBll/735-roll-out-content-store-proxy-postgresql-app-for-live-content-store-in-integration), overall [epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)