### PR TITLE
Alert checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,26 @@ jobs:
       - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
         with:
           format: github
+
+  promcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: 'Run promtool checks'
+        uses: 'KludgeKML/promtool-action@v1'
+        with:
+          # yamllint disable-line rule:line-length
+          args: 'check rules $(find charts/monitoring-config/rules -name *.yaml -not -name *_tests.yaml)'
+
+  promtest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: 'Run promtool tests'
+        uses: 'KludgeKML/promtool-action@v1'
+        with:
+          args: 'test rules charts/monitoring-config/rules/*_tests.yaml'

--- a/charts/monitoring-config/rules/README.md
+++ b/charts/monitoring-config/rules/README.md
@@ -3,7 +3,7 @@
 - Install `promtool` on your machine: `brew install prometheus`
 - Run the following command
 
-    ```sh
+    ```bash
     (GLOBIGNORE='*_tests.*' && promtool check rules *.yaml) &&
       promtool test rules *_tests.yaml
     ```

--- a/charts/monitoring-config/rules/mirrors.yaml
+++ b/charts/monitoring-config/rules/mirrors.yaml
@@ -1,13 +1,14 @@
-- name: MirrorAlerts
-  rules:
-    - record: global:govuk_mirror_freshness_seconds
-      expr: |
-        time() - min(govuk_mirror_last_updated_time) by (backend)
+groups:
+  - name: MirrorAlerts
+    rules:
+      - record: global:govuk_mirror_freshness_seconds
+        expr: |
+          time() - min(govuk_mirror_last_updated_time) by (backend)
 
-    - alert: MirrorFreshnessAlert
-      expr: |
-        global:govuk_mirror_freshness_seconds > 172800
-      annotations:
-        summary: Mirror freshness has exceeded two days
-        description: >-
-          The mirror hasn't been updated in more than two days
+      - alert: MirrorFreshnessAlert
+        expr: |
+          global:govuk_mirror_freshness_seconds > 172800
+        annotations:
+          summary: Mirror freshness has exceeded two days
+          description: >-
+            The mirror hasn't been updated in more than two days

--- a/charts/monitoring-config/rules/pagerdutydrill.yaml
+++ b/charts/monitoring-config/rules/pagerdutydrill.yaml
@@ -1,12 +1,13 @@
 # TODO: Work out how to support BST here
-- name: PagerDutyDrill
-  rules:
-    - alert: PagerDutyDrill
-      expr: |
-        (day_of_week() == 3) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
-      labels:
-        severity: page
-      annotations:
-        summary: PagerDuty test drill
-        description: >-
-          Developers: escalate this alert. SMT: resolve this alert.
+groups:
+  - name: PagerDutyDrill
+    rules:
+      - alert: PagerDutyDrill
+        expr: |
+          (day_of_week() == 3) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
+        labels:
+          severity: page
+        annotations:
+          summary: PagerDuty test drill
+          description: >-
+            Developers: escalate this alert. SMT: resolve this alert.

--- a/charts/monitoring-config/rules/prometheus_disk_space.yaml
+++ b/charts/monitoring-config/rules/prometheus_disk_space.yaml
@@ -1,18 +1,19 @@
-- name: PrometheusDiskSpace
-  rules:
-    - alert: PrometheusDiskSpace
-      expr: |
-          (
-            kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-.*"}
-            /
-            (10 * 1000 * 1000 * 1000)
-          )
-          <
-          5 # GB
-      labels:
-        severity: warning
-        destination: slack-platform-engineering
-      annotations:
-        summary: Prometheus disk space low
-        description: >-
-          Less than 5GB of disk space remaining on Prometheus volumes
+groups:
+  - name: PrometheusDiskSpace
+    rules:
+      - alert: PrometheusDiskSpace
+        expr: |
+            (
+              kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-.*"}
+              /
+              (10 * 1000 * 1000 * 1000)
+            )
+            <
+            5 # GB
+        labels:
+          severity: warning
+          destination: slack-platform-engineering
+        annotations:
+          summary: Prometheus disk space low
+          description: >-
+            Less than 5GB of disk space remaining on Prometheus volumes

--- a/charts/monitoring-config/rules/router.yaml
+++ b/charts/monitoring-config/rules/router.yaml
@@ -1,36 +1,37 @@
-- name: RouterAlerts
-  rules:
-    - record: global:router_requests:rate5m
-      expr: |
-        sum by (job, backend_id, response_code) (
-          rate(router_backend_handler_response_duration_seconds_count{namespace="apps"}[5m])
-        )
-
-    - record: global:router_5xx_responses_per_request_by_backend:ratio_rate5m
-      expr: |2
-          sum without (response_code) (global:router_requests:rate5m{response_code=~"5.."})
-        /
-          sum without (response_code) (global:router_requests:rate5m)
-
-    - record: global:router_5xx_responses_per_request:ratio_rate5m
-      expr: |2
-          sum without (backend_id, response_code) (
-            global:router_requests:rate5m{response_code=~"5.."}
+groups:
+  - name: RouterAlerts
+    rules:
+      - record: global:router_requests:rate5m
+        expr: |
+          sum by (job, backend_id, response_code) (
+            rate(router_backend_handler_response_duration_seconds_count{namespace="apps"}[5m])
           )
-        /
-          sum without (backend_id, response_code) (global:router_requests:rate5m)
 
-    - alert: RouterErrorRatioTooHigh
-      expr: |2
-          global:router_5xx_responses_per_request:ratio_rate5m{job="router"} > 0.1
-        and
-          sum without (backend_id, response_code) (
-            global:router_requests:rate5m{job="router"}
-          ) > 1
-      for: 10m
-      labels:
-        severity: page
-      annotations:
-        summary: Router error ratio too high
-        description: >-
-          More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.
+      - record: global:router_5xx_responses_per_request_by_backend:ratio_rate5m
+        expr: |2
+            sum without (response_code) (global:router_requests:rate5m{response_code=~"5.."})
+          /
+            sum without (response_code) (global:router_requests:rate5m)
+
+      - record: global:router_5xx_responses_per_request:ratio_rate5m
+        expr: |2
+            sum without (backend_id, response_code) (
+              global:router_requests:rate5m{response_code=~"5.."}
+            )
+          /
+            sum without (backend_id, response_code) (global:router_requests:rate5m)
+
+      - alert: RouterErrorRatioTooHigh
+        expr: |2
+            global:router_5xx_responses_per_request:ratio_rate5m{job="router"} > 0.1
+          and
+            sum without (backend_id, response_code) (
+              global:router_requests:rate5m{job="router"}
+            ) > 1
+        for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: Router error ratio too high
+          description: >-
+            More than 10% of HTTP responses from Router were 500-series errors for 10 minutes.

--- a/charts/monitoring-config/rules/signon.yaml
+++ b/charts/monitoring-config/rules/signon.yaml
@@ -1,16 +1,17 @@
-- name: SignonAlerts
-  rules:
-    - record: global:signon_api_user_token_expires_in_seconds
-      expr: |
-        min(signon_api_user_token_expiry_timestamp_seconds) by (api_user, application) - time()
+groups:
+  - name: SignonAlerts
+    rules:
+      - record: global:signon_api_user_token_expires_in_seconds
+        expr: |
+          min(signon_api_user_token_expiry_timestamp_seconds) by (api_user, application) - time()
 
-    - alert: SignonApiUserTokenExpirySoon
-      expr: |
-        global:signon_api_user_token_expires_in_seconds < 1209600
-      for: 1h
-      annotations:
-        summary: Signon API User token is due to expire soon
-        description: >-
-          A token is about to expire within the next two weeks and needs rotating.
-        runbook_url: >-
-          https://docs.publishing.service.gov.uk/manual/alerts/signon-api-user-token-expires-soon.html
+      - alert: SignonApiUserTokenExpirySoon
+        expr: |
+          global:signon_api_user_token_expires_in_seconds < 1209600
+        for: 1h
+        annotations:
+          summary: Signon API User token is due to expire soon
+          description: >-
+            A token is about to expire within the next two weeks and needs rotating.
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/alerts/signon-api-user-token-expires-soon.html

--- a/charts/monitoring-config/templates/prometheus-rules.yaml
+++ b/charts/monitoring-config/templates/prometheus-rules.yaml
@@ -10,6 +10,7 @@ spec:
 {{- range $path, $_ := .Files.Glob "rules/**.yaml" }}
 {{- if not (hasSuffix "_tests.yaml" $path) }}
   # {{ $path }}
-  {{- $.Files.Get $path | nindent 4 }}
+  # {{- $.Files.Get $path | replace "groups:" "" | nindent 2  }}
+  {{- $.Files.Get $path | regexReplaceAll "^Agroups:" "" | nindent 2  }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Adds promtool checking of alerting rules based on KludgeKML/promtool-action@v1 (forked from MatsuriJapon/promtool-action@v1 because that was pinned to an older version of prometheus that rejected some newer durations used in one test)

Updates rules files to work with linter, helm, and promtool.
