### PR TITLE
[4/4] Remove prod live content-store Mongo-to-Postgres cron job

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1378,15 +1378,6 @@ govukApplications:
         sageMakerImage: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::172025368201:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::172025368201:role/search-api-learn-to-rank-govuk
-      contentStoreMongoPostgresCron:
-        schedule: "26 22 * * *"
-        mongoExport:
-          mongoDbUri: "mongodb://\
-            mongo-1.production.govuk-internal.digital,\
-            mongo-2.production.govuk-internal.digital,\
-            mongo-3.production.govuk-internal.digital/content_store_production"
-        postgresImport:
-          databaseUrlSecretName: "content-store-postgres"
 
   - name: hmrc-manuals-api
     helmValues:


### PR DESCRIPTION
As per #1503 but for the production **live** content-store.

[Trello card](https://trello.com/c/kF3aq5YX/954-prepare-advance-prs-for-swapping-the-live-content-store-in-production)

Draft at the moment, to avoid an accidental merge before the switchover is done (PR #1543)