### PR TITLE
Retire LicenceFinder app

### DIFF
--- a/charts/app-config/templates/signon-secrets-sync-configmap.yaml
+++ b/charts/app-config/templates/signon-secrets-sync-configmap.yaml
@@ -62,7 +62,6 @@ data:
       "government-frontend@alphagov.co.uk",
       "hmrc-manuals-api@alphagov.co.uk",
       "info-frontend@alphagov.co.uk",
-      "licencefinder@alphagov.co.uk",
       "local-links-manager@alphagov.co.uk",
       "manuals-publisher@alphagov.co.uk",
       "maslow@alphagov.co.uk",

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1383,29 +1383,6 @@ govukApplications:
 
   - name: info-frontend
 
-  - name: licencefinder
-    repoName: licence-finder
-    helmValues:
-      uploadAssets:
-        # https://github.com/alphagov/licence-finder/blob/e60ad6b/config/application.rb#L35
-        path: /app/public/assets/licencefinder
-        s3Directory: "licencefinder"
-      extraEnv:
-        # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
-        # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
-        - name: ELASTICSEARCH_URI
-          value: *elasticsearch-uri
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.integration.govuk-internal.digital,\
-            mongo-2.integration.govuk-internal.digital,\
-            mongo-3.integration.govuk-internal.digital/licence_finder_production"
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-licence-finder-publishing-api
-              key: bearer_token
-
   - name: link-checker-api
     helmValues:
       dbMigrationEnabled: true
@@ -2038,8 +2015,6 @@ govukApplications:
           value: "http://finder-frontend"
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
-        - name: BACKEND_URL_licencefinder
-          value: "http://licencefinder"
         - name: BACKEND_URL_licensify
           value: "https://licensify.integration.govuk-internal.digital"
         - name: BACKEND_URL_search-api
@@ -2095,8 +2070,6 @@ govukApplications:
           value: "http://finder-frontend"
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
-        - name: BACKEND_URL_licencefinder
-          value: "http://licencefinder"
         - name: BACKEND_URL_licensify
           value: "https://licensify.integration.govuk-internal.digital"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1282,29 +1282,6 @@ govukApplications:
 
   - name: info-frontend
 
-  - name: licencefinder
-    repoName: licence-finder
-    helmValues:
-      uploadAssets:
-        # https://github.com/alphagov/licence-finder/blob/e60ad6b/config/application.rb#L35
-        path: /app/public/assets/licencefinder
-        s3Directory: "licencefinder"
-      extraEnv:
-        # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
-        # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
-        - name: ELASTICSEARCH_URI
-          value: *elasticsearch-uri
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.production.govuk-internal.digital,\
-            mongo-2.production.govuk-internal.digital,\
-            mongo-3.production.govuk-internal.digital/licence_finder_production"
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-licence-finder-publishing-api
-              key: bearer_token
-
   - name: link-checker-api
     helmValues:
       dbMigrationEnabled: true
@@ -1968,8 +1945,6 @@ govukApplications:
           value: "http://finder-frontend"
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
-        - name: BACKEND_URL_licencefinder
-          value: "http://licencefinder"
         - name: BACKEND_URL_licensify
           value: "https://licensify.production.govuk-internal.digital"
         - name: BACKEND_URL_search-api
@@ -2026,8 +2001,6 @@ govukApplications:
           value: "http://finder-frontend"
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
-        - name: BACKEND_URL_licencefinder
-          value: "http://licencefinder"
         - name: BACKEND_URL_licensify
           value: "https://licensify.production.govuk-internal.digital"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1252,30 +1252,6 @@ govukApplications:
 
   - name: info-frontend
 
-  - name: licencefinder
-    repoName: licence-finder
-    helmValues:
-      uploadAssets:
-        # https://github.com/alphagov/licence-finder/blob/e60ad6b/config/application.rb#L35
-        path: /app/public/assets/licencefinder
-        s3Directory: "licencefinder"
-      extraEnv:
-        # TODO: Use a custom DNS name for ElasticSearch/OpenSearch. See
-        # https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint/
-        # TODO: Change this when copying from staging to production.
-        - name: ELASTICSEARCH_URI
-          value: *elasticsearch-uri
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.staging.govuk-internal.digital,\
-            mongo-2.staging.govuk-internal.digital,\
-            mongo-3.staging.govuk-internal.digital/licence_finder_production"
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-licence-finder-publishing-api
-              key: bearer_token
-
   - name: link-checker-api
     helmValues:
       dbMigrationEnabled: true
@@ -1939,8 +1915,6 @@ govukApplications:
           value: "http://finder-frontend"
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
-        - name: BACKEND_URL_licencefinder
-          value: "http://licencefinder"
         - name: BACKEND_URL_licensify
           value: "https://licensify.staging.govuk-internal.digital"
         - name: BACKEND_URL_search-api
@@ -1997,8 +1971,6 @@ govukApplications:
           value: "http://finder-frontend"
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
-        - name: BACKEND_URL_licencefinder
-          value: "http://licencefinder"
         - name: BACKEND_URL_licensify
           value: "https://licensify.staging.govuk-internal.digital"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/www-production-robots.txt
+++ b/charts/app-config/www-production-robots.txt
@@ -20,8 +20,3 @@ Disallow: /
 # https://support.microsoft.com/en-us/help/3019711/the-sharepoint-server-crawler-ignores-directives-in-robots-txt
 User-agent: MS Search 6.0 Robot
 Disallow: /
-
-# Google's crawler was sending requests for each variation of query param for
-# the sectors page of licence-finder # resulting in millions of requests a day.
-User-agent: Googlebot
-Disallow: /licence-finder/*


### PR DESCRIPTION
Licence finder has been replaced by the Find a Licence specialist finder, so remove from K8s configuration.

https://trello.com/c/1VXQW5I1/1620-epic-retire-original-licence-finder-application

