### PR TITLE
Explicitly tell the renamed content-store app to use its original Rails secret key & sentry DSN

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -670,6 +670,8 @@ govukApplications:
       - name: report-delays
         task: "publishing_delay_report:report_delays"
         schedule: "15 2 * * *"
+    rails:
+      secretKeyBaseName: content-store-rails-secret-key-base
     uploadAssets:
       enabled: false
     extraEnv:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -672,6 +672,8 @@ govukApplications:
         schedule: "15 2 * * *"
     rails:
       secretKeyBaseName: content-store-rails-secret-key-base
+    sentry:
+      dsnSecretName: content-store-sentry
     uploadAssets:
       enabled: false
     extraEnv:


### PR DESCRIPTION
Having renamed the app `content-store` -> `content-store-mongo-main` in #1213 , it was failing to start, with an error `could not get secret data from provider`.

This PR tells to use the secret keys for Rails and Sentry based on its original name 

Part of [this Trello card](https://trello.com/c/HMibQBll/735-roll-out-content-store-proxy-postgresql-app-for-live-content-store-in-integration), which is part of an [overall epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)