### PR TITLE
Add Google GA4/BigQuery values to content-data-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -563,6 +563,21 @@ govukApplications:
             secretKeyRef:
               name: content-data-api-google-analytics
               key: private-key
+        - name: BIGQUERY_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: project_id
+        - name: BIGQUERY_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: client_email
+        - name: BIGQUERY_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: private_key
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -563,6 +563,21 @@ govukApplications:
             secretKeyRef:
               name: content-data-api-google-analytics
               key: private-key
+        - name: BIGQUERY_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: project_id
+        - name: BIGQUERY_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: client_email
+        - name: BIGQUERY_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: private_key
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -563,6 +563,21 @@ govukApplications:
             secretKeyRef:
               name: content-data-api-google-analytics
               key: private-key
+        - name: BIGQUERY_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: project_id
+        - name: BIGQUERY_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: client_email
+        - name: BIGQUERY_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: content-data-api-ga4
+              key: private_key
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Follows on from https://github.com/alphagov/govuk-helm-charts/pull/1611

They will allow the app to query data on Google metrics for GOV.UK pages.

Trello card: https://trello.com/c/c4jN6yxT/3330-migrate-ua-metrics-for-views-navigation-to-bigquery-in-content-data-api-5