### PR TITLE
Update `search-api-v2` AWS SM environment variable

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2284,11 +2284,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_ENGINE
+              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2385,11 +2385,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_ENGINE
+              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2337,11 +2337,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_ENGINE
+              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/external-secrets/templates/search-api-v2/google-cloud-discovery-engine-configuration.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-cloud-discovery-engine-configuration.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     kubernetes.io/description: >
       Configuration for Google Cloud Discovery Engine for search-api-v2 (DISCOVERY_ENGINE_DATASTORE
-      and DISCOVERY_ENGINE_ENGINE)
+      and DISCOVERY_ENGINE_SERVING_CONFIG)
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:


### PR DESCRIPTION
The AWS Secrets Manager secret for Discovery Engine configuration for `search-api-v2` now contains a `DISCOVERY_ENGINE_SERVING_CONFIG` env variable instead of a `DISCOVERY_ENGINE_ENGINE` one.

see https://github.com/alphagov/search-v2-infrastructure/pull/87