### PR TITLE
compare 100% of content-store responses in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -768,7 +768,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: '50'
+          value: '100'
 
   - name: draft-content-store-mongo-main
     repoName: content-store


### PR DESCRIPTION
We recently increased the percentage of content-store responses for which the full comparison is run, to 50% on staging, in PR #1312 . Since then, a full run of the govuk-mirror script has been triggered, which provided a really good stress test. 

The proxy & postgres content-store both held up fine under that load (note the comparison time at the bottom of < 1ms, even when the body size is 378k): 

![image](https://github.com/alphagov/govuk-helm-charts/assets/134501/3e7c128b-3115-4807-8cc9-02bfc1122f37)

So we're ready to go back to comparing all responses in staging. 