### PR TITLE
Add pagerduty drill alert - Wednesdays at 10am-ish

### DIFF
--- a/charts/monitoring-config/rules/pagerduty_drill.yaml
+++ b/charts/monitoring-config/rules/pagerduty_drill.yaml
@@ -1,0 +1,31 @@
+- name: PagerDutyDrillAlerts
+  rules:
+    - record: global:time:is_daylight_saving_time
+      expr: |
+        (vector(1) and (month() > 3 and month() < 10))
+        or
+        (vector(1) and (month() == 3 and (day_of_month() - day_of_week()) >= 25) and
+        absent((day_of_month() >= 25) and (day_of_week() == 0)))
+        or
+        (vector(1) and (month() == 10 and (day_of_month() - day_of_week()) < 25) and
+        absent((day_of_month() >= 25) and (day_of_week() == 0)))
+        or
+        (vector(1) and ((month() == 10 and hour() < 1) or (month() == 3 and hour() > 0))
+        and ((day_of_month() >= 25) and (day_of_week() == 0)))
+        or
+        vector(0)
+
+    - record: global:time:london_hour
+      expr: |
+        hour() + 1 * global:time:is_daylight_saving_time
+
+    - alert: PagerDutyDrillAlert
+      expr: |
+        global:time:london_hour == 10 and day_of_week(vector(time())) == 3 and
+        minute(vector(time())) < 3
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        description: >-
+          Pagerduty drill fires at 10am on Wednesdays

--- a/charts/monitoring-config/rules/pagerduty_drill_tests.yaml
+++ b/charts/monitoring-config/rules/pagerduty_drill_tests.yaml
@@ -1,0 +1,54 @@
+rule_files:
+  - pagerduty_drill.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    promql_expr_test:
+      - expr: 'day_of_week(vector(time()))'
+        eval_time: 9241m
+        exp_samples:
+          - value: 3
+
+      - expr: 'hour(vector(time()))'
+        eval_time: 9241m
+        exp_samples:
+          - value: 10
+
+      - expr: 'minute(vector(time()))'
+        eval_time: 9241m
+        exp_samples:
+          - value: 1
+
+  # eval_time starts at epoch unix time 1/1/1970 00:00
+  # alert expected on 3rd day (Wednesday) at 10am
+    alert_rule_test:
+      - eval_time: 9241m
+        alertname: PagerDutyDrillAlert
+        exp_alerts:
+          - exp_labels:
+              severity: page
+            exp_annotations:
+              description: Pagerduty drill fires at 10am on Wednesdays
+
+  # no alert expected before 10am
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 7701m
+        alertname: PagerDutyDrillAlert
+        exp_alerts: []
+
+  # no alert expected after 10am hour
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 7901m
+        alertname: PagerDutyDrillAlert
+        exp_alerts: []
+
+  # no alert expected on different day
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 6901m
+        alertname: PagerDutyDrillAlert
+        exp_alerts: []


### PR DESCRIPTION
This should also handle daylight saving time so no need to change the time manually.

## Reference

https://trello.com/c/atcbGHh1/2156-move-pagerduty-drill-out-of-puppet