### PR TITLE
Don't show configuration description in Renovate PRs

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -27,8 +27,8 @@ spec:
                       key: token
                 - name: RENOVATE_CONFIG_FILE
                   value: /opt/renovate/config.json
-                - name: LOG_LEVEL
-                  value: DEBUG
+                - name: RENOVATE_PR_BODY_TEMPLATE
+                  value: '{{ "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}" }}'
               securityContext:
                 readOnlyRootFilesystem: true
                 runAsUser: 1000


### PR DESCRIPTION
This template is the same as default except it excludes `{{{configDescription}}}`

https://docs.renovatebot.com/configuration-options/#prbodytemplate