### PR TITLE
[1/4] Temporarily stop publishing-api updating content-store in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1911,7 +1911,7 @@ govukApplications:
               name: publishing-api-postgres
               key: DATABASE_URL
         - name: ENQUEUE_PUBLISH_INTENTS
-          value: true
+          value: "true"
 
   - name: release
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1852,7 +1852,7 @@ govukApplications:
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
-      workerEnabled: true
+      workerEnabled: false
       workerResources:
         limits:
           cpu: 4000m
@@ -1910,6 +1910,8 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-postgres
               key: DATABASE_URL
+        - name: ENQUEUE_PUBLISH_INTENTS
+          value: true
 
   - name: release
     helmValues:


### PR DESCRIPTION
Re-do of #1499 for switching over the live content-store. 

To make sure that we have a completely up-to-date content-store database at the point we switchover the proxy to PostgreSQL, we need to temporarily disable publishing-api workers while the mongo-to-postgresql job runs one last time.

[Trello card](https://trello.com/c/kQbZFteC/954-prepare-advance-prs-for-swapping-the-live-content-store-in-production)

It also adds the `ENQUEUE_PUBLISH_INTENTS=true` env var, which will make propagation of publish intents asynchronous once the corresponding [publishing-api PR](https://github.com/alphagov/publishing-api/pull/2566) is merged - before then it will have no effect. 
 ([Trello card for this](https://trello.com/c/a7ngC11v/952-figure-out-how-to-handle-observed-puts-of-publish-intents-while-publishing-api-workers-were-disabled))


I'm raising this as a draft PR so that it doesn't get accidentally merged before the scheduled maintenance period, will convert to a regular PR at that time.