### PR TITLE
Remove govuk-dependency-check in non-prod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1275,7 +1275,6 @@ govukApplications:
     imageValues:
       - "content-store"
       - "content-store-postgresql-branch"
-      - "govuk-dependency-checker"
       - "search-api"
       - "search-api-learn-to-rank"
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1157,7 +1157,6 @@ govukApplications:
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
     imageValues:
-      - "govuk-dependency-checker"
       - "search-api"
       - "search-api-learn-to-rank"
     helmValues:


### PR DESCRIPTION
This doesn't run in non-prod (there's a condition in charts/govuk-jobs/dependabot-metrics-cronjob.yaml), so remove the references to it.