### PR TITLE
Remove draft-content-store proxy app & mongo app in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -782,43 +782,7 @@ govukApplications:
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::172025368201:role/db-backup-govuk
 
-  - name: draft-content-store-mongo-main
-    repoName: content-store
-    helmValues:
-      <<: *content-store
-      replicaCount: 3
-      cronTasks: []
-      rails:
-        createKeyBaseSecret: false
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-      extraEnv:
-        - name: ROUTER_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-draft-content-store-draft-router-api
-              key: bearer_token
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-draft-content-store
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-draft-content-store
-              key: oauth_secret
-        - name: DEFAULT_TTL
-          value: "1"
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.production.govuk-internal.digital,\
-            mongo-2.production.govuk-internal.digital,\
-            mongo-3.production.govuk-internal.digital/draft_content_store_production"
-        - name: PLEK_HOSTNAME_PREFIX
-          value: draft-
-
-  - name: draft-content-store-postgresql-branch
+  - name: draft-content-store
     repoName: content-store-postgresql-branch
     helmValues:
       <<: *content-store
@@ -859,30 +823,6 @@ govukApplications:
               key: DATABASE_URL
         - name: DISABLE_ROUTER_API
           value: "true"
-
-  - name: draft-content-store
-    repoName: content-store-proxy
-    helmValues:
-      rails:
-        enabled: false
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: content-store-proxy-sentry
-      nginxClientMaxBodySize: 20M
-      replicaCount: 3
-      uploadAssets:
-        enabled: false
-      extraEnv:
-        - name: PRIMARY_UPSTREAM
-          value: "http://draft-content-store-postgresql-branch/"
-        - name: SECONDARY_UPSTREAM
-          value: "http://draft-content-store-mongo-main/"
-        - name: WEB_CONCURRENCY
-          value: '4'
-        - name: COMPARISON_SAMPLE_PCT
-          value: '100'
-        - name: SECONDARY_TIMEOUT_SECONDS
-          value: '2'
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
As per #1548 and #1549 , but for production ([Trello card](https://trello.com/c/3Aowp29B/955-remove-the-draft-content-store-proxy-in-all-environments))

* Remove draft-content-store proxy app
* Remove draft-content-store-mongo-main app
* Rename draft-content-store-postgresql-branch app to draft-content-store

As part of cleaning up after switching the draft-content-store in production to PostgreSQL primary (#1500), we can now remove the proxy app and the MongoDB version of the draft-content-store.

Testing on integration and staging has shown this to be _as far as we can tell_ a zero downtime change. On staging we did see 4 errors from the draft-content-store app itself at the point of switchover (13:15), but no evidence of them resulting in errors in other apps:
![image](https://github.com/alphagov/govuk-helm-charts/assets/134501/8c19d923-c937-459a-a0b7-dce07bef478a)
