### PR TITLE
Add RabbitMQ configuration for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2249,6 +2249,12 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: false
+      extraEnv:
+        - name: RABBITMQ_URL
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-rabbitmq
+              key: RABBITMQ_URL
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2314,6 +2314,12 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: false
+      extraEnv:
+        - name: RABBITMQ_URL
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-rabbitmq
+              key: RABBITMQ_URL
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2284,6 +2284,12 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: false
+      extraEnv:
+        - name: RABBITMQ_URL
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-rabbitmq
+              key: RABBITMQ_URL
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/external-secrets/templates/search-api-v2/rabbitmq.yaml
+++ b/charts/external-secrets/templates/search-api-v2/rabbitmq.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: search-api-v2-rabbitmq
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      RabbitMQ connection string for search-api-v2. Fields in SecretsManager are
+      username, password, host, port.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-api-v2-rabbitmq
+    template:
+      data:
+        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
+  dataFrom:
+    - extract:
+        key: govuk/search-api-v2/rabbitmq


### PR DESCRIPTION
- Add an ExternalSecret template for `search-api-v2`'s RabbitMQ config
- Use `RABBITMQ_URL` from the ExternalSecret in `search-api-v2`'s environment configuration