### PR TITLE
Fix image references for licensify

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- range .Values.apps }}
 {{ $_ := set $.Values "appName" .name }}
+{{ $appImage := get $.Values.images (camelcase ( .useImage | default .name )) }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -31,7 +32,7 @@ spec:
         - name: main
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ $.Values.images.LicensifyFrontend.repository }}:{{ $.Values.images.LicensifyFrontend.tag }}"
+          image: "{{ $appImage.repository }}:{{ $appImage.tag }}"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: APP_PORT

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -21,6 +21,7 @@ clamav:
 apps:
   licensifyAdmin:
     name: licensify-admin
+    useImage: licensify-backend
     replicaCount: 1
     port: 9950
     healthcheckPath: "/"


### PR DESCRIPTION
Forgot to change reference to image repository and tag to be specific to the particular app when moving to a shared template for all apps.