### PR TITLE
Use latest image for cronjob

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-sli-collector
+++ b/charts/app-config/image-tags/integration/govuk-sli-collector
@@ -1,3 +1,0 @@
-image_tag: release-727d7dc28ae201a467927f103bf54a4e052f82ba
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/govuk-sli-collector/values.yaml
+++ b/charts/govuk-sli-collector/values.yaml
@@ -7,7 +7,7 @@ offsetMinutes: "10"
 
 image:
   repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-sli-collector"
-  tag: "release"
+  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Since the `govuk-sli-collector` project is only deployed to a single environment, we don't need to refer to more than one image.

I'm not sure what the `release` tag that's being replaced here is, but the job's been failing to pull the image since I moved it out of the `govuk-jobs` chart earlier and I hoped that this might fix that.

---

FWIW, I'll make the corresponding changes to the `govuk-sli-collector`'s Github actions shortly. I'm planning to remove the deploy (`update-image-tag`) step and to fix the image to only build from the latest git release tag (since as far as I can tell, that's a limitation of how we add the `latest` tag to images https://github.com/alphagov/govuk-infrastructure/blob/a046a2c0da8f002e9e4507cd9d14310f2c1669a9/.github/workflows/build-and-push-image.yml#L76).