### PR TITLE
Dump support_contacts DB nightly in integration.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -563,6 +563,7 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
+        - op: backup
 
     transition-postgresql-primary:
       schedule: "24 3 * * *"


### PR DESCRIPTION
Data analysis folks use these dumps.

Later we can maybe save some compute by just replicating them from staging or something, but for now let's just get them up and running again.