### PR TITLE
Dump/restore content-store before publishing-api.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1367,7 +1367,7 @@ govukApplications:
         sagemakerIamRole: arn:aws:iam::172025368201:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::172025368201:role/search-api-learn-to-rank-govuk
       draftContentStoreMongoPostgresCron:
-        schedule: "16 0 * * *"
+        schedule: "26 22 * * *"
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.production.govuk-internal.digital,\
@@ -1376,7 +1376,7 @@ govukApplications:
         postgresImport:
           databaseUrlSecretName: "draft-content-store-postgres"
       contentStoreMongoPostgresCron:
-        schedule: "16 0 * * *"
+        schedule: "26 22 * * *"
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.production.govuk-internal.digital,\

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -107,12 +107,12 @@ cronjobs:
         - op: backup
 
     content-store-postgres:
-      schedule: "16 2 * * *"
+      schedule: "16 0 * * *"  # Keep this before publishing-api.
       db: content_store_production
       operations:
         - op: backup
     draft-content-store-postgres:
-      schedule: "36 2 * * *"
+      schedule: "36 0 * * *"  # Keep this before publishing-api.
       db: draft_content_store_production
       operations:
         - op: backup
@@ -154,7 +154,7 @@ cronjobs:
         - op: backup
 
     publishing-api-postgres:
-      schedule: "37 23 * * *"
+      schedule: "37 1 * * *"
       db: publishing_api_production
       operations:
         - op: backup
@@ -267,14 +267,14 @@ cronjobs:
 
     content-store-postgres:
       db: content_store_production
-      schedule: "16 3 * * *"
+      schedule: "16 2 * * *"  # Keep this before publishing-api.
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
         - op: backup
     draft-content-store-postgres:
       db: draft_content_store_production
-      schedule: "36 3 * * *"
+      schedule: "36 2 * * *"  # Keep this before publishing-api.
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
@@ -331,7 +331,7 @@ cronjobs:
         - op: backup
 
     publishing-api-postgres:
-      schedule: "37 1 * * *"
+      schedule: "37 3 * * *"
       db: publishing_api_production
       operations:
         - op: restore
@@ -462,7 +462,7 @@ cronjobs:
 
     content-store-postgres:
       db: content_store_production
-      schedule: "16 4 * * *"
+      schedule: "16 5 * * *"  # Keep this before publishing-api.
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
@@ -471,7 +471,7 @@ cronjobs:
     # of publishing-api that require it are rectified.
     draft-content-store-postgres:
       db: draft_content_store_production
-      schedule: "36 4 * * *"
+      schedule: "36 5 * * *"  # Keep this before publishing-api.
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
@@ -521,7 +521,7 @@ cronjobs:
           bucket: s3://govuk-staging-database-backups
 
     publishing-api-postgres:
-      schedule: "37 3 * * *"
+      schedule: "37 6 * * *"
       db: publishing_api_production
       operations:
         - op: restore

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -255,7 +255,6 @@ cronjobs:
         - op: backup
 
     content-publisher-postgres:
-      suspend: true
       schedule: "9 1 * * *"
       db: content_publisher_production
       operations:


### PR DESCRIPTION
There's a data consistency issue in the design of Publishing API and Content Store; see https://trello.com/c/HRwJTf6S for details (internal only, sorry). The upshot is that some kinds of publishing operations don't work in the non-production environments after the nightly restore.

Work around this for now by running the content-store backup jobs before the publishing-api backup jobs in the their respective environments.

Also enable the restore/transform/backup job for content-publisher in staging (missed earlier).