### PR TITLE
Improve naming of worker config for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2253,10 +2253,10 @@ govukApplications:
         enabled: false
       workerEnabled: true
       workers:
-        - command: ['bin/rake', 'publish_event_pipeline:process_messages']
-          name: publish-event-pipeline-process-messages
+        - command: ['bin/rake', 'publishing_event_pipeline:process_messages']
+          name: publishing-event-pipeline-process-messages
       extraEnv:
-        - name: PUBLISH_EVENT_MESSAGE_QUEUE_NAME
+        - name: PUBLISHING_EVENT_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: RABBITMQ_URL
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2315,10 +2315,10 @@ govukApplications:
         enabled: false
       workerEnabled: true
       workers:
-        - command: ['bin/rake', 'publish_event_pipeline:process_messages']
-          name: publish-event-pipeline-process-messages
+        - command: ['bin/rake', 'publishing_event_pipeline:process_messages']
+          name: publishing-event-pipeline-process-messages
       extraEnv:
-        - name: PUBLISH_EVENT_MESSAGE_QUEUE_NAME
+        - name: PUBLISHING_EVENT_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: RABBITMQ_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2285,10 +2285,10 @@ govukApplications:
         enabled: false
       workerEnabled: true
       workers:
-        - command: ['bin/rake', 'publish_event_pipeline:process_messages']
-          name: publish-event-pipeline-process-messages
+        - command: ['bin/rake', 'publishing_event_pipeline:process_messages']
+          name: publishing-event-pipeline-process-messages
       extraEnv:
-        - name: PUBLISH_EVENT_MESSAGE_QUEUE_NAME
+        - name: PUBLISHING_EVENT_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: RABBITMQ_URL
           valueFrom:


### PR DESCRIPTION
Use "publishing" rather than "publish" to be more consistent across services and (hopefully) better and more broadly describe semantics of what the worker does.