### PR TITLE
Switch cron job from integration to production

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1237,10 +1237,6 @@ govukApplications:
         sagemakerIamRole: arn:aws:iam::210287912431:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::210287912431:role/search-api-learn-to-rank-govuk
 
-  - name: govuk-sli-collector
-    chartPath: charts/govuk-sli-collector
-    postSyncWorkflowEnabled: "false"
-
   - name: hmrc-manuals-api
     helmValues:
       nginxClientMaxBodySize: 2M

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1348,6 +1348,10 @@ govukApplications:
         sagemakerIamRole: arn:aws:iam::172025368201:role/learn-to-rank-sagemaker
         serviceAccountIamRole: arn:aws:iam::172025368201:role/search-api-learn-to-rank-govuk
 
+  - name: govuk-sli-collector
+    chartPath: charts/govuk-sli-collector
+    postSyncWorkflowEnabled: "false"
+
   - name: hmrc-manuals-api
     helmValues:
       nginxClientMaxBodySize: 2M


### PR DESCRIPTION
We've got `govuk-sli-collector` working in integration and now we need to run it in production so that it can access real data and do the job it's intended for.

We're removing it from integration now because we believe that the costs of running there it outweigh the benefits (of having it readily available for future testing).