### PR TITLE
CSV previews should work with modern urls in Production environment

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1171,6 +1171,9 @@ govukApplications:
             path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
+            path: /media/*/*/preview
+            pathType: ImplementationSpecific
+          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
@@ -1238,6 +1241,9 @@ govukApplications:
         hosts:
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
+            pathType: ImplementationSpecific
+          - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
+            path: /media/*/*/preview
             pathType: ImplementationSpecific
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             path: /assets/frontend/


### PR DESCRIPTION
This is related to previous [PR-CSV previews should work with modern urls](https://github.com/alphagov/govuk-helm-charts/pull/1274) and [PR - CSV previews should work with modern urls in draft state](https://github.com/alphagov/govuk-helm-charts/pull/1283)

PRs above are regarding to integration environment while this PR is regarding configs in Production environment.

[Trello card](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)