### PR TITLE
[2/4] Swap draft-content-store proxy in production to PostgreSQL primary

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -761,9 +761,9 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store-mongo-main/"
-        - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://content-store-mongo-main/"
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT


### PR DESCRIPTION
As per [the plan](https://docs.google.com/document/d/14B3YE978TDbujYnGHL0gm_gnf_EwD5MSHx7iRF24-90/edit), this is the main change involved in switching the draft-content-store in production to use PostgreSQL.

Draft-only for now, to avoid any accidental merge before the scheduled time.

[Trello card](https://trello.com/c/kQbZFteC/949-prepare-advance-prs-for-swapping-the-draft-content-store-in-production)