### PR TITLE
Have yamllint catch duplicate merge keys.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
-        with:
-          format: github
+      - run: yamllint --version && yamllint -f github .
 
   promcheck:
     runs-on: ubuntu-latest

--- a/.yamllint
+++ b/.yamllint
@@ -6,10 +6,8 @@ ignore: |
 rules:
   comments-indentation: disable
   document-start: disable
-  # TODO: set `forbid-duplicated-merge-keys` once
-  # https://www.github.com/adrienverge/yamllint/issues/561 lands.
-  # key-duplicates:
-  #   forbid-duplicated-merge-keys: true
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
   line-length:
     max: 100
     allow-non-breakable-words: true


### PR DESCRIPTION
Duplicate merge keys (`<<: foo`) are brittle because they're not valid in any YAML standard so far and they rely on implementation-dependent behaviour. There's also no advantage to them over specifying a single merge key with a list as its value.

Use the `yamllint` bundled with GitHub's runner image instead of a third-party action.