### PR TITLE
Record 100% trace data for Whitehall integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3069,6 +3069,10 @@ govukApplications:
             secretKeyRef:
               name: whitehall-admin-mysql
               key: DATABASE_URL
+        - name: OTEL_TRACES_SAMPLER
+          value: traceidratio
+        - name: OTEL_TRACES_SAMPLER_ARG
+          value: "1"
       extraVolumes:
         - name: asset-uploads-efs
           nfs:


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

This overrides[^1] the sample rate that's set for all apps in `charts/app-config/templates/env-configmap.yaml`. It controls how much data OpenTelemetry sends to Grafana Tempo.

We're building a Service Level Indicator for publishing (Whitehall->Content Store) and experimenting with traces in Tempo to figure out whether that's the right tool for the job. Since our OpenTelemetry sample rate is currently set to 0.1%, there isn't actually much data in Tempo to experiment with.

[^1]: Does it? I haven't got to the bottom of the `env`/`envFrom` precedence or spotted any existing examples, but surely these variables override the configmap's?