### PR TITLE
Add k8s replica to Router mongo connection string.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1856,7 +1856,7 @@ govukApplications:
               key: oauth_secret
         - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
           value: "mongodb://\
-            router-backend-1,\
+            router-mongo-0,\
             router-backend-2,\
             router-backend-3/router"
 
@@ -1881,7 +1881,7 @@ govukApplications:
               key: oauth_secret
         - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
           value: "mongodb://\
-            router-backend-1,\
+            router-mongo-0,\
             router-backend-2,\
             router-backend-3/draft_router"
 
@@ -1962,7 +1962,7 @@ govukApplications:
           value: ":9394"
         - name: ROUTER_MONGO_URL
           value: &router_mongo_hosts "\
-            router-backend-1,\
+            router-mongo-0,\
             router-backend-2,\
             router-backend-3"
         - name: BACKEND_URL_collections


### PR DESCRIPTION
This is step 1 of 3.

Step 2 is to remove the `router-backend-*` entries once those replicas have been removed from the replicaset, then step 3 is to add a `router-mongo-1` replica once that's up.

[Overall rollout plan](https://docs.google.com/document/d/1_6nAsqAnrYpCOMCVw1cde6xdymgnRPCv6bvbQZ_Yyic/edit)