### PR TITLE
Reduce log verbosity on locations-api in prod/staging.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1531,6 +1531,8 @@ govukApplications:
             secretKeyRef:
               name: locations-api-postgres
               key: DATABASE_URL
+        - name: RAILS_LOG_LEVEL
+          value: warn
         - name: OS_PLACES_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1495,6 +1495,8 @@ govukApplications:
             secretKeyRef:
               name: locations-api-postgres
               key: DATABASE_URL
+        - name: RAILS_LOG_LEVEL
+          value: warn
         - name: OS_PLACES_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
PostcodesCollectionWorker generates about 30k log entries an hour and they're not useful (mostly just messages like "start" containing no other info).