### PR TITLE
Fully-compare 25% of live & 50% of draft content-store-proxy responses in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -757,7 +757,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: '10'
+          value: '25'
 
   - name: db-backup
     chartPath: charts/db-backup
@@ -866,7 +866,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
         - name: COMPARISON_SAMPLE_PCT
-          value: '10'
+          value: '50'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
Since swapping in the production live content-store-proxy in #1317 with very cautious comparison percentages, we've been monitoring the CPU overhead and it looks to be well within its limits:

live: 
![image](https://github.com/alphagov/govuk-helm-charts/assets/134501/5ca29614-93ec-4774-8fbc-c2522b0591fe)

draft:
![Screenshot from 2023-10-19 14-42-37](https://github.com/alphagov/govuk-helm-charts/assets/134501/970b9c96-daf9-4bd3-865d-a1dec67f4d98)

So this PR increases the percentage of requests that will be fully-compared, to 25% of live c/s requests and 50% of draft c/s requests. 

We expect the peak _total_ CPU requirement of the proxy to increase to no more than around 3 CPUs, again well within its limit of 6 CPUs. We'll monitor it, and potentially increase it again later if everything is still OK.