### PR TITLE
`search-api-v2`: scale workers in staging/prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2367,6 +2367,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2313,7 +2313,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
We've successfully run our one-off bulk import in staging, so can scale down the workers there and scale them up in production to run it there.