### PR TITLE
Add ExternalSecret for `search-v2-evaluator`

### DIFF
--- a/charts/external-secrets/templates/search-v2-evaluator/google-cloud-bigquery-configuration.yaml
+++ b/charts/external-secrets/templates/search-v2-evaluator/google-cloud-bigquery-configuration.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: search-v2-evaluator-google-cloud-bigquery-configuration
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Configuration for Google Cloud BigQuery for search-v2-evaluator
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-v2-evaluator-google-cloud-bigquery-configuration
+  dataFrom:
+    - extract:
+        key: govuk/search-v2-evaluator/google-cloud-bigquery-configuration


### PR DESCRIPTION
This Secrets Manager secret contains BigQuery project/dataset/table details and GCP service account credentials provisioned through `search-v2-infrastructure`, and allows the app to store submitted feedback in BigQuery.