### PR TITLE
Add worker for `search-api-v2` in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2251,7 +2251,9 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
-      workerEnabled: false
+      workers:
+        - command: ['bin/rails', 'message_queue:consume_published_documents']
+          name: published-documents-consumer
       extraEnv:
         - name: RABBITMQ_URL
           valueFrom:


### PR DESCRIPTION
This adds a worker consuming from the published documents message queue, in integration only for now while we sort out the other environments (pending on https://github.com/alphagov/govuk-aws/pull/1757)