### PR TITLE
Generate request IDs without using Perl.

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -35,31 +35,11 @@ http {
     return lc($r->uri);
   }';
 
-  {{- if eq .Values.govukEnvironment "staging" }}
   # Set GOVUK-Request-Id if not set
   map $http_govuk_request_id $govuk_request_id {
     default $http_govuk_request_id;
     ''      "$pid-$msec-$remote_addr-$request_length";
   }
-  {{- else }}
-  # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
-  perl_modules perl/lib;
-  perl_set $govuk_request_id '
-    sub {
-      my $r = shift;
-      my $current_header = $r->header_in("GOVUK-Request-Id");
-      if (defined $current_header && $current_header ne "") {
-        return $current_header;
-      } else {
-        my $pid = $r->variable("pid");
-        my $msec = $r->variable("msec");
-        my $remote_addr = $r->variable("remote_addr");
-        my $request_length = $r->variable("request_length");
-        return "$pid-$msec-$remote_addr-$request_length";
-      }
-    }
-  ';
-  {{- end }}
 
   # Map the passed in X-Forwarded-Host if present and default to the server host otherwise.
   map $http_x_forwarded_host $proxy_add_x_forwarded_host {

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -13,10 +13,6 @@ data:
     error_log /dev/stderr warn;
     pid /tmp/nginx.pid;
 
-    {{- if ne .Values.govukEnvironment "staging" }}
-    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
-    {{- end }}
-    
     events {
       worker_connections 1024;
     }
@@ -82,31 +78,11 @@ data:
         '"upstream_response_time":"$upstream_response_time"'
       '}';
     
-      {{- if eq .Values.govukEnvironment "staging" }}
       # Set GOVUK-Request-Id if not set
       map $http_govuk_request_id $govuk_request_id {
         default $http_govuk_request_id;
         ''      "$pid-$msec-$remote_addr-$request_length";
       }
-      {{- else }}
-      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
-      perl_modules perl/lib;
-      perl_set $govuk_request_id '
-        sub {
-          my $r = shift;
-          my $current_header = $r->header_in("GOVUK-Request-Id");
-          if (defined $current_header && $current_header ne "") {
-            return $current_header;
-          } else {
-            my $pid = $r->variable("pid");
-            my $msec = $r->variable("msec");
-            my $remote_addr = $r->variable("remote_addr");
-            my $request_length = $r->variable("request_length");
-            return "$pid-$msec-$remote_addr-$request_length";
-          }
-        }
-      ';
-      {{- end }}
 
       server {
         server_name asset-manager asset-manager.*  ;

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -15,10 +15,6 @@ data:
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
 
-    {{- if ne .Values.govukEnvironment "staging" }}
-    load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
-    {{- end }}
-
     events {
       worker_connections  1024;
     }
@@ -44,32 +40,11 @@ data:
       keepalive_timeout  65;
 
 
-      {{- if eq .Values.govukEnvironment "staging" }}
       # Set GOVUK-Request-Id if not set
       map $http_govuk_request_id $govuk_request_id {
         default $http_govuk_request_id;
         ''      "$pid-$msec-$remote_addr-$request_length";
       }
-      {{- else }}
-      # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
-      perl_modules perl/lib;
-      perl_set $govuk_request_id '
-        sub {
-          my $r = shift;
-          my $current_header = $r->header_in("GOVUK-Request-Id");
-          if (defined $current_header && $current_header ne "") {
-            return $current_header;
-          } else {
-            my $pid = $r->variable("pid");
-            my $msec = $r->variable("msec");
-            my $remote_addr = $r->variable("remote_addr");
-            my $request_length = $r->variable("request_length");
-            return "$pid-$msec-$remote_addr-$request_length";
-          }
-        }
-      ';
-      {{- end }}
-      
 
       # Default values for response headers. These values are used when the
       # header is not already set on the incoming response.


### PR DESCRIPTION
This rolls out #1623 (originally #1200) to production (and integration).

There's still one more usage of Perl to get rid of (in Router, for lowercasing certain URL paths).