### PR TITLE
Tidy up email-alert-api pseudonymisation SQL script.

### DIFF
--- a/charts/db-backup/scripts/email-alert-api.sql
+++ b/charts/db-backup/scripts/email-alert-api.sql
@@ -1,46 +1,52 @@
--- This is supposed to be identical to
--- https://github.com/alphagov/email-alert-api/blob/main/lib/data_hygiene/anonymise_email_addresses.sql
--- TODO: Fix the CI in alphagov/email-alert-api to pull in this script
--- (perhaps via git submodule) instead of running tests against its own copy.
--- TODO: Simplify this script.
-
--- This SQL file anonymises email addresses in the email-alert-api database.
+-- email-alert-api.sql pseudonymises email addresses in the email-alert-api
+-- database. The intent is to take the production dataset and automatically to
+-- produce a dataset somewhat more suitable for loading into the integration
+-- test environment.
 --
--- It tries to preserve structure so that multiple occurences of the same address
--- are mapped to the same anonymous address.
+-- It tries to preserve structure so that multiple occurences of the same
+-- address are mapped to the same "anonymous" address.
 
--- Delete all emails that are older than 1 day old.
-DELETE FROM emails
+-- TODO: generate sufficiently realistic synthetic test data and stop copying
+-- production data outside of production altogether.
+
+-- Drop all emails more than a day old.
+ALTER TABLE emails RENAME TO old_emails;
+
+CREATE TABLE emails (
+  LIKE old_emails INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING INDEXES
+);
+
+ALTER TABLE emails OWNER TO "email-alert-api";
+
+INSERT INTO emails
+SELECT * FROM old_emails  -- noqa: AM04
 WHERE created_at < current_timestamp - interval '1 day';
 
+DROP TABLE old_emails CASCADE;
+
 -- Create a table to store all email addresses.
-CREATE TABLE addresses (id serial, address varchar NOT NULL);
+CREATE TEMP TABLE addresses (id serial, address varchar NOT NULL);
 
 -- Copy all email addresses into the table.
--- Ignore nulled out subscriber addresses.
 INSERT INTO addresses (address)
-SELECT address FROM subscribers WHERE address IS NOT NULL
-UNION DISTINCT
-SELECT address FROM emails;
+SELECT address FROM subscribers WHERE address IS NOT NULL;
 
--- Index the table so we can efficiently lookup addresses.
 CREATE UNIQUE INDEX addresses_index ON addresses (address);
 
--- Set subscribers.address from the auto-incremented id in addresses table.
+INSERT INTO addresses (address)
+SELECT address FROM emails
+ON CONFLICT DO NOTHING;
+
+-- Redact address-containing fields in the subscribers and emails tables.
 UPDATE subscribers s
-SET address = concat('anonymous-', a.id, '@example.com')
+SET address = concat('anon-', a.id, '@example.com')
 FROM addresses AS a
 WHERE a.address = s.address;
 
--- Set emails.address from the auto-incremented id in addresses table.
 UPDATE emails e
 SET
-  address = concat('anonymous-', a.id, '@example.com'),
-  subject = replace(e.subject, e.address, concat('anonymous-', a.id, '@example.com')),
-  body = replace(e.body, e.address, concat('anonymous-', a.id, '@example.com'))
+  address = concat('anon-', a.id, '@example.com'),
+  subject = replace(e.subject, e.address, concat('anon-', a.id, '@example.com')),
+  body = replace(e.body, e.address, concat('anon-', a.id, '@example.com'))
 FROM addresses AS a
 WHERE a.address = e.address;
-
--- Clean up by deleting the addresses table and its index.
-DROP INDEX addresses_index;
-DROP TABLE addresses;


### PR DESCRIPTION
- Use a temporary table so it'll be cleaned up automatically at the end of the session, even if something goes wrong.
- Cheaper to copy the relatively few rows we want to keep into a new table and drop the old one than to delete millions of rows.
- Cheaper to upsert instead of UNION DISTINCT.

It'd be better still to replace the whole thing with a decent set of test data that isn't based on information about real subscribers at all, but I'll leave that for another time.

Tested: ran successfully in staging; finishes in less than a minute now rather than several.