### PR TITLE
Reinstate image-tags for govuk-sli-collector job

### DIFF
--- a/charts/app-config/image-tags/production/govuk-sli-collector
+++ b/charts/app-config/image-tags/production/govuk-sli-collector
@@ -1,0 +1,3 @@
+image_tag: latest
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/govuk-sli-collector/templates/cronjob.yaml
+++ b/charts/govuk-sli-collector/templates/cronjob.yaml
@@ -1,4 +1,6 @@
 {{- $_ := .Values.govukEnvironment | required "govukEnvironment is required" }}
+{{- $imageTagConfig := $.Files.Get (printf "charts/app-config/image-tags/%s/govuk-sli-collector" .Values.govukEnvironment) | fromYaml }}
+{{- $imageTag := $imageTagConfig.image_tag }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -30,7 +32,7 @@ spec:
               emptyDir: {}
           containers:
             - name: main
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              image: "{{ .Values.imageRepository }}:{{ $imageTag }}"
               imagePullPolicy: "Always"
               env:
                 - name: INTERVAL_MINUTES
@@ -55,7 +57,7 @@ spec:
                       name: govuk-sli-collector-sentry
                       key: dsn
                 - name: SENTRY_RELEASE
-                  value: "{{ .Values.image.tag }}"
+                  value: "{{ $imageTag }}"
                 - name: SENTRY_CURRENT_ENV
                   value: "{{ .Values.govukEnvironment }}"
               resources:

--- a/charts/govuk-sli-collector/values.yaml
+++ b/charts/govuk-sli-collector/values.yaml
@@ -5,9 +5,7 @@ govukEnvironment: test
 intervalMinutes: "10"
 offsetMinutes: "10"
 
-image:
-  repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-sli-collector"
-  tag: "latest"
+imageRepository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-sli-collector"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
I've mostly copied this from the `govuk-application` template.

We recently extracted this standalone chart out of the deprecated `govuk-jobs` chart. Since that change meant no longer using the `govuk-application` template, we lost the ability for the cronjob to pull arbitrary images from ECR using `image-tags`. It can now only pull the `latest`-tagged (i.e. `main` branch) image.

After some deliberation, I've decided to add the use of `image-tags` to this standalone chart, allowing us to deploy arbitrary images again. The main motivation for this is for ease/flexibility of future development. It's hard to ignore that significant changes could benefit from the ability to deploy feature branches to integration. And while temporarily enabling the cronjob in integration will require only a small change, re-enabling the use of arbitrary images will be harder work that isn't guaranteed to be approachable for whoever is tasked with making the application code changes.

`automatic_deploys_enabled` and `promote_deployment` are set to false because (as I understand it) they don't mean anything for this non-`app-config` chart.

(https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli)