### PR TITLE
Enable deployment via image tag files for govuk-sli-collector

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-sli-collector
+++ b/charts/app-config/image-tags/integration/govuk-sli-collector
@@ -1,0 +1,3 @@
+image_tag: latest
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/app-config/image-tags/production/govuk-sli-collector
+++ b/charts/app-config/image-tags/production/govuk-sli-collector
@@ -1,0 +1,3 @@
+image_tag: latest
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/app-config/image-tags/staging/govuk-sli-collector
+++ b/charts/app-config/image-tags/staging/govuk-sli-collector
@@ -1,0 +1,3 @@
+image_tag: latest
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1275,6 +1275,8 @@ govukApplications:
   - name: govuk-sli-collector
     chartPath: charts/govuk-sli-collector
     postSyncWorkflowEnabled: "false"
+    imageValues:
+      - "govuk-sli-collector"
 
   - name: hmrc-manuals-api
     helmValues:

--- a/charts/govuk-sli-collector/templates/cronjob.yaml
+++ b/charts/govuk-sli-collector/templates/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               emptyDir: {}
           containers:
             - name: main
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              image: "{{ .Values.images.GovukSliCollector.repository }}:{{ .Values.images.GovukSliCollector.tag }}"
               imagePullPolicy: "Always"
               env:
                 - name: INTERVAL_MINUTES
@@ -55,7 +55,7 @@ spec:
                       name: govuk-sli-collector-sentry
                       key: dsn
                 - name: SENTRY_RELEASE
-                  value: "{{ .Values.image.tag }}"
+                  value: "{{ .Values.images.GovukSliCollector.tag }}"
                 - name: SENTRY_CURRENT_ENV
                   value: "{{ .Values.govukEnvironment }}"
               resources:

--- a/charts/govuk-sli-collector/values.yaml
+++ b/charts/govuk-sli-collector/values.yaml
@@ -5,9 +5,10 @@ govukEnvironment: test
 intervalMinutes: "10"
 offsetMinutes: "10"
 
-image:
-  repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-sli-collector"
-  tag: "latest"
+images:
+  GovukSliCollector:
+    repository: "govuk-sli-collector"
+    tag: "release"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This adds the image tag files for govuk-sli-collector and references them from the argo-app. This allows us to use the existing deployment process to deploy the govuk-sli-collector.

The govuk-sli-collector is only deployed into the production environment. However, the image tags files are available incase it's needed to be deployed into either integration or staging for testing.