### PR TITLE
Fix upload to S3 command in govuk-mirror-sync

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -105,5 +105,5 @@ spec:
                 - /bin/sh
                 - -c
                 - >-
-                  /s5cmd sync --size-only "/data/${WWW_DOMAIN}" "s3://${BUCKET_NAME}/" && \
+                  /s5cmd sync --size-only "/data/${WWW_DOMAIN}" "s3://${BUCKET_NAME}/" && 
                   /s5cmd sync --size-only "/data/${ASSETS_DOMAIN}" "s3://${BUCKET_NAME}/"


### PR DESCRIPTION
The new line gets stripped causing the \ to escape the " " (space), which is then intepreted as part of the command string.