### PR TITLE
Replace transition rake task to import orgs only

### DIFF
--- a/charts/generic-govuk-app/templates/transition-config-cron.yaml
+++ b/charts/generic-govuk-app/templates/transition-config-cron.yaml
@@ -58,10 +58,10 @@ spec:
                 - name: transition-config-efs
                   mountPath: /home/user
           containers:
-            - name: update-transtion-config
+            - name: update-transition-config
               image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
               imagePullPolicy: {{ $.Values.appImage.pullPolicy | default "Always" }}
-              command: ['rake', 'import:all:orgs_sites_hosts']
+              command: ['rake', 'import:all:organisations']
               envFrom:
                 - configMapRef:
                     name: govuk-apps-env


### PR DESCRIPTION
**Note**: should be coordinated with https://github.com/alphagov/transition/pull/1411

The Publishing Platform team is in the process of adding support in transition for adding and deleting sites and hosts directly, through a GUI, thus allowing us to retire transition-config.

The rake task `import:all:orgs_sites_hosts` was used to import:
- organisations from whitehall
- sites and hosts from transition-config into transition.

In the new way of doing things, the source of truth for sites and hosts is going to be the transition app itself.

Organisations still need to be imported from whitehall.

[Trello](https://trello.com/c/toGB61iI/809-remove-cron-job-that-imports-site-data-from-transition-config-to-transition-then-archive-the-transition-config-repo)
