### PR TITLE
Fix smokey config dir for new headless chrome

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -89,3 +89,9 @@ spec:
                   key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            - name: SE_CACHE_PATH
+              value: "/tmp/.cache/selenium"
+            - name: XDG_CONFIG_HOME
+              value: "/tmp/.chrome"
+            - name: XDG_CACHE_HOME
+              value: "/tmp/.chrome"

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -60,3 +60,9 @@ spec:
               secretKeyRef:
                 name: smokey-signon-account
                 key: password
+          - name: SE_CACHE_PATH
+            value: "/tmp/.cache/selenium"
+          - name: XDG_CONFIG_HOME
+            value: "/tmp/.chrome"
+          - name: XDG_CACHE_HOME
+            value: "/tmp/.chrome"


### PR DESCRIPTION
The new headless chrome uses more of the same source code as the Chrome browser. This had led it trying to read and write user config. Here we're setting the user config folder in the /tmp folder (the only writable directory).