### PR TITLE
Turn off yamllint's comments-indentation rule.

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -4,6 +4,7 @@ ignore: |
   charts/*/templates/
 
 rules:
+  comments-indentation: disable
   document-start: disable
   # TODO: set `forbid-duplicated-merge-keys` once
   # https://www.github.com/adrienverge/yamllint/issues/561 lands.


### PR DESCRIPTION
It has some buggy edge cases and it doesn't provide much (if any) value. People generally indent comments sensibly anyway, plus none of the YAML auto-formatters have this weird rule so it just causes hassle for slightly worse results.