### PR TITLE
Disable triggers during bulk load into Postgres.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -57,7 +57,8 @@ restore () {
 
   dropdb -ef --if-exists "$DB_DATABASE-restore"
   createdb -eT template0 "$DB_DATABASE-restore"
-  aws s3 cp "$s3_url" - | progress | pg_restore -d "$DB_DATABASE-restore" --no-comments
+  aws s3 cp "$s3_url" - | progress | pg_restore --no-comments -f - \
+    | psql -d "$DB_DATABASE-restore" -c "SET session_replication_role = 'replica';" -f -
 
   if db_exists "$DB_DATABASE"; then
     dropdb -ef --if-exists "$DB_DATABASE-old"


### PR DESCRIPTION
Turn off triggers during the bulk load stage of the restore, using [session_replication_role](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-SESSION-REPLICATION-ROLE). This should significantly reduce restore times and reduce resource usage of the "environment sync" jobs.

The setting only applies to the session that does the bulk load. Any other clients (e.g. those connected to the original database while the restore is being staged) are unaffected.