### PR TITLE
Move client_id and client_secret to correct part of config file

### DIFF
--- a/charts/licensify/templates/config-template-configmap.yaml
+++ b/charts/licensify/templates/config-template-configmap.yaml
@@ -38,10 +38,10 @@ data:
     authorization_url={{ .Values.config.signonBaseUrl }}/oauth/authorize
     user_details_url={{ .Values.config.signonBaseUrl }}/user.json
     oauth_callback_url_override={{ .Values.config.baseUrl }}/licence-management/admin/oauth
-
-    # Google Analytics config
     client_id={{ `{{ .client_id }}` }}
     client_secret={{ `{{ .client_secret }}` }}
+
+    # Google Analytics config
     googleAnalytics.account.admin={{ .Values.config.googleAnalytics.accountAdmin }}
     googleAnalytics.domain.admin={{ .Values.config.googleAnalytics.domainAdmin }}
     googleAnalytics.account.frontend={{ .Values.config.googleAnalytics.accountFrontend }}


### PR DESCRIPTION
This edit has no effect on application configuration. Just moves the signon client_id and client_secret vars to underneith the correct comment in the config file.