### PR TITLE
Let whitehall-admin use memcache.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3025,6 +3025,8 @@ govukApplications:
           value: *publishing-notify-template
         - name: EMAIL_ADDRESS_OVERRIDE
           value: whitehall-emails-integration@digital.cabinet-office.gov.uk
+        - name: MEMCACHE_SERVERS
+          value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: DATABASE_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2925,6 +2925,8 @@ govukApplications:
           value: govuk-production-whitehall-csvs
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *publishing-notify-template
+        - name: MEMCACHE_SERVERS
+          value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: DATABASE_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2880,6 +2880,8 @@ govukApplications:
           value: *publishing-notify-template
         - name: EMAIL_ADDRESS_OVERRIDE  # TODO: remove in production.
           value: whitehall-emails-staging@digital.cabinet-office.gov.uk
+        - name: MEMCACHE_SERVERS
+          value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: DATABASE_URL


### PR DESCRIPTION
I suspect this will help with the 0.1% 504 ratio on whitehall-admin. At the very least, it'll clear up a bunch of errors about `ECONNREFUSED: localhost:11211`. Might also make whitehall-admin a bit snappier.

https://govuk.zendesk.com/agent/tickets/5434688

This memcache has < 2% peak CPU utilisation, < 25% peak network utilisation and > 14 GiB of available RAM, so adding whitehall-admin should be small beer.

The name is somewhat misleading: it's frontend in the normal sense rather than the oddball GOV.UK sense, i.e. it's a memcache for apps that have UIs, not just apps that serve pages to the general public. Other GOV.UK "backend" apps (i.e. frontends for content management tools) use this memcache already.