### PR TITLE
Revert "Enable dbMigration for content-store-postgresql-branch in all envs"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -692,7 +692,6 @@ govukApplications:
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
-      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo content-store, it will make the
@@ -783,7 +782,6 @@ govukApplications:
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
-      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo draft-content-store, it will make the

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -695,7 +695,6 @@ govukApplications:
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
-      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo content-store, it will make the
@@ -800,7 +799,6 @@ govukApplications:
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
-      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo draft-content-store, it will make the

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -706,7 +706,6 @@ govukApplications:
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
-      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo content-store, it will make the
@@ -811,7 +810,6 @@ govukApplications:
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
-      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo draft-content-store, it will make the


### PR DESCRIPTION
We encountered a strange issue where all runs of `db:migrate` failed with a `read-only filesystem` error, which prevents the application code from being deployed when this setting is true (e.g. [this job](https://argo.eks.integration.govuk.digital/applications/draft-content-store-postgresql-branch?orphaned=false&conditions=false&resource=&node=%2FPod%2Fapps%2Fdraft-content-store-postgresql-branch-dbmigrate-2nxcg&tab=logs))

Reverting it for now so that we can at least deploy code updates and run migrations manually (ignoring the error, and/or using it as a tool to figure out what the problem might be)

Reverts alphagov/govuk-helm-charts#1321