### PR TITLE
Increase WEB_CONCURRENCY for staging content-store-proxy

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -759,7 +759,7 @@ govukApplications:
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY
-          value: '4'
+          value: '8'
 
   - name: draft-content-store-mongo-main
     repoName: content-store


### PR DESCRIPTION
Load testing on staging has found there are still requests being queued up in the content-store-proxy nginx when under sustained heavy load. _We think_ they are waiting for a worker thread from puma in the content-store-proxy app (details in the [Trello card](https://trello.com/c/xNlJWJoi/847-investigate-why-deploying-the-proxy-to-production-caused-error-rates-to-spike-70-errors-of-200-reqs-sec))

This PR just doubles the number of puma workers available for the proxy in staging only, to let us test that theory.  