### PR TITLE
Deploy content-store-proxy app in production (but don't swap it in)

### DIFF
--- a/charts/app-config/image-tags/production/content-store-proxy
+++ b/charts/app-config/image-tags/production/content-store-proxy
@@ -1,0 +1,3 @@
+image_tag: release-a5643ef9011e3a510c5d493e194c5a2ad4bdea09
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -732,6 +732,22 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
+  - name: content-store-proxy
+    repoName: content-store-proxy
+    helmValues:
+      rails:
+        enabled: false
+      sentry:
+        dsnSecretName: content-store-proxy-sentry
+      nginxClientMaxBodySize: 20M
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PRIMARY_UPSTREAM
+          value: "http://content-store/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://content-store-postgresql-branch/"
+
   - name: draft-content-store
     repoName: content-store
     helmValues:
@@ -809,6 +825,24 @@ govukApplications:
               key: DATABASE_URL
         - name: DISABLE_ROUTER_API
           value: "true"
+
+  - name: draft-content-store-proxy
+    repoName: content-store-proxy
+    helmValues:
+      rails:
+        enabled: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: content-store-proxy-sentry
+      nginxClientMaxBodySize: 20M
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PRIMARY_UPSTREAM
+          value: "http://draft-content-store/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://draft-content-store-postgresql-branch/"
+
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
This allows us to check that the application is configured & running correctly, before a subsequent PR swaps it in by renaming applications (e.g. #1273 for staging). 

Makes the same changes as #1270, #1271 and #1272, but for production.

[Trello card](https://trello.com/c/6f6vlfHY/829-roll-out-but-dont-swap-in-the-content-store-proxy-on-production-step-3), part of the overall [Mongo migration epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)