### PR TITLE
Give whitehall-admin workers more RAM headroom in prod.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2861,6 +2861,13 @@ govukApplications:
         requests:
           memory: 2Gi
           cpu: "1"
+      workerResources:
+        limits:
+          memory: 1500Mi
+          cpu: 2000m
+        requests:
+          memory: 512Mi
+          cpu: 500m
       securityContext:
         # Use the same uid/gid for NFS permissions as the old stack, so that
         # files uploaded by whitehall-admin on k8s can be processed by


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/7963 helped smooth out the memory usage but there's at least a suspicion that there are still some cases lurking that cause spikes of large allocations that can OOM workers during publishing tasks, which (because of poor design that we've inherited) can cause tasks to be lost and not retried.

So let's increase the limits by 50% to reduce the chance of being bitten by this, while we fix the underlying issue.