### PR TITLE
Reduce db-backup cronjob history limit.

### DIFF
--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -20,6 +20,8 @@ spec:
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 28800  # 8 hours
   suspend: {{ .suspend | default false }}
+  failedJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 2
   jobTemplate:
     metadata:
       name: {{ $jobFullName }}


### PR DESCRIPTION
The app view in the Argo CD web UI gets quite cluttered otherwise.