### PR TITLE
Remove production content-store proxy and mongo apps

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -687,8 +687,8 @@ govukApplications:
               name: signon-token-content-publisher-whitehall
               key: bearer_token
 
-  - name: content-store-mongo-main
-    repoName: content-store
+  - name: content-store
+    repoName: content-store-postgresql-branch
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.
@@ -706,44 +706,6 @@ govukApplications:
           schedule: "15 2 * * *"
       uploadAssets:
         enabled: false
-      extraEnv:
-        - name: ROUTER_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-content-store-router-api
-              key: bearer_token
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-content-store
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-content-store
-              key: oauth_secret
-        - name: DEFAULT_TTL
-          value: "300"
-        - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://\
-            mongo-1.production.govuk-internal.digital,\
-            mongo-2.production.govuk-internal.digital,\
-            mongo-3.production.govuk-internal.digital/content_store_production"
-        - name: WEB_CONCURRENCY
-          value: '4'
-
-  - name: content-store-postgresql-branch
-    repoName: content-store-postgresql-branch
-    helmValues:
-      <<: *content-store
-      rails:
-        createKeyBaseSecret: false
-        # use the same secret as the mongo content-store, it will make the
-        # eventual switchover easier and reduce toil
-        secretKeyBaseName: content-store-rails-secret-key-base
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: content-store-sentry
       extraEnv:
         - name: SENTRY_ENVIRONMENT
           value: "postgresql-production"
@@ -769,38 +731,8 @@ govukApplications:
             secretKeyRef:
               name: content-store-postgres
               key: DATABASE_URL
-        - name: DISABLE_ROUTER_API
-          value: "true"
         - name: WEB_CONCURRENCY
           value: '4'
-
-  - name: content-store
-    repoName: content-store-proxy
-    helmValues:
-      rails:
-        enabled: false
-      nginxClientMaxBodySize: 20M
-      replicaCount: 6
-      appResources:
-        limits:
-          cpu: 6
-          memory: 2500Mi
-        requests:
-          cpu: 2
-          memory: 2000Mi
-      uploadAssets:
-        enabled: false
-      extraEnv:
-        - name: PRIMARY_UPSTREAM
-          value: "http://content-store-postgresql-branch/"
-        - name: SECONDARY_UPSTREAM
-          value: "http://content-store-mongo-main/"
-        - name: WEB_CONCURRENCY
-          value: '8'
-        - name: COMPARISON_SAMPLE_PCT
-          value: '100'
-        - name: SECONDARY_TIMEOUT_SECONDS
-          value: '2'
 
   - name: db-backup
     chartPath: charts/db-backup


### PR DESCRIPTION
As per #1590 & #1593, but for production.

After switching the live content-store proxy to PostgreSQL in production yesterday, we can now remove the proxy in all environments. #1590 does so for integration, #1593 for staging - this PR does so for production. (see steps 6 & 7 of the [plan](https://docs.google.com/document/d/1JFmnDoZCJBFF2J6-fbaFOzbeImGbNbE0D1nViIzS6aE/edit#heading=h.2g572px7zpvz), and this [Trello card](https://trello.com/c/6MxUbaHm/960-remove-production-live-content-store-proxy) ) .

This will leave us with a single content-store application for each of live & draft, and no more proxy in front.

This single app will still be using the content-store-postgresql-branch ECR repo for now - we have a separate Step 8 of the plan for how to return it to just content-store.


When making the same change for the draft-content-store in #1551 , we found it was a zero _downtime_ change, but a small (<10) number of requests did result in an error right at the point of the new deployment switching in. We think that's probably unavoidable, and the requests should all succeed on retry (any updates should also retry automatically)