### PR TITLE
Switch production draft content-store back to the content-store ECR repo

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -746,13 +746,12 @@ govukApplications:
           eks.amazonaws.com/role-arn: arn:aws:iam::172025368201:role/db-backup-govuk
 
   - name: draft-content-store
-    repoName: content-store-postgresql-branch
+    repoName: content-store
     helmValues:
       <<: *content-store
       rails:
         createKeyBaseSecret: false
-        # use the same secret as the mongo draft-content-store, it will make the
-        # eventual switchover easier and reduce toil
+        # use the same secret as the live content-store, it will reduce toil
         secretKeyBaseName: content-store-rails-secret-key-base
       sentry:
         createSecret: false  # Sentry DSNs are per repo.


### PR DESCRIPTION
We removed the proxy and the mongo content-store applications yesterday (#1598), we've also removed the legacy EC2 mongo instances, so we are ready to switch the content-store applications back to the `content-store` ECR repo in production.

Similar PRs in integration (#1635) and staging (#1637) went through with zero disruption so we're expecting the same for prod.