### PR TITLE
Turn on GOV.UK CSP for CIOP owned rendering apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -975,8 +975,6 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: SUBSCRIPTION_MANAGEMENT_ENABLED
           value: "yes"
         - name: REDIS_URL
@@ -1407,8 +1405,6 @@ govukApplications:
         path: /app/public/assets/licencefinder
         s3Directory: "licencefinder"
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
         # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
         - name: ELASTICSEARCH_URI

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -855,8 +855,6 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: SUBSCRIPTION_MANAGEMENT_ENABLED
           value: "yes"
         - name: REDIS_URL
@@ -1294,8 +1292,6 @@ govukApplications:
         path: /app/public/assets/licencefinder
         s3Directory: "licencefinder"
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
         # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
         - name: ELASTICSEARCH_URI

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -862,8 +862,6 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: SUBSCRIPTION_MANAGEMENT_ENABLED
           value: "yes"
         - name: REDIS_URL
@@ -1264,8 +1262,6 @@ govukApplications:
         path: /app/public/assets/licencefinder
         s3Directory: "licencefinder"
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
         # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
         # TODO: Change this when copying from staging to production.


### PR DESCRIPTION
This turns on the GOV.UK Content Security Policy (CSP) in Email Alert Frontend and Licence Finder, the two apps on www.gov.uk that the Content Interactions on Platform (CIOP) team own.

The Licence Finder application is due to be retired very soon, but we don't anticipate any problems - should we get any we'll just turn this back on until the app is retired.