### PR TITLE
[1/4] Turn off production publishing-api workers, for content-store switchover

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1858,6 +1858,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 0
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
To make sure that we have a completely up-to-date draft-content-store database at the point we switchover the proxy to PostgreSQL, we need to temporarily disable publishing-api workers while the mongo-to-postgresql job runs one last time.

[Trello card](https://trello.com/c/kQbZFteC/949-prepare-advance-prs-for-swapping-the-draft-content-store-in-production) 

I'm raising this as a draft PR so that it doesn't get accidentally merged before the scheduled maintenance period, will convert to a regular PR at that time.