### PR TITLE
Add in-cluster router-mongo nodes to clients in integration.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1850,7 +1850,10 @@ govukApplications:
           value: "mongodb://\
             router-backend-1,\
             router-backend-2,\
-            router-backend-3/router"
+            router-backend-3,\
+            router-mongo-0.router-mongo,\
+            router-mongo-1.router-mongo,\
+            router-mongo-2.router-mongo/router"
 
   - name: draft-router-api
     repoName: router-api
@@ -1875,7 +1878,10 @@ govukApplications:
           value: "mongodb://\
             router-backend-1,\
             router-backend-2,\
-            router-backend-3/draft_router"
+            router-backend-3,\
+            router-mongo-0.router-mongo,\
+            router-mongo-1.router-mongo,\
+            router-mongo-2.router-mongo/draft_router"
 
   - name: router
     helmValues:
@@ -1949,7 +1955,10 @@ govukApplications:
           value: &router_mongo_hosts "\
             router-backend-1,\
             router-backend-2,\
-            router-backend-3"
+            router-backend-3,\
+            router-mongo-0.router-mongo,\
+            router-mongo-1.router-mongo,\
+            router-mongo-2.router-mongo"
         - name: BACKEND_URL_collections
           value: "http://collections"
         - name: BACKEND_URL_content-store


### PR DESCRIPTION
This is so that the clients can still make new connections (e.g. if restarted) once the out-of-cluster replicas are removed.

See #1668.