### PR TITLE
Increase size of govuk-mirror volume

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-pvc.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-pvc.yaml
@@ -8,4 +8,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Gi
+      storage: 1000Gi


### PR DESCRIPTION
We seem to use about 490Gi on a full scrape. This increase gives us a bit more headway. Ideally we need a better way at clearing out old files from the cache.