### PR TITLE
Revert "Add DIGITAL_IDENTITY_ENVIRONMENT vars to relevant apps"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -934,8 +934,6 @@ govukApplications:
             secretKeyRef:
               name: email-alert-api-postgres
               key: DATABASE_URL
-        - name: DIGITAL_IDENTITY_ENVIRONMENT
-          value: integration
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1173,8 +1171,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-asset-manager
               key: bearer_token
-        - name: DIGITAL_IDENTITY_ENVIRONMENT
-          value: integration
         - name: ELECTIONS_API_KEY
           valueFrom:
             secretKeyRef:
@@ -2506,8 +2502,6 @@ govukApplications:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
       extraEnv:
-        - name: DIGITAL_IDENTITY_ENVIRONMENT
-          value: integration
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: RAILS_SERVE_STATIC_FILES

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -820,8 +820,6 @@ govukApplications:
             secretKeyRef:
               name: email-alert-api-postgres
               key: DATABASE_URL
-        - name: DIGITAL_IDENTITY_ENVIRONMENT
-          value: staging
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1038,8 +1036,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-asset-manager
               key: bearer_token
-        - name: DIGITAL_IDENTITY_ENVIRONMENT
-          value: staging
         - name: ELECTIONS_API_KEY
           valueFrom:
             secretKeyRef:
@@ -2369,8 +2365,6 @@ govukApplications:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
       extraEnv:
-        - name: DIGITAL_IDENTITY_ENVIRONMENT
-          value: staging
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: RAILS_SERVE_STATIC_FILES


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#1222

(Solution moved into the gem: https://github.com/alphagov/govuk_personalisation/pull/53)