### PR TITLE
Remove defunct nodes from router-mongo rs in staging.

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2114,6 +2114,12 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
+    helmValues:
+      args:
+        - --config
+        - /etc/mongo/mongodb.conf
+        - --replSet
+        - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo
 
   - name: search-admin
     helmValues:


### PR DESCRIPTION
Remove the deleted members from the router-mongo replicaset's initial config on the command line in staging.

Doing this environment by environment to make sure the replicaset comes back up quickly and automatically when the rolling restart of the statefulset happens.

The previous value is defined in the [router-mongo chart values.yaml](https://github.com/alphagov/govuk-helm-charts/blob/6531675/charts/router-mongo/values.yaml#L12). `production` is the replicaset name that we inherited from the original Puppet-based configuration and (confusingly) is the same in all three environments.

#1668