### PR TITLE
Add work rate graph to Sidekiq dashboard.

### DIFF
--- a/charts/monitoring-config/dashboards/sidekiq-queues.json
+++ b/charts/monitoring-config/dashboards/sidekiq-queues.json
@@ -27,7 +27,7 @@
   "description": "",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -42,6 +42,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "jobs",
@@ -55,6 +56,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -86,7 +88,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 0
@@ -122,6 +124,105 @@
         }
       ],
       "title": "Queue length",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Per-second rate of processed jobs by queue, 5m moving mean.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "jobs per second",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": 1200000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (job, queue) (rate(sidekiq_jobs_total{namespace=\"${namespace}\", job=~\"${app}\"}[5m]))",
+          "interval": "",
+          "legendFormat": "{{job}}:{{queue}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Work rate by queue",
+      "transparent": true,
       "type": "timeseries"
     },
     {
@@ -136,6 +237,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "hours : minutes : seconds",
@@ -149,6 +251,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 4,
@@ -183,7 +286,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 16
       },
       "id": 3,
       "links": [],
@@ -217,12 +320,12 @@
       ],
       "title": "Age of oldest job in queue",
       "transformations": [],
+      "transparent": true,
       "type": "timeseries"
     }
   ],
   "refresh": "",
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
@@ -276,7 +379,7 @@
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "type": "query"
       }
     ]


### PR DESCRIPTION
Add a graph showing rate of processed (completed) work items. Plus some minor improvements:

 - sort the `app` dropdown
 - set transparent background (improves contrast)
 - avoid connecting points across long stretches of nulls (prevents visual glitches)
 - enable shared crosshair

[Preview](https://grafana.eks.production.govuk.digital/d/sengi-sidekiq-queues) (works best if you choose an individual workload from the `app` dropdown, same as before, e.g. [locations-api](https://grafana.eks.production.govuk.digital/d/sengi-sidekiq-queues/?var-app=locations-api-worker), [email-alert-api](https://grafana.eks.production.govuk.digital/d/sengi-sidekiq-queues/?var-app=email-alert-api-worker))