### PR TITLE
Log dep-resolution src content_id only where used.

### DIFF
--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -77,7 +77,6 @@ data:
         '"@timestamp":"$time_iso8601",'
         '"body_bytes_sent":$body_bytes_sent,'
         '"bytes_sent":$bytes_sent,'
-        '"govuk_dependency_resolution_source_content_id":"$http_govuk_dependency_resolution_source_content_id",'
         '"govuk_request_id":"$http_govuk_request_id",'
         '"http_host":"$http_host",'
         '"http_referer":"$http_referer",'


### PR DESCRIPTION
Only content-store actually logs the
[`govuk_dependency_resolution_source_content_id` request header](https://sourcegraph.com/search?q=repo%3Aalphagov+govuk_dependency_resolution_source_content_id), but we were including it on every nginx request log from every app even though it's always empty for all other apps.

There's also no reason for us to include it in nginx logs even for content-store, because it's already included in the app's own request logs and nginx doesn't do anything differently based on the presence or value of that header.

Conservatively: 50 M records/day * 50 bytes = 2.5 GB/day. That's 1.7% of our current 150 GB/day log quota in production.