### PR TITLE
Enable disributed tracing in staging

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -45,10 +45,12 @@ data:
   # Endpoint used to export Open Telemetry data. Only set for integration as
   # being used to demo Jaeger as part of GIFT week. Should be removed if not
   # Jaeger not implemented.
-  {{- if eq .Values.govukEnvironment "integration" }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo-distributor.monitoring.svc.cluster.local:4318"
-  OTEL_RUBY_INSTRUMENTATION_RACK_CONFIG_OPTS: "untraced_endpoints=/healthcheck/live"
+  {{- if ne .Values.govukEnvironment "production" }}
   ENABLE_OPEN_TELEMETRY: "true"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo-distributor.monitoring.svc.cluster.local:4318"
+  OTEL_TRACES_SAMPLER: "traceidratio"
+  OTEL_TRACES_SAMPLER_ARG: '0.3'
+  OTEL_RUBY_INSTRUMENTATION_RACK_CONFIG_OPTS: "untraced_endpoints=/healthcheck/live"
   {{- end }}
 
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}


### PR DESCRIPTION
This enables the Open Telemetry instrumentation for our Rails applications in Staging. Also sets the head sampling rate to 0.3 so we aren't recording everything.

Tested in integration.