### PR TITLE
Upload error template and last updated file to mirrors

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -106,6 +106,13 @@ spec:
                 - -c
                 - |-
                   set -eu
+                  # Retrieve error template
                   mkdir -p /data/error && wget -q -O /data/error/503.html https://${ASSETS_DOMAIN}/templates/503.html.erb
+
+                  # Sync mirrors
                   /s5cmd sync --size-only "/data/${WWW_DOMAIN}" "s3://${BUCKET_NAME}/"
                   /s5cmd sync --size-only "/data/${ASSETS_DOMAIN}" "s3://${BUCKET_NAME}/"
+
+                  # Upload file for checking mirror freshness
+                  touch "/data/${WWW_DOMAIN}/last-updated.txt"
+                  /s5cmd cp "/data/${WWW_DOMAIN}/last-updated.txt" "s3://${BUCKET_NAME}/${WWW_DOMAIN}/last-updated.txt"

--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -104,6 +104,8 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - >-
-                  /s5cmd sync --size-only "/data/${WWW_DOMAIN}" "s3://${BUCKET_NAME}/" && 
+                - |-
+                  set -eu
+                  mkdir -p /data/error && wget -q -O /data/error/503.html https://${ASSETS_DOMAIN}/templates/503.html.erb
+                  /s5cmd sync --size-only "/data/${WWW_DOMAIN}" "s3://${BUCKET_NAME}/"
                   /s5cmd sync --size-only "/data/${ASSETS_DOMAIN}" "s3://${BUCKET_NAME}/"


### PR DESCRIPTION
This modified the mirror sync cronjob to upload the 503 error template and a last updated file which can be used to monitor the freshness of the mirrors.

