### PR TITLE
Add a second router-mongo replica in staging.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1855,7 +1855,7 @@ govukApplications:
               name: signon-app-router-api
               key: oauth_secret
         - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://router-mongo-0/router"
+          value: "mongodb://router-mongo-0,router-mongo-1/router"
 
   - name: draft-router-api
     repoName: router-api
@@ -1877,7 +1877,7 @@ govukApplications:
               name: signon-app-draft-router-api
               key: oauth_secret
         - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://router-mongo-0/draft_router"
+          value: "mongodb://router-mongo-0,router-mongo-1/draft_router"
 
   - name: router
     helmValues:
@@ -1955,7 +1955,7 @@ govukApplications:
         - name: ROUTER_APIADDR
           value: ":9394"
         - name: ROUTER_MONGO_URL
-          value: &router_mongo_hosts "router-mongo-0"
+          value: &router_mongo_hosts "router-mongo-0,router-mongo-1"
         - name: BACKEND_URL_collections
           value: "http://collections"
         - name: BACKEND_URL_content-store
@@ -2040,6 +2040,8 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
+    helmValues:
+      replicas: 2
 
   - name: search-admin
     helmValues:

--- a/charts/router-mongo/templates/service.yaml
+++ b/charts/router-mongo/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if eq (int .Values.replicas) 1 }}
 ---
 # TODO: remove this Service once the out-of-cluster replicaset members are gone.
 apiVersion: v1
@@ -24,3 +25,22 @@ spec:
   ports:
     - port: 27017
       name: mongodb
+{{- else }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "router-mongo.fullname" . }}
+  labels:
+    {{- include "router-mongo.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Headless service for the router-mongo statefulset.
+spec:
+  clusterIP: None
+  selector:
+    {{- include "router-mongo.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: 27017
+      name: mongodb
+{{- end }}

--- a/charts/router-mongo/templates/statefulset.yaml
+++ b/charts/router-mongo/templates/statefulset.yaml
@@ -12,7 +12,7 @@ metadata:
       Router database.
 spec:
   serviceName: {{ $fullName }}
-  replicas: 1  # TODO: run two in-cluster replicas once the old EC2 ones are gone.
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "router-mongo.selectorLabels" $ | nindent 6 }}

--- a/charts/router-mongo/values.yaml
+++ b/charts/router-mongo/values.yaml
@@ -25,6 +25,8 @@ securityContext:
   runAsNonRoot: true
   runAsUser: *uid
 
+replicas: 1
+
 resources:
   limits:
     cpu: 3000m


### PR DESCRIPTION
This is step 3 of 3; see 0e06aba.

We need to keep a headless service around so that the DNS names for the statefulset still work.