### PR TITLE
Revert "Scale out router-mongo to 3 replicas in integration."

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2043,7 +2043,7 @@ govukApplications:
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
     helmValues:
-      replicas: 3
+      replicas: 1
 
   - name: search-admin
     helmValues:


### PR DESCRIPTION
Whoops, merged that one too soon, missed the `rs.remove()` step that was supposed to happen first. Sorry for the noise.

Reverts alphagov/govuk-helm-charts#1684