### PR TITLE
Add backup operation for integration content-stores

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -53,6 +53,7 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
+        - op: backup
     # TODO: stop copying draft content into integration once the design quirks
     # of publishing-api that require it are rectified.
     draft-content-store-postgres:
@@ -61,7 +62,7 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
-
+        - op: backup
 extraEnv:
   - name: VERBOSE
     value: "1"


### PR DESCRIPTION
...so that Data Services can start pulling these nightly and migrate away from their current dependency on nightly MongoDB backups.