### PR TITLE
Don't restore integration account-api nightly.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -403,9 +403,9 @@ cronjobs:
     account-api-postgres:
       schedule: "37 3 * * *"
       db: account-api_production
+      # We don't copy account-api data between environments at present.
       operations:
-        - op: restore
-          bucket: s3://govuk-staging-database-backups
+        - op: backup
 
     authenticating-proxy-postgres:
       schedule: "23 3 * * *"


### PR DESCRIPTION
In the previous (Puppet) config there was only a nightly dump of integration, not a restore. We don't currently do any syncing of data between environments for account-api.