### PR TITLE
Stop {draft-,}content-store-proxy fighting over a secret.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -827,6 +827,9 @@ govukApplications:
     helmValues:
       rails:
         enabled: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: content-store-proxy-sentry
       nginxClientMaxBodySize: 20M
       uploadAssets:
         enabled: false


### PR DESCRIPTION
Should fix the warning condition `ExternalSecret/content-store-proxy-sentry is part of applications cluster-services/content-store and draft-content-store` on the Argo CD apps for these.