### PR TITLE
Deploy (but don't swap-in) the draft & live content-store-proxy apps in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -739,6 +739,23 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
+  - name: content-store-proxy
+    repoName: content-store-proxy
+    helmValues:
+      rails:
+        enabled: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: content-store-proxy-sentry
+      nginxClientMaxBodySize: 20M
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PRIMARY_UPSTREAM
+          value: "http://content-store/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://content-store-postgresql-branch/"
+
   - name: draft-content-store
     repoName: content-store
     helmValues:
@@ -816,6 +833,23 @@ govukApplications:
               key: DATABASE_URL
         - name: DISABLE_ROUTER_API
           value: "true"
+
+  - name: draft-content-store-proxy
+    repoName: content-store-proxy
+    helmValues:
+      rails:
+        enabled: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: content-store-proxy-sentry
+      nginxClientMaxBodySize: 20M
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PRIMARY_UPSTREAM
+          value: "http://draft-content-store/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://draft-content-store-postgresql-branch/"
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
This will allow us to test & make sure the proxy is configured correctly and works, before a separate PR will insert it in front of all content-store requests. 

[Trello card](https://trello.com/c/Arh3oR4f/830-roll-out-the-content-store-proxy-on-staging-step-3), part of [overall content-store migration epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)