### PR TITLE
Remove config item for disused Signon admin API.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2390,11 +2390,6 @@ govukApplications:
               key: DEVISE_SECRET_KEY
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-        - name: SIGNON_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: signon-auth-token
-              key: token
 
   - name: smartanswers
     repoName: smart-answers

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2319,11 +2319,6 @@ govukApplications:
               key: DEVISE_SECRET_KEY
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
-        - name: SIGNON_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: signon-auth-token
-              key: token
 
   - name: smartanswers
     repoName: smart-answers

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2275,11 +2275,6 @@ govukApplications:
               key: DEVISE_SECRET_KEY
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-        - name: SIGNON_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: signon-auth-token
-              key: token
 
   - name: smartanswers
     repoName: smart-answers


### PR DESCRIPTION
All references to this env var in Signon were removed in https://github.com/alphagov/signon/pull/2294