### PR TITLE
Add image-tag file for new content-store-postgresql-branch app in staging

### DIFF
--- a/charts/app-config/image-tags/staging/content-store-postgresql-branch
+++ b/charts/app-config/image-tags/staging/content-store-postgresql-branch
@@ -1,0 +1,3 @@
+image_tag: release-66ad13575f438c571b4be3e38f071ed511143c9a
+automatic_deploys_enabled: true
+promote_deployment: true


### PR DESCRIPTION
The newly-deployed `content-store-postgresql-branch` app in staging can't actually start running, due to an `invalid image name` error in Argo.

I think this is because there is no corresponding file in `charts/image-tags/staging/` - so this PR adds one.

[Trello card](https://trello.com/c/vfvX0CLX/813-add-cronjobs-to-overnight-populate-content-store-postgresql-in-staging-production)