### PR TITLE
content-data workers spool entire reports in RAM :(

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -435,6 +435,14 @@ govukApplications:
           - name: content-data.{{ .Values.k8sExternalDomainSuffix }}
       nginxProxyReadTimeout: 60s
       workerEnabled: true
+      workerReplicaCount: 2
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 0.5
+          memory: 2Gi
       extraEnv:
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
Give them more RAM for now, at least so we can see what's going on more easily (and hopefully get it going again in the short term).

We also don't need 3 workers cos these sit idle like 99.9% of the time and the Sidekiq tasks are huge and not sharded so more workers doesn't make it go faster.