### PR TITLE
Run in-cluster router-mongo replica in integration.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2030,6 +2030,12 @@ govukApplications:
         - name: BACKEND_URL_search-api
           value: "http://search-api"
 
+  - name: router-mongo
+    chartPath: charts/router-mongo
+    postSyncWorkflowEnabled: "false"
+    helmValues:
+      replicas: 1
+
   - name: search-admin
     helmValues:
       dbMigrationEnabled: true


### PR DESCRIPTION
This is the "pioneer" node that will pull the data from the existing replicaset members outside the cluster.

See #1668.