### PR TITLE
Use resources-finalizer in staging/production.

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -7,11 +7,8 @@ kind: Application
 metadata:
   name: {{ .name }}
   namespace: {{ $.Values.argoNamespace | default $.Release.Namespace }}
-  {{- if has $.Values.govukEnvironment (list "test" "integration") }}
-  {{- /* Clean up k8s resources on chart deletion in non-prod only. */}}
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  {{- end }}
+    - resources-finalizer.argocd.argoproj.io
   annotations:
     slackChannel: "{{ .slackChannel }}"
     repoName: "{{ $reponame }}"


### PR DESCRIPTION
We sensibly took a precautionary approach with this to begin with, but it turns out that not having the Argo CD resources-finalizer clean up when an app object is removed is quite problematic: after an app is removed, we end up with disused workloads taking up resources and orphaned PDBs interfering with cluster upgrades.

Cascading deletion of owned resources on app deletion turns out to be the lesser of evils.

We don't currently have any persistent storage managed through this template, so there's no problem there. If we do start introducing persistent storage then we'd have to consider the object lifecycle carefully anyway — and we have options there.

External DNS operator is already configured not to remove names (as is the default), so that's also fine.