### PR TITLE
Schedule the cronjobs to populate content-store-postgres from Mongo in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1255,6 +1255,24 @@ govukApplications:
         sageMakerImage: 696911096973.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::696911096973:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::696911096973:role/search-api-learn-to-rank-govuk
+      draftContentStoreMongoPostgresCron:
+        schedule: "30 6 * * *"
+        mongoExport:
+          mongoDbUri: "mongodb://\
+            mongo-1.staging.govuk-internal.digital,\
+            mongo-2.staging.govuk-internal.digital,\
+            mongo-3.staging.govuk-internal.digital/draft_content_store_production"
+        postgresImport:
+          databaseUrlSecretName: "draft-content-store-postgres"
+      contentStoreMongoPostgresCron:
+        schedule: "15 5 * * *"
+        mongoExport:
+          mongoDbUri: "mongodb://\
+            mongo-1.staging.govuk-internal.digital,\
+            mongo-2.staging.govuk-internal.digital,\
+            mongo-3.staging.govuk-internal.digital/content_store_production"
+        postgresImport:
+          databaseUrlSecretName: "content-store-postgres"
 
   - name: hmrc-manuals-api
     helmValues:


### PR DESCRIPTION
RDS instances for draft- and live- content-store-postgresql have been created in staging, and initial one-time manual set up completed. This PR adds config to schedule the overnight job which will export the Mongo databases to JSON and import them into the RDS Postgres instances every morning.

[Trello card](https://trello.com/c/vfvX0CLX/813-add-cronjobs-to-overnight-populate-content-store-postgresql-in-staging-production)