### PR TITLE
Execute pg_dump via bash, for content-store postgresql dump CronJob

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -174,11 +174,10 @@ spec:
                   mountPath: /pg-dump
             - name: dump-postgresql
               image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
-              command: ["pg_dump"]
+              command: ["bash"]
               args:
-                - --format=custom
-                - --file=/pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production
-                - '${DATABASE_URL}'
+                - "-c"
+                - "pg_dump -F c -f /pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production ${DATABASE_URL}"
               env:
                 - name: DATABASE_URL
                   valueFrom:


### PR DESCRIPTION
Previous attempts at invoking `pg_dump` with the correct parameters have all failed with pg_dump errors on the arguments supplied (#1180 , #1249, #1250).

This attempt implements [@richardTowers' suggestion](https://github.com/alphagov/govuk-helm-charts/pull/1250#discussion_r1296126215) to invoke it with a `bash -c` 

[Trello card](https://trello.com/c/lRyopges/801-fix-invalid-output-format-error-in-the-overnight-dump-of-content-store-postgresql-to-s3)
