### PR TITLE
Update kubeconform schema to k8s 1.26.

### DIFF
--- a/kubernetes_version
+++ b/kubernetes_version
@@ -1,3 +1,5 @@
 # Kubernetes version for kubeconform to use when validating `helm template`
-# output. See .github/workflows/ci.yml.
-KUBERNETES_VERSION=1.25.0
+# output in .github/workflows/ci.yml.
+#
+# Available schema versions: https://github.com/yannh/kubernetes-json-schema
+KUBERNETES_VERSION=1.26.9


### PR DESCRIPTION
This only affects the post-push/pre-merge checks, but we want it to be in sync with the minor version we're running on the real clusters.