### PR TITLE
Bump image tag for `search-v2-evaluator`

### DIFF
--- a/charts/app-config/image-tags/integration/search-v2-evaluator
+++ b/charts/app-config/image-tags/integration/search-v2-evaluator
@@ -1,3 +1,3 @@
-image_tag: v1
+image_tag: v6
 automatic_deploys_enabled: true
 promote_deployment: false


### PR DESCRIPTION
The `v1` image was never actually pushed to ECR, making Argo very sad and confused.