### PR TITLE
Add image-tag file for content-store-proxy in staging

### DIFF
--- a/charts/app-config/image-tags/staging/content-store-proxy
+++ b/charts/app-config/image-tags/staging/content-store-proxy
@@ -1,0 +1,3 @@
+image_tag: release-a5643ef9011e3a510c5d493e194c5a2ad4bdea09
+automatic_deploys_enabled: true
+promote_deployment: false


### PR DESCRIPTION
After deploying the proxy in staging in #1270, the resulting deployment does not start, with a `
Failed to apply default image tag "(...)amazonaws.com/content-store-proxy:": couldn't parse image reference` error - very probably because it's missing the image-tag file. 