### PR TITLE
Add shield advanced protection to EKS ALBs

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -35,6 +35,7 @@ _alb-ingress-defaults: &alb-ingress-defaults
     access_logs.s3.enabled=true,
     access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
     access_logs.s3.prefix=elb/{{ .Release.Name }}
+  alb.ingress.kubernetes.io/shield-advanced-protection: "true"
 
 _alb-ingress-waf-ruleset-www: &alb-ingress-waf-ruleset-www
   alb.ingress.kubernetes.io/wafv2-acl-arn: >-
@@ -258,6 +259,7 @@ govukApplications:
           alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
           alb.ingress.kubernetes.io/healthcheck-path: /readyz
           alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+          alb.ingress.kubernetes.io/shield-advanced-protection: "true"
           external-dns.alpha.kubernetes.io/hostname: bouncer.{{ .Values.k8sExternalDomainSuffix }}
         rules:
           - http:  # Match all hostnames.

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -27,6 +27,7 @@ _alb-ingress-defaults: &alb-ingress-defaults
     access_logs.s3.enabled=true,
     access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
     access_logs.s3.prefix=elb/{{ .Release.Name }}
+  alb.ingress.kubernetes.io/shield-advanced-protection: "true"
 
 _alb-ingress-waf-ruleset-www: &alb-ingress-waf-ruleset-www
   alb.ingress.kubernetes.io/wafv2-acl-arn: >-
@@ -250,6 +251,7 @@ govukApplications:
           alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
           alb.ingress.kubernetes.io/healthcheck-path: /readyz
           alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+          alb.ingress.kubernetes.io/shield-advanced-protection: "true"
           external-dns.alpha.kubernetes.io/hostname: bouncer.{{ .Values.k8sExternalDomainSuffix }}
         rules:
           - http:  # Match all hostnames.

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -34,6 +34,7 @@ _alb-ingress-defaults: &alb-ingress-defaults
     access_logs.s3.enabled=true,
     access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
     access_logs.s3.prefix=elb/{{ .Release.Name }}
+  alb.ingress.kubernetes.io/shield-advanced-protection: "true"
 
 _alb-ingress-waf-ruleset-www: &alb-ingress-waf-ruleset-www
   alb.ingress.kubernetes.io/wafv2-acl-arn: >-
@@ -257,6 +258,7 @@ govukApplications:
           alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
           alb.ingress.kubernetes.io/healthcheck-path: /readyz
           alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+          alb.ingress.kubernetes.io/shield-advanced-protection: "true"
           external-dns.alpha.kubernetes.io/hostname: bouncer.{{ .Values.k8sExternalDomainSuffix }}
         rules:
           - http:  # Match all hostnames.

--- a/charts/argo-services/templates/events/webhook-ingress.yaml
+++ b/charts/argo-services/templates/events/webhook-ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/load-balancer-name: "argo-events"
     alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/shield-advanced-protection: "true"
     external-dns.alpha.kubernetes.io/hostname: "{{ .Values.argoEventsHost }}"
 spec:
   tls:

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -13,6 +13,7 @@ ingress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/healthcheck-path: /healthcheck/ready
+    alb.ingress.kubernetes.io/shield-advanced-protection: "true"
   hosts:
     - name: assets-origin
       paths:


### PR DESCRIPTION
We had this enabled on the load balancers for our EC2 instances, and it's worth bringing across. There's a few benefits, including proactive engagement from the AWS SRT team and better monitoring options in CloudWatch.

We already pay for the subscription as part of the org, so it's free to us at this point.