### PR TITLE
Don't restore integration content-data-api automatically.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -444,6 +444,7 @@ cronjobs:
           bucket: s3://govuk-staging-database-backups
 
     content-data-api-postgresql-primary:
+      suspend: true
       schedule: "35 6 * * 6"
       db: content_performance_manager_production
       dbms: postgres


### PR DESCRIPTION
The RDS instance for the Content Performance data warehouse in integration takes 6-12 hours to do a full restore. Since we already do a (more realistic) restore test in staging and we don't actually need to copy staging/prod data into integration (because the ETL jobs run in integration just as they do in staging/prod), let's just make the integration restore an on-demand-only affair.

This way, integration remains a canary for the rollout pipeline, we're better able to test the ETL jobs because their work doesn't get overwritten by the scheduled restore, and in the unlikely event that a buggy ETL release completely hoses the integration cube we can still run the restore on demand.

The main motivation for this though is that the restore is quite fragile if the content-data-api application is up while it's running. We could work around this but it's really not worth it unless there's a really good reason, since this is the only application that's exhibiting that type of problem.