### PR TITLE
Add Google Tag Manager to Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1785,6 +1785,12 @@ govukApplications:
           value: govuk-integration-publisher-csvs
         - name: AWS_REGION
           value: eu-west-1
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
+        - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
+          value: *publishing-bootstrap-gtm-auth
+        - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
+          value: *publishing-bootstrap-gtm-preview
 
   - name: publishing-api
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1840,6 +1840,8 @@ govukApplications:
           value: govuk-production-publisher-csvs
         - name: AWS_REGION
           value: eu-west-1
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
 
   - name: publishing-api
     helmValues:


### PR DESCRIPTION
This pull request adds Google Tag Manager to Publisher.

The production environment only needs the `GOOGLE_TAG_MANAGER_ID` variable, which means GTM will default to the live configuration.

For the integration environment, we also set the `GOOGLE_TAG_MANAGER_AUTH` and `GOOGLE_TAG_MANAGER_PREVIEW` variables so that GTM uses the integration configuration. This allows us to test GTM configs before publishing them to the live production environment.

Trello card: https://trello.com/c/QOqGTxKq/573-ga4-implementation