### PR TITLE
Fix chart testing (temporarily) and set reloader reloadStrategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,13 @@ jobs:
         with:
           python-version: 3.x
 
+      # TODO: Go back to v2 version once they release a fix
+      # for the cosign issue
+      # https://github.com/helm/chart-testing-action/issues/132
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@cb49023b9227b1097e5eddd8824f48bdea11b1aa
+        with:
+          version: v3.8.0
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yml

--- a/charts/app-config/templates/reloader.yaml
+++ b/charts/app-config/templates/reloader.yaml
@@ -10,6 +10,10 @@ spec:
     repoURL: https://stakater.github.io/stakater-charts
     chart: reloader
     targetRevision: "1.0.46"
+    helm:
+      values:
+        reloader:
+          reloadStrategy: annotations
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Values.argoNamespace }}


### PR DESCRIPTION
https://trello.com/c/52c99wvl/1235-solve-the-problem-of-configmap-secrets-changes-requiring-user-initiated-rollouts-which-are-inevitably-forgotten-some-of-the-time