### PR TITLE
Make content-store-proxys serve from PostgreSQL in integration-only

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -744,9 +744,9 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store-mongo-main/"
-        - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://content-store-mongo-main/"
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
         - name: SECONDARY_TIMEOUT_SECONDS
@@ -850,9 +850,9 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store-mongo-main/"
-        - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://draft-content-store-mongo-main/"
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
         - name: SECONDARY_TIMEOUT_SECONDS


### PR DESCRIPTION
Swap the `PRIMARY_` and `SECONDARY_` upstream URLs, to make the *integration* content-store proxy apps for live and draft serve the responses from PostgreSQL rather than MongoDB.

All requests will still be copied to both DBs, it's just "which response do I serve & prioritize?" that's switching. We'll monitor this for a while and then do staging later on (assuming it goes OK)

[Trello card](https://trello.com/c/aQpkwDUe/931-make-content-store-proxy-serve-from-postgresql-in-integration), first part of [Step 4 of our rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_174)