### PR TITLE
Switch integration draft-content-store back to deploying from content-store repo

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -739,7 +739,7 @@ govukApplications:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/db-backup-govuk
 
   - name: draft-content-store
-    repoName: content-store-postgresql-branch
+    repoName: content-store
     helmValues:
       <<: *content-store
       rails:


### PR DESCRIPTION
After removing the remaining `content-store-proxy` and `content-store-mongo-main`apps yesterday in #1598, we can now return the content-store codebase and helm config to a 'normal' state - ie. a single `content-store` app deployed from an ECR repo called `content-store`, built from the `main` branch.

This is the first step in doing that. 

I've built a `content-store` container from the `port-to-postgresql` branch and pushed it to integration, so deploying this to the integration draft-content-store should be a zero-impact change. Once we've shown this to be the case, I can switch the live content-store in integration, and then both in staging, then production.

Then we'll only need to merge the branch back into main, and we're done.