### PR TITLE
Use `WITH (FORCE)` on full restores of Postgres databases.

### DIFF
--- a/charts/db-backup/backup-postgres.sh
+++ b/charts/db-backup/backup-postgres.sh
@@ -42,8 +42,8 @@ restore () {
   fi
   local s3_url="$BUCKET/$PGHOST/$FILENAME"
   s3_url="$s3_url" dump_is_readable
-  aws s3 cp "$s3_url" - | progress \
-    | pg_restore -Ccd postgres --if-exists --no-comments
+  dropdb -ef --if-exists "$PGDATABASE"
+  aws s3 cp "$s3_url" - | progress | pg_restore -Cd postgres --no-comments
 }
 
 subcommand=${1:-}


### PR DESCRIPTION
This is the least brittle/evil way to avoid problems with locking (e.g. `database ... is being accessed by other users` doing a full restore.

The old govuk_env_sync jobs used to kick out existing clients and set the connection limit to zero (which of course could end up being left that way if the job were to fail).

Tested: ran a restore in staging using this.