### PR TITLE
Fully-compare 100% of draft- and 50% of live- content-store responses in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -757,7 +757,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: '25'
+          value: '50'
         - name: SECONDARY_TIMEOUT_SECONDS
           value: '2'
 
@@ -868,7 +868,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
         - name: COMPARISON_SAMPLE_PCT
-          value: '50'
+          value: '100'
         - name: SECONDARY_TIMEOUT_SECONDS
           value: '2'
 


### PR DESCRIPTION
5 days ago, we increased the percentage of content-store responses to be fully-compared, to 25% live and 50% draft in production. This has resulted in only a small increase in peak CPU load, and an even smaller increase in average CPU load -

![Screenshot from 2023-10-24 12-05-16](https://github.com/alphagov/govuk-helm-charts/assets/134501/53525599-02fe-41fa-b12d-0f398acb7977)

- so we should be safe to increase these percentages to 50% live and 100% draft.