### PR TITLE
Add content-store-postgresql-branch (& draft-) apps in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -697,6 +697,48 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
+  - name: content-store-postgresql-branch
+    repoName: content-store-postgresql-branch
+    helmValues:
+      <<: *content-store
+      rails:
+        createKeyBaseSecret: false
+        # use the same secret as the mongo content-store, it will make the
+        # eventual switchover easier and reduce toil
+        secretKeyBaseName: content-store-rails-secret-key-base
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: content-store-sentry
+      extraEnv:
+        - name: SENTRY_ENVIRONMENT
+          value: "postgresql-staging"
+        - name: ROUTER_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-content-store-router-api
+              key: bearer_token
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-content-store
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-content-store
+              key: oauth_secret
+        - name: DEFAULT_TTL
+          value: "1"
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: content-store-postgres
+              key: DATABASE_URL
+        - name: DISABLE_ROUTER_API
+          value: "true"
+        - name: WEB_CONCURRENCY
+          value: '4'
+
   - name: draft-content-store
     repoName: content-store
     helmValues:
@@ -732,6 +774,48 @@ govukApplications:
             mongo-3.staging.govuk-internal.digital/draft_content_store_production"
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
+
+  - name: draft-content-store-postgresql-branch
+    repoName: content-store-postgresql-branch
+    helmValues:
+      <<: *content-store
+      rails:
+        createKeyBaseSecret: false
+        # use the same secret as the mongo draft-content-store, it will make the
+        # eventual switchover easier and reduce toil
+        secretKeyBaseName: content-store-rails-secret-key-base
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: content-store-sentry
+      extraEnv:
+        - name: SENTRY_ENVIRONMENT
+          value: "postgresql-draft-staging"
+        - name: ROUTER_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-draft-content-store-draft-router-api
+              key: bearer_token
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-draft-content-store
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-draft-content-store
+              key: oauth_secret
+        - name: DEFAULT_TTL
+          value: "1"
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: draft-content-store-postgres
+              key: DATABASE_URL
+        - name: DISABLE_ROUTER_API
+          value: "true"
 
   - name: content-tagger
     helmValues:
@@ -1154,6 +1238,8 @@ govukApplications:
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
     imageValues:
+      - "content-store"
+      - "content-store-postgresql-branch"
       - "search-api"
       - "search-api-learn-to-rank"
     helmValues:


### PR DESCRIPTION
[Trello card](https://trello.com/c/vfvX0CLX/813-add-cronjobs-to-overnight-populate-content-store-postgresql-in-staging-production) - completes [step 1 of the rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_36). 
Allows us to start populating the PostgreSQL databases in staging before introducing the proxy app in front of both PostgreSQL & Mongo versions (a subsequent PR will do that separately).