### PR TITLE
Add govuk-exporter chart

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1287,6 +1287,11 @@ govukApplications:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
+  - name: govuk-exporter
+    chartPath: charts/govuk-exporter
+    helmValues:
+      replicaCount: 1
+
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1332,6 +1332,11 @@ govukApplications:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
+  - name: govuk-exporter
+    chartPath: charts/govuk-exporter
+    helmValues:
+      replicaCount: 1
+
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1304,6 +1304,11 @@ govukApplications:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
+  - name: govuk-exporter
+    chartPath: charts/govuk-exporter
+    helmValues:
+      replicaCount: 1
+
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"

--- a/charts/govuk-exporter/.helmignore
+++ b/charts/govuk-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/govuk-exporter/Chart.yaml
+++ b/charts/govuk-exporter/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: govuk-exporter
+description: A Prometheus exporter for GOV.UK
+type: application
+version: 0.1.0

--- a/charts/govuk-exporter/templates/deployment.yaml
+++ b/charts/govuk-exporter/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+        app.kubernetes.io/name: {{ .Values.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      containers:
+        - name: app
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-exporter:latest 
+          imagePullPolicy: "Always"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          ports:
+            - name: metrics
+              containerPort: 8000
+          livenessProbe: &probe
+            httpGet:
+              path: /metrics
+              port: http
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            <<: *probe
+            failureThreshold: 2
+          startupProbe:
+            <<: *probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/govuk-exporter/templates/service.yaml
+++ b/charts/govuk-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Values.name }} 

--- a/charts/govuk-exporter/values.yaml
+++ b/charts/govuk-exporter/values.yaml
@@ -1,0 +1,25 @@
+# Default values for govuk-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: govuk-exporter
+
+replicaCount: 1
+
+securityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+service:
+  type: ClusterIP
+  port: 8000
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
This adds the helm chart used to deploy govuk-exporter (a Prometheus exporter).

https://github.com/alphagov/govuk-exporter