### PR TITLE
Maximise availability during Postgres restores.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -7,13 +7,13 @@ source_dir=$(dirname "${BASH_SOURCE[0]}")
 export PGUSER=$DB_USER
 export PGPASSWORD=$DB_PASSWORD
 export PGHOST=$DB_HOST
-export PGDATABASE=$DB_DATABASE
-readonly PGUSER PGPASSWORD PGHOST PGDATABASE
+export PGDATABASE=postgres
 
 backup () {
   local s3_path
-  s3_path="$PGHOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$PGDATABASE.gz"
-  pg_dump -Fc -Z1 | progress | aws s3 cp - "$BUCKET/$s3_path"
+  s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
+  PGDATABASE=$DB_DATABASE \
+    pg_dump -Fc -Z1 | progress | aws s3 cp - "$BUCKET/$s3_path"
 }
 
 transform () {
@@ -31,10 +31,17 @@ restore () {
   if [[ "$GOVUK_ENVIRONMENT" = *"prod"* ]]; then
     : "${REALLY_RESTORE_ONTO_PRODUCTION?}"
   fi
-  local s3_url="$BUCKET/$PGHOST/$FILENAME"
+  local s3_url="$BUCKET/$DB_HOST/$FILENAME"
   s3_url="$s3_url" dump_is_readable
-  dropdb -ef --if-exists "$PGDATABASE"
-  aws s3 cp "$s3_url" - | progress | pg_restore -Cd postgres --no-comments
+
+  dropdb -ef --if-exists "$DB_DATABASE-restore"
+  createdb -eT template0 "$DB_DATABASE-restore"
+  aws s3 cp "$s3_url" - | progress | pg_restore -d "$DB_DATABASE-restore" --no-comments
+  psql -c "ALTER DATABASE \"$DB_DATABASE-restore\" OWNER TO \"$DB_OWNER\";" || true
+
+  psql -c "ALTER DATABASE \"$DB_DATABASE\" RENAME TO \"$DB_DATABASE-old\";" || true
+  psql -c "ALTER DATABASE \"$DB_DATABASE-restore\" RENAME TO \"$DB_DATABASE\";"
+  dropdb -ef --if-exists "$DB_DATABASE-old"
 }
 
 subcommand=${1:-}

--- a/charts/db-backup/scripts/lib.sh
+++ b/charts/db-backup/scripts/lib.sh
@@ -12,7 +12,7 @@ EOF
 }
 
 progress () {
-  stdbuf -eL -- pv -fi 10 -F '%t %r %b'
+  stdbuf -e0 -- pv -fi 10 -F '%t %r %b'
 }
 
 # List available backups in ascending date order.
@@ -27,5 +27,6 @@ list () {
 : "${DB_PASSWORD:?required}"
 : "${DB_HOST:?required}"
 : "${DB_DATABASE:?required}"
+: "${DB_OWNER:=${DB_DATABASE%_production}}"
 : "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
 readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET


### PR DESCRIPTION
- Restore into a new database, then switch names with the old one.
- Create the target database if it doesn't already exist.
- Try to set the database owner (defaulting to the GOV.UK convention of the client app's username being the database name without the `_production` suffix), so that Rails database "migrations" (i.e. automated schema changes) should continue to work.
- Another stab in the dark at trying to get the progress logs to work in real time. (Not expecting any change; stderr is always supposed to be unbuffered anyway, but setting it to line-buffered was silly in any case.)

Tested: ran it on a copy of content_data_admin in staging; restore-then-dump job succeeded with and without a pre-existing target database.