### PR TITLE
Stop using transition-config-cron in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2816,8 +2816,10 @@ govukApplications:
           - name: transition.{{ .Values.k8sExternalDomainSuffix }}
       dbMigrationEnabled: true
       workerEnabled: true
-      transitionConfigEnabled: true
       cronTasks:
+        - name: import-all-organisations
+          task: "import:all:organisations"
+          schedule: "00 09-19 * * 1-5"
         - name: import-dns
           task: "import:dns_details"
           schedule: "3 07-19 * * 1-5"
@@ -2833,14 +2835,6 @@ govukApplications:
         - name: refresh-materialized-hits
           task: "import:hits:refresh_materialized"
           schedule: "38 0,12 * * *"
-      extraVolumes:
-        - name: transition-config-efs
-          nfs:
-            server: *assets-nfs
-            path: /transition
-      appExtraVolumeMounts:
-        - name: transition-config-efs
-          mountPath: /app/data
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
https://trello.com/c/8lQCsx3y/862-identify-all-things-related-to-transition-config-elsewhere-in-alphagov-and-update-or-remove-the-references

Stop using transition-config-cron in integration and instead, replace
it with a standard cron task for the Transition app.

If I've understood transition-config-cron correctly, it makes data from
the transition-config repository available to the Transition app and
then invokes one of the Transition app's Rake tasks.

The Rake task that it invokes:

1. already lives in the Transition app, and
2. no longer requires data from the transition-config repository (since
   https://github.com/alphagov/govuk-helm-charts/pull/1296)

I'm having trouble fully understanding the transition-config-cron file,
so I'm testing the waters first by limiting this change to integration.
If it works as expected, I'll then make this change for production and
staging and remove transition-config-cron altogether.