### PR TITLE
Add/ Update Siteimprove vars for Content Data Admin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -437,17 +437,17 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-data-admin-content-data-api
               key: bearer_token
-        - name: SITE_IMPROVE_API_CLIENT_USERNAME
+        - name: SITEIMPROVE_API_CLIENT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: content-data-admin-site-improve-api-client
+              name: content-data-admin-siteimprove-api-client
               key: username
-        - name: SITE_IMPROVE_API_CLIENT_PASSWORD
+        - name: SITEIMPROVE_API_CLIENT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: content-data-admin-site-improve-api-client
+              name: content-data-admin-siteimprove-api-client
               key: password
-        - name: SITE_IMPROVE_SITE_ID
+        - name: SITEIMPROVE_SITE_ID
           value: "27169161461"
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -443,6 +443,18 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-data-admin-content-data-api
               key: bearer_token
+        - name: SITEIMPROVE_API_CLIENT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: content-data-admin-siteimprove-api-client
+              key: username
+        - name: SITEIMPROVE_API_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: content-data-admin-siteimprove-api-client
+              key: password
+        - name: SITEIMPROVE_SITE_ID
+          value: "27169161461"
         # These GA/GTM values are not secrets
         # https://www.github.com/alphagov/govuk-puppet/pull/8041
         - name: GOOGLE_TAG_MANAGER_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -448,6 +448,18 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-data-admin-content-data-api
               key: bearer_token
+        - name: SITEIMPROVE_API_CLIENT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: content-data-admin-siteimprove-api-client
+              key: username
+        - name: SITEIMPROVE_API_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: content-data-admin-siteimprove-api-client
+              key: password
+        - name: SITEIMPROVE_SITE_ID
+          value: "27169161461"
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: GOOGLE_TAG_MANAGER_AUTH

--- a/charts/external-secrets/templates/content-data-admin/siteimprove.yaml
+++ b/charts/external-secrets/templates/content-data-admin/siteimprove.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: content-data-admin-site-improve-api-client
+  name: content-data-admin-siteimprove-api-client
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: content-data-admin-site-improve-api-client
+    name: content-data-admin-siteimprove-api-client
   dataFrom:
     - extract:
-        key: govuk/content-data-admin/site-improve-api-client
+        key: govuk/content-data-admin/siteimprove-api-client


### PR DESCRIPTION

Add Siteimprove vars to production, staging for use in Content Data Admin.

Standardises variable names (Siteimprove is one word, lower case i, so siteimprove/SITEIMPROVE rather than site-improve/SITE_IMPROVE).