### PR TITLE
Revert "Update Helm release kube-prometheus-stack to v55 (integration)"

### DIFF
--- a/charts/monitoring-config/helm-versions/integration
+++ b/charts/monitoring-config/helm-versions/integration
@@ -1,4 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
-https://prometheus-community.github.io/helm-charts kube-prometheus-stack: "55.3.1"
+https://prometheus-community.github.io/helm-charts kube-prometheus-stack: "51.10.0"
 https://prometheus-community.github.io/helm-charts prometheus-pushgateway: "2.4.2"
 https://oauth2-proxy.github.io/manifests oauth2-proxy: "6.23.1"


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#1601

Grafana crashes while trying to apply DB migrations:

```
Error: ✗ failed to check table existence: pq: password authentication failed for user "root"
```