### PR TITLE
Ignore CSV preview pages

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -63,7 +63,7 @@ spec:
                 - name: ALLOWED_DOMAINS
                   value: www.{{ .Values.externalDomainSuffix }},{{ .Values.assetsDomain }}
                 - name: DISALLOWED_URL_RULES
-                  value: '/apply-for-a-licence(/|$),/business-finance-support(/|$),/drug-device-alerts\.atom,/drug-safety-update\.atom,/foreign-travel-advice\.atom,/government/announcements\.atom,/government/publications\.atom,/government/statistics\.atom,/licence-finder/,/search(/|$)'
+                  value: '/apply-for-a-licence(/|$),/business-finance-support(/|$),/drug-device-alerts\.atom,/drug-safety-update\.atom,/foreign-travel-advice\.atom,/government/announcements\.atom,/government/publications\.atom,/government/statistics\.atom,/licence-finder/,/search(/|$),\.csv/preview$'
                 - name: CONCURRENCY
                   value: "30"
                 - name: RATE_LIMIT_TOKEN


### PR DESCRIPTION
There's a conflict between the URL structure of our CSV preview pages and the corresponding CSV files. Specifically, the crawler generates a directory for preview pages using the same name as the CSV file (e.g. "example.com/media/foo.csv" to store "example.com/media/foo.csv/preview.html"). If the directory is created before the file, the latter can't be saved because a directory with an identical name already exists, and vice versa. This issue was also present in our previous mirroring script.

To ensure that we successfully mirror all CSV files, we've decided to skip mirroring the preview pages for now.