### PR TITLE
Allow `search-api-v2` workers to export metrics

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2283,6 +2283,9 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       extraEnv:
+        # Required for document sync worker to be able to export metrics
+        - name: GOVUK_PROMETHEUS_EXPORTER
+          value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: RABBITMQ_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2345,6 +2345,9 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       extraEnv:
+        # Required for document sync worker to be able to export metrics
+        - name: GOVUK_PROMETHEUS_EXPORTER
+          value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: RABBITMQ_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2299,6 +2299,9 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       extraEnv:
+        # Required for document sync worker to be able to export metrics
+        - name: GOVUK_PROMETHEUS_EXPORTER
+          value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: RABBITMQ_URL


### PR DESCRIPTION
This app has a persistent background worker that needs the Prometheus exporter to be running in order to be able to export metrics.