### PR TITLE
Fix env var type value type for content data admin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -518,7 +518,7 @@ govukApplications:
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: FIND_CONTENT_QUERY_PAGE_SIZE
-          value: 1000
+          value: "1000"
 
   - name: content-data-api
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -510,7 +510,7 @@ govukApplications:
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: FIND_CONTENT_QUERY_PAGE_SIZE
-          value: 1000
+          value: "1000"
 
   - name: content-data-api
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -518,7 +518,7 @@ govukApplications:
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: FIND_CONTENT_QUERY_PAGE_SIZE
-          value: 1000
+          value: "1000"
 
   - name: content-data-api
     helmValues:


### PR DESCRIPTION
Argo cannot apply this K8s resource manifest as it expects string for the value of env vars.