### PR TITLE
Give whitehall and mongodb restores more RAM again.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -32,9 +32,9 @@ resources:
 _mongoResources: &mongo-resources
   resources:
     limits:
-      memory: 1Gi
+      memory: 1280Mi
     requests:
-      memory: 576Mi
+      memory: 768Mi
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -236,9 +236,9 @@ cronjobs:
         - op: backup
       resources: &whitehall-resources
         limits:
-          memory: 768Mi
+          memory: 1Gi
         requests:
-          memory: 384Mi
+          memory: 512Mi
 
 
   staging:


### PR DESCRIPTION
Tempted to set up VPA just for these :/

It shouldn't be using this much memory, but this time I couldn't find the corresponding oom-killer logs and the Prometheus metrics are way too coarse for this sort of thing, so kinda just guessing here.

Tested: ran the whitehall-mysql one successfully in staging.