### PR TITLE
Reduce the CPU load of content-store-proxy by only comparing a given percentage of requests

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -834,6 +834,8 @@ govukApplications:
           value: "http://draft-content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
+        - name: COMPARISON_SAMPLE_PCT
+          value: 50
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -770,6 +770,8 @@ govukApplications:
           value: "http://content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY
           value: '8'
+        - name: COMPARISON_SAMPLE_PCT
+          value: 10
 
   - name: draft-content-store-mongo-main
     repoName: content-store

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -760,6 +760,8 @@ govukApplications:
           value: "http://content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY
           value: '8'
+        - name: COMPARISON_SAMPLE_PCT
+          value: 10
 
   - name: draft-content-store-mongo-main
     repoName: content-store


### PR DESCRIPTION
After encountering further scale issues with a production rollout of the content-store-proxy earlier this week, an [investigation](https://trello.com/c/krmNL5Z9/855-benchmark-the-cpu-overhead-of-the-content-store-proxy) concluded that the additional CPU-bound overhead of comparing the Mongo & Postgres responses every time was unacceptable in the much busier environment of production.

Having amended the proxy code in [#43](https://github.com/alphagov/content-store-proxy/pull/43) and [#44](https://github.com/alphagov/content-store-proxy/pull/44),  this PR adds the environment variable which controls the percentage of  requests to be fully compared.

We've set the percentages to 50% in integration, and 10% in staging and production. We can adjust further if needed. 