### PR TITLE
Fully-compare all content-store responses in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -757,7 +757,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
-          value: '50'
+          value: '100'
         - name: SECONDARY_TIMEOUT_SECONDS
           value: '2'
 


### PR DESCRIPTION
In #1340 we increased the percentage of production live content-store responses to be fully-compared, from 25% to 50%. This was deployed around 3:20pm on Oct 24th, and since then the CPU workload has hardly changed, staying well within its limits of 6 CPUs:

![Screenshot from 2023-10-26 14-34-55](https://github.com/alphagov/govuk-helm-charts/assets/134501/edc0b5b6-cf25-435a-b406-ec3faec1505c)

We think we should therefore be fine to increase the percentage to 100%, so we're fully-comparing all responses for differences.