### PR TITLE
Eliminate the "noop" container in db-backup jobs.

### DIFF
--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -54,8 +54,12 @@ spec:
                 defaultMode: 0555  # world-executable
             - name: tmp  # aws-cli requires a writable dir.
               emptyDir: {}
+  {{- range $i, $_ := $job.operations }}
+    {{- if and (eq $i 0) (gt (len $job.operations) 1) }}
           initContainers:
-  {{- range $job.operations }}
+    {{- else if eq $i (sub (len $job.operations) 1) }}
+          containers:
+    {{- end }}
             - name: {{ .op }}
               image: {{ $.Values.imageRef | quote }}
               command:
@@ -98,10 +102,4 @@ spec:
                 - name: tmp
                   mountPath: /tmp
   {{- end }}
-          containers:
-            - name: noop
-              image: {{ $.Values.imageRef | quote }}
-              command: ["true"]
-              securityContext:
-                {{- toYaml $.Values.securityContext | nindent 16 }}
 {{- end }}


### PR DESCRIPTION
Make the last step in the workflow a regular container instead of an initContainer, instead of defining a dummy "noop" container (which tended to get in the way when viewing logs etc.)

Tested: inspected `helm template` output. Job with one step has just one regular container and no initContainers; job with two steps has one initContainer and one regular container; job with three steps has two initContainers and one regular container.