### PR TITLE
Remove draft-content-store proxy & mongo app in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -783,41 +783,7 @@ govukApplications:
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/db-backup-govuk
 
-  - name: draft-content-store-mongo-main
-    repoName: content-store
-    helmValues:
-      <<: *content-store
-      rails:
-        createKeyBaseSecret: false
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-      extraEnv:
-        - name: ROUTER_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-draft-content-store-draft-router-api
-              key: bearer_token
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-draft-content-store
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-draft-content-store
-              key: oauth_secret
-        - name: DEFAULT_TTL
-          value: "1"
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.integration.govuk-internal.digital,\
-            mongo-2.integration.govuk-internal.digital,\
-            mongo-3.integration.govuk-internal.digital/draft_content_store_production"
-        - name: PLEK_HOSTNAME_PREFIX
-          value: draft-
-
-  - name: draft-content-store-postgresql-branch
+  - name: draft-content-store
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
@@ -858,27 +824,6 @@ govukApplications:
               key: DATABASE_URL
         - name: DISABLE_ROUTER_API
           value: "true"
-
-  - name: draft-content-store
-    repoName: content-store-proxy
-    helmValues:
-      rails:
-        enabled: false
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: content-store-proxy-sentry
-      nginxClientMaxBodySize: 20M
-      uploadAssets:
-        enabled: false
-      extraEnv:
-        - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store-postgresql-branch/"
-        - name: SECONDARY_UPSTREAM
-          value: "http://draft-content-store-mongo-main/"
-        - name: COMPARISON_SAMPLE_PCT
-          value: '100'
-        - name: SECONDARY_TIMEOUT_SECONDS
-          value: '2'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
Now that we've successfully switched the draft-content-store in production to use Postgres as its primary upstream, and that's bedded in for several days, we can start removing the proxies in all environments and just using the postgres content-store app directly ([Trello card](https://trello.com/c/3Aowp29B/955-remove-the-draft-content-store-proxy-in-all-environments))

This PR is integration-only, to allow us to test both the process and the assumption that it will be a zero-downtime change.

* remove the `draft-content-store` proxy app
* rename the `draft-content-store-postgresql-branch` app to just `draft-content-store`
* remove the `draft-content-store-mongo-main` app

