### PR TITLE
Turn off staging publishing-api workers, as a trial run for #1499 later

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1827,6 +1827,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 0
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
Later today we'll be deploying a sequence of PRs starting with #1499, to switch production's draft-content-store over to PostgreSQL. 

This PR lets us trial the as-yet-untried parts of the process on staging first - I chose staging rather than integration as it's 
a) supposed to be the most prod-like environment, and
b) not used for training, so should not cause any user disruption

We'll revert this PR later to turn the workers back on 