### PR TITLE
Fix Mongo connection strings (staging).

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1855,7 +1855,10 @@ govukApplications:
               name: signon-app-router-api
               key: oauth_secret
         - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://router-mongo-0,router-mongo-1/router"
+          value: "mongodb://\
+            router-mongo-0.router-mongo,\
+            router-mongo-1.router-mongo,\
+            router-mongo-2.router-mongo/router"
 
   - name: draft-router-api
     repoName: router-api
@@ -1877,7 +1880,10 @@ govukApplications:
               name: signon-app-draft-router-api
               key: oauth_secret
         - name: MONGODB_URI  # Hostnames need to match those shown in MongoDB rs.status().
-          value: "mongodb://router-mongo-0,router-mongo-1/draft_router"
+          value: "mongodb://\
+            router-mongo-0.router-mongo,\
+            router-mongo-1.router-mongo,\
+            router-mongo-2.router-mongo/draft_router"
 
   - name: router
     helmValues:
@@ -1955,7 +1961,10 @@ govukApplications:
         - name: ROUTER_APIADDR
           value: ":9394"
         - name: ROUTER_MONGO_URL
-          value: &router_mongo_hosts "router-mongo-0,router-mongo-1"
+          value: &router_mongo_hosts "\
+            router-mongo-0.router-mongo,\
+            router-mongo-1.router-mongo,\
+            router-mongo-2.router-mongo"
         - name: BACKEND_URL_collections
           value: "http://collections"
         - name: BACKEND_URL_content-store

--- a/charts/router-mongo/templates/statefulset.yaml
+++ b/charts/router-mongo/templates/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
       enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 12 }}
+      # TODO: remove dnsConfig once #1668 is done.
       dnsConfig:
         searches:
           - {{ $fullName }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/router-mongo/values.yaml
+++ b/charts/router-mongo/values.yaml
@@ -9,7 +9,7 @@ args:
   - --config
   - /etc/mongo/mongodb.conf
   - --replSet
-  - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-backend-1,router-backend-2,router-backend-3
+  - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo,router-backend-1,router-backend-2,router-backend-3
 
 podSecurityContext:
   fsGroup: &uid 999


### PR DESCRIPTION
- Simpler to go with the names from the statefulset (like `router-mongo-0.router-mongo`) than require every client to have a special dnsConfig just so we can have shorter names.
- Mongo replicasets are oldskool; even number of nodes => [gonna have a bad time](https://youtu.be/7aUGBT1DZDI).