### PR TITLE
Avoid cpu-throttling publishing-api workers.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1702,6 +1702,13 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerResources:
+        limits:
+          cpu: 4000m
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
       cronTasks:
         - name: events-export
           task: "events:export_to_s3"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1678,6 +1678,13 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerResources:
+        limits:
+          cpu: 4000m
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       cronTasks:
         - name: events-export
           task: "events:export_to_s3"


### PR DESCRIPTION
This should speed up bulk republishing jobs while reducing their impact on API performance, without spending any more on resources (just increasing utilisation of what we're already paying for).

The RAM quotas in prod are staying the same here; we just have to specify them because YAML.