### PR TITLE
`search-api-v2` workers: scale integration/staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2278,7 +2278,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2309,6 +2309,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
- Scale down workers to default count in integration now that bulk import has finished and been verified
- Scale up workers in staging in anticipation of running there