### PR TITLE
Pass `suspend` field from cronTasks to CronJobs.

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/component: "{{ .name }}"
 spec:
   schedule: "{{ .schedule }}"
+  suspend: {{ .suspend | default false }}
   jobTemplate:
     metadata:
       name: "{{ $fullName }}-{{ .name }}"

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -24,6 +24,18 @@ workers:
 dbMigrationEnabled: false
 dbMigrationCommand: ["rails", "db:migrate"]
 
+# cronTasks is a list of {name, command, schedule} and/or {name, task,
+# schedule}, which represent CronJobs to run either an arbitrary command or a
+# Rake task. An optional `suspend` field is passed through to the CronJob spec
+# if present.
+cronTasks: []
+#  - name: mail-fetcher
+#    command: "script/mail_fetcher"
+#    schedule: "*/15 * * * *"
+#  - name: reports-generate
+#    task: "reports:generate"  # Rake task.
+#    schedule: "3 * * * *"
+
 # extraVolumes defines Volumes on the app Pods (in both deployment.yaml and
 # worker-deployment.yaml).
 extraVolumes: []


### PR DESCRIPTION
This lets us use cronjobs as templates for manually-triggered / one-shot jobs by specifying `suspend: true` in the job's entry in the `cronTasks` Helm value.

Also document the `cronTasks` value.