### PR TITLE
Use server-side apply for kube-prometheus-stack application

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/application.yaml
@@ -20,4 +20,5 @@ spec:
     automated: null
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true
 {{ end }}


### PR DESCRIPTION
This fixes argo putting an enormous annotation on some CRDs that is too long for the k8s API to accept

https://trello.com/c/pOfajLA2/980-install-kube-prometheus-stack-chart-via-argo-cd-instead-of-terraform