### PR TITLE
set same limits on response comparison for draft & live content-store proxy apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -741,6 +741,8 @@ govukApplications:
           value: "http://content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: COMPARISON_SAMPLE_PCT
+          value: '50'
 
   - name: draft-content-store-mongo-main
     repoName: content-store
@@ -835,7 +837,7 @@ govukApplications:
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
-          value: 50
+          value: '50'
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -771,7 +771,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: 10
+          value: '10'
 
   - name: draft-content-store-mongo-main
     repoName: content-store
@@ -870,6 +870,8 @@ govukApplications:
           value: "http://draft-content-store-postgresql-branch/"
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: COMPARISON_SAMPLE_PCT
+          value: '10'
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -761,7 +761,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: 10
+          value: '10'
 
   - name: draft-content-store-mongo-main
     repoName: content-store
@@ -858,6 +858,8 @@ govukApplications:
           value: "http://draft-content-store-mongo-main/"
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
+        - name: COMPARISON_SAMPLE_PCT
+          value: '10'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
also quote all values - I suspect this might be the cause of an '[invalid patch](https://argo.eks.staging.govuk.digital/applications/content-store?orphaned=false&operation=false&resource=&conditions=true)' issue when deploying this app to staging & prod. Follows on from #1307 ([Trello card](https://trello.com/c/gF3XSEqC/864-reduce-the-cpu-load-imposed-by-content-store-proxy))