### PR TITLE
Increase min/max resource allocation for content-store(-proxy) in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -747,6 +747,13 @@ govukApplications:
   - name: content-store
     repoName: content-store-proxy
     helmValues:
+      appResources:
+        limits:
+          cpu: 6
+          memory: 2500Mi
+        requests:
+          cpu: 1
+          memory: 1Gi
       rails:
         enabled: false
       nginxClientMaxBodySize: 20M


### PR DESCRIPTION
On staging, content-store(-proxy) currently just has the default resources:
```
          resources:
            limits:
              cpu: '1'
              memory: 1Gi
            requests:
              cpu: 50m
              memory: 512Mi
```
(this snippet was pasted out of the[ Live Manifest on staging](https://argo.eks.staging.govuk.digital/applications/content-store?orphaned=false&resource=&node=apps%2FDeployment%2Fapps%2Fcontent-store)) 

Now that it's been in use for a while, we can [see](https://grafana.eks.staging.govuk.digital/d/a164a7f0339f99e89cea5cb47e9be617/kubernetes-compute-resources-workload?var-datasource=default&var-cluster=&var-namespace=apps&var-workload=content-store&var-type=deployment&orgId=1&refresh=10s) that it's actually using between 0.5-1.0 CPUs and ~900MB RAM per pod:

![image](https://github.com/alphagov/govuk-helm-charts/assets/134501/26ccb2fc-635f-4460-b1f7-4cb8886dbe7f)

We think the resulting CPU-throttling is responsible for some of the response comparisons (which are CPU-intensive) taking [over 10s on Kubernetes](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/goto/74ae49fe619d04f47358871c3b8f32aa?security_tenant=global), when they complete in around 1ms on developer laptops.  

So this PR increases the requested & max allocations. 

Caveat: I'm still not totally clear whether all of these requests/limits apply per deployment or per container - so when choosing the new values I was mostly guided by the "CPU/Memory Requests %" columns in the above graph. We can always tune further if needed
