### PR TITLE
Make the (draft)contentStoreMongoPostgresCron job only defined in integration

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -1,3 +1,5 @@
+
+{{- if eq .Values.govukEnvironment "integration" }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -214,3 +216,4 @@ spec:
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
+{{- end }}


### PR DESCRIPTION
Second attempt at fixing the issue described in #1251 