### PR TITLE
Update Kubernetes version to 1.27.7

### DIFF
--- a/kubernetes_version
+++ b/kubernetes_version
@@ -2,4 +2,4 @@
 # output in .github/workflows/ci.yml.
 #
 # Available schema versions: https://github.com/yannh/kubernetes-json-schema
-KUBERNETES_VERSION=1.26.9
+KUBERNETES_VERSION=1.27.7


### PR DESCRIPTION
Description:
- See [#1004](https://github.com/alphagov/govuk-infrastructure/pull/1004) for corresponding PR to Terraform production cluster to 1.27
- Updates Kubernetes version to 1.27.7