### PR TITLE
Increase limits for Asset Manager virus scanning

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -20,11 +20,12 @@ data:
     Foreground yes
     LogTime yes
     LogVerbose yes
+    MaxFiles 20000
     # Whitehall and Specialist Publisher allow up to 500 MB uploads. Keep in
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).
     MaxFileSize 500M
-    MaxScanSize 1200M
+    MaxScanSize 2000M
     MaxScanTime 0
     MaxThreads 20
     SelfCheck 900


### PR DESCRIPTION
We are seeing issues where users uploading some files have those marked as "infected" when they are not.

In the two cases that we have investigated, this is caused by ClamAV raising either `Heuristics.Limits.Exceeded.MaxFiles` or `Heuristics.Limits.Exceeded.MaxScanSize`.  Full details of the investigation are in a comment on the linked Trello card.

Therefore increasing the size limit for MaxFiles from the default of 10,000 to 20,000 and MaxScanSize from 1200M to 2000M.

These new limits have been tested on a local version of ClamAV and have confirmed the affected files are now properly scanned.

[Trello card](https://trello.com/c/aL2EUaIv)