### PR TITLE
Adding alert when no message received for 60 mins.

### DIFF
--- a/charts/monitoring-config/dashboards/email-alert-monitoring.json
+++ b/charts/monitoring-config/dashboards/email-alert-monitoring.json
@@ -1,0 +1,185 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2047,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Timestamp of last successful email-alert-api end-to-end probe. Metrics are via pushgateway.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeAsIsoNoDateIfToday"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "medical_alerts"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "travel_alerts_last_successful_run_timestamp_seconds{job=\"email-alert-monitoring\"} * 1000",
+          "legendFormat": "travel_alerts",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "medical_alerts_last_successful_run_timestamp_seconds{job=\"email-alert-monitoring\"} * 1000",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "medical_alerts",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Time of last success",
+      "transparent": true,
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2023-10-08T23:00:00.000Z",
+    "to": "2023-10-11T22:59:59.000Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Email alert monitoring",
+  "uid": "fe0c86f6-a016-444c-89ad-d576d906ca82",
+  "version": 5,
+  "weekStart": ""
+}

--- a/charts/monitoring-config/rules/email_alert_monitoring.yaml
+++ b/charts/monitoring-config/rules/email_alert_monitoring.yaml
@@ -2,16 +2,14 @@ groups:
   - name: EmailAlertMonitoringAlerts
     rules:
       - alert: TravelAlert
-        expr: time() - travel_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"} > 1h
-        for: 60m
+        expr: time() - travel_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"} > 3600
         labels:
           severity: page
         annotations:
           summary: No travel alert probe email seen in the last 1h.
 
       - alert: MedicalAlert
-        expr: time() - medical_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"} > 1h
-        for: 60m
+        expr: time() - medical_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"} > 3600
         labels:
           severity: page
         annotations:

--- a/charts/monitoring-config/rules/email_alert_monitoring.yaml
+++ b/charts/monitoring-config/rules/email_alert_monitoring.yaml
@@ -1,0 +1,18 @@
+groups:
+  - name: EmailAlertMonitoringAlerts
+    rules:
+      - alert: TravelAlert
+        expr: time() - travel_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"} > 1h
+        for: 60m
+        labels:
+          severity: page
+        annotations:
+          summary: No travel alert probe email seen in the last 1h.
+
+      - alert: MedicalAlert
+        expr: time() - medical_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"} > 1h
+        for: 60m
+        labels:
+          severity: page
+        annotations:
+          summary: No medical alert probe email seen in the last 1h.

--- a/charts/monitoring-config/rules/email_alert_monitoring_tests.yaml
+++ b/charts/monitoring-config/rules/email_alert_monitoring_tests.yaml
@@ -1,6 +1,6 @@
 rule_files:
   - email_alert_monitoring.yaml
- 
+
 evaluation_interval: 1m
 
 tests:
@@ -8,7 +8,7 @@ tests:
     interval: 1m
     input_series:
       - series: 'travel_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"}'
-        values: '0x60'
+        values: '0x70'
 
     alert_rule_test:
       - eval_time: 59m
@@ -19,6 +19,7 @@ tests:
         alertname: TravelAlert
         exp_alerts:
           - exp_labels:
+              job: email-alert-monitoring
               severity: page
             exp_annotations:
               summary: No travel alert probe email seen in the last 1h.
@@ -27,17 +28,18 @@ tests:
     interval: 1m
     input_series:
       - series: 'medical_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"}'
-        values: '0x60'
- 
+        values: '0x70'
+
     alert_rule_test:
       - eval_time: 59m
         alertname: MedicalAlert
         exp_alerts: []
- 
+
       - eval_time: 61m
         alertname: MedicalAlert
         exp_alerts:
           - exp_labels:
+              job: email-alert-monitoring
               severity: page
             exp_annotations:
-              summary: No medical alert probe email seen in the last 1h.    
+              summary: No medical alert probe email seen in the last 1h.

--- a/charts/monitoring-config/rules/email_alert_monitoring_tests.yaml
+++ b/charts/monitoring-config/rules/email_alert_monitoring_tests.yaml
@@ -1,0 +1,43 @@
+rule_files:
+  - email_alert_monitoring.yaml
+ 
+evaluation_interval: 1m
+
+tests:
+  - name: travel_test
+    interval: 1m
+    input_series:
+      - series: 'travel_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"}'
+        values: '0x60'
+
+    alert_rule_test:
+      - eval_time: 59m
+        alertname: TravelAlert
+        exp_alerts: []
+
+      - eval_time: 61m
+        alertname: TravelAlert
+        exp_alerts:
+          - exp_labels:
+              severity: page
+            exp_annotations:
+              summary: No travel alert probe email seen in the last 1h.
+
+  - name: medical_test
+    interval: 1m
+    input_series:
+      - series: 'medical_alerts_last_successful_run_timestamp_seconds{job="email-alert-monitoring"}'
+        values: '0x60'
+ 
+    alert_rule_test:
+      - eval_time: 59m
+        alertname: MedicalAlert
+        exp_alerts: []
+ 
+      - eval_time: 61m
+        alertname: MedicalAlert
+        exp_alerts:
+          - exp_labels:
+              severity: page
+            exp_annotations:
+              summary: No medical alert probe email seen in the last 1h.    


### PR DESCRIPTION
Adding Dashboard whch shows metrics from email alert monitoring succcefull runs by timestamp.

Based on dashboard created in production:
https://grafana.eks.production.govuk.digital/d/fe0c86f6-a016-444c-89ad-d576d906ca82/email-alert-monitoring-testing?orgId=1

Covers:
Travel alert runs and Medical alert runs

Metrics from the following draft PR which adds support for push gateway: https://github.com/alphagov/email-alert-monitoring/pull/99

Adding Alert:
Alert is set to alert when no messages have been received for 30mins using https://prometheus.io/docs/concepts/metric_types/#counter https://prometheus.io/docs/prometheus/latest/querying/functions/#increase

https://trello.com/c/oOokPLVF/1203-alert-on-email-alert-monitoring-jobs-failures-testng