### PR TITLE
Use the original ECR repo name for renamed content-store app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -664,6 +664,7 @@ govukApplications:
             key: bearer_token
 
 - name: content-store-mongo-main
+  repoName: content-store
   helmValues: &content-store
     nginxClientMaxBodySize: 20M
     cronTasks:


### PR DESCRIPTION
As well as restoring the original sentry & rails secret names (#1215), we also need to restore the original `repoName` for the content-store app