### PR TITLE
Enable content-store-mongo-to-postgres-cronjob in staging & prod

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -1,5 +1,4 @@
 
-{{- if eq .Values.govukEnvironment "integration" }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -173,4 +172,3 @@ spec:
                   mountPath: /tmp
                 - name: pg-dump
                   mountPath: /pg-dump
-{{- end }}


### PR DESCRIPTION
Whilst we only had PostgreSQL content-store databases & apps in integration, we surrounded the whole definition of this cronjob in `if environment == integration`  _(not that exact syntax, but that effect)_.

Now that we have introduced the PostgreSQL DBs and applications in staging & production too, we need to remove this restriction so that the job can be defined, and start populating those databases every night.

[Trello card](https://trello.com/c/vfvX0CLX/813-add-cronjobs-to-overnight-populate-content-store-postgresql-in-staging-production), part of [Step 1 of the rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_36)