### PR TITLE
Fully-compare all integration content-store-proxy responses

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -742,7 +742,7 @@ govukApplications:
         - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
-          value: '50'
+          value: '100'
 
   - name: db-backup
     chartPath: charts/db-backup
@@ -846,7 +846,7 @@ govukApplications:
         - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
-          value: '50'
+          value: '100'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
Overall CPU workload for the content-store proxy in integration is well within its limits - 
![image](https://github.com/alphagov/govuk-helm-charts/assets/134501/5eb0e261-dad0-42e7-9eb6-57c478f03e4e)

- we can compare 100% of content-store responses, as we have done in staging