### PR TITLE
Swap in the draft-content-store-proxy only, in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -771,42 +771,6 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
 
-  - name: draft-content-store
-    repoName: content-store
-    helmValues:
-      <<: *content-store
-      replicaCount: 3
-      cronTasks: []
-      rails:
-        createKeyBaseSecret: false
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-      extraEnv:
-        - name: ROUTER_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-draft-content-store-draft-router-api
-              key: bearer_token
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-draft-content-store
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-draft-content-store
-              key: oauth_secret
-        - name: DEFAULT_TTL
-          value: "1"
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.production.govuk-internal.digital,\
-            mongo-2.production.govuk-internal.digital,\
-            mongo-3.production.govuk-internal.digital/draft_content_store_production"
-        - name: PLEK_HOSTNAME_PREFIX
-          value: draft-
-
   - name: draft-content-store-mongo-main
     repoName: content-store
     helmValues:
@@ -885,7 +849,7 @@ govukApplications:
         - name: DISABLE_ROUTER_API
           value: "true"
 
-  - name: draft-content-store-proxy
+  - name: draft-content-store
     repoName: content-store-proxy
     helmValues:
       rails:


### PR DESCRIPTION
[Trello card](https://trello.com/c/D5eHDqCa/836-swap-in-the-content-store-proxy-in-production), part of Step 3 in the [overall rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_120) for migrating content-store off MongoDB.

This PR:

* renames `draft-content-store-proxy` to `draft-content-store`
* drops the old `draft-content-store` config - there is a duplicate existing deployment already running under the name `draft-content-store-mongo-main` which the proxy is already pointing to

We'll keep a close eye on the request error rates while deploying this, and revert quickly if there are any problems