### PR TITLE
Re-enable staging publishing-api workers

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1770,7 +1770,7 @@ govukApplications:
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
-      workerEnabled: false
+      workerEnabled: true
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
After switching the draft-content-store proxy over to Postgres the other day, looks like we forgot to re-enable the publishing-api workers on staging.