### PR TITLE
Swap-in the production content-store proxies

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -646,7 +646,8 @@ govukApplications:
               name: signon-token-content-publisher-whitehall
               key: bearer_token
 
-  - name: content-store
+  - name: content-store-mongo-main
+    repoName: content-store
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.
@@ -662,6 +663,10 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
+      rails:
+        secretKeyBaseName: content-store-rails-secret-key-base
+      sentry:
+        dsnSecretName: content-store-sentry
       uploadAssets:
         enabled: false
       extraEnv:
@@ -732,7 +737,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-proxy
+  - name: content-store
     repoName: content-store-proxy
     helmValues:
       rails:
@@ -752,13 +757,13 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store/"
+          value: "http://content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY
           value: '8'
 
-  - name: draft-content-store
+  - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:
       <<: *content-store
@@ -836,7 +841,7 @@ govukApplications:
         - name: DISABLE_ROUTER_API
           value: "true"
 
-  - name: draft-content-store-proxy
+  - name: draft-content-store
     repoName: content-store-proxy
     helmValues:
       rails:
@@ -850,7 +855,7 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store/"
+          value: "http://draft-content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY


### PR DESCRIPTION
Second attempt at rolling out the changes in #1286, after making config tweaks in #1292 and #1294 to increase the allocated capacity. [Trello card](https://trello.com/c/D5eHDqCa/836-swap-in-the-content-store-proxy-in-production), step 3 of the [overall rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_120)

Summary of changes:

- Renames the apps `content-store` and `draft-content-store` to be `content-store-mongo-main` and `draft-content-store-mongo-main`
- Renames the apps `content-store-proxy` and `draft-content-store-proxy` to `content-store` and `draft-content-store`
- All requests for http://content-store/ and http://draft-content-store/ will then be routed to the proxies, and then proxied to the corresponding `(draft-)content-store-mongo-main` content-store app - i.e. we will still be ultimately serving content-store requests from the current Mongo version (not Postgres yet)
- The requests will be replayed to the `(draft-)content-store-postgresql-branch` apps so that the response times/statuses/body-sizes can be compared (Logit visualisations ready for [draft](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/visualize?security_tenant=global#/edit/4dc52430-48b5-11ee-a74d-01e41446e74b?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-15m%2Cto%3Anow))) and [live](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/visualize?security_tenant=global#/edit/41a6aee0-48b4-11ee-a74d-01e41446e74b?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-15m%2Cto%3Anow))) )

We'll take care to only merge this at a time when we can be alert for any increased error rates, and take appropriate action (i.e. revert) quickly.