### PR TITLE
Remove disused MQ monitoring heartbeat.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1797,9 +1797,6 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
-        - name: heartbeat
-          task: "heartbeat_messages:send"
-          schedule: "*/4 * * * *"
         - name: search-api-v2-bulk-import
           task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
           schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1861,9 +1861,6 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
-        - name: heartbeat
-          task: "heartbeat_messages:send"
-          schedule: "*/4 * * * *"
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1813,9 +1813,6 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
-        - name: heartbeat
-          task: "heartbeat_messages:send"
-          schedule: "*/4 * * * *"
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This used to drive a non-paging/dashboard-only Icinga alert that would show when a heartbeat message hadn't been read from the queue for > 5 minutes.

We now have a much better MQ dashboard so the heartbeat cronjob is obsolete. Hadn't spotted that when we ported this over; assumed it was some sort of keepalive workaround or something (otherwise we'd have dropped it months ago).

Tested: turns out these cronjobs haven't been running for several weeks because of bug introduced into the app's Helm template, so we know empirically that we're just fine without them.