### PR TITLE
Add SECONDARY_TIMEOUT_SECONDS values for content-store-proxy in all envs

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -743,6 +743,8 @@ govukApplications:
           value: "http://content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
+        - name: SECONDARY_TIMEOUT_SECONDS
+          value: '2'
 
   - name: db-backup
     chartPath: charts/db-backup
@@ -847,6 +849,8 @@ govukApplications:
           value: "http://draft-content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
+        - name: SECONDARY_TIMEOUT_SECONDS
+          value: '2'
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -758,6 +758,8 @@ govukApplications:
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
           value: '25'
+        - name: SECONDARY_TIMEOUT_SECONDS
+          value: '2'
 
   - name: db-backup
     chartPath: charts/db-backup
@@ -867,6 +869,8 @@ govukApplications:
           value: '4'
         - name: COMPARISON_SAMPLE_PCT
           value: '50'
+        - name: SECONDARY_TIMEOUT_SECONDS
+          value: '2'
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -769,6 +769,8 @@ govukApplications:
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
+        - name: SECONDARY_TIMEOUT_SECONDS
+          value: '2'
 
   - name: db-backup
     chartPath: charts/db-backup
@@ -876,6 +878,8 @@ govukApplications:
           value: "http://draft-content-store-postgresql-branch/"
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
+        - name: SECONDARY_TIMEOUT_SECONDS
+          value: '2'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
This will supply the value after which [the proxy will stop waiting for the secondary response](https://github.com/alphagov/content-store-proxy/pull/51), and therefore hopefully stop the 2 minutes of Sentry alerts every morning when the Mongo-to-Postgres cron job completes.

Full details in [this Trello card](https://trello.com/c/xse8nT4S/913-add-a-timeout-to-the-secondary-response-in-content-store-proxy) - 2 seconds has been chosen because the frontend apps timeout their requests at 4 seconds, and Kibana logs show that in the last 7 days, only 3 requests have taken longer than that:
![image](https://github.com/alphagov/govuk-helm-charts/assets/134501/f82c03f6-b44e-434e-a52a-a7fb65274c53)
