### PR TITLE
Increase content store replica count in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -664,7 +664,7 @@ govukApplications:
   - name: content-store
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
-      replicaCount: 6
+      replicaCount: 7
       cronTasks:
         - name: report-delays
           task: "publishing_delay_report:report_delays"


### PR DESCRIPTION
# What
Update the content store replica count in staging from 6 to 7

# Why
As part of the 2nd line drill for scaling up an application

https://docs.publishing.service.gov.uk/manual/2nd-line-drills.html#drill-scaling-up-an-application 

https://trello.com/c/fPEXeNU4/2019-2nd-line-drill-scaling-up-an-application