### PR TITLE
Prepare for `search-api-v2` integration bulk import

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1798,7 +1798,7 @@ govukApplications:
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_published_things[bulk.search_api_v2_sync]"
           schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)
           suspend: true
       extraEnv:
@@ -2278,7 +2278,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 10
+      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
- Update `search-api-v2` worker count to 25 to be able to complete an entire import in a working day (to avoid getting mixed up in the nighly Publishing API DB reset)
- Use new, more efficient Rake task on `publishing-api` for document requeue