### PR TITLE
Enable continuous deployment of govuk-dependency-checker

### DIFF
--- a/charts/app-config/image-tags/production/govuk-dependency-checker
+++ b/charts/app-config/image-tags/production/govuk-dependency-checker
@@ -1,2 +1,3 @@
 image_tag: release-f90d2dc5d5a3e8337314c1ca454f9d5b17b9db5d
-promote_deployment: false
+promote_deployment: true
+automatic_deploys_enabled: true


### PR DESCRIPTION
Discussed with @theseanything .

GOVUK Dependency Checker is a script, and currently isn't automatically deployed to prod - still requires someone to manually do it. Very little risk if it breaks, so no benefit in keeping it manually deployed.