### PR TITLE
Set `workerEnabled` for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2251,6 +2251,7 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
+      workerEnabled: true
       workers:
         - command: ['bin/rails', 'message_queue:consume_published_documents']
           name: published-documents-consumer


### PR DESCRIPTION
Turns out simply setting `workers` isn't enough as this value is false by default!