### PR TITLE
Swap-in the draft & live content-store-proxy apps in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -661,7 +661,8 @@ govukApplications:
               name: signon-token-content-publisher-whitehall
               key: bearer_token
 
-  - name: content-store
+  - name: content-store-mongo-main
+    repoName: content-store
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       replicaCount: 6
@@ -669,6 +670,10 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
+      rails:
+        secretKeyBaseName: content-store-rails-secret-key-base
+      sentry:
+        dsnSecretName: content-store-sentry
       uploadAssets:
         enabled: false
       extraEnv:
@@ -739,7 +744,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-proxy
+  - name: content-store
     repoName: content-store-proxy
     helmValues:
       rails:
@@ -749,11 +754,11 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store/"
+          value: "http://content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
 
-  - name: draft-content-store
+  - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:
       <<: *content-store
@@ -831,7 +836,7 @@ govukApplications:
         - name: DISABLE_ROUTER_API
           value: "true"
 
-  - name: draft-content-store-proxy
+  - name: draft-content-store
     repoName: content-store-proxy
     helmValues:
       rails:


### PR DESCRIPTION
Having deployed the draft & live content-store-proxy apps on staging (#1270), and made sure they're running OK (#1271 & #1272), the next step in the [rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_120) is to swap them in, by renaming the apps as we did for integration (#1196 and #1213):

`content-store` -> `content-store-mongo-main`
`content-store-proxy` -> `content-store`
and
`draft-content-store` -> `draft-content-store-mongo-main`
`draft-content-store-proxy` -> `draft-content-store`
  
 This will route all requests for content-store to the proxy, where it will then proxy to `content-store-mongo-main` and serve that response. It will also replay the request to `content-store-postgresql-branch`, and compare the two responses for any differences.

[Trello card link](https://trello.com/c/Arh3oR4f/830-roll-out-the-content-store-proxy-on-staging-step-3)