### PR TITLE
Re-enable updates to live content-store after switching it to postgresql

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1812,7 +1812,7 @@ govukApplications:
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
-      workerEnabled: false
+      workerEnabled: true
       workerResources:
         limits:
           cpu: 4000m
@@ -1870,8 +1870,6 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-postgres
               key: DATABASE_URL
-        - name: ENQUEUE_PUBLISH_INTENTS
-          value: "true"
 
   - name: release
     helmValues:


### PR DESCRIPTION
rollback of #1542 to re-enable updates to live content-store, after switching the proxy to postgres in #1543 

[Trello card](https://trello.com/c/M29YnFKp/959-switch-live-content-store-proxy-to-postgresql-in-production)