### PR TITLE
Remove WIP postgres dump & s3 upload from content-store mongo-to-postgres cron job

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -146,6 +146,7 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
+          containers:
             - name: import-mongo-data-to-postgresql
               image: "{{ .Values.images.ContentStorePostgresqlBranch.repository }}:{{ .Values.images.ContentStorePostgresqlBranch.tag }}"
               imagePullPolicy: "Always"
@@ -172,47 +173,4 @@ spec:
                   mountPath: /tmp
                 - name: pg-dump
                   mountPath: /pg-dump
-            - name: dump-postgresql
-              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
-              command: ["bash"]
-              args:
-                - "-c"
-                - "pg_dump -F c -f /pg-dump/$(date +%Y-%m-%dT%H:%M:%S)-content_store_production ${DATABASE_URL}"
-              env:
-                - name: DATABASE_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: "{{ .Values.contentStoreMongoPostgresCron.postgresImport.databaseUrlSecretName }}"
-                      key: DATABASE_URL
-              {{- with .Values.resources }}
-              resources:
-                {{- . | toYaml | trim | nindent 16 }}
-              {{- end }}
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-              volumeMounts:
-                - name: app-tmp
-                  mountPath: /tmp
-                - name: pg-dump
-                  mountPath: /pg-dump
-          containers:
-            - name: upload-to-s3
-              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
-              command:
-                - aws
-                - s3
-                - sync
-                - /pg-dump
-                - s3://govuk-integration-database-backups/draft-content-store/
-              {{- with .Values.jobResources }}
-              resources:
-                {{- . | toYaml | trim | nindent 12 }}
-              {{- end }}
-              volumeMounts:
-                - name: pg-dump
-                  mountPath: /pg-dump
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
 {{- end }}


### PR DESCRIPTION
This last step was never completed, and will be superceded by the more general [replacement for the old env_sync job](https://trello.com/c/JjTHY62V/1200-govukenvsync-environment-data-sync-and-database-backup-restore).

[Trello card](https://trello.com/c/sXtNCMq1/811-remove-wip-content-store-dump-upload-to-s3)