### PR TITLE
Improve the Slack failure notification for the `post-sync` workflow.

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -125,14 +125,14 @@ spec:
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
                 - name: text
-                  value: "Post sync workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                  value: "Post-deploy (smoke test and promote-to-next-environment) workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
                 - name: blocks
                   value: |
                     [{
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "Post sync workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                          "text": "Post-deploy (smoke test and promote-to-next-environment) workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}."
                       },
                       "accessory": {
                         "type": "button",


### PR DESCRIPTION
Most people deploying code to GOV.UK probably don't care about the Argo CD lifecycle terminology, so "post-sync" isn't super helpful as a name.

Change the wording of the message to convey what the workflow does.

Also refer to it as post-deploy rather than post-sync, since in the developer-facing tooling we mostly talk about deployment rather than sync (i.e. the Argo CD term). I'm less sure about this part though, because the workflow is internally still called "post-sync". OTOH it's still just as easy to search for the error message 🤷 (and I suppose it didn't strictly match the workflow name before since it had a space instead of the `-`)

Kudos to @chao-xian for pointing out the wtf-ness of the message :D