### PR TITLE
Reduce log verbosity on email-alert-api in prod/staging.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -903,6 +903,8 @@ govukApplications:
           value: &frontend-notify-template cb633abc-6ae6-4843-ae6f-82ca500b6de2
         - name: GOVUK_NOTIFY_RECIPIENTS
           value: '*'
+        - name: RAILS_LOG_LEVEL
+          value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -909,6 +909,8 @@ govukApplications:
           value: &frontend-notify-template 2844a647-6bf1-4b01-a25c-569d2cc00849
         - name: GOVUK_NOTIFY_RECIPIENTS
           value: email-alert-api-staging@digital.cabinet-office.gov.uk
+        - name: RAILS_LOG_LEVEL
+          value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY


### PR DESCRIPTION
This should significantly help with log quota. The INFO messages aren't generally very useful and we can always turn up the verbosity ad-hoc if we need to debug something.