### PR TITLE
Add `search-v2-evaluator` application

### DIFF
--- a/charts/app-config/image-tags/integration/search-v2-evaluator
+++ b/charts/app-config/image-tags/integration/search-v2-evaluator
@@ -1,0 +1,3 @@
+image_tag: v1
+automatic_deploys_enabled: true
+promote_deployment: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2310,6 +2310,33 @@ govukApplications:
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
 
+  - name: search-v2-evaluator
+    helmValues:
+      dbMigrationEnabled: false
+      uploadAssets:
+        enabled: false
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-defaults, *alb-ingress-waf-ruleset-backend]
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "try-new-search-engine.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: try-new-search-engine.{{ .Values.k8sExternalDomainSuffix }}
+      extraEnv:
+        - name: BASIC_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: basic-auth
+              key: password
+        - name: BASIC_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: basic-auth
+              key: username
+
   - name: service-manual-publisher
     helmValues:
       dbMigrationEnabled: true


### PR DESCRIPTION
This is a short-lived application that will be used internally and allows users to try out and provide feedback on the results of the new Google Vertex-powered `search-api-v2` before it goes live through Finder Frontend.

- Add new `search-v2-evaluator` app to `app-config` in integration, with a custom ingress on `try-new-search-engine` (as it won't be accessible through the primary domain), reusing existing basic auth username and password from the rest of the estate (this isn't a super sensitive app, it's read-only anyway, we only want to not have it blatantly publicly accessible)
- Add matching image tag to `app-config`