### PR TITLE
Disable Sentry for `search-v2-evaluator`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2315,6 +2315,8 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
+      sentry:
+        enabled: false
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
This is an internal, temporary app and doesn't need it.