### PR TITLE
Reduce s5cmd parallelism to reduce excessive RAM usage.

### DIFF
--- a/charts/db-backup/scripts/backup-mongo
+++ b/charts/db-backup/scripts/backup-mongo
@@ -16,7 +16,7 @@ backup () {
 }
 
 dump_is_readable () {
-  s5cmd cat "$1" | gzip -d | head -c 100 | grep -q concurrent_collections
+  s5cmd cat -c 1 -p 1 "$1" | gzip -d | head -c 100 | grep -q concurrent_collections
 }
 
 restore () {
@@ -27,7 +27,7 @@ restore () {
   local s3_url="$BUCKET/$DB_HOST/$FILENAME"
   dump_is_readable "$s3_url"
 
-  s5cmd cat "$s3_url" | gzip -d | mongorestore "$db_url" --archive --drop -j 1
+  s5cmd cat -c 1 "$s3_url" | gzip -d | mongorestore "$db_url" --archive --drop -j 1
 }
 
 transform () {

--- a/charts/db-backup/scripts/backup-mysql
+++ b/charts/db-backup/scripts/backup-mysql
@@ -19,7 +19,7 @@ transform () {
 }
 
 dump_is_readable () {
-  s5cmd cat "$1" | gzip -d | head -n5 \
+  s5cmd cat -c 1 -p 1 "$1" | gzip -d | head -n5 \
     | tee /dev/fd/2 | grep 'MySQL dump' >/dev/null 2>&1
 }
 
@@ -32,7 +32,7 @@ restore () {
   dump_is_readable "$s3_url"
   mysqladmin drop -f "$DB_DATABASE" || true
   mysqladmin create "$DB_DATABASE"
-  s5cmd cat "$s3_url" | gzip -d | progress | mysql "$DB_DATABASE"
+  s5cmd cat -c 1 "$s3_url" | gzip -d | progress | mysql "$DB_DATABASE"
 }
 
 write_config () {

--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -24,7 +24,7 @@ transform () {
 }
 
 dump_is_readable () {
-  s5cmd cat "$1" | head | file - | tee /dev/fd/2 \
+  s5cmd cat -c 1 -p 1 "$1" | head | file - | tee /dev/fd/2 \
     | grep -iq 'PostgreSQL custom database dump'
 }
 
@@ -62,7 +62,7 @@ restore () {
 
   dropdb -ef --if-exists "$DB_DATABASE-restore"
   createdb -eT template0 "$DB_DATABASE-restore"
-  s5cmd cat "$s3_url" | progress | pg_restore --no-comments -f - \
+  s5cmd cat -c 1 "$s3_url" | progress | pg_restore --no-comments -f - \
     | psql -d "$DB_DATABASE-restore" -c "SET session_replication_role = 'replica';" -f -
 
   if db_exists "$DB_DATABASE"; then


### PR DESCRIPTION
s5cmd sometimes uses >2 GB RAM (wss) because it's doing a bunch of parallel transfers. We don't actually benefit much from this parallelism, but the unbounded and unpredictable memory usage is a reliability problem.

- Set parallel transfers to 1.
- Set the chunk size to 1 MB when doing the exploratory GET for the file magic check.

See https://www.github.com/peak/s5cmd/pull/593.