### PR TITLE
Add missing FIND_CONTENT_QUERY_PAGE_SIZE var for Content Data Admin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -517,6 +517,8 @@ govukApplications:
           value: *publishing-notify-template
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+        - name: FIND_CONTENT_QUERY_PAGE_SIZE
+          value: 1000
 
   - name: content-data-api
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -517,6 +517,8 @@ govukApplications:
           value: *publishing-notify-template
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+        - name: FIND_CONTENT_QUERY_PAGE_SIZE
+          value: 1000
 
   - name: content-data-api
     helmValues:


### PR DESCRIPTION
Adds the variable to integration and staging as the app relies on the variable in those environments as well.  

Related to:
https://github.com/alphagov/content-data-admin/commit/ed764dd01900aec39da00dc114807fc7ff6ddb9a