### PR TITLE
Switch prod live content-store back to content-store ECR repo

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -690,7 +690,6 @@ govukApplications:
               key: bearer_token
 
   - name: content-store
-    repoName: content-store-postgresql-branch
     helmValues: &content-store
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.


### PR DESCRIPTION
As per #1643 but for the live content-store. 

This will remove another temporary special case added to ease the transition to PostgreSQL, and we'll then have both draft and live content-store apps deployed once again from the standard repo name ('content-store') in all environments.

All previous deployments of a similar change (to integration/staging, and prod draft) were zero-downtime & zero-disruption, so we expect the same for this change. 