### PR TITLE
Scale down `search-api-v2` to default levels

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2367,7 +2367,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
We've finished our production one-off import and can now return to business as usual.