### PR TITLE
[2/4] Swap production live content-store-proxy to PostgreSQL

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -763,9 +763,9 @@ govukApplications:
         enabled: false
       extraEnv:
         - name: PRIMARY_UPSTREAM
-          value: "http://content-store-mongo-main/"
-        - name: SECONDARY_UPSTREAM
           value: "http://content-store-postgresql-branch/"
+        - name: SECONDARY_UPSTREAM
+          value: "http://content-store-mongo-main/"
         - name: WEB_CONCURRENCY
           value: '8'
         - name: COMPARISON_SAMPLE_PCT


### PR DESCRIPTION
As per #1500 , but for the **live** content-store in production ([Trello card](https://trello.com/c/kF3aq5YX/954-prepare-advance-prs-for-swapping-the-live-content-store-in-production))

Previous similar deployments for prod draft, and in integration & staging shows that this should be a zero-downtime change.

Draft at the moment, to avoid an accidental merge before the scheduled time