### PR TITLE
Run pg_terminate_backend() in its own transaction.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -31,21 +31,25 @@ db_exists () {
 }
 
 rename_db () {
-  psql -1 <<EOF
+  psql <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
 WHERE pid <> pg_backend_pid() AND datname='$1';
-ALTER DATABASE "$1" OWNER TO session_user;
-ALTER DATABASE "$1" RENAME TO "$2";
+BEGIN;
+  ALTER DATABASE "$1" OWNER TO session_user;
+  ALTER DATABASE "$1" RENAME TO "$2";
+COMMIT;
 EOF
 }
 
 swap_dbs () {
-  psql -1 <<EOF
+  psql <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
 WHERE pid <> pg_backend_pid() AND datname IN ('$1', '$2');
-ALTER DATABASE "$2" OWNER TO session_user;
-ALTER DATABASE "$2" RENAME TO "$3";
-ALTER DATABASE "$1" RENAME TO "$2";
+BEGIN;
+  ALTER DATABASE "$2" OWNER TO session_user;
+  ALTER DATABASE "$2" RENAME TO "$3";
+  ALTER DATABASE "$1" RENAME TO "$2";
+COMMIT;
 EOF
 }
 


### PR DESCRIPTION
If there are other superuser processes on the target database, pg_terminate_backend() can fail (at least on some of our Postgres instances, until we sort out whatever's slightly wonky with the grants):

    + psql -1
    ERROR:  must be a superuser to terminate superuser process
    ERROR:  current transaction is aborted, commands ignored until end of transaction block

We don't want to roll back the rename transaction when that happens.

(The wonkiness with the grants is that `aws_db_admin` is already supposed to be a superuser, but apparently that's not consistently true for all our RDS/Postgres instances. Or something like that.)

Tested: successfully ran the `content-data-admin-postgres` restore+backup job in staging (installed temporarily via `helm install`).