### PR TITLE
A writeable volume at /tmp for govuk-sli-collector

### DIFF
--- a/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml
@@ -31,6 +31,9 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser }}
             runAsGroup: {{ .Values.securityContext.runAsGroup }}
           restartPolicy: Never
+          volumes:
+            - name: app-tmp
+              emptyDir: {}
           containers:
             - name: main
               image: "{{ .Values.images.GovukSliCollector.repository }}:{{ .Values.images.GovukSliCollector.tag }}"
@@ -68,4 +71,7 @@ spec:
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: app-tmp
+                  mountPath: /tmp
 {{- end }}


### PR DESCRIPTION
Because we run our containers with read-only root filesystems and MRI expects a writeable TMPDIR, our Ruby containers all require a writeable volume mounted at /tmp