### PR TITLE
Avoid creating unwanted PodDisruptionBudgets.

### DIFF
--- a/charts/generic-govuk-app/templates/pdb.yaml
+++ b/charts/generic-govuk-app/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget }}
+{{- if and .Values.appEnabled .Values.podDisruptionBudget }}
 {{- $fullName := include "generic-govuk-app.fullname" . }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
This eliminates an unwanted `pdb/email-alert-monitoring` in production. We only want PDBs to be created automatically for serving workloads and not things like cronjobs or other arbitrary stuff.