### PR TITLE
CSV previews should work with modern urls in draft state

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1203,6 +1203,9 @@ govukApplications:
             path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
             pathType: ImplementationSpecific
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+            path: /media/*/*/preview
+            pathType: ImplementationSpecific
+          - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/
       rails:
         createKeyBaseSecret: false


### PR DESCRIPTION
This is related to a previous [PR-CSV previews should work with modern urls](https://github.com/alphagov/govuk-helm-charts/pull/1274)

Assets were served from `draft-frontend` instead before publish, request to assets-origin will be redirected to draft-assets automatically hence we are adding the rule for `/media/*/*/preview` under draft-frontend as well.

[Trello card for context](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)