### PR TITLE
Bump the resource limits for whitehall-admin

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3032,8 +3032,8 @@ govukApplications:
     helmValues:
       appResources:
         limits:
-          memory: 4Gi
-          cpu: "2"
+          memory: 8Gi
+          cpu: "4"
         requests:
           memory: 2Gi
           cpu: "1"


### PR DESCRIPTION
We've observed a bit of a pattern emerging where Whitehall's CPU and memory usage has been spiking and hitting Kube resource limits.

It's not entirely clear what is causing the resource usage spikes, but it seems to be having a detrimental effect on pods being able to serve other requests to users.

So for now, I'm proposing we double the upper limits of resources available to Whitehall in production. Having discussed it with @aldavidson, we this this seems like a reasonable increase.

For more context, see this Slack thread:
https://gds.slack.com/archives/CADKZN519/p1699027473948409?thread_ts=1699023676.948439&cid=CADKZN519