### PR TITLE
Removing name

### DIFF
--- a/charts/app-config/templates/kubescape.yaml
+++ b/charts/app-config/templates/kubescape.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
 spec:
   destination:
-    name: kubescape
     namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
     server: 'https://kubernetes.default.svc' # change to your server
   source:


### PR DESCRIPTION
Getting error:
application destination can't have both name and server defined: kubescape https://kubernetes.default.svc