### PR TITLE
Add runbook to monitoring alert annotations

### DIFF
--- a/charts/monitoring-config/rules/signon.yaml
+++ b/charts/monitoring-config/rules/signon.yaml
@@ -12,3 +12,4 @@
         summary: Signon API User token is due to expire soon
         description: >-
           A token is about to expire within the next two weeks and needs rotating.
+        runbook_url: https://docs.publishing.service.gov.uk/manual/alerts/signon-api-user-token-expires-soon.html


### PR DESCRIPTION
Adds runbook annotation for signon tokens alert pointing to the relevant developer docs. Actually consumed by https://github.com/alphagov/govuk-infrastructure/pull/961