### PR TITLE
[3/4] Re enable publishing-api workers in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1860,7 +1860,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 0
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
After switching the draft-content-store proxy to PostgreSQL (#1500 ), we'll need to re-enable the publishing-api workers which we turned off as the first step in the process (#1499). 

[Trello card](https://trello.com/c/kQbZFteC/949-prepare-advance-prs-for-swapping-the-draft-content-store-in-production) 