### PR TITLE
Swap-in live content-store-proxy in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -646,7 +646,8 @@ govukApplications:
               name: signon-token-content-publisher-whitehall
               key: bearer_token
 
-  - name: content-store
+  - name: content-store-mongo-main
+    repoName: content-store
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.
@@ -690,19 +691,6 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-mongo-main
-    repoName: content-store
-    helmValues:
-      <<: *content-store
-      rails:
-        createKeyBaseSecret: false
-        # use the same secret as the mongo content-store, it will make the
-        # eventual switchover easier and reduce toil
-        secretKeyBaseName: content-store-rails-secret-key-base
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: content-store-sentry
-
   - name: content-store-postgresql-branch
     repoName: content-store-postgresql-branch
     helmValues:
@@ -745,7 +733,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
-  - name: content-store-proxy
+  - name: content-store
     repoName: content-store-proxy
     helmValues:
       rails:


### PR DESCRIPTION
Third iteration of swapping-in the live content-store-proxy in production ( [Trello card](https://trello.com/c/D5eHDqCa/836-swap-in-the-content-store-proxy-in-production) ). 

Since [rolling back](https://github.com/alphagov/govuk-helm-charts/pull/1301) the last iteration (#1300), we've made two major performance improvements (in [content-store-proxy](https://github.com/alphagov/content-store-proxy/pull/48) and [content-store-postgresql-branch](https://github.com/alphagov/content-store/pull/1163)) and observed the staging setup handle a full govuk-mirror run without any of the `HTTP 499` timeouts seen on previous runs, and without ever coming close to maxing-out its CPU allocation. As a result, we were able to return to [fully-comparing 100% of responses on staging](https://github.com/alphagov/govuk-helm-charts/pull/1313).

For this production rollout, we'll stick with 10% initially and watch the response times, then increase the percentage once we're confident it's safe to do so. As before, we'll make sure to only merge this at a time when we're able to monitor it attentively and rollback promptly if there are any issues.