### PR TITLE
Fix bash syntax error in update-image-tag workflow.

### DIFF
--- a/.github/workflows/update-image-tag.yml
+++ b/.github/workflows/update-image-tag.yml
@@ -58,7 +58,7 @@ jobs:
 
           yq -i '.image_tag = env(image_tag)' "${config_file}"
 
-          UPDATED=$([-z git status --porcelain] && echo 'true' || echo 'false')
+          UPDATED=$(if [ -z "$(git status --porcelain)" ]; then echo true; else echo false; fi)
           echo "updated=${UPDATED}" >> "${GITHUB_OUTPUT}"
 
       - name: Push changes


### PR DESCRIPTION
Was missing a space after `[`.

```bash
UPDATED=$([-z git status --porcelain] && echo 'true' || echo 'false')
bash: [-z: command not found
```

Also https://www.shellcheck.net/wiki/SC2015, but we got away with that one because `echo` would always succeed there.

Kinda need a way to run shellcheck on scripts embedded in GitHub Actions YAML like this, I didn't find any ready-made solutions for that. Maybe something like https://github.com/mschuett/yaml-shellcheck in a GitHub Action?