### PR TITLE
CSV previews should work with modern urls

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1141,6 +1141,9 @@ govukApplications:
             path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+            path: /media/*/*/preview
+            pathType: ImplementationSpecific
+          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/


### PR DESCRIPTION
We are migrating away from legacy url path in whitehall assets. Router and nginx config has a special list of urls that are directed to frontend instead of whitehall. The change is to include the new url in the configuration.

After adding the new url to whitehall_uploaded_assets_routes, it will be used by both assets-origin and draft-assets.