### PR TITLE
Bump link-checker-api to v23

### DIFF
--- a/charts/app-config/image-tags/integration/link-checker-api
+++ b/charts/app-config/image-tags/integration/link-checker-api
@@ -1,3 +1,3 @@
-image_tag: v22
+image_tag: v23
 automatic_deploys_enabled: true
 promote_deployment: true


### PR DESCRIPTION
Something seems to have gone wrong with this workflow. Now GitHub actions is happy to trigger Argo Workflows, but Argo Workflows doesn't seem to be able to do the deploy:

[Example failed Argo Workflow](https://argo-workflows.eks.production.govuk.digital/workflows/apps/link-checker-api-deploy-image-integrationzjd9g?tab=workflow&nodeId=link-checker-api-deploy-image-integrationzjd9g&nodePanelView=summary)

I've checked ECR and the v23 tag is already there, so I think we just need to bump the helm config to get this going again.