### PR TITLE
Move cron job from govuk-jobs into its own chart

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1219,14 +1219,11 @@ govukApplications:
     imageValues:
       - "content-store"
       - "content-store-postgresql-branch"
-      - "govuk-sli-collector"
       - "search-api"
       - "search-api-learn-to-rank"
     helmValues:
       govukMirrorSync:
         iamRoleArn: arn:aws:iam::210287912431:role/govuk-mirror-sync
-      govukSliCollector:
-        enabled: true
       learnToRank:
         elasticsearchUri: &elasticsearch-uri
           https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com
@@ -1239,6 +1236,10 @@ govukApplications:
         sageMakerImage: 210287912431.dkr.ecr.eu-west-1.amazonaws.com/search
         sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
+
+  - name: govuk-sli-collector
+    chartPath: charts/govuk-sli-collector
+    postSyncWorkflowEnabled: "false"
 
   - name: hmrc-manuals-api
     helmValues:

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -23,9 +23,6 @@ images:
   GovukDependencyChecker:
     repository: "govuk-dependency-checker"
     tag: "release"
-  GovukSliCollector:
-    repository: "govuk-sli-collector"
-    tag: "release"
   SearchApi:
     repository: "search-api"
     tag: "release"
@@ -35,11 +32,6 @@ images:
 
 govukMirrorSync:
   schedule: "0 0 * * *"
-
-govukSliCollector:
-  enabled: false
-  intervalMinutes: "10"
-  offsetMinutes: "10"
 
 learnToRank:
   elasticsearchUri: ""

--- a/charts/govuk-sli-collector/Chart.yaml
+++ b/charts/govuk-sli-collector/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: govuk-sli-collector
+description: Cronjob for GOV.UK SLI Collector (https://github.com/alphagov/govuk-sli-collector/)
+type: application
+version: 1.0.0

--- a/charts/govuk-sli-collector/templates/_helpers.tpl
+++ b/charts/govuk-sli-collector/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "govuk-sli-collector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "govuk-sli-collector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "govuk-sli-collector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "govuk-sli-collector.labels" -}}
+helm.sh/chart: {{ include "govuk-sli-collector.chart" . }}
+{{ include "govuk-sli-collector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "govuk-sli-collector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "govuk-sli-collector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ include "govuk-sli-collector.fullname" . }}
+{{- end }}

--- a/charts/govuk-sli-collector/templates/cronjob.yaml
+++ b/charts/govuk-sli-collector/templates/cronjob.yaml
@@ -1,48 +1,42 @@
-{{- if .Values.govukSliCollector.enabled }}
+{{- $_ := .Values.govukEnvironment | required "govukEnvironment is required" }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "govuk-sli-collector"
+  name: {{ include "govuk-sli-collector.fullname" . }}
   labels:
-    app: "govuk-sli-collector"
-    app.kubernetes.io/component: "govuk-sli-collector"
+    {{- include "govuk-sli-collector.labels" . | nindent 4 }}
 spec:
-  schedule: "*/{{ .Values.govukSliCollector.intervalMinutes }} * * * *"
+  schedule: "*/{{ .Values.intervalMinutes }} * * * *"
   jobTemplate:
     metadata:
-      name: "govuk-sli-collector"
+      name: {{ include "govuk-sli-collector.fullname" . }}
       labels:
-        app: "govuk-sli-collector"
-        app.kubernetes.io/component: "govuk-sli-collector"
+        {{- include "govuk-sli-collector.selectorLabels" . | nindent 8 }}
     spec:
       backoffLimit: 0
       template:
         metadata:
-          name: "govuk-sli-collector"
+          name: {{ include "govuk-sli-collector.fullname" . }}
           labels:
-            app: "govuk-sli-collector"
-            app.kubernetes.io/component: "govuk-sli-collector"
+            {{- include "govuk-sli-collector.selectorLabels" . | nindent 12 }}
         spec:
           enableServiceLinks: false
           securityContext:
-            fsGroup: {{ .Values.securityContext.runAsGroup }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           restartPolicy: Never
           volumes:
             - name: app-tmp
               emptyDir: {}
           containers:
             - name: main
-              image: "{{ .Values.images.GovukSliCollector.repository }}:{{ .Values.images.GovukSliCollector.tag }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: "Always"
               env:
                 - name: INTERVAL_MINUTES
-                  value: "{{ .Values.govukSliCollector.intervalMinutes }}"
+                  value: "{{ .Values.intervalMinutes }}"
                 - name: OFFSET_MINUTES
-                  value: "{{ .Values.govukSliCollector.offsetMinutes }}"
+                  value: "{{ .Values.offsetMinutes }}"
                 - name: LOGIT_OPENSEARCH_BASIC_AUTH
                   valueFrom:
                     secretKeyRef:
@@ -61,17 +55,13 @@ spec:
                       name: govuk-sli-collector-sentry
                       key: dsn
                 - name: SENTRY_RELEASE
-                  value: "{{ .Values.images.GovukSliCollector.tag }}"
+                  value: "{{ .Values.image.tag }}"
                 - name: SENTRY_CURRENT_ENV
                   value: "{{ .Values.govukEnvironment }}"
-              {{- with .Values.resources }}
               resources:
-                {{- . | toYaml | trim | nindent 16 }}
-              {{- end }}
+                {{- toYaml .Values.resources | nindent 16 }}
               securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
+                {{- toYaml .Values.securityContext | nindent 16 }}
               volumeMounts:
                 - name: app-tmp
                   mountPath: /tmp
-{{- end }}

--- a/charts/govuk-sli-collector/templates/logit-opensearch-api-external-secret.yaml
+++ b/charts/govuk-sli-collector/templates/logit-opensearch-api-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: govuk-sli-collector-logit-opensearch-api
   labels:
-    {{- include "external-secrets.labels" . | nindent 4 }}
+    {{- include "govuk-sli-collector.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
       Basic auth credentials for Logit's OpenSearch API, used for querying log

--- a/charts/govuk-sli-collector/templates/sentry-external-secret.yaml
+++ b/charts/govuk-sli-collector/templates/sentry-external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: govuk-sli-collector-sentry
   labels:
-    {{- include "external-secrets.labels" . | nindent 4 }}
+    {{- include "govuk-sli-collector.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >
       DSN for Sentry

--- a/charts/govuk-sli-collector/values.yaml
+++ b/charts/govuk-sli-collector/values.yaml
@@ -1,0 +1,39 @@
+# Default values for govuk-sli-collector.
+
+govukEnvironment: test
+
+intervalMinutes: "10"
+offsetMinutes: "10"
+
+image:
+  repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-sli-collector"
+  tag: "release"
+
+nameOverride: ""
+fullnameOverride: ""
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+
+externalSecrets:
+  refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+  deletionPolicy: Delete
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

This combines the existing `govuk-sli-collector` cron job template with the defaults from a fresh `helm create` while taking some cues from existing standalone cron job charts (e.g. `search-index-env-sync` and `smokey`).

(I copied the `resources` config from `search-index-env-sync`. I don't really know what a good first go at that is.)

It was suggested that this move out of `govuk-jobs` could coincide with removing this project's entry from `charts/app-config/image-tags` and always using the `latest` image. I haven't figured out what the relationship between those two things is, so I'm currently planning to make that change separately.