### PR TITLE
Scale up integration workers for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2280,7 +2280,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 5
+      workerReplicaCount: 10
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
Our bulk import is running a bit slow with 5 workers, so let's chuck 10 workers at it.

This is a one off task (hopefully), so should be able to scale down to something more reasonable again by tomorrow afternoon.