### PR TITLE
Add Licensing to the Signon Secrets Sync

### DIFF
--- a/charts/app-config/templates/signon-secrets-sync-configmap.yaml
+++ b/charts/app-config/templates/signon-secrets-sync-configmap.yaml
@@ -20,6 +20,8 @@ data:
       "Email Alert API",
       "HMRC Manuals API",
       "Imminence",
+      "Licensing",
+      "Licensing (EKS Test)",
       "Link Checker API",
       "Local Links Manager",
       "Manuals Publisher",


### PR DESCRIPTION
## What?
This adds Licensing (and an additional EKS Test app) to the Signon Credentials Sync Task, so we can keep the creds in sync on Staging.