### PR TITLE
Adding random string to Account-ID Kubescape

### DIFF
--- a/charts/app-config/templates/kubescape.yaml
+++ b/charts/app-config/templates/kubescape.yaml
@@ -17,7 +17,8 @@ spec:
         - values.yaml
       parameters:
         - name: account
-          value: '123456' # Dummy value
+          # Dummy value string for testing purpose
+          value: "mgsQy3ett5"
         - name: clusterName
           value: 'govuk-integration-new'
         - name: server


### PR DESCRIPTION
Account-id requires a string - helm template error message:

`wrong type for value; expected string; got int64 Use --debug flag to render out invalid YAML`

Random string generated via:
`cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1`