### PR TITLE
Increase max CPU limit for content-store-proxy to 6 in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -756,7 +756,7 @@ govukApplications:
       replicaCount: 6
       appResources:
         limits:
-          cpu: 4
+          cpu: 6
           memory: 2500Mi
         requests:
           cpu: 2


### PR DESCRIPTION
This is in preparation for another swap-in on production. Testing on staging after making two big performance improvements (in [content-store-proxy](https://github.com/alphagov/content-store-proxy/pull/48) and [content-store-postgresql-branch](https://github.com/alphagov/content-store/pull/1163)) has [shown](https://github.com/alphagov/govuk-helm-charts/pull/1313) this should be plenty, but production load is more sustained - so its better to over-allocate and then reduce if possible.