### PR TITLE
Mark non-retryable jobs as not ok for CA to evict.

### DIFF
--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -37,6 +37,8 @@ spec:
           labels:
             {{- include "db-backup.selectorLabels" $ | nindent 12 }}
             app.kubernetes.io/component: {{ $jobName }}
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           enableServiceLinks: false
           restartPolicy: Never


### PR DESCRIPTION
We don't really want PDBs for these (because they're ephemeral) but we still want Cluster Autoscaler to leave them alone.