### PR TITLE
Update Google Cloud configuration for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2263,17 +2263,12 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       extraVolumes:
-        - name: search-api-v2-google-key-read
+        - name: search-api-v2-google-cloud-credentials
           secret:
-            secretName: search-api-v2-google-key-read
-        - name: search-api-v2-google-key-write
-          secret:
-            secretName: search-api-v2-google-key-write
+            secretName: search-api-v2-google-cloud-credentials
       appExtraVolumeMounts:
-        - name: search-api-v2-google-key-read
-          mountPath: /etc/keys/google-key-read
-        - name: search-api-v2-google-key-write
-          mountPath: /etc/keys/google-key-write
+        - name: search-api-v2-google-cloud-credentials
+          mountPath: /etc/credentials/google-cloud
       extraEnv:
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
@@ -2282,10 +2277,18 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-rabbitmq
               key: RABBITMQ_URL
-        - name: GOOGLE_KEYFILE_READ
-          value: /etc/keys/google-key-read.json
-        - name: GOOGLE_KEYFILE_WRITE
-          value: /etc/keys/google-key-write.json
+        - name: GOOGLE_CLOUD_CREDENTIALS
+          value: /etc/credentials/google-cloud/credentials.json
+        - name: DISCOVERY_ENGINE_DATASTORE
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_DATASTORE
+        - name: DISCOVERY_ENGINE_ENGINE
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_ENGINE
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/external-secrets/templates/search-api-v2/google-cloud-credentials.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-cloud-credentials.yaml
@@ -1,12 +1,12 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: search-api-v2-google-key-read
+  name: search-api-v2-google-cloud-credentials
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      Credentials used by search-api-v2 to access Google Cloud Discovery Engine (read-only)
+      Credentials used by search-api-v2 to access Google Cloud Discovery Engine
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: search-api-v2-google-key-read
+    name: search-api-v2-google-cloud-credentials
   dataFrom:
     - extract:
-        key: govuk/search-api-v2/google-key-read
+        key: govuk/search-api-v2/google-cloud-credentials

--- a/charts/external-secrets/templates/search-api-v2/google-cloud-discovery-engine-configuration.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-cloud-discovery-engine-configuration.yaml
@@ -1,12 +1,13 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: search-api-v2-google-key-write
+  name: search-api-v2-google-cloud-discovery-engine-configuration
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      Credentials used by search-api-v2 to access Google Cloud Discovery Engine (write-only)
+      Configuration for Google Cloud Discovery Engine for search-api-v2 (DISCOVERY_ENGINE_DATASTORE
+      and DISCOVERY_ENGINE_ENGINE)
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
@@ -14,7 +15,7 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: search-api-v2-google-key-write
+    name: search-api-v2-google-cloud-discovery-engine-configuration
   dataFrom:
     - extract:
-        key: govuk/search-api-v2/google-key-write
+        key: govuk/search-api-v2/google-cloud-discovery-engine-configuration


### PR DESCRIPTION
- Remove read/write credentials separation (`search-api-v2` will stay a monolithic app for the time being)
- Add new ExternalSecret for Discovery Engine configuration (`DISCOVERY_ENGINE_DATASTORE` and `DISCOVERY_ENGINE_ENGINE`)
- Add new credentials and configuration to integration app environment