### PR TITLE
Log the generated govuk_request_id value

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -13,10 +13,14 @@ data:
     error_log /dev/stderr warn;
     pid /tmp/nginx.pid;
 
+    {{- if ne .Values.govukEnvironment "staging" }}
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+    {{- end }}
+
     events {
       worker_connections 1024;
     }
-
+    
     http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;
@@ -57,7 +61,7 @@ data:
         '"@timestamp":"$time_iso8601",'
         '"body_bytes_sent":$body_bytes_sent,'
         '"bytes_sent":$bytes_sent,'
-        '"govuk_request_id":"$http_govuk_request_id",'
+        '"govuk_request_id":"$govuk_request_id",'
         '"http_host":"$http_host",'
         '"http_referer":"$http_referer",'
         '"http_user_agent":"$http_user_agent",'
@@ -77,12 +81,32 @@ data:
         '"upstream_addr":"$upstream_addr",'
         '"upstream_response_time":"$upstream_response_time"'
       '}';
-
+    
+      {{- if eq .Values.govukEnvironment "staging" }}
       # Set GOVUK-Request-Id if not set
       map $http_govuk_request_id $govuk_request_id {
         default $http_govuk_request_id;
         ''      "$pid-$msec-$remote_addr-$request_length";
       }
+      {{- else }}
+      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+      perl_modules perl/lib;
+      perl_set $govuk_request_id '
+        sub {
+          my $r = shift;
+          my $current_header = $r->header_in("GOVUK-Request-Id");
+          if (defined $current_header && $current_header ne "") {
+            return $current_header;
+          } else {
+            my $pid = $r->variable("pid");
+            my $msec = $r->variable("msec");
+            my $remote_addr = $r->variable("remote_addr");
+            my $request_length = $r->variable("request_length");
+            return "$pid-$msec-$remote_addr-$request_length";
+          }
+        }
+      ';
+      {{- end }}
 
       server {
         server_name asset-manager asset-manager.*  ;

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -15,6 +15,10 @@ data:
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
 
+    {{- if ne .Values.govukEnvironment "staging" }}
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+    {{- end }}
+
     events {
       worker_connections  1024;
     }
@@ -39,11 +43,33 @@ data:
       sendfile        on;
       keepalive_timeout  65;
 
+
+      {{- if eq .Values.govukEnvironment "staging" }}
       # Set GOVUK-Request-Id if not set
       map $http_govuk_request_id $govuk_request_id {
         default $http_govuk_request_id;
         ''      "$pid-$msec-$remote_addr-$request_length";
       }
+      {{- else }}
+      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+      perl_modules perl/lib;
+      perl_set $govuk_request_id '
+        sub {
+          my $r = shift;
+          my $current_header = $r->header_in("GOVUK-Request-Id");
+          if (defined $current_header && $current_header ne "") {
+            return $current_header;
+          } else {
+            my $pid = $r->variable("pid");
+            my $msec = $r->variable("msec");
+            my $remote_addr = $r->variable("remote_addr");
+            my $request_length = $r->variable("request_length");
+            return "$pid-$msec-$remote_addr-$request_length";
+          }
+        }
+      ';
+      {{- end }}
+      
 
       # Default values for response headers. These values are used when the
       # header is not already set on the incoming response.
@@ -62,7 +88,7 @@ data:
         '"@timestamp":"$time_iso8601",'
         '"body_bytes_sent":$body_bytes_sent,'
         '"bytes_sent":$bytes_sent,'
-        '"govuk_request_id":"$http_govuk_request_id",'
+        '"govuk_request_id":"$govuk_request_id",'
         '"http_host":"$http_host",'
         '"http_referer":"$http_referer",'
         '"http_user_agent":"$http_user_agent",'


### PR DESCRIPTION
Because if we only log the incoming header value, sometimes there is no request id and a useless - gets logged.