### PR TITLE
Add Licensify helm chart and values for integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1321,6 +1321,61 @@ govukApplications:
 
   - name: info-frontend
 
+  - name: licensify
+    chartPath: charts/licensify
+    imageValues:
+      - "licensify-admin"
+      - "licensify-backend"
+      - "licensify-feed"
+      - "licensify-frontend"
+    helmValues:
+      assetManagerNFS: *assets-nfs
+      licensifyAdmin:
+        ingress:
+          annotations:
+            <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+            alb.ingress.kubernetes.io/healthcheck-path: /
+          hosts:
+            - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
+      licensifyFeed:
+        ingress:
+          annotations:
+            <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+            alb.ingress.kubernetes.io/healthcheck-path: >-
+              /licence-management/feed/process-applications
+          hosts:
+            - name: licensify-feed.{{ .Values.k8sExternalDomainSuffix }}
+      licensifyFrontend:
+        ingress:
+          annotations:
+            <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+            alb.ingress.kubernetes.io/healthcheck-path: /apply-for-a-licence
+          hosts:
+            - name: licensify.{{ .Values.k8sExternalDomainSuffix }}
+      extraEnv:
+        - name: APPLICATION_FORM_AWS_REGION
+          value: eu-west-1
+        - name: APPLICATION_FORM_BUCKET_NAME
+          value: govuk-licensing-application-forms-integration
+      config:
+        mongo:
+          dbHosts:
+            - licensify-documentdb-0.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
+            - licensify-documentdb-1.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
+            - licensify-documentdb-2.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
+        baseUrl: https://licensify-admin.eks.integration.govuk.digital
+        frontendBaseUrl: https://licensify.eks.integration.govuk.digital
+        signonBaseUrl: https://signon.integration.publishing.service.gov.uk
+        licenceFinderUrl: https://www-origin.integration.publishing.service.gov.uk/licence-finder
+        performancePlatformUrl: >-
+          https://www.integration.performance.service.gov.uk/data/licensing/application
+        googleAnalytics:
+          accountAdmin: UA-34519962-2
+          domainAdmin: integration.publishing.service.gov.uk
+          accountFrontend: UA-34519962-1
+          domainFrontend: integration.publishing.service.gov.uk
+        noReplyMailAddress: noreply-licensing-preview@digital.cabinet-office.gov.uk
+
   - name: link-checker-api
     helmValues:
       dbMigrationEnabled: true

--- a/charts/licensify/Chart.yaml
+++ b/charts/licensify/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: licensify
+description: A Helm chart for GOV.UK Licensing
+type: application
+version: 0.1.0

--- a/charts/licensify/templates/_helpers.tpl
+++ b/charts/licensify/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Release.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "licensify.chart" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "licensify.labels" -}}
+helm.sh/chart: {{ include "licensify.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: "licensify"
+app.kubernetes.io/name: {{ .Values.appName }}
+app.kubernetes.io/instance: {{ .Values.appName }}-{{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "licensify.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -1,0 +1,72 @@
+{{ $app := .Values.clamav }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ $app.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $app.name }}
+  template:
+    metadata:
+      labels:
+        {{- include "licensify.labels" . | nindent 8}}
+        app: {{ $app.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: main
+          command:
+            - "/unpriv-init"
+          securityContext:
+           {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ $app.image.repository }}:{{ $app.image.tag }}"
+          imagePullPolicy: {{ $app.image.pullPolicy }}
+          env:
+            - name: CLAMAV_NO_FRESHCLAMD
+              value: "true"
+          ports:
+            - name: clamav
+              containerPort: {{ $app.service.port }}
+          livenessProbe: &app-probe
+            tcpSocket:
+              port: clamav
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            <<: *app-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+          startupProbe:
+            <<: *app-probe
+            failureThreshold: 15
+            periodSeconds: 5
+            timeoutSeconds: 2
+            initialDelaySeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: app-tmp
+              mountPath: /tmp
+            - name: app-clamav-db
+              mountPath: /var/lib/clamav
+      volumes:
+        - name: app-tmp
+          emptyDir: {}
+        - name: app-clamav-db
+          nfs:
+            server: "{{ .Values.assetManagerNFS }}"
+            path: /clamav-db
+            readOnly: true

--- a/charts/licensify/templates/clamav/service.yaml
+++ b/charts/licensify/templates/clamav/service.yaml
@@ -1,0 +1,19 @@
+{{ $app := .Values.clamav }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  type: {{ $app.service.type }}
+  ports:
+    - name: app
+      port: {{ $app.service.port }}
+      targetPort: clamav
+      protocol: TCP
+  selector:
+    app: {{ $app.name }}

--- a/charts/licensify/templates/config-externalsecret.yaml
+++ b/charts/licensify/templates/config-externalsecret.yaml
@@ -1,0 +1,49 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "fullname" . }}
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: licensify-config
+    template:
+      engineVersion: v2
+      templateFrom:
+      - target: Data
+        configMap:
+          name: licensify-config-template
+          items:
+          - key: config.properties
+            templateAs: Values
+  data:
+  - secretKey: aws_access_key_id
+    remoteRef:
+      key: govuk/licensify
+      property: aws_access_key_id
+  - secretKey: aws_access_secret_key
+    remoteRef:
+      key: govuk/licensify
+      property: aws_access_secret_key
+  - secretKey: mongo_database_auth_password
+    remoteRef:
+      key: govuk/licensify
+      property: mongo_database_auth_password
+  - secretKey: client_id
+    remoteRef:
+      key: govuk/licensify
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: govuk/licensify
+      property: client_secret
+  - secretKey: performance_platform_bearer_token
+    remoteRef:
+      key: govuk/licensify
+      property: "performance_platform_bearer_token"
+  - secretKey: notify_key_api
+    remoteRef:
+      key: govuk/licensify
+      property: "notify_key_api"

--- a/charts/licensify/templates/config-template-configmap.yaml
+++ b/charts/licensify/templates/config-template-configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: licensify-config-template
+data:
+  config.properties: |
+    {{ if .Values.config.clamAntivirusHost }}
+    clam.antivirus.host={{ .Values.config.clamAntivirusHost }}
+    {{ end }}
+    scheduled.virus.scan.cron.expression={{ .Values.config.scheduledVirusScanCronExpression }}
+
+    # AWS Config
+    amazon.key.access={{ `{{ .aws_access_key_id }}` }}
+    amazon.key.secret={{ `{{ .aws_access_secret_key }}` }}
+
+    # MongoDB Config
+    mongo.database.hosts={{ join "," .Values.config.mongo.dbHosts }}
+    mongo.database.reference.name={{ .Values.config.mongo.dbReferenceName }}
+    mongo.database.audit.name={{ .Values.config.mongo.dbAuditName }}
+    mongo.database.auth.enabled={{ .Values.config.mongo.dbAuthEnabled }}
+    mongo.database.auth.username={{ .Values.config.mongo.dbAuthUsername }}
+    mongo.database.auth.password={{ `{{ .mongo_database_auth_password }}` }}
+    mongo.database.slaveok={{ .Values.config.mongo.dbSlaveOk }}
+
+    # Elms config
+    places.api.url={{ .Values.config.placesApiUrl }}
+    feedActor={{ .Values.config.feedActor }}
+    uploadUrlBase={{ .Values.config.frontendBaseUrl }}/
+    elms.frontend.host={{ .Values.config.frontendBaseUrl }}/
+    elms.admin.host={{ .Values.config.baseUrl }}/
+    elms.pdf.apihost={{ .Values.config.elmsPdfApiHost }}
+    elms.max.appProcessAttemptCount="{{ .Values.config.elmsMaxAppProcessAttemptCount }}"
+    govuk.url={{ .Values.config.frontendBaseUrl }}
+
+    # Authorization config
+    signon.url={{ .Values.config.signonBaseUrl }}
+    access_token_url={{ .Values.config.signonBaseUrl }}/oauth/access_token
+    authorization_url={{ .Values.config.signonBaseUrl }}/oauth/authorize
+    user_details_url={{ .Values.config.signonBaseUrl }}/user.json
+    oauth_callback_url_override={{ .Values.config.baseUrl }}/licence-management/admin/oauth
+
+    # Google Analytics config
+    client_id={{ `{{ .client_id }}` }}
+    client_secret={{ `{{ .client_secret }}` }}
+    googleAnalytics.account.admin={{ .Values.config.googleAnalytics.accountAdmin }}
+    googleAnalytics.domain.admin={{ .Values.config.googleAnalytics.domainAdmin }}
+    googleAnalytics.account.frontend={{ .Values.config.googleAnalytics.accountFrontend }}
+    googleAnalytics.domain.frontend={{ .Values.config.googleAnalytics.domainFrontend }}
+
+    # Payment provider config
+    worldpay.redirectUrl={{ .Values.config.frontendBaseUrl }}/apply-for-a-licence/payment/worldpayComplete
+    worldpay.cancelled.redirectUrl={{ .Values.config.frontendBaseUrl }}/apply-for-a-licence/payment/worldpayCancelled
+    paymentsTestMode={{ .Values.config.paymentsTestMode }}
+    noReplyMailAddress={{ .Values.config.noReplyMailAddress }}
+
+    # License Finder config
+    licenceFinderUrl={{ .Values.config.licenceFinderUrl }}
+
+    # Performance platform config
+    performance.platform.service.url={{ .Values.config.performancePlatformUrl }}
+    performance.platform.bearer.token={{ `{{ .performance_platform_bearer_token }}` }}
+    performance.data.sender.cron.expression={{ .Values.config.performanceDataSenderCronExpression }}
+
+    # Notify config
+    notify.key.api={{ `{{ .notify_key_api }}` }}
+    {{ if .Values.config.notifyKeyService }}
+    notify.key.service={{ .Values.config.notifyKeyService }}
+    {{ end }}
+    {{ if .Values.config.notifyTemplateAuthority }}
+    notify.template.authority={{ .Values.config.notifyTemplateAuthority }}
+    {{ end }}
+
+    # Other config
+    app.timezone.id={{ .Values.config.appTimezoneId }}
+    is.master.node={{ .Values.config.isMasterNode }}
+
+    # Development config
+    {{ if .Values.config.isTest }}
+    is.test={{ .Values.config.isTest }}
+    {{ end }}
+    {{ if .Values.config.licenceApplicationPurgeExpiredAfter }}
+    licenceApplication.purgeExpiredAfter={{ .Values.config.licenceApplicationPurgeExpiredAfter }}
+    {{ end }}
+    {{ if .Values.config.pdfCacheSeconds }}
+    pdfCacheSeconds= {{ .Values.config.pdfCacheSeconds }}
+    {{ end }}
+    {{ if .Values.config.uncollectedExpiryEnabled }}
+    uncollected.expiry.enabled= {{ .Values.config.uncollectedExpiryEnabled }}
+    {{ end }}

--- a/charts/licensify/templates/licensify-admin/deployment.yaml
+++ b/charts/licensify/templates/licensify-admin/deployment.yaml
@@ -1,0 +1,80 @@
+{{ $app := .Values.licensifyAdmin }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ $app.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $app.name }}
+  template:
+    metadata:
+      labels:
+        {{- include "licensify.labels" . | nindent 8}}
+        app: {{ $app.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      containers:
+        - name: main
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.images.LicensifyBackend.repository }}:{{ .Values.images.LicensifyBackend.tag }}"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: APP_PORT
+              value: "{{ $app.port }}"
+            - name: SBT_MODE
+              value: docker
+            - name: APPLICATION_FORM_AWS_ACCESS_KEY_ID
+              value: do-not-use
+            - name: APPLICATION_FORM_AWS_SECRET_KEY
+              value: do-not-use
+            - name: GDS_CONFIG_FILE
+              value: /etc/licensing/config.properties
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $app.port }}
+          livenessProbe: &app-probe
+            httpGet:
+              path: {{ $app.healthcheckPath }} 
+              port: http
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            <<: *app-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+          startupProbe:
+            <<: *app-probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: licensify-config
+              mountPath: "/etc/licensing"
+              readOnly: true
+            - name: app-tmp
+              mountPath: /tmp
+      volumes:
+        - name: licensify-config
+          secret:
+            secretName: licensify-config
+        - name: app-tmp
+          emptyDir: {}

--- a/charts/licensify/templates/licensify-admin/ingress.yaml
+++ b/charts/licensify/templates/licensify-admin/ingress.yaml
@@ -1,0 +1,26 @@
+{{ $app := .Values.licensifyAdmin }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" $ | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+  annotations:
+    {{- (tpl (toYaml $app.ingress.annotations) $) | trim | nindent 4 }}
+spec:
+  rules:
+    {{- range $app.ingress.hosts }}
+    - host: {{ (tpl .name $) | quote }}
+      http:
+        paths:
+          - path: {{ .path | default "/" | quote }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ $app.name }}
+                port:
+                  number: {{ $app.service.port }}
+    {{- end }}

--- a/charts/licensify/templates/licensify-admin/service.yaml
+++ b/charts/licensify/templates/licensify-admin/service.yaml
@@ -1,0 +1,18 @@
+{{ $app := .Values.licensifyAdmin }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  type: NodePort
+  ports:
+    - name: app
+      port: {{ $app.service.port }}
+      targetPort: {{ $app.port }}
+  selector:
+    app: {{ $app.name }}

--- a/charts/licensify/templates/licensify-backend/deployment.yaml
+++ b/charts/licensify/templates/licensify-backend/deployment.yaml
@@ -1,0 +1,80 @@
+{{ $app := .Values.licensifyBackend }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ $app.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $app.name }}
+  template:
+    metadata:
+      labels:
+        {{- include "licensify.labels" . | nindent 8}}
+        app: {{ $app.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      containers:
+        - name: main
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.images.LicensifyBackend.repository }}:{{ .Values.images.LicensifyBackend.tag }}"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: APP_PORT
+              value: "{{ $app.port }}"
+            - name: SBT_MODE
+              value: docker
+            - name: APPLICATION_FORM_AWS_ACCESS_KEY_ID
+              value: do-not-use
+            - name: APPLICATION_FORM_AWS_SECRET_KEY
+              value: do-not-use
+            - name: GDS_CONFIG_FILE
+              value: /etc/licensing/config.properties
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $app.port }}
+          livenessProbe: &app-probe
+            httpGet:
+              path: {{ $app.healthcheckPath }} 
+              port: http
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            <<: *app-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+          startupProbe:
+            <<: *app-probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: licensify-config
+              mountPath: "/etc/licensing"
+              readOnly: true
+            - name: app-tmp
+              mountPath: /tmp
+      volumes:
+        - name: licensify-config
+          secret:
+            secretName: licensify-config
+        - name: app-tmp
+          emptyDir: {}

--- a/charts/licensify/templates/licensify-backend/service.yaml
+++ b/charts/licensify/templates/licensify-backend/service.yaml
@@ -1,0 +1,18 @@
+{{ $app := .Values.licensifyBackend }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  type: NodePort
+  ports:
+    - name: app
+      port: {{ $app.service.port }}
+      targetPort: {{ $app.port }}
+  selector:
+    app: {{ $app.name }}

--- a/charts/licensify/templates/licensify-feed/deployment.yaml
+++ b/charts/licensify/templates/licensify-feed/deployment.yaml
@@ -1,0 +1,80 @@
+{{ $app := .Values.licensifyFeed }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ $app.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $app.name }}
+  template:
+    metadata:
+      labels:
+        {{- include "licensify.labels" . | nindent 8}}
+        app: {{ $app.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      containers:
+        - name: main
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.images.LicensifyFeed.repository }}:{{ .Values.images.LicensifyFeed.tag }}"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: APP_PORT
+              value: "{{ $app.port }}"
+            - name: SBT_MODE
+              value: docker
+            - name: APPLICATION_FORM_AWS_ACCESS_KEY_ID
+              value: do-not-use
+            - name: APPLICATION_FORM_AWS_SECRET_KEY
+              value: do-not-use
+            - name: GDS_CONFIG_FILE
+              value: /etc/licensing/config.properties
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $app.port }}
+          livenessProbe: &app-probe
+            httpGet:
+              path: {{ $app.healthcheckPath }} 
+              port: http
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            <<: *app-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+          startupProbe:
+            <<: *app-probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: licensify-config
+              mountPath: "/etc/licensing"
+              readOnly: true
+            - name: app-tmp
+              mountPath: /tmp
+      volumes:
+        - name: licensify-config
+          secret:
+            secretName: licensify-config
+        - name: app-tmp
+          emptyDir: {}

--- a/charts/licensify/templates/licensify-feed/ingress.yaml
+++ b/charts/licensify/templates/licensify-feed/ingress.yaml
@@ -1,0 +1,26 @@
+{{ $app := .Values.licensifyFeed }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" $ | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+  annotations:
+    {{- (tpl (toYaml $app.ingress.annotations) $) | trim | nindent 4 }}
+spec:
+  rules:
+    {{- range $app.ingress.hosts }}
+    - host: {{ (tpl .name $) | quote }}
+      http:
+        paths:
+          - path: {{ .path | default "/" | quote }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ $app.name }}
+                port:
+                  number: {{ $app.service.port }}
+    {{- end }}

--- a/charts/licensify/templates/licensify-feed/service.yaml
+++ b/charts/licensify/templates/licensify-feed/service.yaml
@@ -1,0 +1,18 @@
+{{ $app := .Values.licensifyFeed }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  type: NodePort
+  ports:
+    - name: app
+      port: {{ $app.service.port }}
+      targetPort: {{ $app.port }}
+  selector:
+    app: {{ $app.name }}

--- a/charts/licensify/templates/licensify-frontend/deployment.yaml
+++ b/charts/licensify/templates/licensify-frontend/deployment.yaml
@@ -1,0 +1,80 @@
+{{ $app := .Values.licensifyFrontend }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ $app.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $app.name }}
+  template:
+    metadata:
+      labels:
+        {{- include "licensify.labels" . | nindent 8}}
+        app: {{ $app.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      containers:
+        - name: main
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.images.LicensifyFrontend.repository }}:{{ .Values.images.LicensifyFrontend.tag }}"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: APP_PORT
+              value: "{{ $app.port }}"
+            - name: SBT_MODE
+              value: docker
+            - name: APPLICATION_FORM_AWS_ACCESS_KEY_ID
+              value: do-not-use
+            - name: APPLICATION_FORM_AWS_SECRET_KEY
+              value: do-not-use
+            - name: GDS_CONFIG_FILE
+              value: /etc/licensing/config.properties
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $app.port }}
+          livenessProbe: &app-probe
+            httpGet:
+              path: {{ $app.healthcheckPath }} 
+              port: http
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            <<: *app-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+          startupProbe:
+            <<: *app-probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: licensify-config
+              mountPath: "/etc/licensing"
+              readOnly: true
+            - name: app-tmp
+              mountPath: /tmp
+      volumes:
+        - name: licensify-config
+          secret:
+            secretName: licensify-config
+        - name: app-tmp
+          emptyDir: {}

--- a/charts/licensify/templates/licensify-frontend/ingress.yaml
+++ b/charts/licensify/templates/licensify-frontend/ingress.yaml
@@ -1,0 +1,26 @@
+{{ $app := .Values.licensifyFrontend }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" $ | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+  annotations:
+    {{- (tpl (toYaml $app.ingress.annotations) $) | trim | nindent 4 }}
+spec:
+  rules:
+    {{- range $app.ingress.hosts }}
+    - host: {{ (tpl .name $) | quote }}
+      http:
+        paths:
+          - path: {{ .path | default "/" | quote }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ $app.name }}
+                port:
+                  number: {{ $app.service.port }}
+    {{- end }}

--- a/charts/licensify/templates/licensify-frontend/service.yaml
+++ b/charts/licensify/templates/licensify-frontend/service.yaml
@@ -1,0 +1,18 @@
+{{ $app := .Values.licensifyFrontend }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $app.name }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4}}
+    app: {{ $app.name }}
+    app.kubernetes.io/component: app
+spec:
+  type: NodePort
+  ports:
+    - name: app
+      port: {{ $app.service.port }}
+      targetPort: {{ $app.port }}
+  selector:
+    app: {{ $app.name }}

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -1,0 +1,115 @@
+# Licensify Components
+replicaCount: 1
+
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1001
+  runAsGroup: 1001
+
+clamav:
+  name: clamav
+  replicaCount: 1
+  image:
+    repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/clamav
+    tag: latest
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    port: 3310
+
+licensifyAdmin:
+  name: licensify-admin
+  replicaCount: 1
+  port: 9950
+  healthcheckPath: "/"
+  ingress:
+    annotations: {}
+  service:
+    port: 80
+
+licensifyBackend:
+  name: licensify-backend
+  replicaCount: 1
+  port: 9920
+  healthcheckPath: "/"
+  service:
+    port: 9920
+
+licensifyFeed:
+  name: licensify-feed
+  replicaCount: 1
+  port: 9940
+  healthcheckPath: "/licence-management/feed/process-applications"
+  ingress:
+    annotations: {}
+  service:
+    port: 80
+
+licensifyFrontend:
+  name: licensify-frontend
+  replicaCount: 1
+  port: 9903
+  healthcheckPath: "/apply-for-a-licence"
+  ingress:
+    annotations: {}
+  service:
+    port: 80
+
+resources:
+  limits:
+    cpu: 1
+    memory: 1500Mi
+  requests:
+    cpu: 500m
+    memory: 800Mi
+
+extraEnv: []
+
+config:
+  clamAntivirusHost: clamav
+
+  mongo:
+    dbHosts: []
+    dbReferenceName: licensify-refdata
+    dbAuditName: licensify-audit
+    dbAuthEnabled: true
+    dbAuthUsername: master
+    dbSlaveOk: false
+
+  elmsPdfApiHost: https://gdspreprodaws.aptosolutions.co.uk/GDSELMS-5/
+  elmsMaxAppProcessAttemptCount: 6
+
+  baseUrl: https://licensify-admin
+  frontendBaseUrl: https://licensify
+  signonBaseUrl: https://signon
+  licenceFinderUrl: https://www.test.publishing.service.gov.uk/licence-finder
+
+  placesApiUrl: http://places-api:9700/places
+
+  appTimezoneId: Europe/London
+  feedActor: true
+  isMasterNode: true
+  paymentsTestMode: true
+  performanceDataSenderCronExpression: 0 0 1 * * ?
+  scheduledVirusScanCronExpression: 0 0 16 * * ?
+
+  performancePlatformUrl: >-
+    https://performance/data/licensing/application
+  googleAnalytics:
+    accountAdmin: UA-XXXXXXXX-X
+    domainAdmin: test.publishing.service.gov.uk
+    accountFrontend: UA-XXXXXXXX-X
+    domainFrontend: test.publishing.service.gov.uk
+  noReplyMailAddress: test@example.com
+
+images:
+  LicensifyFeed:
+    repository: licensify-feed
+    tag: latest
+  LicensifyBackend:
+    repository: licensify-backend
+    tag: latest
+  LicensifyFrontend:
+    repository: licensify-frontend
+    tag: latest


### PR DESCRIPTION
This adds the helm chart to run Licensify and the values for integration.

It consists of 5 components: admin, backend, frontend, feed and clamav. Admin and backend use the same image. 

Clamav is configured to use the virus definitions used by asset manager, as they are regularly updated.

Tested with:
```
helm install licensify charts/licensify --values <(
    helm template charts/app-config --values charts/app-config/values-integration.yaml |
        yq e '.|select(.metadata.name == "licensify").spec.source.helm.values'
)
```