### PR TITLE
Add ALERT_LISTENER_EMAIL_ACCOUNT values to email-alert-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -970,6 +970,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-api-account-api
               key: bearer_token
+        - name: ALERT_LISTENER_EMAIL_ACCOUNT
+          value: email-alert-api-integration@digital.cabinet-office.gov.uk
         - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
           value: email-alert-api-integration@digital.cabinet-office.gov.uk
         - name: DATABASE_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -972,6 +972,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-api-account-api
               key: bearer_token
+        - name: ALERT_LISTENER_EMAIL_ACCOUNT
+          value: email-alert-api-alert-listener@digital.cabinet-office.gov.uk
         - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
           value: email-alert-api-bulk-migrate@digital.cabinet-office.gov.uk
         - name: DATABASE_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -988,6 +988,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-api-account-api
               key: bearer_token
+        - name: ALERT_LISTENER_EMAIL_ACCOUNT
+          value: email-alert-api-staging@digital.cabinet-office.gov.uk
         - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
           value: email-alert-api-staging@digital.cabinet-office.gov.uk
         - name: DATABASE_URL


### PR DESCRIPTION
To ensure there's some kind of account that a person can manually check, add an env var that specifies an email address that will always receive Medical / Travel alerts in each env. (because it's only going to be used as a manual backstop to the alert monitoring code, this doesn't need to be a paid-for gmail account, but can be a much simpler to set up and cheaper google group).

https://trello.com/c/iDshBFBL/2280-add-setup-task-to-ensure-that-canary-accounts-are-available-in-email-alert-api