### PR TITLE
Suppress mongosh startup boilerplate message.

### DIFF
--- a/charts/db-backup/scripts/backup-mongo
+++ b/charts/db-backup/scripts/backup-mongo
@@ -32,7 +32,7 @@ restore () {
 
 transform () {
   shift
-  (cd "$source_dir" && mongosh "$db_url" < "$1")
+  (cd "$source_dir" && mongosh --quiet "$db_url" < "$1")
 }
 
 subcommand=${1:-}


### PR DESCRIPTION
Specifying [`--quiet`](https://www.mongodb.com/docs/mongodb-shell/reference/options/#std-option-mongosh.--quiet) makes the logs slightly more readable by not printing a bunch of boilerplate on startup. Still outputs the actual statements being executed and any errors etc.