### PR TITLE
Integration assets ingress needs to be public.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1139,7 +1139,6 @@ govukApplications:
           alb.ingress.kubernetes.io/load-balancer-name: assets-origin
           alb.ingress.kubernetes.io/group.name: assets-origin
           alb.ingress.kubernetes.io/group.order: '16'
-          alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
           alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
         hosts:
@@ -1196,7 +1195,6 @@ govukApplications:
           alb.ingress.kubernetes.io/load-balancer-name: assets-origin
           alb.ingress.kubernetes.io/group.name: assets-origin
           alb.ingress.kubernetes.io/group.order: '15'
-          alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
           alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
@@ -2450,7 +2448,6 @@ govukApplications:
           alb.ingress.kubernetes.io/load-balancer-name: assets-origin
           alb.ingress.kubernetes.io/group.name: assets-origin
           alb.ingress.kubernetes.io/group.order: '30'
-          alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
           alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
         hosts:


### PR DESCRIPTION
Same as production already is. It's only staging that's supposed to be GDS-only.

The reason it needs to be publicly reachable is the long-standing oddball usage of the integration environment for training users of the content management system (which doesn't necessarily take place at GDS).

This is acceptable for now (at least until we can run the end-to-end stack in minikube/kind/k3s), because draft assets are still behind auth-proxy and there should never be anything sensitive in integration anyway (unlike staging, which is allowed to contain pre-publication content from production). Also because this is just restoring the same access that people had before we moved to Kubernetes, when we mistakenly gave the assets LB the wrong firewall ruleset.