### PR TITLE
Swap-in the live & draft content-store-proxies in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -646,7 +646,8 @@ govukApplications:
               name: signon-token-content-publisher-whitehall
               key: bearer_token
 
-  - name: content-store
+  - name: content-store-mongo-main
+    repoName: content-store
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.
@@ -662,6 +663,10 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
+      rails:
+        secretKeyBaseName: content-store-rails-secret-key-base
+      sentry:
+        dsnSecretName: content-store-sentry
       uploadAssets:
         enabled: false
       extraEnv:
@@ -732,7 +737,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-proxy
+  - name: content-store
     repoName: content-store-proxy
     helmValues:
       rails:
@@ -744,11 +749,11 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store/"
+          value: "http://content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
 
-  - name: draft-content-store
+  - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:
       <<: *content-store
@@ -826,7 +831,7 @@ govukApplications:
         - name: DISABLE_ROUTER_API
           value: "true"
 
-  - name: draft-content-store-proxy
+  - name: draft-content-store
     repoName: content-store-proxy
     helmValues:
       rails:
@@ -839,7 +844,7 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store/"
+          value: "http://draft-content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
 


### PR DESCRIPTION
As the last part of the [content-store mongo migration rollout plan step 3](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_120), swap-in the proxies for live- and draft- content-stores in the production ( [Trello card](https://trello.com/c/D5eHDqCa/836-swap-in-the-content-store-proxy-in-production), [overall epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb) ).

Takes the same approach as for staging (#1273, #1280) and integration (#1213, #1215) :

- renames the apps `content-store` and `draft-content-store` to be `content-store-mongo-main` and `draft-content-store-mongo-main`
- renames the apps `content-store-proxy` and `draft-content-store-proxy` to `content-store` and `draft-content-store`
- all requests for http://content-store/ and http://draft-content-store/ will then be routed to the proxies, and then proxied to the corresponding `(draft-)content-store-mongo-main` content-store app - i.e. _we will still be ultimately serving content-store requests from the current Mongo version_ (not Postgres yet)  
- the requests will be replayed to the `(draft-)content-store-postgresql-branch` apps so that the response times/statuses/body-sizes can be compared (Logit visualisations ready for [draft](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/visualize?security_tenant=global#/edit/4dc52430-48b5-11ee-a74d-01e41446e74b?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-15m%2Cto%3Anow))) and [live](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/visualize?security_tenant=global#/edit/41a6aee0-48b4-11ee-a74d-01e41446e74b?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-15m%2Cto%3Anow))) ), to build confidence in their equivalence before a _later_ PR will [swap the primary & secondary upstream URLs](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_174)  - possibly for a short trial period at first, similarly to how the Kubernetes platform was tested before rollout.

### Risks
There is a possibility that a small number of requests to content-store may be dropped at the point of changeover, depending on exactly where they get to in the stack at that point. Also, because of the critical nature of content-store, any issues in rolling this out can have knock-on effects for frontend apps. Therefore we should take care to only merge this PR at a point when we have both relatively low traffic, and a decent amount of tech staff around to detect any issues and take any appropriate action. We should also notify tech 2nd line support beforehand. 

 