### PR TITLE
Add env var to Content Data Admin

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -517,6 +517,8 @@ govukApplications:
           value: *publishing-notify-template
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+        - name: FIND_CONTENT_QUERY_PAGE_SIZE
+          value: 1000
 
   - name: content-data-api
     helmValues:


### PR DESCRIPTION
Add an env var and reduce the page size to 1000 to reduce memory usage. I have no particular reason to pick this number.

https://trello.com/c/MU9KwkRP/3368-improve-performance-of-content-data-csv-exports-3