### PR TITLE
Fix in-cluster DNS names for router-mongo.

### DIFF
--- a/charts/router-mongo/templates/statefulset.yaml
+++ b/charts/router-mongo/templates/statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 12 }}
       dnsConfig:
         searches:
+          - {{ $fullName }}.{{ .Release.Namespace }}.svc.cluster.local
           - blue.{{ $.Values.govukEnvironment }}.govuk-internal.digital
       volumes:
         - name: config

--- a/charts/router-mongo/values.yaml
+++ b/charts/router-mongo/values.yaml
@@ -9,7 +9,7 @@ args:
   - --config
   - /etc/mongo/mongodb.conf
   - --replSet
-  - production/router-mongo-0,router-backend-1,router-backend-2,router-backend-3
+  - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-backend-1,router-backend-2,router-backend-3
 
 podSecurityContext:
   fsGroup: &uid 999


### PR DESCRIPTION
I forgot about the extra label for the service name.

I'll update the hostnames in the replicaset config so that the extra search path can be cleaned up afterwards.