### PR TITLE
Revert "feature flag for hew homepage design"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1173,8 +1173,6 @@ govukApplications:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
       extraEnv:
-        - name: NEW_DESIGN
-          value: impact
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *frontend-notify-template
         - name: MEMCACHE_SERVERS


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#1316

https://trello.com/c/IhFaIzdI/2220-remove-the-now-redundant-newdesign-code-from-frontend-m
