### PR TITLE
Make publish-intents asynchronous in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1826,7 +1826,7 @@ govukApplications:
               name: publishing-api-postgres
               key: DATABASE_URL
         - name: ENQUEUE_PUBLISH_INTENTS
-          value: true
+          value: "true"
 
   - name: release
     helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1825,6 +1825,8 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-postgres
               key: DATABASE_URL
+        - name: ENQUEUE_PUBLISH_INTENTS
+          value: true
 
   - name: release
     helmValues:


### PR DESCRIPTION
This temporary change will allow us to test the following 2 PRs as part of preparing to switchover the live content-store in production on Monday:

https://github.com/alphagov/publishing-api/pull/2566

Once this is deployed, I'll manually test the change has the desired effect, then revert this PR