### PR TITLE
Disable overnight mongo-to-postgres job for draft-content-store in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1374,15 +1374,6 @@ govukApplications:
         sageMakerImage: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::172025368201:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::172025368201:role/search-api-learn-to-rank-govuk
-      draftContentStoreMongoPostgresCron:
-        schedule: "26 22 * * *"
-        mongoExport:
-          mongoDbUri: "mongodb://\
-            mongo-1.production.govuk-internal.digital,\
-            mongo-2.production.govuk-internal.digital,\
-            mongo-3.production.govuk-internal.digital/draft_content_store_production"
-        postgresImport:
-          databaseUrlSecretName: "draft-content-store-postgres"
       contentStoreMongoPostgresCron:
         schedule: "26 22 * * *"
         mongoExport:


### PR DESCRIPTION
After switching the draft-content-store proxy to PostgreSQL (#1500), and re-enabling the publishing-api workers (#1501) which we turned off as the first step in the process (#1499), and assuming that we haven't seen any issues that would make us want to rollback in the subsequent few hours, we will need to remove the overnight mongo-to-postgres export/import job for the draft-content-store (at this point, the source of truth will be PostgreSQL). 

[Trello card](https://trello.com/c/kQbZFteC/949-prepare-advance-prs-for-swapping-the-draft-content-store-in-production) 