### PR TITLE
Add one-off `search-api-v2` import task to integration `publishing-api`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1782,6 +1782,10 @@ govukApplications:
         - name: heartbeat
           task: "heartbeat_messages:send"
           schedule: "*/4 * * * *"
+        - name: search-api-v2-bulk-import
+          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
+          schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)
+          suspend: true
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This adds a "one-shot" task template to the `publishing-api` values to be able to run a bulk import to `search-api-v2`, on integration only for now.

(see alphagov/govuk-helm-charts#1399)