### PR TITLE
Update `search-api-v2` environment

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2299,11 +2299,11 @@ govukApplications:
               key: RABBITMQ_URL
         - name: GOOGLE_CLOUD_CREDENTIALS
           value: /etc/credentials/google-cloud/credentials.json
-        - name: DISCOVERY_ENGINE_DATASTORE
+        - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
+              key: DISCOVERY_ENGINE_DATASTORE_BRANCH
         - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2381,11 +2381,11 @@ govukApplications:
               key: RABBITMQ_URL
         - name: GOOGLE_CLOUD_CREDENTIALS
           value: /etc/credentials/google-cloud/credentials.json
-        - name: DISCOVERY_ENGINE_DATASTORE
+        - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
+              key: DISCOVERY_ENGINE_DATASTORE_BRANCH
         - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2329,11 +2329,11 @@ govukApplications:
               key: RABBITMQ_URL
         - name: GOOGLE_CLOUD_CREDENTIALS
           value: /etc/credentials/google-cloud/credentials.json
-        - name: DISCOVERY_ENGINE_DATASTORE
+        - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
+              key: DISCOVERY_ENGINE_DATASTORE_BRANCH
         - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We now populate the configuration in Secrets Manager with a key pointing directly at a datastore branch, rather than just the parent datastore, so update the environment variable configuration for `search-api-v2` to reflect that.