### PR TITLE
Use exponential backoff when retrying deployment workflows.

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -6,8 +6,12 @@ spec:
   entrypoint: handle-sync-event
   onExit: exit-handler
   retryStrategy:
-    limit: "3"
     expression: "asInt(lastRetry.exitCode) > 1"
+    limit: 3
+    backoff:
+      duration: "2m"
+      factor: 2
+      maxDuration: "16m"
   arguments:
     parameters:
       - name: application

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -13,7 +13,11 @@ spec:
         parameters:
           - name: extra-args
       retryStrategy:
-        limit: "2"
+        limit: 2
+        backoff:
+          duration: "2m"
+          factor: 2
+          maxDuration: "16m"
       container:
         image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
         command:


### PR DESCRIPTION
We've seen these workflow steps blowing through their retries quite quickly and failing permanently in situations (such as rolling node upgrades in integration) where waiting a bit longer before retrying might have led to success.

Try an exponential backoff (with exponent=2) starting at 2 minutes, keeping the retry counts the same for now.

https://argoproj.github.io/argo-workflows/walk-through/retrying-failed-or-errored-steps/

I haven't tested this yet; I'll roll it back if it doesn't work!