### PR TITLE
Remove content-store custom rails secret key base name in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -686,8 +686,6 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
-      rails:
-        secretKeyBaseName: content-store-rails-secret-key-base
       sentry:
         dsnSecretName: content-store-sentry
       uploadAssets:


### PR DESCRIPTION
After removing the proxy in #1590, the content-store application failed to start, as it could not find the external secret named `content-store-rails-secret-key-base`

We found that the secret name is [more coupled to the ECR repo name than we thought](https://github.com/alphagov/govuk-helm-charts/blob/58bd04c2ccfd7766f751e8d31e0e3bbb875808cd/charts/generic-govuk-app/templates/rails-secret-key-base-external-secret.yaml#L5), and that it would introduce unacceptably more complexity to change that.

The easiest way to get the application to start is therefore to manually add a line to the AWS Secret for `content-store-postgresql-branch` (done), and to stop trying to get it to use the secret name from another repo (this PR) 