### PR TITLE
Remove perl dependency from govuk request

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -35,7 +35,13 @@ http {
     return lc($r->uri);
   }';
 
+  {{- if eq .Values.govukEnvironment "staging" }}
   # Set GOVUK-Request-Id if not set
+  map $http_govuk_request_id $govuk_request_id {
+    default $http_govuk_request_id;
+    ''      "$pid-$msec-$remote_addr-$request_length";
+  }
+  {{- else }}
   # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
   perl_modules perl/lib;
   perl_set $govuk_request_id '
@@ -53,6 +59,7 @@ http {
       }
     }
   ';
+  {{- end }}
 
   # Map the passed in X-Forwarded-Host if present and default to the server host otherwise.
   map $http_x_forwarded_host $proxy_add_x_forwarded_host {
@@ -75,7 +82,7 @@ http {
     '"@timestamp":"$time_iso8601",'
     '"body_bytes_sent":$body_bytes_sent,'
     '"bytes_sent":$bytes_sent,'
-    '"govuk_request_id":"$http_govuk_request_id",'
+    '"govuk_request_id":"$govuk_request_id",'
     '"http_host":"$http_host",'
     '"http_referer":"$http_referer",'
     '"http_user_agent":"$http_user_agent",'

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -13,12 +13,14 @@ data:
     error_log /dev/stderr warn;
     pid /tmp/nginx.pid;
 
-    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
-
     events {
       worker_connections 1024;
     }
 
+    {{- if ne .Values.govukEnvironment "staging" }}
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+    {{- end }}
+    
     http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;
@@ -59,7 +61,7 @@ data:
         '"@timestamp":"$time_iso8601",'
         '"body_bytes_sent":$body_bytes_sent,'
         '"bytes_sent":$bytes_sent,'
-        '"govuk_request_id":"$http_govuk_request_id",'
+        '"govuk_request_id":"$govuk_request_id",'
         '"http_host":"$http_host",'
         '"http_referer":"$http_referer",'
         '"http_user_agent":"$http_user_agent",'
@@ -79,15 +81,20 @@ data:
         '"upstream_addr":"$upstream_addr",'
         '"upstream_response_time":"$upstream_response_time"'
       '}';
-
+    
+      {{- if eq .Values.govukEnvironment "staging" }}
       # Set GOVUK-Request-Id if not set
+      map $http_govuk_request_id $govuk_request_id {
+        default $http_govuk_request_id;
+        ''      "$pid-$msec-$remote_addr-$request_length";
+      }
+      {{- else }}
       # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
       perl_modules perl/lib;
       perl_set $govuk_request_id '
         sub {
           my $r = shift;
           my $current_header = $r->header_in("GOVUK-Request-Id");
-
           if (defined $current_header && $current_header ne "") {
             return $current_header;
           } else {
@@ -99,6 +106,7 @@ data:
           }
         }
       ';
+      {{- end }}
 
       server {
         server_name asset-manager asset-manager.*  ;

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -13,14 +13,14 @@ data:
     error_log /dev/stderr warn;
     pid /tmp/nginx.pid;
 
-    events {
-      worker_connections 1024;
-    }
-
     {{- if ne .Values.govukEnvironment "staging" }}
     load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
     {{- end }}
     
+    events {
+      worker_connections 1024;
+    }
+
     http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -15,11 +15,13 @@ data:
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
 
-    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
-
     events {
       worker_connections  1024;
     }
+
+    {{- if ne .Values.govukEnvironment "staging" }}
+    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+    {{- end }}
 
     http {
       include       /etc/nginx/mime.types;
@@ -41,7 +43,14 @@ data:
       sendfile        on;
       keepalive_timeout  65;
 
+
+      {{- if eq .Values.govukEnvironment "staging" }}
       # Set GOVUK-Request-Id if not set
+      map $http_govuk_request_id $govuk_request_id {
+        default $http_govuk_request_id;
+        ''      "$pid-$msec-$remote_addr-$request_length";
+      }
+      {{- else }}
       # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
       perl_modules perl/lib;
       perl_set $govuk_request_id '
@@ -59,6 +68,8 @@ data:
           }
         }
       ';
+      {{- end }}
+      
 
       # Default values for response headers. These values are used when the
       # header is not already set on the incoming response.
@@ -77,7 +88,7 @@ data:
         '"@timestamp":"$time_iso8601",'
         '"body_bytes_sent":$body_bytes_sent,'
         '"bytes_sent":$bytes_sent,'
-        '"govuk_request_id":"$http_govuk_request_id",'
+        '"govuk_request_id":"$govuk_request_id",'
         '"http_host":"$http_host",'
         '"http_referer":"$http_referer",'
         '"http_user_agent":"$http_user_agent",'

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -15,13 +15,13 @@ data:
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
 
-    events {
-      worker_connections  1024;
-    }
-
     {{- if ne .Values.govukEnvironment "staging" }}
     load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
     {{- end }}
+
+    events {
+      worker_connections  1024;
+    }
 
     http {
       include       /etc/nginx/mime.types;


### PR DESCRIPTION
This is a reattempt of this pr https://github.com/alphagov/govuk-helm-charts/pull/1200

The previous attempt failed because nginx `load_module` directive was at a wrong place in the file