### PR TITLE
Don't time out whitehall-admin requests prematurely.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2959,6 +2959,7 @@ govukApplications:
       workerEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
+      nginxProxyReadTimeout: 60s
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2963,6 +2963,7 @@ govukApplications:
       workerEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
+      nginxProxyReadTimeout: 60s
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2952,6 +2952,7 @@ govukApplications:
       workerEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
+      nginxProxyReadTimeout: 60s
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Some whitehall-admin requests are slow; let's not make it worse by giving up in the reverse proxy before the application does.