### PR TITLE
Make staging content-store-proxies serve from PostgreSQL

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -762,9 +762,9 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store-mongo-main/"
-        - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://content-store-mongo-main/"
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT
@@ -873,9 +873,9 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store-mongo-main/"
-        - name: SECONDARY_UPSTREAM
           value: "http://draft-content-store-postgresql-branch/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://draft-content-store-mongo-main/"
         - name: COMPARISON_SAMPLE_PCT
           value: '100'
         - name: SECONDARY_TIMEOUT_SECONDS


### PR DESCRIPTION
Having switched integration earlier today in #1406, we can now switch staging to serve & prioritise responses from the Postgres content-store, and copy to MongoDB as the secondary.

[Trello card](https://trello.com/c/VM6VCTjo/932-make-content-store-proxy-serve-from-postgresql-in-staging), second part of [Step 4 of our rollout plan](https://docs.google.com/presentation/d/1BMvv71helDENeaBo23gDHjoN74A9lqtGU5NDgQiUab4/edit#slide=id.g2762d4e8b40_0_174)