### PR TITLE
Fix govuk-exporter config

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1287,16 +1287,6 @@ govukApplications:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
 
-  - name: govuk-exporter
-    chartPath: charts/govuk-exporter
-    helmValues:
-      replicaCount: 1
-      extraEnv:
-        - name: MIRROR_FRESHNESS_URL
-          value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
-        - name: BACKENDS
-          value: "mirrorS3,mirrorS3Replica,mirrorGCS"
-
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1291,6 +1291,11 @@ govukApplications:
     chartPath: charts/govuk-exporter
     helmValues:
       replicaCount: 1
+      extraEnv:
+        - name: MIRROR_FRESHNESS_URL
+          value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
+        - name: BACKENDS
+          value: "mirrorS3,mirrorS3Replica,mirrorGCS"
 
   - name: govuk-jobs
     chartPath: charts/govuk-jobs

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1336,6 +1336,11 @@ govukApplications:
     chartPath: charts/govuk-exporter
     helmValues:
       replicaCount: 1
+      extraEnv:
+        - name: MIRROR_FRESHNESS_URL
+          value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
+        - name: BACKENDS
+          value: "mirrorS3,mirrorS3Replica,mirrorGCS"
 
   - name: govuk-jobs
     chartPath: charts/govuk-jobs

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1308,6 +1308,11 @@ govukApplications:
     chartPath: charts/govuk-exporter
     helmValues:
       replicaCount: 1
+      extraEnv:
+        - name: MIRROR_FRESHNESS_URL
+          value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
+        - name: BACKENDS
+          value: "mirrorS3,mirrorGCS"
 
   - name: govuk-jobs
     chartPath: charts/govuk-jobs

--- a/charts/govuk-exporter/templates/deployment.yaml
+++ b/charts/govuk-exporter/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           ports:
             - name: metrics
               containerPort: 8000
+          env:
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
           livenessProbe: &probe
             httpGet:
               path: /metrics

--- a/charts/govuk-exporter/values.yaml
+++ b/charts/govuk-exporter/values.yaml
@@ -23,3 +23,11 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
+extraEnv:
+  - name: MIRROR_FRESHNESS_URL
+    value: ""
+  - name: BACKENDS
+    value: ""
+  - name: REFRESH_INTERVAL
+    value: 4h


### PR DESCRIPTION
This removes govuk-exporter from integration as we don't run mirrors in that environment, so no metrics to collect.

This also adds the essential configuration environment variables for staging and production.