### PR TITLE
Use environment-specific image for cronjob

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1275,6 +1275,9 @@ govukApplications:
   - name: govuk-sli-collector
     chartPath: charts/govuk-sli-collector
     postSyncWorkflowEnabled: "false"
+    helmValues:
+      image:
+        tag: "deployed-to-production"
 
   - name: hmrc-manuals-api
     helmValues:

--- a/charts/govuk-sli-collector/values.yaml
+++ b/charts/govuk-sli-collector/values.yaml
@@ -7,7 +7,6 @@ offsetMinutes: "10"
 
 image:
   repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-sli-collector"
-  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

This supersedes https://github.com/alphagov/govuk-helm-charts/pull/1640 (because I haven't managed to get it working).

And it depends on https://github.com/alphagov/govuk-infrastructure/pull/1046 and https://github.com/alphagov/govuk-sli-collector/pull/6.

Since this isn't an app, it doesn't use Argo workflows or `image-tags`, but we'd still like to be able to deploy separate images to each environment as and when it's needed. We've made some corresponding changes to make this possible in [`govuk-infrastructure`](https://github.com/alphagov/govuk-infrastructure/pull/1046) and [`govuk-sli-collector`](https://github.com/alphagov/govuk-sli-collector/pull/6).

This cronjob only currently runs in production, but I can easily imagine wanting to temporarily re-enable it in integration for some testing, debugging, etc. When that happens, I don't want the developer who's given that task to have to figure this other stuff out, I want them to be able to just add the integration-equivalent version of this `values-production.yml` entry into `values-integration.yml`.