### PR TITLE
[Do not merge - only in case of emergency] rollback the integration live content-store to just the mongo version

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -663,18 +663,13 @@ govukApplications:
             name: signon-token-content-publisher-whitehall
             key: bearer_token
 
-- name: content-store-mongo-main
-  repoName: content-store
+- name: content-store
   helmValues: &content-store
     nginxClientMaxBodySize: 20M
     cronTasks:
       - name: report-delays
         task: "publishing_delay_report:report_delays"
         schedule: "15 2 * * *"
-    rails:
-      secretKeyBaseName: content-store-rails-secret-key-base
-    sentry:
-      dsnSecretName: content-store-sentry
     uploadAssets:
       enabled: false
     extraEnv:
@@ -741,8 +736,7 @@ govukApplications:
       - name: DISABLE_ROUTER_API
         value: "true"
 
-- name: content-store
-  repoName: content-store-proxy
+- name: content-store-proxy
   helmValues:
     rails:
       enabled: false
@@ -751,7 +745,7 @@ govukApplications:
       enabled: false
     extraEnv:
       - name: PRIMARY_UPSTREAM
-        value: "http://content-store-mongo-main/"
+        value: "http://content-store/"
       - name: SECONDARY_UPSTREAM
         value: "http://content-store-postgresql-branch/"
 


### PR DESCRIPTION
As I'm away until August 14th, and the rollout of dual-running on mongo & postgres for the integration _live_ content-store had to be split across several PRs (#1213 , #1215 and #1216), this is a single draft PR to use in case of emergency, which will revert those 3 in one go