### PR TITLE
Reduce gzip compression on backups.

### DIFF
--- a/charts/db-backup/backup-postgres.sh
+++ b/charts/db-backup/backup-postgres.sh
@@ -13,7 +13,7 @@ readonly PGUSER PGPASSWORD PGHOST PGDATABASE
 backup () {
   local s3_path
   s3_path="$PGHOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$PGDATABASE.gz"
-  pg_dump -Fc | progress | aws s3 cp - "$BUCKET/$s3_path"
+  pg_dump -FcZ1 | progress | aws s3 cp - "$BUCKET/$s3_path"
 }
 
 dump_is_readable () {


### PR DESCRIPTION
gzip (and pg_restore) set the zlib compression level to 6 by default, which takes several times the CPU time of level 1.

The backup jobs are bottlenecked on CPU (and are single-threaded), and we don't care about a extra few % improvement in compression ratio.

This should save cores and speed up backups (and possibly also restores, to a lesser extent).