### PR TITLE
Updating Clam config and clamdscan path

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -151,7 +151,7 @@ govukApplications:
         name: asset-manager-nginx-conf
       extraEnv:
         - name: ASSET_MANAGER_CLAMSCAN_PATH
-          value: /usr/bin/clamdscan
+          value: /usr/local/bin/clamdscan
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -158,7 +158,7 @@ govukApplications:
         name: asset-manager-nginx-conf
       extraEnv:
         - name: ASSET_MANAGER_CLAMSCAN_PATH
-          value: /usr/bin/clamdscan
+          value: /usr/local/bin/clamdscan
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -80,7 +80,7 @@ clamdResources:
     memory: 2000Mi
 
 # clamMountConfigPath is the path to which the clamav.conf and freshclam.conf are mounted
-clamMountConfigPath: "/etc/clamav"
+clamMountConfigPath: "/usr/local/etc"
 
 # assetManagerNFS is the address of the NFSv4 (or Amazon EFS) server where uploaded
 assetManagerNFS: "asset-manager-efs.dev.gov.uk"


### PR DESCRIPTION
This changes paths for Staging and Production:

New ClamAV config and engine 1.2.1 has been tested in integration -  Uploading asset on Whitehall, then checking logs to see virus scan completed and asset added to AWS S3.

Pre req:(this code should be merged after)
https://github.com/alphagov/asset-manager/pull/1248

Tested output of change via helm template:
`helm template asset-clam ../asset-manager --values <(helm template . --values values-${ENV}| yq e '.|select(.metadata.name == "asset-manager").spec.source.helm.values') --set sentry.createSecret=false`

Output for Prod mount:

```
              volumeMounts:
                - name: etc-clamav mountPath: /usr/local/etc
```

Output for Staging mount:

 ```
    volumeMounts:
                - name: etc-clamav mountPath: /usr/local/etc
```

https://trello.com/c/TicAq9G1/1238-update-clamav-engine-to-latest-version