### PR TITLE
Fix bad regex in db_exists check.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -29,7 +29,7 @@ dump_is_readable () {
 }
 
 db_exists () {
-  psql -Alqt | grep -Eo '^\w+\|' | grep -Fq "$1|"
+  psql -Alqt | grep -Eo '^[^|]+\|' | grep -Fq "$1|"
 }
 
 rename_db () {


### PR DESCRIPTION
Wasn't allowing for database names containing dashes.

Tested: command now returns as expected for names like `email-alert-api_production`.