### PR TITLE
Auto-merge some reloader and external-secrets updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,12 @@
       "automergeType": "branch"
     },
     {
+      "matchPackageNames": ["external-secrets"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
       "matchFileNames": ["**/helm-versions/*"],
       "additionalBranchPrefix": "{{replace '^.+\\/' '' packageFile}}-",
       "commitMessageSuffix": " ({{replace '^.+\\/' '' packageFile}})"

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,12 @@
       "automergeType": "branch"
     },
     {
+      "matchPackageNames": ["reloader"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
       "matchFileNames": ["**/helm-versions/*"],
       "additionalBranchPrefix": "{{replace '^.+\\/' '' packageFile}}-",
       "commitMessageSuffix": " ({{replace '^.+\\/' '' packageFile}})"


### PR DESCRIPTION
Reloader isn't mission critical, and external-secrets patches seem safe to auto-merge (and are quite frequent).

#1661