### PR TITLE
Run in-cluster router-mongo in production.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2156,6 +2156,10 @@ govukApplications:
         - name: BACKEND_URL_search-api
           value: "http://search-api"
 
+  - name: router-mongo
+    chartPath: charts/router-mongo
+    postSyncWorkflowEnabled: "false"
+
   - name: search-admin
     helmValues:
       dbMigrationEnabled: true


### PR DESCRIPTION
See #1668.

This is the prod equivalent of #1682 (deploy the stateful set with just 1 replica) and #1684 (scale it out to 3 replicas). It turned out there was no benefit in doing those two steps separately, cos the new replicas can't mess with anything until they're explicitly joined to the Mongo replicaset anyway.