### PR TITLE
Add static mirror request monitoring from Grafana

### DIFF
--- a/charts/monitoring-config/dashboards/static-mirror-requests.json
+++ b/charts/monitoring-config/dashboards/static-mirror-requests.json
@@ -35,7 +35,7 @@
             "custom": {
               "axisCenteredZero": false,
               "axisColorMode": "text",
-              "axisLabel": "",
+              "axisLabel": "Total requests",
               "axisPlacement": "auto",
               "barAlignment": 0,
               "drawStyle": "line",
@@ -157,7 +157,7 @@
             "custom": {
               "axisCenteredZero": false,
               "axisColorMode": "text",
-              "axisLabel": "",
+              "axisLabel": "Total HTTP requests/s",
               "axisPlacement": "auto",
               "barAlignment": 0,
               "drawStyle": "line",
@@ -369,7 +369,7 @@
             "custom": {
               "axisCenteredZero": false,
               "axisColorMode": "text",
-              "axisLabel": "",
+              "axisLabel": "Total HTTP errors/s",
               "axisPlacement": "auto",
               "barAlignment": 0,
               "drawStyle": "line",


### PR DESCRIPTION
The static mirror dashboard was created manually using the Grafana UI. This PR replicates the dashboard to terraform.

Trello: https://trello.com/c/xrq1YM3B/3359-add-grafana-dashboard-for-monitoring-requests-to-the-mirror-to-govuk-helm-charts-2