### PR TITLE
Add alerting rules for Signon API User tokens

### DIFF
--- a/charts/monitoring-config/rules/signon.yaml
+++ b/charts/monitoring-config/rules/signon.yaml
@@ -1,0 +1,15 @@
+groups:
+  - name: SignonAlerts
+    rules:
+      - record: global:signon_api_user_token_expires_in_seconds
+        expr: |
+          min(signon_api_user_token_expiry_timestamp_seconds) by (api_user, application) - time()
+
+      - alert: SignonApiUserTokenExpirySoon
+        expr: |
+          global:signon_api_user_token_expires_in_seconds < 1209600
+        for: 10m
+        annotations:
+          summary: Signon API User token is due to expire soon
+          description: >-
+            A token is about to expire within the next two weeks and needs rotating.


### PR DESCRIPTION
This will make prometheus fire an alert if a token will expire in the next two weeks.