### PR TITLE
Fully-compare more content-store responses in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -768,7 +768,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: '10'
+          value: '50'
 
   - name: draft-content-store-mongo-main
     repoName: content-store
@@ -866,7 +866,7 @@ govukApplications:
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
-          value: '10'
+          value: '100'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
In #1307 we reduced the percentage of mongo/postgresql content-store responses that we fully compare, to reduce the CPU overhead introduced by the comparison.

Since then, we've found and fixed two major bottlenecks - one in the [proxy code that did the comparison](https://github.com/alphagov/content-store-proxy/pull/48), and one in the [postgres content-store itself](https://github.com/alphagov/content-store/pull/1163) - and have subsequently completed a load test in staging without any of the `HTTP 499` timeouts that marked previous tests, and [without even coming close to maxing out the recently-increased resource limits](https://grafana.eks.staging.govuk.digital/d/a164a7f0339f99e89cea5cb47e9be617/kubernetes-compute-resources-workload?var-datasource=default&var-cluster=&var-namespace=apps&var-workload=content-store&var-type=deployment&orgId=1&from=1697104180000&to=1697104320000)

So, we're ready to increase the percentage of responses we compare again. 
We're going for 50% on the live content-store, and 100% on the draft as that gets much less traffic. If it still performs well after this change, we can up it to 100% later