### PR TITLE
Reduce log verbosity on asset-manager in prod/staging.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -182,6 +182,8 @@ govukApplications:
             secretKeyRef:
               name: asset-manager-docdb
               key: MONGODB_URI
+        - name: RAILS_LOG_LEVEL
+          value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: AWS_REGION

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -190,6 +190,8 @@ govukApplications:
             secretKeyRef:
               name: asset-manager-docdb
               key: MONGODB_URI
+        - name: RAILS_LOG_LEVEL
+          value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: AWS_REGION


### PR DESCRIPTION
This should significantly help with log quota. The INFO messages aren't generally very useful and we can always turn up the verbosity ad-hoc if we need to debug something. We also having distributed tracing these days.