### PR TITLE
Add MySQL support to db-backup chart. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           show-progress: false
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
+        env:
+          SHELLCHECK_OPTS: -xP SCRIPTDIR
 
   yamllint:
     runs-on: ubuntu-latest

--- a/charts/db-backup/backup-mysql.sh
+++ b/charts/db-backup/backup-mysql.sh
@@ -1,34 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-export LC_ALL=C.UTF-8  # Prevent i18n from affecting command outputs (e.g. `type`).
-export HOME=${TMPDIR:-/tmp}  # For aws-cli and the mysql* tools.
-
-usage () {
-  self=$(basename "$0")
-  cat >&2 <<EOF
-$self is a tool for streaming mysqldump output to/from Amazon S3 (or
-compatible), for backup and to copy data between environments.
-EOF
-  exit 64
-}
-
-progress () {
-  stdbuf -eL -- pv -fi 10 -F '%t %r %b'
-}
+source_dir=$(dirname "${BASH_SOURCE[0]}")
+. "$source_dir/lib.sh"
 
 backup () {
   local s3_path
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   mysqldump --single-transaction "$DB_DATABASE" \
     | progress | gzip -c | aws s3 cp - "$BUCKET/$s3_path"
-}
-
-# List available backups in ascending date order.
-list () {
-  local db_name_re
-  db_name_re=$(echo "$DB_DATABASE" | tr _- .)
-  aws s3 ls "$BUCKET/$DB_HOST/" | grep -Eo "[-0-9:TZ_]+-$db_name_re\.gz"
 }
 
 dump_is_readable () {
@@ -65,14 +45,6 @@ EOF
 
 subcommand=${1:-}
 [[ $(type -t "$subcommand") == function ]] || usage
-
-: "${GOVUK_ENVIRONMENT:?required}"
-: "${DB_USER:=aws_db_admin}"
-: "${DB_PASSWORD:?required}"
-: "${DB_HOST:?required}"
-: "${DB_DATABASE:?required}"
-: "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
-readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET
 
 write_config
 [[ "${VERBOSE:-0}" -ge 1 ]] && set -x

--- a/charts/db-backup/backup-mysql.sh
+++ b/charts/db-backup/backup-mysql.sh
@@ -14,7 +14,7 @@ EOF
 }
 
 progress () {
-  pv -fi 10 -F '%t %r %b'
+  stdbuf -eL -- pv -fi 10 -F '%t %r %b'
 }
 
 backup () {

--- a/charts/db-backup/backup-mysql.sh
+++ b/charts/db-backup/backup-mysql.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+export LC_ALL=C.UTF-8  # Prevent i18n from affecting command outputs (e.g. `type`).
+export HOME=${TMPDIR:-/tmp}  # For aws-cli and the mysql* tools.
+
+usage () {
+  self=$(basename "$0")
+  cat >&2 <<EOF
+$self is a tool for streaming mysqldump output to/from Amazon S3 (or
+compatible), for backup and to copy data between environments.
+EOF
+  exit 64
+}
+
+progress () {
+  pv -fi 10 -F '%t %r %b'
+}
+
+backup () {
+  local s3_path
+  s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
+  mysqldump --single-transaction "$DB_DATABASE" \
+    | progress | gzip -c | aws s3 cp - "$BUCKET/$s3_path"
+}
+
+# List available backups in ascending date order.
+list () {
+  local db_name_re
+  db_name_re=$(echo "$DB_DATABASE" | tr _- .)
+  aws s3 ls "$BUCKET/$DB_HOST/" | grep -Eo "[-0-9:TZ_]+-$db_name_re\.gz"
+}
+
+dump_is_readable () {
+  set +o pipefail  # We expect SIGPIPE here, but only here.
+  (aws s3 cp "$s3_url" - 2>/dev/null) | gzip -cd | head -n5 \
+    | tee /dev/fd/2 | grep 'MySQL dump' >/dev/null 2>&1
+  local ret=$?
+  set -o pipefail
+  return $ret
+}
+
+restore () {
+  : "${FILENAME:=$(list | tail -1)}"  # Use latest dump if not specified.
+  if [[ "$GOVUK_ENVIRONMENT" = *"prod"* ]]; then
+    : "${REALLY_RESTORE_ONTO_PRODUCTION?}"
+  fi
+  local s3_url="$BUCKET/$DB_HOST/$FILENAME"
+  s3_url="$s3_url" dump_is_readable
+  mysqladmin drop -f "$DB_DATABASE" || true
+  mysqladmin create "$DB_DATABASE"
+  aws s3 cp "$s3_url" - | gzip -cd | progress | mysql "$DB_DATABASE"
+}
+
+write_config () {
+  cat > "$HOME/.my.cnf" <<EOF
+[client]
+user=$DB_USER
+password=$DB_PASSWORD
+host=$DB_HOST
+[mysqldump]
+set-gtid-purged=OFF  # https://bugs.mysql.com/bug.php?id=109685#c530123
+EOF
+}
+
+subcommand=${1:-}
+[[ $(type -t "$subcommand") == function ]] || usage
+
+: "${GOVUK_ENVIRONMENT:?required}"
+: "${DB_USER:=aws_db_admin}"
+: "${DB_PASSWORD:?required}"
+: "${DB_HOST:?required}"
+: "${DB_DATABASE:?required}"
+: "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
+readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET
+
+write_config
+[[ "${VERBOSE:-0}" -ge 1 ]] && set -x
+$subcommand "$@"
+echo "done"

--- a/charts/db-backup/backup-postgres.sh
+++ b/charts/db-backup/backup-postgres.sh
@@ -1,33 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-export LC_ALL=C.UTF-8  # Prevent i18n from affecting command outputs (e.g. `type`).
-export HOME=${TMPDIR:-/tmp}  # aws-cli hates readonlyRootFilesystem :(
+source_dir=$(dirname "${BASH_SOURCE[0]}")
+. "$source_dir/lib.sh"
 
-usage () {
-  self=$(basename "$0")
-  cat >&2 <<EOF
-$self is a tool for streaming Postgres pg_dump/pg_restore to/from Amazon S3 (or
-compatible), for backup and to copy data between environments.
-EOF
-  exit 64
-}
-
-progress () {
-  stdbuf -eL -- pv -fi 10 -F '%t %r %b'
-}
+export PGUSER=$DB_USER
+export PGPASSWORD=$DB_PASSWORD
+export PGHOST=$DB_HOST
+export PGDATABASE=$DB_DATABASE
+readonly PGUSER PGPASSWORD PGHOST PGDATABASE
 
 backup () {
   local s3_path
   s3_path="$PGHOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$PGDATABASE.gz"
   pg_dump -Fc | progress | aws s3 cp - "$BUCKET/$s3_path"
-}
-
-# List available backups in ascending date order.
-list () {
-  local db_name_re
-  db_name_re=$(echo "$PGDATABASE" | tr _- .)
-  aws s3 ls "$BUCKET/$PGHOST/" | grep -Eo "[-0-9:TZ_]+-$db_name_re\.gz"
 }
 
 dump_is_readable () {
@@ -49,20 +35,6 @@ restore () {
 subcommand=${1:-}
 [[ $(type -t "$subcommand") == function ]] || usage
 
-: "${GOVUK_ENVIRONMENT:?required}"
-: "${DB_USER:=aws_db_admin}"
-: "${DB_PASSWORD:?required}"
-: "${DB_HOST:?required}"
-: "${DB_DATABASE:?required}"
-: "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
 [[ "${VERBOSE:-0}" -ge 1 ]] && set -x
-
-readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET
-export PGUSER=$DB_USER
-export PGPASSWORD=$DB_PASSWORD
-export PGHOST=$DB_HOST
-export PGDATABASE=$DB_DATABASE
-readonly PGUSER PGPASSWORD PGHOST PGDATABASE
-
 $subcommand "$@"
 echo "done"

--- a/charts/db-backup/backup-postgres.sh
+++ b/charts/db-backup/backup-postgres.sh
@@ -14,7 +14,7 @@ EOF
 }
 
 progress () {
-  pv -fi 10 -F '%t %r %b'
+  stdbuf -eL -- pv -fi 10 -F '%t %r %b'
 }
 
 backup () {

--- a/charts/db-backup/backup-postgres.sh
+++ b/charts/db-backup/backup-postgres.sh
@@ -50,13 +50,19 @@ subcommand=${1:-}
 [[ $(type -t "$subcommand") == function ]] || usage
 
 : "${GOVUK_ENVIRONMENT:?required}"
-: "${PGUSER:=aws_db_admin}"
-: "${PGPASSWORD:?required}"
-: "${PGHOST:?required}"
-: "${PGDATABASE:?required}"
+: "${DB_USER:=aws_db_admin}"
+: "${DB_PASSWORD:?required}"
+: "${DB_HOST:?required}"
+: "${DB_DATABASE:?required}"
 : "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
 [[ "${VERBOSE:-0}" -ge 1 ]] && set -x
 
-readonly GOVUK_ENVIRONMENT PGUSER PGPASSWORD PGHOST PGDATABASE BUCKET
+readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET
+export PGUSER=$DB_USER
+export PGPASSWORD=$DB_PASSWORD
+export PGHOST=$DB_HOST
+export PGDATABASE=$DB_DATABASE
+readonly PGUSER PGPASSWORD PGHOST PGDATABASE
 
 $subcommand "$@"
+echo "done"

--- a/charts/db-backup/lib.sh
+++ b/charts/db-backup/lib.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+export LC_ALL=C.UTF-8  # Prevent i18n from affecting command outputs (e.g. `type`).
+export HOME=${TMPDIR:-/tmp}  # For aws-cli and the mysql* tools.
+
+usage () {
+  self=$(basename "$0")
+  cat >&2 <<EOF
+$self is a tool for streaming database dumps to/from Amazon S3 (or
+compatible), for backup and to copy data between environments.
+EOF
+  exit 64
+}
+
+progress () {
+  stdbuf -eL -- pv -fi 10 -F '%t %r %b'
+}
+
+# List available backups in ascending date order.
+list () {
+  local db_name_re
+  db_name_re=$(echo "$DB_DATABASE" | tr _- .)
+  aws s3 ls "$BUCKET/$DB_HOST/" | grep -Eo "[-0-9:TZ_]+-$db_name_re\.gz"
+}
+
+: "${GOVUK_ENVIRONMENT:?required}"
+: "${DB_USER:=aws_db_admin}"
+: "${DB_PASSWORD:?required}"
+: "${DB_HOST:?required}"
+: "${DB_DATABASE:?required}"
+: "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
+readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET

--- a/charts/db-backup/templates/configmap.yaml
+++ b/charts/db-backup/templates/configmap.yaml
@@ -7,3 +7,5 @@ metadata:
 data:
   backup-postgres: |
     {{- $.Files.Get "backup-postgres.sh" | trim | nindent 4 }}
+  backup-mysql: |
+    {{- $.Files.Get "backup-mysql.sh" | trim | nindent 4 }}

--- a/charts/db-backup/templates/configmap.yaml
+++ b/charts/db-backup/templates/configmap.yaml
@@ -9,3 +9,5 @@ data:
     {{- $.Files.Get "backup-postgres.sh" | trim | nindent 4 }}
   backup-mysql: |
     {{- $.Files.Get "backup-mysql.sh" | trim | nindent 4 }}
+  lib.sh: |
+    {{- $.Files.Get "lib.sh" | trim | nindent 4 }}

--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -65,16 +65,16 @@ spec:
               env:
                 - name: GOVUK_ENVIRONMENT
                   value: {{ $.Values.govukEnvironment }}
-                - name: PGUSER
+                - name: DB_USER
                   value: {{ $job.dbUser | default "aws_db_admin" }}
-                - name: PGPASSWORD
+                - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: {{ $fullName }}-passwd
                       key: {{ $dbHost }}
-                - name: PGHOST
+                - name: DB_HOST
                   value: {{ $dbHost }}
-                - name: PGDATABASE
+                - name: DB_DATABASE
                   value: {{ .db | default $job.db }}
                 - name: BUCKET
                   value: {{ .bucket }}

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -75,18 +75,17 @@ cronjobs:
       operations:
         - op: backup
 
-    # # TODO: implement MySQL support.
-    # collections-publisher-mysql:
-    #   schedule: "21 23 * * *"
-    #   db: collections_publisher_production
-    #   operations:
-    #     - op: backup
+    collections-publisher-mysql:
+      schedule: "21 23 * * *"
+      db: collections_publisher_production
+      operations:
+        - op: backup
 
-    # contacts-admin-mysql:
-    #   schedule: "49 23 * * *"
-    #   db: contacts_production
-    #   operations:
-    #     - op: backup
+    contacts-admin-mysql:
+      schedule: "49 23 * * *"
+      db: contacts_production
+      operations:
+        - op: backup
 
     content-data-admin-postgres:
       schedule: "4 23 * * *"
@@ -160,17 +159,17 @@ cronjobs:
       operations:
         - op: backup
 
-    # release-mysql:
-    #   schedule: "11 23 * * *"
-    #   db: release_production
-    #   operations:
-    #     - op: backup
+    release-mysql:
+      schedule: "11 23 * * *"
+      db: release_production
+      operations:
+        - op: backup
 
-    # search-admin-mysql:
-    #   schedule: "56 23 * * *"
-    #   db: search_admin_production
-    #   operations:
-    #     - op: backup
+    search-admin-mysql:
+      schedule: "56 23 * * *"
+      db: search_admin_production
+      operations:
+        - op: backup
 
     service-manual-publisher-postgres:
       schedule: "49 23 * * *"
@@ -178,11 +177,11 @@ cronjobs:
       operations:
         - op: backup
 
-    # signon-mysql:
-    #   schedule: "3 23 * * *"
-    #   db: signon_production
-    #   operations:
-    #     - op: backup
+    signon-mysql:
+      schedule: "3 23 * * *"
+      db: signon_production
+      operations:
+        - op: backup
 
     support-api-postgres:
       schedule: "38 23 * * *"
@@ -222,21 +221,21 @@ cronjobs:
           bucket: s3://govuk-production-database-backups
         - op: backup
 
-    # collections-publisher-mysql:
-    #   schedule: "21 1 * * *"
-    #   db: collections_publisher_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-production-database-backups
-    #     - op: backup
+    collections-publisher-mysql:
+      schedule: "21 1 * * *"
+      db: collections_publisher_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
 
-    # contacts-admin-mysql:
-    #   schedule: "49 1 * * *"
-    #   db: contacts_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-production-database-backups
-    #     - op: backup
+    contacts-admin-mysql:
+      schedule: "49 1 * * *"
+      db: contacts_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
 
     content-data-admin-postgres:
       schedule: "4 1 * * *"
@@ -341,21 +340,21 @@ cronjobs:
     #       script: sanitise_publishing_api_production.sql
     #     - op: backup
 
-    # release-mysql:
-    #   schedule: "11 1 * * 1"  # Daily would be overkill.
-    #   db: release_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-production-database-backups
-    #     - op: backup
+    release-mysql:
+      schedule: "11 1 * * 1"  # Daily would be overkill.
+      db: release_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
 
-    # search-admin-mysql:
-    #   schedule: "56 1 * * *"
-    #   db: search_admin_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-production-database-backups
-    #     - op: backup
+    search-admin-mysql:
+      schedule: "56 1 * * *"
+      db: search_admin_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
 
     service-manual-publisher-postgres:
       schedule: "49 1 * * *"
@@ -365,13 +364,12 @@ cronjobs:
           bucket: s3://govuk-production-database-backups
         - op: backup
 
-    # signon-mysql:
-    #   schedule: "3 1 * * *"
-    #   db: signon_production
-    #   operations:
-    #    - op: restore
-    #      bucket: s3://govuk-production-database-backups
-    #     - op: backup
+    signon-mysql:
+      schedule: "3 1 * * *"
+      db: signon_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
 
     support-api-postgres:
       schedule: "38 1 * * *"
@@ -422,19 +420,19 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-staging-database-backups
 
-    # collections-publisher-mysql:
-    #   schedule: "21 3 * * *"
-    #   db: collections_publisher_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-staging-database-backups
+    collections-publisher-mysql:
+      schedule: "21 3 * * *"
+      db: collections_publisher_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
 
-    # contacts-admin-mysql:
-    #   schedule: "49 3 * * *"
-    #   db: contacts_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-staging-database-backups
+    contacts-admin-mysql:
+      schedule: "49 3 * * *"
+      db: contacts_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
 
     content-data-admin-postgres:
       schedule: "4 3 * * *"
@@ -451,13 +449,13 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-staging-database-backups
 
-#   content-publisher-postgres:
-    # schedule: "9 3 * * *"
-    # db: content_publisher_production
-    # operations:
-    #   - op: restore
-    #     bucket: s3://govuk-staging-database-backups
-    #   - op: backup
+    # content-publisher-postgres:
+    #   schedule: "9 3 * * *"
+    #   db: content_publisher_production
+    #   operations:
+    #     - op: restore
+    #       bucket: s3://govuk-staging-database-backups
+    #     - op: backup
 
     content-store-postgres:
       db: content_store_production
@@ -483,13 +481,13 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-staging-database-backups
 
-#   email-alert-api-postgres:
-    # schedule: "54 3 * * *"
-    # db: email-alert-api_production
-    # operations:
-    #   - op: restore
-    #     bucket: s3://govuk-staging-database-backups
-    #   - op: backup
+    # email-alert-api-postgres:
+    #   schedule: "54 3 * * *"
+    #   db: email-alert-api_production
+    #   operations:
+    #     - op: restore
+    #       bucket: s3://govuk-staging-database-backups
+    #     - op: backup
 
     imminence-postgres:
       schedule: "18 3 * * *"
@@ -519,27 +517,27 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-staging-database-backups
 
-#   publishing-api-postgres:
-    # schedule: "37 3 * * *"
-    # db: publishing_api_production
-    # operations:
-    #   - op: restore
-    #     bucket: s3://govuk-staging-database-backups
-    #   - op: backup
-
-    # release-mysql:
-    #   schedule: "11 3 * * 1"
-    #   db: release_production
+    # publishing-api-postgres:
+    #   schedule: "37 3 * * *"
+    #   db: publishing_api_production
     #   operations:
     #     - op: restore
     #       bucket: s3://govuk-staging-database-backups
+    #     - op: backup
 
-    # search-admin-mysql:
-    #   schedule: "56 3 * * *"
-    #   db: search_admin_production
-    #   operations:
-    #     - op: restore
-    #       bucket: s3://govuk-staging-database-backups
+    release-mysql:
+      schedule: "11 3 * * 1"
+      db: release_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
+
+    search-admin-mysql:
+      schedule: "56 3 * * *"
+      db: search_admin_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
 
     service-manual-publisher-postgres:
       schedule: "49 3 * * *"
@@ -548,14 +546,21 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-staging-database-backups
 
-    # signon-mysql:
-    #   suspend: true
-    #   schedule: "3 3 * * *"
-    #   db: signon_production
-    #   operations:
-    #    - op: restore
-    #      # Integration Signon accounts are not synced from production/staging.
-    #      bucket: s3://govuk-integration-database-backups
+    # Integration Signon accounts are not synced from production/staging.
+    signon-mysql-backup:
+      schedule: "3 3 * * *"
+      db: signon_production
+      operations:
+        - op: backup
+          bucket: s3://govuk-integration-database-backups
+
+    signon-mysql-restore:
+      suspend: true
+      schedule: "0 0 * * 0"
+      db: signon_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-integration-database-backups
 
     support-api-postgres:
       schedule: "38 3 * * *"


### PR DESCRIPTION
Support `mysqldump` backup and restore for MySQL databases. Enable the cronjobs for the MySQL databases except whitehall-mysql, which needs a (yet to be implemented) data transformation between staging and integration.

Also fix the buffering on the progress log output.

https://trello.com/c/JjTHY62V

Tested: successfully ran the jobs for `signon-mysql` end-to-end from production through to integration (and `service-manual-publisher-postgres` backup/restore in staging as a regression test).