### PR TITLE
Migrate Kubescape to ArgoCD

### DIFF
--- a/charts/app-config/templates/kubescape.yaml
+++ b/charts/app-config/templates/kubescape.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.govukEnvironment "integration" }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -12,18 +13,16 @@ spec:
     repoURL: 'https://github.com/kubescape/helm-charts'
     targetRevision: HEAD
     helm:
+    helm:
       valueFiles:
         - values.yaml
       parameters:
         - name: account
-          valueFrom:
-            secretKeyRef:
-              name: kubescape-account-id
-              key: accountGuid
+          value: '123456' # Dummy value
         - name: clusterName
-          value: 'govuk-integration-new' # add cluster name
+          value: 'govuk-integration-new'
         - name: server
-          value: 'https://kubernetes.default.svc' # add Kubescape-compatible backend service URL
+          value: 'https://kubernetes.default.svc'
   project: default
   syncPolicy:
     syncOptions:
@@ -38,3 +37,4 @@ spec:
       jsonPointers:
         - /data
         - /metadata
+{{ end }}

--- a/charts/app-config/templates/kubescape.yaml
+++ b/charts/app-config/templates/kubescape.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubescape
+spec:
+  destination:
+    name: kubescape
+    namespace: kubescape
+    server: 'https://kubernetes.default.svc' # change to your server
+  source:
+    path: charts/kubescape-operator
+    repoURL: 'https://github.com/kubescape/helm-charts'
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: account
+          valueFrom:
+            secretKeyRef:
+              name: kubescape-account-id
+              key: accountGuid
+        - name: clusterName
+          value: 'govuk-integration-new' # add cluster name
+        - name: server
+          value: 'https://kubernetes.default.svc' # add Kubescape-compatible backend service URL
+  project: default
+  syncPolicy:
+    syncOptions:
+      - PruneLast=true
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: core
+      kind: ConfigMap
+      name: ks-cloud-config
+      namespace: kubescape
+      jsonPointers:
+        - /data
+        - /metadata

--- a/charts/external-secrets/templates/kubescape/account.yaml
+++ b/charts/external-secrets/templates/kubescape/account.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kubescape-account-id
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Kubescape Account ID https://cloud.armosec.io/dashboard.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: kubescape-account-id
+  dataFrom:
+    - extract:
+        key: govuk/kubescape


### PR DESCRIPTION
Deploy Kubescape to Integration via Argo - _testing change._

Currently Kubescape is installed via Terraform. (https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/cluster-services/kubescape.tf)

https://trello.com/c/0WhZJoHD/1229-update-kubescape-to-use-non-deprecated-helm-chart

