### PR TITLE
Reliability improvements to db-backup jobs.

### DIFF
--- a/charts/db-backup/scripts/lib.sh
+++ b/charts/db-backup/scripts/lib.sh
@@ -22,11 +22,17 @@ list () {
   s5cmd ls "$BUCKET/$DB_HOST/" | grep -Eo "[-0-9:TZ_]+-$db_name_re\.gz"
 }
 
+# foo-bar -> foo_bar
+# draft-foo-bar_production -> foo_bar
+default_db_owner () {
+  echo "${1%_production}" | sed -E 's/^(draft[_-])?(.*)/\2/' | tr - _
+}
+
 : "${GOVUK_ENVIRONMENT:?required}"
 : "${DB_USER:=aws_db_admin}"
 : "${DB_PASSWORD:=}"
 : "${DB_HOST:?required}"
 : "${DB_DATABASE:?required}"
-: "${DB_OWNER:=$(echo "${DB_DATABASE%_production}" | tr - _)}"
+: "${DB_OWNER:=$(default_db_owner "$DB_DATABASE")}"
 : "${BUCKET:=s3://govuk-$GOVUK_ENVIRONMENT-database-backups}"
 readonly GOVUK_ENVIRONMENT DB_USER DB_PASSWORD DB_HOST DB_DATABASE BUCKET

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -29,6 +29,14 @@ resources:
     cpu: 400m
     memory: 384Mi
 
+# TODO: figure out why memory usage is so spiky in these cases.
+_s5cmdRamWorkaround: &s5cmd-ram-workaround
+  resources:
+    limits:
+      memory: 2048Mi
+    requests:
+      memory: 1536Mi
+
 _mongoResources: &mongo-resources
   resources:
     limits:
@@ -116,11 +124,13 @@ cronjobs:
         - op: backup
 
     content-store-postgres:
+      <<: *s5cmd-ram-workaround
       schedule: "06 21 * * *"  # Keep this before publishing-api.
       db: content_store_production
       operations:
         - op: backup
     draft-content-store-postgres:
+      <<: *s5cmd-ram-workaround
       schedule: "16 21 * * *"  # Keep this before publishing-api.
       db: draft_content_store_production
       operations:
@@ -163,15 +173,11 @@ cronjobs:
         - op: backup
 
     publishing-api-postgres:
+      <<: *s5cmd-ram-workaround
       schedule: "36 21 * * *"
       db: publishing_api_production
       operations:
         - op: backup
-      resources: &pubapi-resources
-        limits:
-          memory: 1024Mi
-        requests:
-          memory: 768Mi
 
     release-mysql:
       schedule: "11 23 * * *"
@@ -308,6 +314,7 @@ cronjobs:
         - op: backup
 
     content-store-postgres:
+      <<: *s5cmd-ram-workaround
       db: content_store_production
       schedule: "06 22 * * *"
       operations:
@@ -315,6 +322,7 @@ cronjobs:
           bucket: s3://govuk-production-database-backups
         - op: backup
     draft-content-store-postgres:
+      <<: *s5cmd-ram-workaround
       db: draft_content_store_production
       schedule: "16 22 * * *"
       operations:
@@ -373,9 +381,9 @@ cronjobs:
         - op: backup
 
     publishing-api-postgres:
+      <<: *s5cmd-ram-workaround
       schedule: "36 1 * * *"
       db: publishing_api_production
-      resources: *pubapi-resources
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
@@ -553,6 +561,7 @@ cronjobs:
         - op: backup
 
     content-store-postgres:
+      <<: *s5cmd-ram-workaround
       db: content_store_production
       schedule: "06 23 * * *"
       operations:
@@ -562,6 +571,7 @@ cronjobs:
     # TODO: stop copying draft content into integration once the design quirks
     # of publishing-api that require it are rectified.
     draft-content-store-postgres:
+      <<: *s5cmd-ram-workaround
       db: draft_content_store_production
       schedule: "16 23 * * *"
       operations:
@@ -613,9 +623,9 @@ cronjobs:
           bucket: s3://govuk-staging-database-backups
 
     publishing-api-postgres:
+      <<: *s5cmd-ram-workaround
       schedule: "36 5 * * *"
       db: publishing_api_production
-      resources: *pubapi-resources
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups


### PR DESCRIPTION
- Infer the role name correctly for draft-content-store.
- Give the oom-prone jobs more RAM again (since I don't have time to figure out why just those few jobs seem to use so much).

Tested: installed temporarily with `helm install` and successfully ran a Postgres and a MySQL restore+backup job.