### PR TITLE
Enable Renovate cronjob; auto-merge for Renovate PRs

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -7,7 +7,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      suspend: true
+      suspend: false
       template:
         spec:
           containers:

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+  "platformAutomerge": true,
   "argocd": {
     "fileMatch": [
       "charts\\/.*\\.yaml$"


### PR DESCRIPTION
This only gets Renovate to turn on auto-merge on its PRs. Tests still need to pass, and the PRs will still need approval at the moment.