### PR TITLE
Remove manualDeployment field from deployment workflows

### DIFF
--- a/charts/argo-services/templates/events/update-image-tag-sensor.yaml
+++ b/charts/argo-services/templates/events/update-image-tag-sensor.yaml
@@ -35,10 +35,6 @@ spec:
           - dest: spec.arguments.parameters.3.value
             src:
               dependencyName: update-image-tag
-              dataKey: body.manualDeploy
-          - dest: spec.arguments.parameters.4.value
-            src:
-              dependencyName: update-image-tag
               dataKey: body.promoteDeployment
           - dest: metadata.generateName
             src:
@@ -63,7 +59,6 @@ spec:
                   - name: environment
                   - name: repoName
                   - name: imageTag
-                  - name: manualDeploy
                   - name: promoteDeployment
               workflowTemplateRef:
                 name: deploy-image

--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -10,7 +10,6 @@ spec:
       - name: environment
       - name: repoName
       - name: imageTag
-      - name: manualDeploy
       - name: promoteDeployment
   templates:
     - name: deploy-image
@@ -27,8 +26,6 @@ spec:
                   value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: imageTag
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
-                - name: manualDeploy
-                  value: "{{"{{workflow.parameters.manualDeploy}}"}}"
                 - name: promoteDeployment
                   value: "{{"{{workflow.parameters.promoteDeployment}}"}}"
         - - name: add-deployed-to-tag

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -51,8 +51,6 @@ spec:
                   value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: imageTag
                   value: "{{"{{workflow.parameters.imageTag}}"}}"
-                - name: manualDeploy
-                  value: "false"
                 - name: promoteDeployment
                   value: "true"
 
@@ -82,7 +80,6 @@ spec:
         - name: environment
         - name: repoName
         - name: imageTag
-        - name: manualDeploy
         - name: promoteDeployment
       script:
         image: curlimages/curl
@@ -95,7 +92,6 @@ spec:
               "environment": "{{"{{inputs.parameters.environment}}"}}",
               "repoName": "{{"{{inputs.parameters.repoName}}"}}",
               "imageTag": "{{"{{inputs.parameters.imageTag}}"}}",
-              "manualDeploy": "{{"{{inputs.parameters.manualDeploy}}"}}",
               "promoteDeployment": "{{"{{inputs.parameters.promoteDeployment}}"}}"
             }'
         env:

--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -9,7 +9,6 @@ spec:
       - name: environment
       - name: repoName
       - name: imageTag
-      - name: manualDeploy
       - name: promoteDeployment
   templates:
     - name: update-image-tag
@@ -18,8 +17,6 @@ spec:
           - name: environment
           - name: repoName
           - name: imageTag
-          - name: manualDeploy
-            default: "false"
           - name: promoteDeployment
             default: "false"
       script:
@@ -42,8 +39,6 @@ spec:
             value: "{{"{{inputs.parameters.environment}}"}}"
           - name: REPO_NAME
             value: "{{"{{inputs.parameters.repoName}}"}}"
-          - name: MANUAL_DEPLOY
-            value: "{{"{{inputs.parameters.manualDeploy}}"}}"
           - name: PROMOTE_DEPLOYMENT
             value: "{{"{{inputs.parameters.promoteDeployment}}"}}"
         source: |


### PR DESCRIPTION
This is no longer used in favor of the promoteDeploy field.