### PR TITLE
Ensure `search-api-v2` Google secrets get decoded

### DIFF
--- a/charts/external-secrets/templates/search-api-v2/google-key-read.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-key-read.yaml
@@ -18,3 +18,4 @@ spec:
   dataFrom:
     - extract:
         key: govuk/search-api-v2/google-key-read
+        decodingStrategy: Base64

--- a/charts/external-secrets/templates/search-api-v2/google-key-write.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-key-write.yaml
@@ -18,3 +18,4 @@ spec:
   dataFrom:
     - extract:
         key: govuk/search-api-v2/google-key-write
+        decodingStrategy: Base64


### PR DESCRIPTION
These are base64 encoded at the source, and need to be decoded through the operator.