### PR TITLE
Enable Sentry for `search-v2-evaluator`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2320,8 +2320,6 @@ govukApplications:
   - name: search-v2-evaluator
     helmValues:
       dbMigrationEnabled: false
-      sentry:
-        enabled: false
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2411,8 +2411,6 @@ govukApplications:
   - name: search-v2-evaluator
     helmValues:
       dbMigrationEnabled: false
-      sentry:
-        enabled: false
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2349,8 +2349,6 @@ govukApplications:
   - name: search-v2-evaluator
     helmValues:
       dbMigrationEnabled: false
-      sentry:
-        enabled: false
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Even though this is a temporary MVP for internal use, we don't want to have to rely on people complaining to find out something is wrong!