### PR TITLE
content-data-api non-prod data sync daily->weekly.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -247,7 +247,7 @@ cronjobs:
         - op: backup
 
     content-data-api-postgresql-primary:
-      schedule: "35 1 * * *"
+      schedule: "35 1 * * 6"
       db: content_performance_manager_production
       dbms: postgres
       operations:
@@ -444,7 +444,7 @@ cronjobs:
           bucket: s3://govuk-staging-database-backups
 
     content-data-api-postgresql-primary:
-      schedule: "35 3 * * *"
+      schedule: "35 6 * * 6"
       db: content_performance_manager_production
       dbms: postgres
       operations:


### PR DESCRIPTION
The content data warehouse doesn't need to be copied from production to staging/integration daily, and long-running restore jobs were interfering with post-deployment checks and causing hassle for developers.

Also saves significant resources.