### PR TITLE
Install Reloader in integration and add annotation to any app using generic-govuk-app chart

### DIFF
--- a/charts/app-config/templates/reloader.yaml
+++ b/charts/app-config/templates/reloader.yaml
@@ -1,0 +1,21 @@
+{{ if eq .Values.govukEnvironment "integration" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+spec:
+  project: reloader
+  source:
+    repoURL: https://stakater.github.io/stakater-charts
+    path: reloader
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.argoNamespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+{{ end }}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app: {{ $fullName }}
     app.kubernetes.io/name: {{ $fullName }}
     app.kubernetes.io/component: app
+  {{- if eq .Values.govukEnvironment "integration" }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 2


### PR DESCRIPTION
https://trello.com/c/52c99wvl/1235-solve-the-problem-of-configmap-secrets-changes-requiring-user-initiated-rollouts-which-are-inevitably-forgotten-some-of-the-time