### PR TITLE
Specify the database when running psql transforms.

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -20,7 +20,7 @@ backup () {
 
 transform () {
   shift
-  (cd "$source_dir" && psql < "$1")
+  (cd "$source_dir" && psql "$DB_DATABASE" < "$1")
 }
 
 dump_is_readable () {


### PR DESCRIPTION
This makes it consistent with how we're running the MySQL ones and fixes the failures on the email-alert-api transform script.

Tested: succeeded in staging (run via Helm install with patched values).