### PR TITLE
Initialise image-tags for govuk-sli-collector

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-sli-collector
+++ b/charts/app-config/image-tags/integration/govuk-sli-collector
@@ -1,0 +1,3 @@
+image_tag: v2
+automatic_deploys_enabled: true
+promote_deployment: false


### PR DESCRIPTION
`update-image-tag` is failing because it can't find this file (https://argo-workflows.eks.production.govuk.digital/workflows/apps/govuk-sli-collector-deploy-image-integrationw574c?tab=workflow&nodeId=govuk-sli-collector-deploy-image-integrationw574c-2654996479&sidePanel=logs:govuk-sli-collector-deploy-image-integrationw574c-2654996479:main)

(We only (attempt to) deploy this project to integration right now.)