### PR TITLE
Update versions of 3rd-party GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: linting
 on: [push]
 jobs:
   chart-testing:
-    name: Chart testing
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -20,7 +19,7 @@ jobs:
           python-version: 3.x
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yml
@@ -32,11 +31,6 @@ jobs:
           do
             helm template "${c}" "charts/${c}" --output-dir helm-dist
           done
-
-      - name: Login to Github Packages
-        run: |
-          echo "${{ github.token }}" |
-            docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
 
       - name: Read Kubernetes version from /kubernetes_version
         run: "grep KUBERNETES_VERSION kubernetes_version >> $GITHUB_ENV"
@@ -53,12 +47,10 @@ jobs:
             helm-dist
 
   shellcheck:
-    name: Shellcheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
 
   yamllint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Release Charts
+# See /README.md#versioned-vs-unversioned-charts.
+name: Release versioned charts
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   release:
@@ -11,23 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: main
           fetch-depth: 0
+          sparse-checkout: |
+            charts/argo-bootstrap
+            charts/ingress-class
+            charts/cluster-secret-store
+            charts/cluster-secrets
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.10.0
+        uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_SKIP_EXISTING: "true"
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # GOV.UK Helm Charts
 
-
 ## Getting started
 
 See [Helm's documentation](https://helm.sh/docs) to get started with Helm.
@@ -10,13 +9,19 @@ cluster or ask [#govuk-platform-engineering] in Slack.
 
 [GOV.UK Kubernetes Cluster User Docs]: https://govuk-k8s-user-docs.publishing.service.gov.uk/
 
+## Versioned vs unversioned charts
+
+Most of the charts in this repository are designed to be deployed via [Argo
+CD](https://argo-cd.readthedocs.io/en/stable/) rather than by `helm install`.
+For these charts, we don't use `Chart.Version` or Helm's packaging system.
+
+A few charts are still installed via `helm install` ([via
+Terraform](https://github.com/search?q=repo%3Aalphagov%2Fgovuk-infrastructure+path%3Aterraform%2Fdeployments%2Fcluster-services+alphagov.github.io)).
+Those charts are [automatically packaged and
+pushed](https://github.com/alphagov/govuk-helm-charts/blob/main/.github/workflows/release.yml)
+to our Helm repository when a change to `Chart.Version` is merged.
 
 ## Local development
-
-Most of the charts in this repository are designed to be installed via [Argo
-CD] rather than by `helm`. We hope to improve portability over time.
-
-[Argo CD]: https://argo-cd.readthedocs.io/en/stable/
 
 ### Prerequisites
 
@@ -39,7 +44,6 @@ CD] rather than by `helm`. We hope to improve portability over time.
     git config core.hooksPath git-hooks
     ```
 
-
 ### Installing an application chart without Argo CD
 
 ```sh
@@ -55,7 +59,6 @@ helm install $USER-${APP?} ../generic-govuk-app --values <(
 
 You can inspect the final template output by running `helm template` instead of
 `helm install`.
-
 
 ### Chart repository
 

--- a/kubernetes_version
+++ b/kubernetes_version
@@ -1,3 +1,3 @@
-# Kubernetes version for kubeconform to use when validating helm template
+# Kubernetes version for kubeconform to use when validating `helm template`
 # output. See .github/workflows/ci.yml.
-KUBERNETES_VERSION=1.24.0
+KUBERNETES_VERSION=1.25.0


### PR DESCRIPTION
Also:
- Avoid creating tags and releases for the unversioned charts (the ones we deploy via Argo CD), since having those releases/tags lying around is kinda confusing as they don't represent anything useful.
- Update the k8s version that we validate against with kubeconform.

Tested: regression-tested the chart-releaser workflow by pushing a chart version update (with the workflow temporarily patched to trigger from the PR branch) and verified that the release worked.