### PR TITLE
Add Google Tag Manager env variable for Whitehall

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2877,6 +2877,8 @@ govukApplications:
             secretKeyRef:
               name: signon-app-whitehall
               key: oauth_secret
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: GTM-P93SHJ4Z
         - name: GOVUK_UPLOADS_ROOT
           value: &whitehall-uploads-path /uploads
         - name: ASSET_MANAGER_BEARER_TOKEN


### PR DESCRIPTION
In advance of GA4 we're adding Tag Manager to whitehall: https://github.com/alphagov/whitehall/pull/8046

In keeping with Content Publisher the application code looks for an environment variable for the id - which this PR provides.

https://trello.com/c/EDrVRCsv/1515-set-up-ga4-property-and-gtm-container