### PR TITLE
Revert version of chart-testing-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,8 @@ jobs:
         with:
           python-version: 3.x
 
-      # TODO: Go back to v2 version once they release a fix
-      # for the cosign issue
-      # https://github.com/helm/chart-testing-action/issues/132
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@cb49023b9227b1097e5eddd8824f48bdea11b1aa
+        uses: helm/chart-testing-action@v2
         with:
           version: v3.8.0
 


### PR DESCRIPTION
A new version of the action has been released which fixes the cosign issue