### PR TITLE
Switch integration live content-store back to content-store repo

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -694,7 +694,6 @@ govukApplications:
               key: bearer_token
 
   - name: content-store
-    repoName: content-store-postgresql-branch
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       cronTasks:


### PR DESCRIPTION
As per #1634 , but for the integration live content-store.

In this case the `repoName:` line is no longer needed, as the repoName matches the app name.