### PR TITLE
Improve `search-api-v2` Google credentials consumption

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2282,13 +2282,6 @@ govukApplications:
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
-      extraVolumes:
-        - name: search-api-v2-google-cloud-credentials
-          secret:
-            secretName: search-api-v2-google-cloud-credentials
-      appExtraVolumeMounts:
-        - name: search-api-v2-google-cloud-credentials
-          mountPath: /etc/credentials/google-cloud
       extraEnv:
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
@@ -2298,7 +2291,10 @@ govukApplications:
               name: search-api-v2-rabbitmq
               key: RABBITMQ_URL
         - name: GOOGLE_CLOUD_CREDENTIALS
-          value: /etc/credentials/google-cloud/credentials.json
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
         - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2364,13 +2364,6 @@ govukApplications:
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
-      extraVolumes:
-        - name: search-api-v2-google-cloud-credentials
-          secret:
-            secretName: search-api-v2-google-cloud-credentials
-      appExtraVolumeMounts:
-        - name: search-api-v2-google-cloud-credentials
-          mountPath: /etc/credentials/google-cloud
       extraEnv:
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
@@ -2380,7 +2373,10 @@ govukApplications:
               name: search-api-v2-rabbitmq
               key: RABBITMQ_URL
         - name: GOOGLE_CLOUD_CREDENTIALS
-          value: /etc/credentials/google-cloud/credentials.json
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
         - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2312,13 +2312,6 @@ govukApplications:
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
-      extraVolumes:
-        - name: search-api-v2-google-cloud-credentials
-          secret:
-            secretName: search-api-v2-google-cloud-credentials
-      appExtraVolumeMounts:
-        - name: search-api-v2-google-cloud-credentials
-          mountPath: /etc/credentials/google-cloud
       extraEnv:
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
@@ -2328,7 +2321,10 @@ govukApplications:
               name: search-api-v2-rabbitmq
               key: RABBITMQ_URL
         - name: GOOGLE_CLOUD_CREDENTIALS
-          value: /etc/credentials/google-cloud/credentials.json
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
         - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The GCP client accepts this configuration as JSON straight in the `GOOGLE_CLOUD_CREDENTIALS` environment variable, meaning we can bypass all the faff of having a separate secret for the credentials and mounting them into the container and pointing the env var at them.

see alphagov/search-v2-infrastructure#123