### PR TITLE
Add `search-api-v2` external secret for Google keys

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2274,6 +2274,16 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-rabbitmq
               key: RABBITMQ_URL
+        - name: GOOGLE_KEY_READ
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-key-read
+              key: GOOGLE_KEY_READ
+        - name: GOOGLE_KEY_WRITE
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-key-write
+              key: GOOGLE_KEY_WRITE
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/external-secrets/templates/search-api-v2/google-key-read.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-key-read.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: search-api-v2-google-key-read
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials used by search-api-v2 to access Google Cloud Discovery Engine (read-only)
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-api-v2-google-key-read
+  dataFrom:
+    - extract:
+        key: govuk/search-api-v2/google-key-read

--- a/charts/external-secrets/templates/search-api-v2/google-key-write.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-key-write.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: search-api-v2-google-key-write
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials used by search-api-v2 to access Google Cloud Discovery Engine (write-only)
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-api-v2-google-key-write
+  dataFrom:
+    - extract:
+        key: govuk/search-api-v2/google-key-write


### PR DESCRIPTION
- Add external secrets for read-only and write-only keys for Google Discovery Engine ("Vertex AI")
- Bind secrets into to `search-api-v2` app/worker in integration through `extraEnv`