### PR TITLE
Increase WEB_CONCURRENCY on content-store-proxy to 8 in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -756,7 +756,7 @@ govukApplications:
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY
-          value: '4'
+          value: '8'
 
   - name: draft-content-store
     repoName: content-store


### PR DESCRIPTION
A third round of load-testing in staging after applying #1294 found that this was enough to eliminate the `HTTP 499 (Client closed connection)` errors previously seen in the content-store-proxy even after applying #1292. (details in the comments on [this Trello card](https://trello.com/c/xNlJWJoi/847-investigate-why-deploying-the-proxy-to-production-caused-error-rates-to-spike-70-errors-of-200-reqs-sec) )So let's apply the same change to production, and try rolling out in prod again.