### PR TITLE
Don't try to terminate rdsadmin connections.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -33,25 +33,22 @@ db_exists () {
 }
 
 rename_db () {
-  psql <<EOF
+  psql -1v ON_ERROR_STOP=1 <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-WHERE pid <> pg_backend_pid() AND datname='$1';
-BEGIN;
-  ALTER DATABASE "$1" OWNER TO session_user;
-  ALTER DATABASE "$1" RENAME TO "$2";
-COMMIT;
+WHERE pid <> pg_backend_pid() AND usename <> 'rdsadmin' AND datname = '$1';
+ALTER DATABASE "$1" OWNER TO session_user;
+ALTER DATABASE "$1" RENAME TO "$2";
 EOF
 }
 
 swap_dbs () {
-  psql <<EOF
+  psql -1v ON_ERROR_STOP=1 <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-WHERE pid <> pg_backend_pid() AND datname IN ('$1', '$2');
-BEGIN;
-  ALTER DATABASE "$2" OWNER TO session_user;
-  ALTER DATABASE "$2" RENAME TO "$3";
-  ALTER DATABASE "$1" RENAME TO "$2";
-COMMIT;
+WHERE pid <> pg_backend_pid() AND usename <> 'rdsadmin'
+  AND datname IN ('$1', '$2');
+ALTER DATABASE "$2" OWNER TO session_user;
+ALTER DATABASE "$2" RENAME TO "$3";
+ALTER DATABASE "$1" RENAME TO "$2";
 EOF
 }
 


### PR DESCRIPTION
Amazon's RDS flavor of Postgres has some irritating quirks regarding the superuser attribute. It's not possible to log in as a superuser or to assign the superuser attribute to a role, and the replacement `rds_superuser` role doesn't work very much like an actual superuser.

So we need to be more selective about which connections we try to terminate before swapping databases around at the end of a full restore, because Amazon doesn't let us grant ourselves sufficient privileges to terminate all connections.

Make sure that:
 - the swaparoo transaction doesn't roll back for want of not being able to kick out a superuser connection (which isn't possible in RDS)
 - the script fails if the transaction does roll back

This is intended to help avoid rolling back where we shouldn't, while also not masking real errors that we want to surface.

Tested: installed via Helm in staging and successfully ran a restore of content-data-admin.