### PR TITLE
Scale-up/-out the content-store-proxy in production & staging

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -740,6 +740,14 @@ govukApplications:
       sentry:
         dsnSecretName: content-store-proxy-sentry
       nginxClientMaxBodySize: 20M
+      replicaCount: 6
+      appResources:
+        limits:
+          cpu: 4
+          memory: 2500Mi
+        requests:
+          cpu: 2
+          memory: 2000Mi
       uploadAssets:
         enabled: false
       extraEnv:
@@ -747,6 +755,8 @@ govukApplications:
           value: "http://content-store/"
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: WEB_CONCURRENCY
+          value: '4'
 
   - name: draft-content-store
     repoName: content-store
@@ -835,6 +845,7 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
         dsnSecretName: content-store-proxy-sentry
       nginxClientMaxBodySize: 20M
+      replicaCount: 3
       uploadAssets:
         enabled: false
       extraEnv:
@@ -842,7 +853,8 @@ govukApplications:
           value: "http://draft-content-store/"
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
-
+        - name: WEB_CONCURRENCY
+          value: '4'
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -750,6 +750,7 @@ govukApplications:
       rails:
         enabled: false
       nginxClientMaxBodySize: 20M
+      replicaCount: 6
       uploadAssets:
         enabled: false
       extraEnv:
@@ -757,6 +758,8 @@ govukApplications:
           value: "http://content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: WEB_CONCURRENCY
+          value: '4'
 
   - name: draft-content-store-mongo-main
     repoName: content-store
@@ -845,6 +848,7 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
         dsnSecretName: content-store-proxy-sentry
       nginxClientMaxBodySize: 20M
+      replicaCount: 3
       uploadAssets:
         enabled: false
       extraEnv:


### PR DESCRIPTION
A previous trial rollout of the content-store-proxies (#1286) hit some performance problems on production and was reverted (#1288) after causing elevated timeout rates in the front end apps.

[Investigation](https://trello.com/c/xNlJWJoi/847-investigate-why-deploying-the-proxy-to-production-caused-error-rates-to-spike-70-errors-of-200-reqs-sec) led us to conclude that the default app config was not enough to handle the full concurrency of the production traffic 'firehose', leading to requests being queued up at the proxy app (or the nginx in front of it). Some subsequent load testing against staging reproduced similar behaviour at similar levels of sustained concurrency (10k requests, max concurrency of 200).

This PR adds the relevant config lines to give the proxy apps in staging and production as much concurrency (i.e. replicas & puma workers) as the content-store apps behind them, as well as the same (elevated) limits on CPU and RAM.

We'll do another round of load testing on staging after deploying these changes, and if the results are better, we can then try another rollout to production.


 