### PR TITLE
Update request rates, errors, durations dashboard

### DIFF
--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -56,6 +56,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -186,6 +187,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 4,
@@ -346,6 +348,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -512,7 +515,7 @@
           "reverse": false
         }
       },
-      "pluginVersion": "9.5.5",
+      "pluginVersion": "10.1.5",
       "targets": [
         {
           "datasource": {

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -603,51 +603,20 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(http_request_duration_seconds{namespace=\"${namespace}\"}, job)",
+        "definition": "label_values(http_requests_total{namespace=\"${namespace}\"},job)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "app",
         "options": [],
         "query": {
-          "query": "label_values(http_request_duration_seconds{namespace=\"${namespace}\"}, job)",
+          "query": "label_values(http_requests_total{namespace=\"${namespace}\"},job)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "definition": "label_values(http_request_duration_seconds{namespace=\"${namespace}\"}, quantile)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "quantile",
-        "multi": true,
-        "name": "quantile",
-        "options": [],
-        "query": {
-          "query": "label_values(http_request_duration_seconds{namespace=\"${namespace}\"}, quantile)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 4,
         "type": "query"
       },
       {

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -555,7 +555,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -429,7 +429,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (job) (increase(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval])) / sum by (job) (increase(http_request_duration_seconds_count{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval]))",
+          "expr": "sum by (job) (rate(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval])) / sum by (job) (rate(http_request_duration_seconds_count{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval]))",
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -441,7 +441,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (increase(http_request_duration_seconds_sum{namespace=\"${namespace}\"}[$__rate_interval])) / sum (increase(http_request_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum (rate(http_request_duration_seconds_sum{namespace=\"${namespace}\"}[$__rate_interval])) / sum (rate(http_request_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "all",
           "range": true,

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -500,7 +500,8 @@
           "show": true
         },
         "rowsFrame": {
-          "layout": "auto"
+          "layout": "auto",
+          "value": "Number of requests"
         },
         "tooltip": {
           "show": true,

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -117,7 +117,8 @@
       "options": {
         "legend": {
           "calcs": [
-            "mean"
+            "mean",
+            "max"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -276,7 +277,8 @@
       "options": {
         "legend": {
           "calcs": [
-            "sum"
+            "mean",
+            "max"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -405,7 +407,8 @@
       "options": {
         "legend": {
           "calcs": [
-            "mean"
+            "mean",
+            "max"
           ],
           "displayMode": "table",
           "placement": "right",

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -429,7 +429,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "avg(http_request_duration_seconds{namespace=\"${namespace}\", job=~\"${app}\",quantile=~\"${quantile}\"}) by (job)",
+          "expr": "sum by (job) (increase(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval])) / sum by (job) (increase(http_request_duration_seconds_count{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval]))",
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -441,7 +441,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(http_request_duration_seconds{namespace=\"${namespace}\", quantile=~\"${quantile}\"})",
+          "expr": "sum (increase(http_request_duration_seconds_sum{namespace=\"${namespace}\"}[$__rate_interval])) / sum (increase(http_request_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "all",
           "range": true,

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -563,6 +563,7 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": [

--- a/charts/monitoring-config/dashboards/app-requests.json
+++ b/charts/monitoring-config/dashboards/app-requests.json
@@ -456,85 +456,62 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Controller Action times sorted by application and sortable by maximum time taken",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Request Time (s)",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "hue",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "always",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
             }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 13,
+        "h": 9,
         "w": 24,
         "x": 0,
         "y": 20
       },
-      "id": 5,
+      "id": 4,
       "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Viridis",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
         "legend": {
-          "calcs": [
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "width": 300
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
         }
       },
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -542,19 +519,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "label_replace(avg without (pod, instance) (http_request_duration_seconds{namespace=\"${namespace}\", job=~\"${app}\", quantile=~\"${quantile}\"}), \"a\", \"$1\", \"job\", \"(.*)\")",
-          "interval": "",
-          "legendFormat": "{{job}} {{controller}} {{action}} {{quantile}}",
+          "expr": "sum by (le) (increase(http_request_duration_seconds_bucket{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "sort": "current",
-          "sortDesc": false
+          "refId": "A"
         }
       ],
-      "title": "Request duration per App/Controller/Action",
-      "transformations": [],
-      "type": "timeseries"
+      "title": "Distribution of Request Durations",
+      "type": "heatmap"
     }
   ],
   "refresh": "1m",


### PR DESCRIPTION
There are a few changes here, which I've tried to describe in individual commits to make it easier to review.

The request rates, errors, durations dashboard has numerous issues. The most immediately serious one is that the metric it's using to work out which apps exist no longer includes most apps (because of the switch to histograms in https://github.com/alphagov/govuk_app_config/pull/318), but there were also a few issues stemming from the confusing nature of prometheus summaries.

I've also taken the opportunity to switch the request durations visualisation to use a heatmap, which I think is a more useful representation of the information. 

| Before | After (note: different time span) |
|-----|-----|
| ![image](https://github.com/alphagov/govuk-helm-charts/assets/1696784/43f78bec-8405-4472-a89b-952791fc2eb4) | ![image](https://github.com/alphagov/govuk-helm-charts/assets/1696784/44412718-021f-403f-8927-379466350dd3) |

You can play with the new version of the dashboard here: https://grafana.eks.production.govuk.digital/d/cdeb0607-02e2-4c51-8b7a-398a1c1e2936/richard-towersat-app-request-rates-errors-durations
