### PR TITLE
Increase integration worker count for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2259,6 +2259,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 5
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
We're about to run our first bulk import of existing data (600k documents from publishing API), so need to dial up the concurrency on this. We expect to go back down to a single worker once we're done with the need for bulk import.