### PR TITLE
Increase the memory and cpu limits of govuk-mirror

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -45,11 +45,11 @@ spec:
               workingDir: /data
               resources:
                 limits:
-                  cpu: 2
-                  memory: 8000Mi
+                  cpu: 4
+                  memory: 10000Mi
                 requests:
-                  cpu: 1
-                  memory: 2000Mi
+                  cpu: 2
+                  memory: 5000Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -84,7 +84,7 @@ spec:
                   memory: 8000Mi
                 requests:
                   cpu: 1
-                  memory: 2000Mi
+                  memory: 5000Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
This is to prevent the scraping container from being OOMKilled and throttled.