### PR TITLE
Remove custom sentry DSN secret name for integration live content-store

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -686,8 +686,6 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
-      sentry:
-        dsnSecretName: content-store-sentry
       uploadAssets:
         enabled: false
       extraEnv:


### PR DESCRIPTION
After removing the proxy, we found that the `content-store` app would not start, with config errors relating to secret names not being found.

The custom secret names for rails secret key base and sentry dsn were added to allow dual-running of two content-stores, but they don't appear to work with a single app that's using a different repo name.

Removing the custom name worked for the rails secret key base (#1603) - this PR does the same for sentry DSN