### PR TITLE
Scale `search-api-v2` worker replicas back up

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2284,6 +2284,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2375,6 +2375,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2313,6 +2313,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 25
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
We've fixed some bugs with the content import, which means we need to run full bulk imports in all environments again.