### PR TITLE
Re-enable router API from draft-content-store

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -822,8 +822,6 @@ govukApplications:
             secretKeyRef:
               name: draft-content-store-postgres
               key: DATABASE_URL
-        - name: DISABLE_ROUTER_API
-          value: "true"
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -835,8 +835,6 @@ govukApplications:
             secretKeyRef:
               name: draft-content-store-postgres
               key: DATABASE_URL
-        - name: DISABLE_ROUTER_API
-          value: "true"
 
   - name: content-tagger
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -837,8 +837,6 @@ govukApplications:
             secretKeyRef:
               name: draft-content-store-postgres
               key: DATABASE_URL
-        - name: DISABLE_ROUTER_API
-          value: "true"
 
   - name: content-tagger
     helmValues:


### PR DESCRIPTION
The `DISABLE_ROUTER_API` flag was introduced when we rolled out content-store-proxy, to prevent dual-writing and potential conflicts from both Mongo and PostgreSQL content-stores writing to Router.

When we removed the proxy and the Mongo content-store for the draft stack in #1551, this flag should have been removed at the same time. 

