### PR TITLE
Add service monitor to govuk-exporter 

### DIFF
--- a/charts/govuk-exporter/templates/deployment.yaml
+++ b/charts/govuk-exporter/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             readOnlyRootFilesystem: true
           ports:
             - name: metrics
-              containerPort: 8000
+              containerPort: 9090
           env:
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}

--- a/charts/govuk-exporter/templates/servicemonitor.yaml
+++ b/charts/govuk-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    app.kubernetes.io/name: {{ .Values.name }}
+spec:
+  jobLabel: {{ .Values.name }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  namespaceSelector:
+    matchNames:
+    - apps
+  endpoints:
+  - port: metrics
+    interval: 10m

--- a/charts/govuk-exporter/values.yaml
+++ b/charts/govuk-exporter/values.yaml
@@ -14,7 +14,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 8000
+  port: 9090
 
 resources:
   limits:


### PR DESCRIPTION
This adds the service monitor and changes the metrics port to the standard port number.