### PR TITLE
Add Postgres backup/restore jobs for content-store.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1297,24 +1297,7 @@ govukApplications:
         sageMakerImage: 210287912431.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
-      draftContentStoreMongoPostgresCron:
-        schedule: "30 6 * * *"
-        mongoExport:
-          mongoDbUri: "mongodb://\
-            mongo-1.integration.govuk-internal.digital,\
-            mongo-2.integration.govuk-internal.digital,\
-            mongo-3.integration.govuk-internal.digital/draft_content_store_production"
-        postgresImport:
-          databaseUrlSecretName: "draft-content-store-postgres"
-      contentStoreMongoPostgresCron:
-        schedule: "15 5 * * *"
-        mongoExport:
-          mongoDbUri: "mongodb://\
-            mongo-1.integration.govuk-internal.digital,\
-            mongo-2.integration.govuk-internal.digital,\
-            mongo-3.integration.govuk-internal.digital/content_store_production"
-        postgresImport:
-          databaseUrlSecretName: "content-store-postgres"
+
   - name: hmrc-manuals-api
     helmValues:
       nginxClientMaxBodySize: 2M

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -744,6 +744,10 @@ govukApplications:
         - name: COMPARISON_SAMPLE_PCT
           value: '50'
 
+  - name: db-backup
+    chartPath: charts/db-backup
+    postSyncWorkflowEnabled: "false"
+
   - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -759,6 +759,10 @@ govukApplications:
         - name: COMPARISON_SAMPLE_PCT
           value: '10'
 
+  - name: db-backup
+    chartPath: charts/db-backup
+    postSyncWorkflowEnabled: "false"
+
   - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1342,7 +1342,7 @@ govukApplications:
         sagemakerIamRole: arn:aws:iam::172025368201:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::172025368201:role/search-api-learn-to-rank-govuk
       draftContentStoreMongoPostgresCron:
-        schedule: "30 6 * * *"
+        schedule: "16 0 * * *"
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.production.govuk-internal.digital,\
@@ -1351,7 +1351,7 @@ govukApplications:
         postgresImport:
           databaseUrlSecretName: "draft-content-store-postgres"
       contentStoreMongoPostgresCron:
-        schedule: "15 5 * * *"
+        schedule: "16 0 * * *"
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.production.govuk-internal.digital,\

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -770,6 +770,10 @@ govukApplications:
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
 
+  - name: db-backup
+    chartPath: charts/db-backup
+    postSyncWorkflowEnabled: "false"
+
   - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1314,24 +1314,6 @@ govukApplications:
         sageMakerImage: 696911096973.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::696911096973:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::696911096973:role/search-api-learn-to-rank-govuk
-      draftContentStoreMongoPostgresCron:
-        schedule: "30 6 * * *"
-        mongoExport:
-          mongoDbUri: "mongodb://\
-            mongo-1.staging.govuk-internal.digital,\
-            mongo-2.staging.govuk-internal.digital,\
-            mongo-3.staging.govuk-internal.digital/draft_content_store_production"
-        postgresImport:
-          databaseUrlSecretName: "draft-content-store-postgres"
-      contentStoreMongoPostgresCron:
-        schedule: "15 5 * * *"
-        mongoExport:
-          mongoDbUri: "mongodb://\
-            mongo-1.staging.govuk-internal.digital,\
-            mongo-2.staging.govuk-internal.digital,\
-            mongo-3.staging.govuk-internal.digital/content_store_production"
-        postgresImport:
-          databaseUrlSecretName: "content-store-postgres"
 
   - name: hmrc-manuals-api
     helmValues:

--- a/charts/db-backup/Chart.yaml
+++ b/charts/db-backup/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: db-backup
+description: Cronjobs for database backup/restore
+type: application
+version: 1.0.0

--- a/charts/db-backup/backup-postgres.sh
+++ b/charts/db-backup/backup-postgres.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+export LC_ALL=C.UTF-8  # Prevent i18n from affecting command outputs (e.g. `type`).
+export HOME=${TMPDIR:-/tmp}  # aws-cli hates readonlyRootFilesystem :(
+
+usage () {
+  self=$(basename "$0")
+  cat >&2 <<EOF
+$self is a tool for streaming Postgres pg_dump/pg_restore to/from Amazon S3 (or
+compatible), for backup and to copy data between environments.
+EOF
+  exit 64
+}
+
+progress () {
+  pv -fi 10 -F '%t %r %b'
+}
+
+backup () {
+  local s3_path
+  s3_path="$PGHOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$PGDATABASE.gz"
+  pg_dump -Fc | progress | aws s3 cp - "$BUCKET/$s3_path"
+}
+
+# List available backups in ascending date order.
+list () {
+  local db_name_re
+  db_name_re=$(echo "$PGDATABASE" | tr _- .)
+  aws s3 ls "$BUCKET/$PGHOST/" | grep -Eo "[-0-9:TZ_]+-$db_name_re\.gz"
+}
+
+dump_is_readable () {
+  (aws s3 cp "$s3_url" - 2>/dev/null || true) | head | file - | tee /dev/fd/2 \
+    | grep -iq 'PostgreSQL custom database dump'
+}
+
+restore () {
+  : "${FILENAME:=$(list | tail -1)}"  # Use latest dump if not specified.
+  if [[ "$GOVUK_ENVIRONMENT" = *"prod"* ]]; then
+    : "${REALLY_RESTORE_ONTO_PRODUCTION?}"
+  fi
+  local s3_url="$BUCKET/$PGHOST/$FILENAME"
+  s3_url="$s3_url" dump_is_readable
+  aws s3 cp "$s3_url" - | progress \
+    | pg_restore -Ccd postgres --if-exists --no-comments
+}
+
+subcommand=${1:-}
+[[ $(type -t "$subcommand") == function ]] || usage
+
+: "${GOVUK_ENVIRONMENT:?required}"
+: "${PGUSER:=aws_db_admin}"
+: "${PGPASSWORD:?required}"
+: "${PGHOST:?required}"
+: "${PGDATABASE:?required}"
+: "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
+[[ "${VERBOSE:-0}" -ge 1 ]] && set -x
+
+readonly GOVUK_ENVIRONMENT PGUSER PGPASSWORD PGHOST PGDATABASE BUCKET
+
+$subcommand "$@"

--- a/charts/db-backup/templates/_helpers.tpl
+++ b/charts/db-backup/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "db-backup.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "db-backup.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "db-backup.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "db-backup.labels" -}}
+helm.sh/chart: {{ include "db-backup.chart" . }}
+{{ include "db-backup.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "db-backup.selectorLabels" -}}
+app: {{ include "db-backup.name" . }}
+app.kubernetes.io/name: {{ include "db-backup.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "db-backup.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "db-backup.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/db-backup/templates/configmap.yaml
+++ b/charts/db-backup/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "db-backup.fullname" . }}
+  labels:
+    {{- include "db-backup.labels" . | nindent 4 }}
+data:
+  backup-postgres: |
+    {{- $.Files.Get "backup-postgres.sh" | trim | nindent 4 }}

--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -1,0 +1,102 @@
+{{- $_ := .Values.govukEnvironment | required "govukEnvironment is required" }}
+{{- $fullName := include "db-backup.fullname" . }}
+
+{{- range $jobName, $job := get .Values.cronjobs .Values.govukEnvironment }}
+  {{- $jobFullName := printf "%s-%s" $fullName $jobName }}
+  {{- /* Job name should be same as DB hostname except for "draft" databases. */}}
+  {{- $dbHost := $job.host | default $jobName }}
+  {{- /* Last word of the database hostname is normally "postgres", "mysql" etc. */}}
+  {{- $dbms := $job.dbms | default (regexFind "[^-]+$" $dbHost) }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $jobFullName }}
+  labels:
+    {{- include "db-backup.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+spec:
+  schedule: {{ $job.schedule | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 28800  # 8 hours
+  suspend: {{ .suspend | default false }}
+  jobTemplate:
+    metadata:
+      name: {{ $jobFullName }}
+      labels:
+        {{- include "db-backup.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: {{ $jobName }}
+    spec:
+      activeDeadlineSeconds: 43200  # 12 hours
+      backoffLimit: 0
+      template:
+        metadata:
+          name: {{ $jobFullName }}
+          labels:
+            {{- include "db-backup.selectorLabels" $ | nindent 12 }}
+            app.kubernetes.io/component: {{ $jobName }}
+        spec:
+          enableServiceLinks: false
+          restartPolicy: Never
+          dnsConfig:
+            searches:
+              - blue.{{ $.Values.govukEnvironment }}.govuk-internal.digital
+              - {{ $.Values.govukEnvironment }}.govuk-internal.digital
+          serviceAccountName: {{ include "db-backup.serviceAccountName" $ }}
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ $fullName }}
+                defaultMode: 0555  # world-executable
+            - name: tmp  # aws-cli requires a writable dir.
+              emptyDir: {}
+          initContainers:
+  {{- range $job.operations }}
+            - name: {{ .op }}
+              image: {{ $.Values.imageRef | quote }}
+              command:
+                - /opt/bin/backup-{{ $dbms }}
+              args:
+                - {{ .op }}
+              env:
+                - name: GOVUK_ENVIRONMENT
+                  value: {{ $.Values.govukEnvironment }}
+                - name: PGUSER
+                  value: {{ $job.dbUser | default "aws_db_admin" }}
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $fullName }}-passwd
+                      key: {{ $dbHost }}
+                - name: PGHOST
+                  value: {{ $dbHost }}
+                - name: PGDATABASE
+                  value: {{ .db | default $job.db }}
+                - name: BUCKET
+                  value: {{ .bucket }}
+                {{- with $.Values.extraEnv }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
+                {{- with .extraEnv }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
+              resources:
+                {{- $.Values.resources | toYaml | nindent 16 }}
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /opt/bin
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+  {{- end }}
+          containers:
+            - name: noop
+              image: {{ $.Values.imageRef | quote }}
+              command: ["true"]
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+{{- end }}

--- a/charts/db-backup/templates/externalsecrets.yaml
+++ b/charts/db-backup/templates/externalsecrets.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "db-backup.fullname" . }}-passwd
+  labels:
+    {{- include "db-backup.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Map of hostname to aws_db_admin password for backup/restore of databases
+      hosted in RDS. TODO: stop using passwords.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: {{ include "db-backup.fullname" . }}-passwd
+  dataFrom:
+    - extract:
+        key: govuk/db-backup/passwd

--- a/charts/db-backup/templates/serviceaccount.yaml
+++ b/charts/db-backup/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: false
+metadata:
+  name: {{ include "db-backup.serviceAccountName" . }}
+  labels:
+    {{- include "db-backup.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -22,26 +22,26 @@ govukEnvironment: staging
 cronjobs:
   production:
     content-store-postgres:
-      schedule: "16 1 * * *"
+      schedule: "16 2 * * *"
       db: content_store_production
       operations:
         - op: backup
     draft-content-store-postgres:
-      schedule: "16 1 * * *"
+      schedule: "36 2 * * *"
       db: draft_content_store_production
       operations:
         - op: backup
   staging:
     content-store-postgres:
       db: content_store_production
-      schedule: "16 2 * * *"
+      schedule: "16 3 * * *"
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
         - op: backup
     draft-content-store-postgres:
       db: draft_content_store_production
-      schedule: "16 2 * * *"
+      schedule: "36 3 * * *"
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
@@ -49,7 +49,7 @@ cronjobs:
   integration:
     content-store-postgres:
       db: content_store_production
-      schedule: "16 3 * * *"
+      schedule: "16 4 * * *"
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
@@ -57,7 +57,7 @@ cronjobs:
     # of publishing-api that require it are rectified.
     draft-content-store-postgres:
       db: draft_content_store_production
-      schedule: "16 3 * * *"
+      schedule: "36 4 * * *"
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -1,0 +1,100 @@
+# Default values for db-backup.
+
+nameOverride: ""
+fullnameOverride: ""
+# https://github.com/alphagov/govuk-infrastructure/tree/main/images/toolbox
+imageRef: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox"
+
+# govukEnvironment determines which set of cronjobs to use from `cronjobs`
+# below. When running under Argo CD, the ../app-config chart passes the
+# appropriate value for govukEnvironment in by default.
+govukEnvironment: staging
+
+# cronjobs defines a set of k8s CronJobs that should exist in each environment
+# (production, staging, integration). Each CronJob consists of one or more
+# operations which run as a sequence of InitContainers.
+#
+# Each environment has a map of job names to job configs. If the job name (i.e.
+# the map key) is of the form <app-name>-<dbms>, for example
+# link-checker-api-postgres, then the DBMS hostname and DBMS type (postgres,
+# mysql etc.) can be inferred. These can be specified explicitly via the `host`
+# and `dbms` keys in the job config.
+cronjobs:
+  production:
+    content-store-postgres:
+      schedule: "16 1 * * *"
+      db: content_store_production
+      operations:
+        - op: backup
+    draft-content-store-postgres:
+      schedule: "16 1 * * *"
+      db: draft_content_store_production
+      operations:
+        - op: backup
+  staging:
+    content-store-postgres:
+      db: content_store_production
+      schedule: "16 2 * * *"
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
+    draft-content-store-postgres:
+      db: draft_content_store_production
+      schedule: "16 2 * * *"
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
+  integration:
+    content-store-postgres:
+      db: content_store_production
+      schedule: "16 3 * * *"
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
+    # TODO: stop copying draft content into integration once the design quirks
+    # of publishing-api that require it are rectified.
+    draft-content-store-postgres:
+      db: draft_content_store_production
+      schedule: "16 3 * * *"
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
+
+extraEnv:
+  - name: VERBOSE
+    value: "1"
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+
+serviceAccount:
+  create: true
+  name: db-backup
+  annotations:
+    # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
+    eks.amazonaws.com/role-arn: arn:aws:iam::696911096973:role/db-backup-govuk
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 512Mi
+  requests:
+    cpu: 500m
+    memory: 128Mi
+
+externalSecrets:
+  refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+  deletionPolicy: Delete

--- a/charts/search-index-env-sync/templates/cronjob.yaml
+++ b/charts/search-index-env-sync/templates/cronjob.yaml
@@ -64,9 +64,11 @@ spec:
                   {{- toYaml . | nindent 16 }}
                 {{- end }}
               resources:
+                {{- $.Values.resources | toYaml | nindent 16 }}
               securityContext:
                 {{- toYaml $.Values.securityContext | nindent 16 }}
               volumeMounts:
                 - name: scripts
                   mountPath: /opt/bin
+                  readOnly: true
 {{- end }}


### PR DESCRIPTION
This is designed to replace [govuk_env_sync] in the very near future.

For now, we just configure the jobs for the new (not yet serving user traffic in production) Postgres-based version of content-store.

[govuk_env_sync]: https://github.com/alphagov/govuk-puppet/tree/main/modules/govuk_env_sync

https://trello.com/c/JjTHY62V