### PR TITLE
Add govuk-sli-collector job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1321,11 +1321,14 @@ govukApplications:
     imageValues:
       - "content-store"
       - "content-store-postgresql-branch"
+      - "govuk-sli-collector"
       - "search-api"
       - "search-api-learn-to-rank"
     helmValues:
       govukMirrorSync:
         iamRoleArn: arn:aws:iam::210287912431:role/govuk-mirror-sync
+      govukSliCollector:
+        enabled: true
       learnToRank:
         elasticsearchUri: &elasticsearch-uri
           https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com

--- a/charts/external-secrets/templates/govuk-sli-collector/logit-opensearch-api.yaml
+++ b/charts/external-secrets/templates/govuk-sli-collector/logit-opensearch-api.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-sli-collector-logit-opensearch-api
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Basic auth credentials for Logit's OpenSearch API, used for querying log
+      data. basic-auth is the base64 combined username:password string and host
+      is the API URL (with no endpoint path).
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-sli-collector-logit-opensearch-api
+  dataFrom:
+    - extract:
+        key: govuk/govuk-sli-collector/logit-opensearch-api

--- a/charts/external-secrets/templates/govuk-sli-collector/sentry.yaml
+++ b/charts/external-secrets/templates/govuk-sli-collector/sentry.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-sli-collector-sentry
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      DSN for Sentry
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: govuk-sli-collector-sentry
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: govuk/common/sentry
+        property: govuk-sli-collector-dsn

--- a/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.govukSliCollector.enabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "govuk-sli-collector"
+  labels:
+    app: "govuk-sli-collector"
+    app.kubernetes.io/component: "govuk-sli-collector"
+spec:
+  schedule: "*/{{ .Values.govukSliCollector.intervalMinutes }} * * * *"
+  jobTemplate:
+    metadata:
+      name: "govuk-sli-collector"
+      labels:
+        app: "govuk-sli-collector"
+        app.kubernetes.io/component: "govuk-sli-collector"
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          name: "govuk-sli-collector"
+          labels:
+            app: "govuk-sli-collector"
+            app.kubernetes.io/component: "govuk-sli-collector"
+        spec:
+          enableServiceLinks: false
+          securityContext:
+            fsGroup: {{ .Values.securityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+          restartPolicy: Never
+          containers:
+            - name: main
+              image: "{{ .Values.images.GovukSliCollector.repository }}:{{ .Values.images.GovukSliCollector.tag }}"
+              imagePullPolicy: "Always"
+              env:
+                - name: INTERVAL_MINUTES
+                  value: "{{ .Values.govukSliCollector.intervalMinutes }}"
+                - name: OFFSET_MINUTES
+                  value: "{{ .Values.govukSliCollector.offsetMinutes }}"
+                - name: LOGIT_OPENSEARCH_BASIC_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: govuk-sli-collector-logit-opensearch-api
+                      key: basic-auth
+                - name: LOGIT_OPENSEARCH_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: govuk-sli-collector-logit-opensearch-api
+                      key: host
+                - name: PROMETHEUS_PUSHGATEWAY_URL
+                  value: http://prometheus-pushgateway.monitoring.svc.cluster.local:9091
+              {{- with .Values.resources }}
+              resources:
+                {{- . | toYaml | trim | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+{{- end }}

--- a/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml
@@ -52,6 +52,15 @@ spec:
                       key: host
                 - name: PROMETHEUS_PUSHGATEWAY_URL
                   value: http://prometheus-pushgateway.monitoring.svc.cluster.local:9091
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: govuk-sli-collector-sentry
+                      key: dsn
+                - name: SENTRY_RELEASE
+                  value: "{{ .Values.images.GovukSliCollector.tag }}"
+                - name: SENTRY_CURRENT_ENV
+                  value: "{{ .Values.govukEnvironment }}"
               {{- with .Values.resources }}
               resources:
                 {{- . | toYaml | trim | nindent 16 }}

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -20,6 +20,9 @@ images:
   GovukDependencyChecker:
     repository: "govuk-dependency-checker"
     tag: "release"
+  GovukSliCollector:
+    repository: "govuk-sli-collector"
+    tag: "release"
   SearchApi:
     repository: "search-api"
     tag: "release"
@@ -29,6 +32,11 @@ images:
 
 govukMirrorSync:
   schedule: "0 0 * * *"
+
+govukSliCollector:
+  enabled: false
+  intervalMinutes: "5"
+  offsetMinutes: "10"
 
 learnToRank:
   elasticsearchUri: ""


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

This adds a new cron job to `govuk-jobs` for the [govuk-sli-collector](https://github.com/alphagov/govuk-sli-collector) script. The intention is to run it every few minutes. Once we've got it working in integration we're planning to switch to running it in production only.

(These changes are mostly cribbed from the templates for `content-store-mongo-to-postgres-cron` and `dependabot-metrics`. If it wasn't already a given: I don't understand every detail.)

Questions:
1. What does `automatic_deploys_enabled: true` do by itself? (i.e. with `promote_deployment: false`)
2. Since this isn't an app, am I right to think that it won't have access to the secret defined in `charts/generic-govuk-app/templates/sentry-external-secret.yaml`? (I've added an external secret, but it'd like to remove it if it's redundant)
3. Will stdout/stderr be written to `/var/log/containers/*` by default or do I need to configure that somewhere?

Related: https://github.com/alphagov/govuk-sli-collector/pull/4