### PR TITLE
Revert "content-data workers spool entire reports in RAM :("

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -449,14 +449,6 @@ govukApplications:
           - name: content-data.{{ .Values.k8sExternalDomainSuffix }}
       nginxProxyReadTimeout: 60s
       workerEnabled: true
-      workerReplicaCount: 2
-      workerResources:
-        limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
-          cpu: 0.5
-          memory: 2Gi
       extraEnv:
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
This reverts commit 3f4effc4a87a3f390642c1cd92b8b97be6d5d7d8 and takes the values back to the defaults.

We reduced page size for those queries:
- https://github.com/alphagov/content-data-admin/commit/ed764dd01900aec39da00dc114807fc7ff6ddb9a
- https://github.com/alphagov/govuk-helm-charts/pull/1636
- https://github.com/alphagov/govuk-helm-charts/pull/1645


https://trello.com/c/MU9KwkRP/3368-improve-performance-of-content-data-csv-exports-3