### PR TITLE
Disable uniqueness and foreign key checks during bulk MySQL load.

### DIFF
--- a/charts/db-backup/scripts/backup-mysql
+++ b/charts/db-backup/scripts/backup-mysql
@@ -43,6 +43,8 @@ write_config () {
 user=$DB_USER
 password=$DB_PASSWORD
 host=$DB_HOST
+[mysql]
+init-command="SET SESSION unique_checks=0, foreign_key_checks=0;"
 [mysqldump]
 set-gtid-purged=OFF  # https://bugs.mysql.com/bug.php?id=109685#c530123
 EOF


### PR DESCRIPTION
This should help speed up Whitehall restores, which should help with the nightly environment sync as well as improving RTO if we need to restore into production.

https://dev.mysql.com/doc/refman/8.0/en/optimizing-innodb-bulk-data-loading.html

Tested: successfully ran the restore+dump job for search-admin-mysql in staging. Settings only affect the session (not global).