### PR TITLE
More RAM headroom for database copy jobs.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -24,10 +24,10 @@ podSecurityContext:
 resources:
   limits:
     cpu: 2000m
-    memory: 576Mi
+    memory: 640Mi
   requests:
     cpu: 400m
-    memory: 288Mi
+    memory: 384Mi
 
 _mongoResources: &mongo-resources
   resources:


### PR DESCRIPTION
Seems the publishing-api restore still OOMs occasionally, so bump the requirements again.