### PR TITLE
Stop contentStoreMongoPostgresCron running on production

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1284,6 +1284,7 @@ govukApplications:
         sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
       draftContentStoreMongoPostgresCron:
+        schedule: "30 6 * * *"
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.integration.govuk-internal.digital,\
@@ -1292,6 +1293,7 @@ govukApplications:
         postgresImport:
           databaseUrlSecretName: "draft-content-store-postgres"
       contentStoreMongoPostgresCron:
+        schedule: "15 5 * * *"
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.integration.govuk-internal.digital,\

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -40,14 +40,14 @@ learnToRank:
   serviceAccountIamRole: ""
 
 draftContentStoreMongoPostgresCron:
-  schedule: "30 6 * * *"
+  schedule: ""
   mongoExport:
     mongoDbUri: ""
   postgresImport:
     databaseUrlSecretName: "draft-content-store-postgres"
 
 contentStoreMongoPostgresCron:
-  schedule: "15 5 * * *"
+  schedule: ""
   mongoExport:
     mongoDbUri: ""
   postgresImport:


### PR DESCRIPTION
The `contentStoreMongoPostgresCron` and `draftContentStoreMongoPostgresCron` jobs should only be running in integration. But it turns out they're also trying to run on production and staging too. This doesn't actually do any harm, as they don't have databases to connect to in any environment other than integration - but it uses unnecessary resources and causes UI bloat.

I think the root of the problem is that the default schedule was defined in the wrong place, and therefore the jobs are being scheduled in all environments.

This PR shifts the schedule value into the integration-specific files, and will hopefully stop them running anywhere except integration. 