### PR TITLE
Drop redundant request_uri field from nginx logs.

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -86,7 +86,6 @@ http {
     '"request_query_string":"$query_string",'
     '"request_method":"$request_method",'
     '"request_time":$request_time,'
-    '"request_uri":"$request_uri",'
     '"sent_http_content_type":"$sent_http_content_type",'
     '"sent_http_location":"$sent_http_location",'
     '"server_name":"$server_name",'

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -70,7 +70,6 @@ data:
         '"request_query_string":"$query_string",'
         '"request_method":"$request_method",'
         '"request_time":$request_time,'
-        '"request_uri":"$request_uri",'
         '"sent_http_content_type":"$sent_http_content_type",'
         '"sent_http_location":"$sent_http_location",'
         '"server_name":"$server_name",'

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -89,7 +89,6 @@ data:
         '"request_query_string":"$query_string",'
         '"request_method":"$request_method",'
         '"request_time":$request_time,'
-        '"request_uri":"$request_uri",'
         '"sent_http_content_type":"$sent_http_content_type",'
         '"sent_http_location":"$sent_http_location",'
         '"server_port":"$server_port",'


### PR DESCRIPTION
This field is literally just a concatenation of three other fields that we already log (request_method, request_uri, server_protocol) so it's just taking up space and doesn't even make querying any easier.

This should significantly help to reduce our log storage costs, which have been creeping up again lately.