### PR TITLE
Email Alert Frontend no longer needs Publishing API access

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -985,11 +985,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-frontend-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-email-alert-frontend-publishing-api
-              key: bearer_token
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -877,11 +877,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-frontend-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-email-alert-frontend-publishing-api
-              key: bearer_token
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -884,11 +884,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-frontend-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-email-alert-frontend-publishing-api
-              key: bearer_token
         - name: EMAIL_ALERT_AUTH_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION

Email Alert Frontend no longer has a publishing_rake task which needs publishing API access, so remove the key.

https://trello.com/c/hJVUjqbs/31-frontend-apps-publish-content-items-to-publishing-api