### PR TITLE
Add backup/restore jobs for Router MongoDB.

### DIFF
--- a/charts/db-backup/scripts/backup-mongo
+++ b/charts/db-backup/scripts/backup-mongo
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+source_dir=$(dirname "${BASH_SOURCE[0]}")
+. "$source_dir/lib.sh"
+
+: "${DB_MONGO_REPLICASET:=$DB_HOST}"
+
+backup () {
+  local s3_path
+  s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
+  mongodump -h "$DB_MONGO_REPLICASET" --archive \
+    | progress | gzip -1 | aws s3 cp - "$BUCKET/$s3_path"
+}
+
+transform () {
+  shift
+  (cd "$source_dir" && mongo -h "$DB_MONGO_REPLICASET" "$DB_DATABASE" < "$1")
+}
+
+dump_is_readable () {
+  set +o pipefail  # We expect SIGPIPE here, but only here.
+  (aws s3 cp "$s3_url" - 2>/dev/null) | gzip -d | head -c 100 \
+    | grep -q concurrent_collections
+  local ret=$?
+  set -o pipefail
+  return $ret
+}
+
+restore () {
+  : "${FILENAME:=$(list | tail -1)}"  # Use latest dump if not specified.
+  if [[ "$GOVUK_ENVIRONMENT" = *"prod"* ]]; then
+    : "${REALLY_RESTORE_ONTO_PRODUCTION?}"
+  fi
+  local s3_url="$BUCKET/$DB_HOST/$FILENAME"
+  s3_url="$s3_url" dump_is_readable
+
+  aws s3 cp "$s3_url" - | gzip -d | progress | \
+    mongorestore -h "$DB_MONGO_REPLICASET" --archive --drop
+}
+
+write_config () {
+  cat > "$HOME/.my.cnf" <<EOF
+EOF
+}
+
+subcommand=${1:-}
+[[ $(type -t "$subcommand") == function ]] || usage
+
+write_config
+[[ "${VERBOSE:-0}" -ge 1 ]] && set -x
+$subcommand "$@"
+echo "done"

--- a/charts/db-backup/scripts/lib.sh
+++ b/charts/db-backup/scripts/lib.sh
@@ -24,7 +24,7 @@ list () {
 
 : "${GOVUK_ENVIRONMENT:?required}"
 : "${DB_USER:=aws_db_admin}"
-: "${DB_PASSWORD:?required}"
+: "${DB_PASSWORD:=}"
 : "${DB_HOST:?required}"
 : "${DB_DATABASE:?required}"
 : "${DB_OWNER:=$(echo "${DB_DATABASE%_production}" | tr - _)}"

--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -74,6 +74,7 @@ spec:
               env:
                 - name: GOVUK_ENVIRONMENT
                   value: {{ $.Values.govukEnvironment }}
+                {{- if not $job.noAuth }}
                 - name: DB_USER
                   value: {{ $job.dbUser | default "aws_db_admin" }}
                 - name: DB_PASSWORD
@@ -81,8 +82,11 @@ spec:
                     secretKeyRef:
                       name: {{ $fullName }}-passwd
                       key: {{ $dbHost }}
+                {{- end }}
                 - name: DB_HOST
                   value: {{ $dbHost }}
+                - name: DB_MONGO_REPLICASET
+                  value: {{ $job.replicaSet | default "" }}
                 - name: DB_DATABASE
                   value: {{ .db | default $job.db }}
                 - name: BUCKET

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -165,6 +165,14 @@ cronjobs:
       operations:
         - op: backup
 
+    router-mongo:
+      schedule: "27 23 * * *"
+      db: all
+      replicaSet: router-backend-1,router-backend-2,router-backend-3
+      noAuth: true
+      operations:
+        - op: backup
+
     search-admin-mysql:
       schedule: "56 23 * * *"
       db: search_admin_production
@@ -342,6 +350,16 @@ cronjobs:
     release-mysql:
       schedule: "11 1 * * 1"  # Daily would be overkill.
       db: release_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
+
+    router-mongo:
+      schedule: "27 0 * * *"
+      db: all
+      replicaSet: router-backend-1,router-backend-2,router-backend-3
+      noAuth: true
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
@@ -533,6 +551,16 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
+
+    router-mongo:
+      schedule: "27 2 * * *"
+      db: all
+      replicaSet: router-backend-1,router-backend-2,router-backend-3
+      noAuth: true
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
+        - op: backup
 
     search-admin-mysql:
       schedule: "56 3 * * *"


### PR DESCRIPTION
Just Router for now, since the others are hosted on DocumentDB so we need to support authentication for those.

Tested: backup works in staging (installed temporarily with `helm install`). Restore works onto a local MongoDB replicaset of the same version running in Docker.