### PR TITLE
re-enable comparing all responses from content-store on production draft content store

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -868,7 +868,7 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
         - name: COMPARISON_SAMPLE_PCT
-          value: '0'
+          value: '100'
         - name: SECONDARY_TIMEOUT_SECONDS
           value: '2'
 


### PR DESCRIPTION
_don't merge this until https://github.com/alphagov/content-store-proxy/pull/56 has been deployed to production_

In response to an incident yesterday, we disabled all response comparisons in production in #1373 while we investigated the underlying cause. The cause has been found and [fixed](https://github.com/alphagov/content-store-proxy/pull/56) so we should be OK to re-enable comparisons. ([Trello card](https://trello.com/c/ScvwYac3/925-incident-action-rescue-all-exceptions-thrown-in-response-comparison-in-content-store-proxy))

I'm doing this as two separate PRs so that I can confirm this works on the draft content-store first (it works fine in integration and staging, but an extra confirmation step can't hurt). A subsequent PR will re-enable them on the live content-store.