### PR TITLE
Increase concurrency rate for govuk-mirror

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -65,7 +65,7 @@ spec:
                 - name: DISALLOWED_URL_RULES
                   value: '/apply-for-a-licence(/|$),/business-finance-support(/|$),/drug-device-alerts\.atom,/drug-safety-update\.atom,/foreign-travel-advice\.atom,/government/announcements\.atom,/government/publications\.atom,/government/statistics\.atom,/licence-finder/,/search(/|$)'
                 - name: CONCURRENCY
-                  value: "10"
+                  value: "30"
                 - name: RATE_LIMIT_TOKEN
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
To increase the request rate slightly, still much lower than 100 (what it was before).