### PR TITLE
Add Sentry configuration for Asset Manager worker

### DIFF
--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -79,8 +79,15 @@ spec:
           env:
             - name: GOVUK_UPLOADS_ROOT
               value: *uploads-path
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.repoName }}-sentry
+                  key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            {{- end }}
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
We are not currently seeing errors from Asset Manager workers being logged to Sentry.

This is because there is no configuration of the SENTRY_DSN environment variable, which is configured for all other GOV.UK workers.

Therefore adding this so we can see errors which occur within the worker process (including virus scanning).

[Trello card](https://trello.com/c/aL2EUaIv)