### PR TITLE
Allow content-store-proxy to create its Sentry DSN secret

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -744,9 +744,6 @@ govukApplications:
     helmValues:
       rails:
         enabled: false
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: content-store-proxy-sentry
       nginxClientMaxBodySize: 20M
       uploadAssets:
         enabled: false


### PR DESCRIPTION
A copy and paste issue in #1270 meant both draft- and live content-stores  had `createSecret: false` in their sentry values. This stopped the secret being created, and meant that the containers could not start