### PR TITLE
Add prometheus alerts for mirror freshness

### DIFF
--- a/charts/monitoring-config/rules/mirrors.yaml
+++ b/charts/monitoring-config/rules/mirrors.yaml
@@ -1,0 +1,13 @@
+- name: MirrorAlerts
+  rules:
+    - record: global:govuk_mirror_freshness_seconds
+      expr: |
+        time() - min(govuk_mirror_last_updated_time) by (backend)
+
+    - alert: MirrorFreshnessAlert
+      expr: |
+        govuk_mirror_freshness_seconds < 172800
+      annotations:
+        summary: Mirror freshness has exceeded two days
+        description: >-
+          The mirror hasn't been updated in more than two days

--- a/charts/monitoring-config/rules/mirrors_tests.yaml
+++ b/charts/monitoring-config/rules/mirrors_tests.yaml
@@ -1,0 +1,32 @@
+rule_files:
+  - mirrors.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'govuk_mirror_last_updated_time{backend="backend1"}'
+        values: '1622478600'
+
+    promql_expr_test:
+      - expr: |
+          time() - min(govuk_mirror_last_updated_time) by (backend)
+        eval_time: 1622500200
+        exp_samples:
+          - labels: 'global:govuk_mirror_freshness_seconds{backend="backend1"}'
+            value: 21600
+
+  - interval: 1m
+    input_series:
+      - series: 'govuk_mirror_last_updated_time{backend="backend1"}'
+        values: '1622478600'
+
+    alert_rule_test:
+      - eval_time: 1622694600  # 48 hours and 30 minutes later
+        alertname: MirrorFreshnessAlert
+        exp_labels:
+          backend: backend1
+        exp_annotations:
+          summary: Mirror freshness has exceeded two days
+          description: The mirror hasn't been updated in more than two days


### PR DESCRIPTION
This alerts fires when the mirrors have exceed two days since they've been updated.