### PR TITLE
fix 504 timeout errors in apps calling draft-content-store in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -849,7 +849,7 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store/"
+          value: "http://draft-content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
 


### PR DESCRIPTION
A misconfiguration when swapping-in content-store-proxy on staging (#1273) meant that the draft-content-store-proxy was trying to forward requests to itself. This caused 504 Gateway Timeouts in calling applications.