### PR TITLE
Improve worker configuration for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2253,9 +2253,11 @@ govukApplications:
         enabled: false
       workerEnabled: true
       workers:
-        - command: ['bin/rails', 'message_queue:consume_published_documents']
-          name: published-documents-consumer
+        - command: ['bin/rake', 'publish_event_pipeline:process_messages']
+          name: publish-event-pipeline-process-messages
       extraEnv:
+        - name: PUBLISH_EVENT_MESSAGE_QUEUE_NAME
+          value: search_api_v2_published_documents
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2315,9 +2315,11 @@ govukApplications:
         enabled: false
       workerEnabled: true
       workers:
-        - command: ['bin/rails', 'message_queue:consume_published_documents']
-          name: published-documents-consumer
+        - command: ['bin/rake', 'publish_event_pipeline:process_messages']
+          name: publish-event-pipeline-process-messages
       extraEnv:
+        - name: PUBLISH_EVENT_MESSAGE_QUEUE_NAME
+          value: search_api_v2_published_documents
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2285,9 +2285,11 @@ govukApplications:
         enabled: false
       workerEnabled: true
       workers:
-        - command: ['bin/rails', 'message_queue:consume_published_documents']
-          name: published-documents-consumer
+        - command: ['bin/rake', 'publish_event_pipeline:process_messages']
+          name: publish-event-pipeline-process-messages
       extraEnv:
+        - name: PUBLISH_EVENT_MESSAGE_QUEUE_NAME
+          value: search_api_v2_published_documents
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- Change name of worker and command run following refactoring in the app
- Add an environment variable `PUBLISH_EVENT_MESSAGE_QUEUE_NAME` to the configuration to remove a magic string from the application.