### PR TITLE
Bump resources on the mirror scraper

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -45,10 +45,10 @@ spec:
               resources:
                 limits:
                   cpu: 4
-                  memory: 15000Mi
+                  memory: 20000Mi
                 requests:
                   cpu: 2
-                  memory: 10000Mi
+                  memory: 15000Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
We're seeing this job not run to completion, with errors such as:

> Jan  9 01:57:22 ip-10-13-29-166 kernel: Memory cgroup out of memory: Killed process 2720094 (govuk-mirror) total-vm:13084964kB, anon-rss:8341956kB, file-rss:9092kB, shmem-rss:0kB, UID:1001 pgtables:23380kB oom_score_adj:922

Bumping the memory limits to see if it'll finish with a few more resources.

The nodes that this runs on should have plenty of head room to cope with this.