### PR TITLE
Temporarily re-add draftContentSoreMongoPostgresCron in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1358,6 +1358,7 @@ govukApplications:
         serviceAccountIamRole: arn:aws:iam::696911096973:role/search-api-learn-to-rank-govuk
       draftContentStoreMongoPostgresCron:
         schedule: "26 22 * * *"
+        suspended: true
         mongoExport:
           mongoDbUri: "mongodb://\
             mongo-1.production.govuk-internal.digital,\

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1356,7 +1356,15 @@ govukApplications:
         sageMakerImage: 696911096973.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::696911096973:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::696911096973:role/search-api-learn-to-rank-govuk
-
+      draftContentStoreMongoPostgresCron:
+        schedule: "26 22 * * *"
+        mongoExport:
+          mongoDbUri: "mongodb://\
+            mongo-1.production.govuk-internal.digital,\
+            mongo-2.production.govuk-internal.digital,\
+            mongo-3.production.govuk-internal.digital/draft_content_store_production"
+        postgresImport:
+          databaseUrlSecretName: "draft-content-store-postgres"
   - name: hmrc-manuals-api
     helmValues:
       nginxClientMaxBodySize: 2M


### PR DESCRIPTION
...so that we can trial manually triggering this job, and make sure it completes while the DB is under daytime load

