### PR TITLE
Add DIGITIAL_IDENTITY_ENVIRONMENT vars to relevant apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -931,6 +931,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-api-postgres
               key: DATABASE_URL
+        - name: DIGITAL_IDENTITY_ENVIRONMENT
+          value: integration
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1168,6 +1170,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-asset-manager
               key: bearer_token
+        - name: DIGITAL_IDENTITY_ENVIRONMENT
+          value: integration
         - name: ELECTIONS_API_KEY
           valueFrom:
             secretKeyRef:
@@ -2499,6 +2503,8 @@ govukApplications:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
       extraEnv:
+        - name: DIGITAL_IDENTITY_ENVIRONMENT
+          value: integration
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: RAILS_SERVE_STATIC_FILES

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -820,6 +820,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-api-postgres
               key: DATABASE_URL
+        - name: DIGITAL_IDENTITY_ENVIRONMENT
+          value: staging
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1036,6 +1038,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-asset-manager
               key: bearer_token
+        - name: DIGITAL_IDENTITY_ENVIRONMENT
+          value: staging
         - name: ELECTIONS_API_KEY
           valueFrom:
             secretKeyRef:
@@ -2365,6 +2369,8 @@ govukApplications:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
       extraEnv:
+        - name: DIGITAL_IDENTITY_ENVIRONMENT
+          value: staging
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: RAILS_SERVE_STATIC_FILES


### PR DESCRIPTION
- Frontend, Email Alert API and Static all use the GovukPersonalisation::URLs calls which return DI login links
- Currently these all go to live, update to use the env var put in place for this.

https://github.com/alphagov/govuk_personalisation/blob/main/lib/govuk_personalisation/urls.rb#L97-L104

Have confirmed with OneLogin that these are the right hostnames for these environments.

Part of this work:
https://trello.com/c/SiAQ3dZU/2086-redirect-govuk-account-to-homeaccountgovuk