### PR TITLE
Fix port reference for healthchecks

### DIFF
--- a/charts/govuk-exporter/templates/deployment.yaml
+++ b/charts/govuk-exporter/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           livenessProbe: &probe
             httpGet:
               path: /metrics
-              port: http
+              port: metrics
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30

--- a/charts/govuk-exporter/templates/service.yaml
+++ b/charts/govuk-exporter/templates/service.yaml
@@ -8,8 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: metrics
       protocol: TCP
-      name: http
   selector:
     app: {{ .Values.name }} 


### PR DESCRIPTION
Incorrectly was referencing the `http` port, when it doesn't exist.