### PR TITLE
Change renderer of /government/placeholder in staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1047,6 +1047,8 @@ govukApplications:
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/
+          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+            path: /government/placeholder/
       replicaCount: 4
       appResources:
         limits:
@@ -2978,20 +2980,6 @@ govukApplications:
         requests:
           memory: 2Gi
           cpu: "1"
-      ingress:
-        enabled: true
-        annotations:
-          <<: [*alb-ingress-defaults, *alb-ingress-waf-ruleset-www]
-          alb.ingress.kubernetes.io/load-balancer-name: assets-origin
-          alb.ingress.kubernetes.io/group.name: assets-origin
-          alb.ingress.kubernetes.io/group.order: '10'
-          alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
-        hosts:
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/placeholder/
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /assets/whitehall/
       rails:
         createKeyBaseSecret: false
       sentry:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1018,6 +1018,8 @@ govukApplications:
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/
+          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+            path: /government/placeholder/
       appResources:
         limits:
           cpu: 4
@@ -2928,21 +2930,6 @@ govukApplications:
   - name: whitehall-frontend
     repoName: whitehall
     helmValues:
-      ingress:
-        enabled: true
-        annotations:
-          <<: [*alb-ingress-defaults, *alb-ingress-waf-ruleset-www]
-          alb.ingress.kubernetes.io/load-balancer-name: assets-origin
-          alb.ingress.kubernetes.io/group.name: assets-origin
-          alb.ingress.kubernetes.io/group.order: '10'
-          alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
-          alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
-        hosts:
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/placeholder/
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /assets/whitehall/
       rails:
         createKeyBaseSecret: false
       sentry:


### PR DESCRIPTION
Step 2 in removing the rendering of /government/placeholder from whitehall: route the path to frontend instead of whitehall-frontend.

Per Bruce, we can also remove all ingress rules for whitehall-frontend, since nothing else should be being served on
assets.publishing.service.gov.uk by Whitehall Frontend.

We've done this in integration and haven't observed any 404 errors for `/assets/whitehall`.

[Trello](https://trello.com/c/81j2sbeq/710-move-rendering-of-https-wwwgovuk-government-placeholder-out-of-whitehall)