### PR TITLE
Use existing Secrets Manager secrets for AlertManager routing config

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanager-secret.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanager-secret.yaml
@@ -11,7 +11,15 @@ spec:
   target:
     name: alertmanager-receivers
     creationPolicy: Owner
-  dataFrom:
-    - extract:
-        key: govuk/kube-prometheus-stack/alertmanager-receivers
+  data:
+    - secretKey: pagerduty_routing_key
+      remoteRef:
+        key: govuk/alertmanager/pagerduty-routing-key
+        decodingStrategy: None
+        version: AWSCURRENT
+    - secretKey: slack_api_url
+      remoteRef:
+        key: govuk/slack-webhook-url
+        decodingStrategy: None
+        version: AWSCURRENT
 {{ end }}


### PR DESCRIPTION
https://trello.com/c/pOfajLA2/980-install-kube-prometheus-stack-chart-via-argo-cd-instead-of-terraform