### PR TITLE
Delete existing branch before updating image tag

### DIFF
--- a/charts/argo-services/scripts/update-image-tag.sh
+++ b/charts/argo-services/scripts/update-image-tag.sh
@@ -20,6 +20,12 @@ if [[ "${current_image_tag}" = "${IMAGE_TAG}" ]]; then
   exit 0
 fi
 
+# Delete branch at origin if already exists
+if git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}"; then
+    echo "Deleting existing branch ${BRANCH} at origin"
+    git push origin --delete "${BRANCH}"
+fi
+
 git checkout -b "${BRANCH}"
 
 yq -i '.image_tag = env(IMAGE_TAG)' "${FILE}"


### PR DESCRIPTION
This prevents failures on update image tag workflow re-runs. This is because subsequent runs attempt to re-use the existing branch which can be out of date, cause subsquent pushed to be rejected.

We should just always start from a clean branch, as we don't care what previous workflow runs have done.