### PR TITLE
Attempt 2 at turning off publishing-api workers (staging only)

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1826,8 +1826,7 @@ govukApplications:
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
-      workerEnabled: true
-      workerReplicaCount: 0
+      workerEnabled: false
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
The previous attempt to turn off staging publishing-api workers just by setting `workerReplicaCount: 0` (#1522) didn't work.
Describing the deployment showed:

```
Replicas:               2 desired | 2 updated | 2 total | 2 available | 0 unavailable
...
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  publishing-api-worker-7d84994566 (0/0 replicas created), publishing-api-worker-7cc55d64cb (0/0 replicas created)
NewReplicaSet:   publishing-api-worker-7f75cc5574 (2/2 replicas created)
``` 
for over 10 minutes.

This PR removes the previous setting and goes with `workerEnabled: false` instead