### PR TITLE
Revert "Export, compress & upload the draft-content-store-postgresql-branch DB to S3"

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -142,6 +142,7 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
+          containers:
             - name: import-mongo-data-to-postgresql
               image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
               imagePullPolicy: "Always"
@@ -166,49 +167,3 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
-                - name: pg-dump
-                  mountPath: /pg-dump
-            - name: dump-postgresql
-              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
-              command: ["pg_dump"]
-              args:
-                - "-F c"
-                - "-f /pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production"
-                - "${DATABASE_URL}"
-              env:
-                - name: DATABASE_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
-                      key: DATABASE_URL
-              {{- with .Values.resources }}
-              resources:
-                {{- . | toYaml | trim | nindent 16 }}
-              {{- end }}
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-              volumeMounts:
-                - name: app-tmp
-                  mountPath: /tmp
-                - name: pg-dump
-                  mountPath: /pg-dump
-          containers:
-            - name: upload-to-s3
-              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
-              command:
-                - aws
-                - s3
-                - sync
-                - /pg-dump
-                - s3://govuk-integration-database-backups/draft-content-store/
-              {{- with .Values.jobResources }}
-              resources:
-                {{- . | toYaml | trim | nindent 12 }}
-              {{- end }}
-              volumeMounts:
-                - name: pg-dump
-                  mountPath: /pg-dump
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#1180 , as it caused a sync error :

> Failed sync attempt to 029b7f8b42e6cef43aec52a5ef859215e3a908d0: one or more objects failed to apply, reason: CronJob.batch "content-store-mongo-to-postgres-cron" is invalid: [spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].name: Not found: "pg-dump", spec.jobTemplate.spec.template.spec.initContainers[1].volumeMounts[2].name: Not found: "pg-dump", spec.jobTemplate.spec.template.spec.initContainers[2].volumeMounts[1].name: Not found: "pg-dump"] (retried 5 times).