### PR TITLE
Add email alert api bearer token for content data admin in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -459,6 +459,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-data-admin-content-data-api
               key: bearer_token
+        - name: EMAIL_ALERT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-content-data-admin-email-alert-api
+              key: bearer_token
         - name: SITEIMPROVE_API_CLIENT_USERNAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Allow content data admin to access email-alert-api so that it can retrieve subscriber list metrics (INTEGRATION ONLY FOR THE MOMENT)

https://trello.com/c/xng5X4uX/30-add-email-statistics-into-content-data-admin
