### PR TITLE
Use ExternalSecret for `search-v2-evaluator` env

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2343,6 +2343,26 @@ govukApplications:
             secretKeyRef:
               name: basic-auth
               key: username
+        - name: GOOGLE_CLOUD_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
+        - name: BIGQUERY_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_PROJECT
+        - name: BIGQUERY_DATASET
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_DATASET
+        - name: BIGQUERY_TABLE
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_TABLE
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2434,6 +2434,26 @@ govukApplications:
             secretKeyRef:
               name: basic-auth
               key: username
+        - name: GOOGLE_CLOUD_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
+        - name: BIGQUERY_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_PROJECT
+        - name: BIGQUERY_DATASET
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_DATASET
+        - name: BIGQUERY_TABLE
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_TABLE
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2372,6 +2372,26 @@ govukApplications:
             secretKeyRef:
               name: basic-auth
               key: username
+        - name: GOOGLE_CLOUD_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
+        - name: BIGQUERY_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_PROJECT
+        - name: BIGQUERY_DATASET
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_DATASET
+        - name: BIGQUERY_TABLE
+          valueFrom:
+            secretKeyRef:
+              name: search-v2-evaluator-google-cloud-bigquery-configuration
+              key: BIGQUERY_TABLE
 
   - name: service-manual-publisher
     helmValues:


### PR DESCRIPTION
This uses the new external secret for BigQuery configuration to set up environment variables for `search-v2-evaluator`.

c.f. https://github.com/alphagov/govuk-helm-charts/pull/1492/files