### PR TITLE
Avoid creating broken cronjobs in govuk-jobs chart.

### DIFF
--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -94,7 +94,7 @@ metadata:
     app: "content-store-mongo-to-postgres-cron"
     app.kubernetes.io/component: "content-store-mongo-to-postgres-cron"
 spec:
-  schedule: "{{ .Values.draftContentStoreMongoPostgresCron.schedule }}"  
+  schedule: "{{ .Values.contentStoreMongoPostgresCron.schedule }}"  
   jobTemplate:
     metadata:
       name: "content-store-mongo-to-postgres-cron"

--- a/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
+++ b/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.draftContentStoreMongoPostgresCron.schedule }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -83,7 +83,8 @@ spec:
                   mountPath: /mongo-export
                 - name: app-tmp
                   mountPath: /tmp
-
+{{- end }}
+{{- if .Values.contentStoreMongoPostgresCron.schedule }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -172,3 +173,4 @@ spec:
                   mountPath: /tmp
                 - name: pg-dump
                   mountPath: /pg-dump
+{{- end }}


### PR DESCRIPTION
Don't create the (draft)contentStoreMongoPostgresCron cronjobs unless they have a schedule configured. Fixes a minor bug introduced in #1268.

Also an inconsequential fix for the schedule on contentStoreMongoPostgresCron (it was using the schedule for the draft one, but they're set the same anyway at the moment).

https://trello.com/c/JjTHY62V