### PR TITLE
Enable and add worker for all `search-api-v2` envs

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2313,7 +2313,10 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
-      workerEnabled: false
+      workerEnabled: true
+      workers:
+        - command: ['bin/rails', 'message_queue:consume_published_documents']
+          name: published-documents-consumer
       extraEnv:
         - name: RABBITMQ_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2283,7 +2283,10 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
-      workerEnabled: false
+      workerEnabled: true
+      workers:
+        - command: ['bin/rails', 'message_queue:consume_published_documents']
+          name: published-documents-consumer
       extraEnv:
         - name: RABBITMQ_URL
           valueFrom:


### PR DESCRIPTION
- Add the `published-documents-consumer` worker to staging and production along the lines of the working integration one

Depends on https://github.com/alphagov/govuk-aws/pull/1757 being merged and applied to staging/production.