### PR TITLE
Fix image pull backoff error on newly-promoted cronjob content-store-mongo-to-postgres-cronjob

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1268,6 +1268,8 @@ govukApplications:
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
     imageValues:
+      - "content-store"
+      - "content-store-postgresql-branch"
       - "govuk-dependency-checker"
       - "search-api"
       - "search-api-learn-to-rank"


### PR DESCRIPTION
The newly-promoted `content-store-mongo-to-postgres-cronjob` ([Trello card](https://trello.com/c/vfvX0CLX/813-add-cronjobs-to-overnight-populate-content-store-postgresql-in-staging-production)) is failing on production only, with the error:
```
message: 'Back-off pulling image "content-store:release"'
reason: ImagePullBackOff
```

On inspection & comparison with other environment files in [staging](https://github.com/alphagov/govuk-helm-charts/pull/1257/files#diff-3eb4196efb16ab24d6fc85dafa7f08cdd71948e43958ad2d48e143a531089cffR1241-R1242) and [integration](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-integration.yaml#L1269-L1270), it looks like it's missing the relevant image references in the `imageValues` attribute. This PR should hopefully fix the problem.