### PR TITLE
Mount Google credentials into directory

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2262,9 +2262,9 @@ govukApplications:
             secretName: search-api-v2-google-key-write
       appExtraVolumeMounts:
         - name: search-api-v2-google-key-read
-          mountPath: /etc/keys/google-key-read.json
+          mountPath: /etc/keys/google-key-read
         - name: search-api-v2-google-key-write
-          mountPath: /etc/keys/google-key-write.json
+          mountPath: /etc/keys/google-key-write
       extraEnv:
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents


### PR DESCRIPTION
We've changed the secret to contain a single key (`credentials.json`)
that should be created as a file in the appropriate directory.