### PR TITLE
Improve env config in `cron-task` template

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -62,8 +62,22 @@ spec:
                 - configMapRef:
                     name: govuk-apps-env
               env:
+                {{- if .Values.rails.enabled }}
+                - name: SECRET_KEY_BASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.rails.secretKeyBaseName | default (printf "%s-rails-secret-key-base" .Values.repoName) }}
+                      key: secret-key-base
+                {{- end }}
+                {{- if .Values.sentry.enabled }}
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.sentry.dsnSecretName | default (printf "%s-sentry" .Values.repoName) }}
+                      key: dsn
                 - name: SENTRY_RELEASE
                   value: "{{ $.Values.appImage.tag }}"
+                {{- end }}
                 {{- with $.Values.extraEnv }}
                   {{- . | toYaml | trim | nindent 16 }}
                 {{- end }}


### PR DESCRIPTION
These currently work differently from deployments and workers, when they should be consistent and have the same environment configuration available to them.

- Add `SENTRY_DSN` if Sentry is enabled for the project
- Don't add `SENTRY_RELASE` if Sentry is not enabled (for consistency)
- Add `SECRET_KEY_BASE` is Rails is enabled for the project