### PR TITLE
Turn off report-only for CSP for navigation and homepage apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -268,8 +268,6 @@ govukApplications:
   - name: collections
     helmValues:
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -288,8 +286,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1153,8 +1149,6 @@ govukApplications:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: MEMCACHE_SERVERS
@@ -1219,8 +1213,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: PLEK_HOSTNAME_PREFIX
@@ -1259,8 +1251,6 @@ govukApplications:
   - name: government-frontend
     helmValues:
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
 
@@ -1274,8 +1264,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
@@ -1392,10 +1380,6 @@ govukApplications:
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 
   - name: info-frontend
-    helmValues:
-      extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
 
   - name: licencefinder
     repoName: licence-finder

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -274,8 +274,6 @@ govukApplications:
           cpu: 1
           memory: 1Gi
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -294,8 +292,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1060,8 +1056,6 @@ govukApplications:
           cpu: 2
           memory: 1Gi
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: MEMCACHE_SERVERS
@@ -1127,8 +1121,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: PLEK_HOSTNAME_PREFIX
@@ -1175,8 +1167,6 @@ govukApplications:
           cpu: 1
           memory: 1500Mi
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
 
@@ -1190,8 +1180,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
@@ -1291,10 +1279,6 @@ govukApplications:
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
 
   - name: info-frontend
-    helmValues:
-      extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
 
   - name: licencefinder
     repoName: licence-finder

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -279,8 +279,6 @@ govukApplications:
           cpu: 1
           memory: 1Gi
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -299,8 +297,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1030,8 +1026,6 @@ govukApplications:
           cpu: 2
           memory: 1Gi
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: MEMCACHE_SERVERS
@@ -1098,8 +1092,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: PLEK_HOSTNAME_PREFIX
@@ -1145,8 +1137,6 @@ govukApplications:
           cpu: 1
           memory: 1500Mi
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
 
@@ -1160,8 +1150,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
@@ -1261,10 +1249,6 @@ govukApplications:
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
   - name: info-frontend
-    helmValues:
-      extraEnv:
-        - name: GOVUK_CSP_REPORT_ONLY
-          value: "true"
 
   - name: licencefinder
     repoName: licence-finder


### PR DESCRIPTION
This PR is the last step in the roll-out of the GOV.UK Content Security Policy for rendering applications following [1] and [2]. This turns off report only made, and thus turning on enforcement, for the following applications:

- Collections (and draft)
- Frontend (and draft)
- Government Frontend (and draft)
- Info Frontend

[1]: https://github.com/alphagov/govuk-helm-charts/pull/1224
[2]: https://github.com/alphagov/govuk-helm-charts/pull/1182