### PR TITLE
More fixes for database restore jobs.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -26,6 +26,27 @@ dump_is_readable () {
     | grep -iq 'PostgreSQL custom database dump'
 }
 
+db_exists () {
+  psql -Alqt |grep -Eo '^\w+\|' |grep -Fq "$1|"
+}
+
+rename_db () {
+  psql -1 <<EOF
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+WHERE pid <> pg_backend_pid() AND datname='$1';
+ALTER DATABASE "$1" RENAME TO "$2";
+EOF
+}
+
+swap_dbs () {
+  psql -1 <<EOF
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+WHERE pid <> pg_backend_pid() AND datname IN ('$1', '$2');
+ALTER DATABASE "$2" RENAME TO "$3";
+ALTER DATABASE "$1" RENAME TO "$2";
+EOF
+}
+
 restore () {
   : "${FILENAME:=$(list | tail -1)}"  # Use latest dump if not specified.
   if [[ "$GOVUK_ENVIRONMENT" = *"prod"* ]]; then
@@ -37,10 +58,15 @@ restore () {
   dropdb -ef --if-exists "$DB_DATABASE-restore"
   createdb -eT template0 "$DB_DATABASE-restore"
   aws s3 cp "$s3_url" - | progress | pg_restore -d "$DB_DATABASE-restore" --no-comments
-  psql -c "ALTER DATABASE \"$DB_DATABASE-restore\" OWNER TO \"$DB_OWNER\";" || true
 
-  psql -c "ALTER DATABASE \"$DB_DATABASE\" RENAME TO \"$DB_DATABASE-old\";" || true
-  psql -c "ALTER DATABASE \"$DB_DATABASE-restore\" RENAME TO \"$DB_DATABASE\";"
+  if db_exists "$DB_DATABASE"; then
+    dropdb -ef --if-exists "$DB_DATABASE-old"
+    swap_dbs "$DB_DATABASE-restore" "$DB_DATABASE" "$DB_DATABASE-old"
+  else
+    rename_db "$DB_DATABASE-restore" "$DB_DATABASE"
+  fi
+  psql -c "ALTER DATABASE \"$DB_DATABASE\" OWNER TO \"$DB_OWNER\";" || true
+
   dropdb -ef --if-exists "$DB_DATABASE-old"
 }
 

--- a/charts/db-backup/scripts/lib.sh
+++ b/charts/db-backup/scripts/lib.sh
@@ -27,6 +27,6 @@ list () {
 : "${DB_PASSWORD:?required}"
 : "${DB_HOST:?required}"
 : "${DB_DATABASE:?required}"
-: "${DB_OWNER:=${DB_DATABASE%_production}}"
+: "${DB_OWNER:=$(echo "${DB_DATABASE%_production}" | tr - _)}"
 : "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
 readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET


### PR DESCRIPTION
Let's just put up with having two code paths depending on whether the target database already exist or not.

Also fix the inferred owner username/role for local-links-manager-postgres and do the `ALTER DATABASE ... OWNER` after renaming (because otherwise it fails because we don't have permission).

Tested: restore+backup worked on a copy of content-data-admin-postgres.

#### Alternatives considered

Considered [putting the logic in a PL/pgSQL procedure](https://github.com/alphagov/govuk-helm-charts/pull/1451#discussion_r1394116850), but that seemed like it'd be harder to troubleshoot if anything unexpected happens later. As much as I dislike that the shell script is getting more complex, at least it's easy enough to see what what's gone wrong from the trace when it fails.