### PR TITLE
Remove unnecessary router-mongo svc template kludge.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2033,8 +2033,6 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
-    helmValues:
-      replicas: 3
 
   - name: search-admin
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2049,8 +2049,6 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
-    helmValues:
-      replicas: 3
 
   - name: search-admin
     helmValues:

--- a/charts/router-mongo/templates/service.yaml
+++ b/charts/router-mongo/templates/service.yaml
@@ -1,31 +1,3 @@
-{{- if eq (int .Values.replicas) 1 }}
----
-# TODO: remove this Service once the out-of-cluster replicaset members are gone.
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "router-mongo.fullname" . }}
-  labels:
-    {{- include "router-mongo.labels" . | nindent 4 }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
-    kubernetes.io/description: >
-      Temporary service to let Mongo nodes outside the k8s cluster connect to
-      the one inside the cluster. Obsolete once the out-of-cluster nodes have
-      been removed from the replicaset. Needs to be deleted before scaling out
-      the statefulset beyond its initial replica.
-spec:
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-    - 10.0.0.0/8
-  selector:
-    {{- include "router-mongo.selectorLabels" . | nindent 4 }}
-  ports:
-    - port: 27017
-      name: mongodb
-{{- else }}
 ---
 apiVersion: v1
 kind: Service
@@ -43,4 +15,3 @@ spec:
   ports:
     - port: 27017
       name: mongodb
-{{- end }}

--- a/charts/router-mongo/values.yaml
+++ b/charts/router-mongo/values.yaml
@@ -25,7 +25,7 @@ securityContext:
   runAsNonRoot: true
   runAsUser: *uid
 
-replicas: 1
+replicas: 3
 
 resources:
   limits:


### PR DESCRIPTION
It's much simpler to have just the final, headless service in the Helm template and create separate services (outside Helm/Argo) for the temporary load balancer stuff that's only needed during the migration. (Especially since we need one service for each new node, because we have to add the new nodes before we remove the old ones.)