### PR TITLE
Transform Signon app URLs appropriately in staging.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2473,6 +2473,10 @@ govukApplications:
               key: DEVISE_SECRET_KEY
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+        - name: SIGNON_APPS_URI_SUB_PATTERN
+          value: publishing.service.gov.uk
+        - name: SIGNON_APPS_URI_SUB_REPLACEMENT
+          value: staging.publishing.service.gov.uk
 
   - name: smartanswers
     repoName: smart-answers


### PR DESCRIPTION
There used to be a [horrible hack in the old govuk_env_sync script](https://github.com/alphagov/govuk-puppet/blob/aa75027/modules/govuk_env_sync/files/govuk_env_sync.sh#L537-L573) that would substitute the prod domain name for the staging domain name when running the nightly restore of the prod Signon database into Staging.

The new backup/restore scripts don't do this (since it was brittle and complicated and has nothing to do with backup/restore), so do the substitution in the Signon config. This is way simpler to understand and keeps the config where it belongs, along with the rest of the staging configuration for Signon.