### PR TITLE
Swap-in the live content-store-proxy in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -646,7 +646,8 @@ govukApplications:
               name: signon-token-content-publisher-whitehall
               key: bearer_token
 
-  - name: content-store
+  - name: content-store-mongo-main
+    repoName: content-store
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.
@@ -690,19 +691,6 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-mongo-main
-    repoName: content-store
-    helmValues:
-      <<: *content-store
-      rails:
-        createKeyBaseSecret: false
-        # use the same secret as the mongo content-store, it will make the
-        # eventual switchover easier and reduce toil
-        secretKeyBaseName: content-store-rails-secret-key-base
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: content-store-sentry
-
   - name: content-store-postgresql-branch
     repoName: content-store-postgresql-branch
     helmValues:
@@ -745,7 +733,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-proxy
+  - name: content-store
     repoName: content-store-proxy
     helmValues:
       rails:


### PR DESCRIPTION
[Trello card](https://trello.com/c/D5eHDqCa/836-swap-in-the-content-store-proxy-in-production), part of Step 3 in the [overall rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_120) for migrating content-store off MongoDB.

Following the same pattern as for the draft-content-store yesterday (#1299), this PR is only slightly more involved as the original `content-store` helm values are defined as a reference-able block, reused in all other content-stores.  

* renames `content-store-proxy` to `content-store`
* moves the reusable block from the old `content-store` to `content-store-mongo-main`
* deletes the old `content-store` app

(these last two are effectively equivalent to renaming `content-store` to `content-store-mongo-main` and dropping the existing `content-store-mongo-main` - and that's how `git diff` shows it)

As there is a duplicate existing deployment already running under the name `content-store-mongo-main` which the proxy is already pointing to, this should be as near to zero-downtime as we can get. 

We'll keep a close eye on the request error rates while (and after) deploying this - which will probably be shortly after 10am -  and revert quickly if there are any problems