### PR TITLE
Try a different format for specifying arguments, to fix "pg_dump invalid output format -F c specified" errors

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -174,9 +174,9 @@ spec:
               image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
               command: ["pg_dump"]
               args:
-                - "-F c"
-                - "-f /pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production"
-                - "${DATABASE_URL}"
+                - --format=custom
+                - --file=/pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production
+                - '${DATABASE_URL}'
               env:
                 - name: DATABASE_URL
                   valueFrom:


### PR DESCRIPTION
The `pg_dump` section of the overnight export-content-store-mongo-to-postresql CronJob is failing with a strange error:

`pg_dump error invalid output format c specified`

This is odd, because the github-cli image installs pg_dump v15 (latest), and the -F c flag is [explicitly supported](https://www.postgresql.org/docs/15/app-pgdump.html)`

This PR tries a different format for the job command arguments, to try and fix the error.
  
[Trello card](https://trello.com/c/lRyopges/801-fix-invalid-output-format-error-in-the-overnight-dump-of-content-store-postgresql-to-s3)