### PR TITLE
Remove explicit sentry DSN name for content-store-proxy in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -738,8 +738,6 @@ govukApplications:
     helmValues:
       rails:
         enabled: false
-      sentry:
-        dsnSecretName: content-store-proxy-sentry
       nginxClientMaxBodySize: 20M
       replicaCount: 6
       appResources:


### PR DESCRIPTION
We don't need to explicitly set this value, sentry DSNs are per-repo. We don't have this line in integration or staging, so let's remove it here too for consistency