### PR TITLE
Fix multiple alerting rules

### DIFF
--- a/charts/monitoring-config/rules/router.yaml
+++ b/charts/monitoring-config/rules/router.yaml
@@ -1,37 +1,36 @@
-groups:
-  - name: RouterAlerts
-    rules:
-      - record: global:router_requests:rate5m
-        expr: |
-          sum by (job, backend_id, response_code) (
-            rate(router_backend_handler_response_duration_seconds_count{namespace="apps"}[5m])
+- name: RouterAlerts
+  rules:
+    - record: global:router_requests:rate5m
+      expr: |
+        sum by (job, backend_id, response_code) (
+          rate(router_backend_handler_response_duration_seconds_count{namespace="apps"}[5m])
+        )
+
+    - record: global:router_5xx_responses_per_request_by_backend:ratio_rate5m
+      expr: |2
+          sum without (response_code) (global:router_requests:rate5m{response_code=~"5.."})
+        /
+          sum without (response_code) (global:router_requests:rate5m)
+
+    - record: global:router_5xx_responses_per_request:ratio_rate5m
+      expr: |2
+          sum without (backend_id, response_code) (
+            global:router_requests:rate5m{response_code=~"5.."}
           )
+        /
+          sum without (backend_id, response_code) (global:router_requests:rate5m)
 
-      - record: global:router_5xx_responses_per_request_by_backend:ratio_rate5m
-        expr: |2
-            sum without (response_code) (global:router_requests:rate5m{response_code=~"5.."})
-          /
-            sum without (response_code) (global:router_requests:rate5m)
-
-      - record: global:router_5xx_responses_per_request:ratio_rate5m
-        expr: |2
-            sum without (backend_id, response_code) (
-              global:router_requests:rate5m{response_code=~"5.."}
-            )
-          /
-            sum without (backend_id, response_code) (global:router_requests:rate5m)
-
-      - alert: RouterErrorRatioTooHigh
-        expr: |2
-            global:router_5xx_responses_per_request:ratio_rate5m{job="router"} > 0.1
-          and
-            sum without (backend_id, response_code) (
-              global:router_requests:rate5m{job="router"}
-            ) > 1
-        for: 10m
-        labels:
-          severity: page
-        annotations:
-          summary: Router error ratio too high
-          description: >-
-            More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.
+    - alert: RouterErrorRatioTooHigh
+      expr: |2
+          global:router_5xx_responses_per_request:ratio_rate5m{job="router"} > 0.1
+        and
+          sum without (backend_id, response_code) (
+            global:router_requests:rate5m{job="router"}
+          ) > 1
+      for: 10m
+      labels:
+        severity: page
+      annotations:
+        summary: Router error ratio too high
+        description: >-
+          More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.

--- a/charts/monitoring-config/rules/signon.yaml
+++ b/charts/monitoring-config/rules/signon.yaml
@@ -1,15 +1,14 @@
-groups:
-  - name: SignonAlerts
-    rules:
-      - record: global:signon_api_user_token_expires_in_seconds
-        expr: |
-          min(signon_api_user_token_expiry_timestamp_seconds) by (api_user, application) - time()
+- name: SignonAlerts
+  rules:
+    - record: global:signon_api_user_token_expires_in_seconds
+      expr: |
+        min(signon_api_user_token_expiry_timestamp_seconds) by (api_user, application) - time()
 
-      - alert: SignonApiUserTokenExpirySoon
-        expr: |
-          global:signon_api_user_token_expires_in_seconds < 1209600
-        for: 10m
-        annotations:
-          summary: Signon API User token is due to expire soon
-          description: >-
-            A token is about to expire within the next two weeks and needs rotating.
+    - alert: SignonApiUserTokenExpirySoon
+      expr: |
+        global:signon_api_user_token_expires_in_seconds < 1209600
+      for: 10m
+      annotations:
+        summary: Signon API User token is due to expire soon
+        description: >-
+          A token is about to expire within the next two weeks and needs rotating.

--- a/charts/monitoring-config/templates/prometheus-rules.yaml
+++ b/charts/monitoring-config/templates/prometheus-rules.yaml
@@ -6,9 +6,10 @@ metadata:
   labels:
     app: monitoring-config
 spec:
+  groups:
 {{- range $path, $_ := .Files.Glob "rules/**.yaml" }}
 {{- if not (hasSuffix "_tests.yaml" $path) }}
   # {{ $path }}
-  {{- $.Files.Get $path | nindent 2 }}
+  {{- $.Files.Get $path | nindent 4 }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
This previous template imported each alerting yaml file each with the top level key groups. This meant only one file was used to represents the groups value.