### PR TITLE
Add content-data-api GA4 external secret

### DIFF
--- a/charts/external-secrets/templates/content-data-api/ga4.yaml
+++ b/charts/external-secrets/templates/content-data-api/ga4.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
-      GA4 credentials used by Content data API.
+      Google Analytics (GA4) credentials used by Content Data API.
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:

--- a/charts/external-secrets/templates/content-data-api/ga4.yaml
+++ b/charts/external-secrets/templates/content-data-api/ga4.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: content-data-api-ga4
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      GA4 credentials used by Content data API.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: content-data-api-ga4
+  dataFrom:
+    - extract:
+        key: govuk/content-data-api/ga4


### PR DESCRIPTION
This will be used within the app as well as the ETL cron job. It contains the GA4/Bigquery project ID and service account credentials which allows the app to query data on Google metrics for GOV.UK pages.

Trello card: https://trello.com/c/c4jN6yxT/3330-migrate-ua-metrics-for-views-navigation-to-bigquery-in-content-data-api-5