### PR TITLE
Take ownership of databases before renaming them.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -34,6 +34,7 @@ rename_db () {
   psql -1 <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
 WHERE pid <> pg_backend_pid() AND datname='$1';
+ALTER DATABASE "$1" OWNER TO session_user;
 ALTER DATABASE "$1" RENAME TO "$2";
 EOF
 }
@@ -42,6 +43,7 @@ swap_dbs () {
   psql -1 <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
 WHERE pid <> pg_backend_pid() AND datname IN ('$1', '$2');
+ALTER DATABASE "$2" OWNER TO session_user;
 ALTER DATABASE "$2" RENAME TO "$3";
 ALTER DATABASE "$1" RENAME TO "$2";
 EOF


### PR DESCRIPTION
It seems the default privileges vary between some of our Postgres instances; on some, we can `ALTER DATABASE RENAME` anything we like as `aws_db_admin` whereas on others we can't.

Make the restore script robust to either case.

Tested: draft-content-store job (which previously failed on rename permissions) succeeds with this in staging.