### PR TITLE
Slow down MongoDB statefulset rollouts in nonprod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2092,6 +2092,13 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
+    helmValues:  # TODO(#1668): remove overrides once defaults updated.
+      minReadySeconds: 60
+      args:
+        - --config
+        - /etc/mongo/mongodb.conf
+        - --replSet
+        - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo
 
   - name: search-admin
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2114,7 +2114,8 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
-    helmValues:
+    helmValues:  # TODO(#1668): remove overrides once defaults updated.
+      minReadySeconds: 60
       args:
         - --config
         - /etc/mongo/mongodb.conf

--- a/charts/router-mongo/templates/statefulset.yaml
+++ b/charts/router-mongo/templates/statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
 spec:
   serviceName: {{ $fullName }}
   replicas: {{ .Values.replicas }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "router-mongo.selectorLabels" $ | nindent 6 }}


### PR DESCRIPTION
Also remove the dead replicas from the initial config on the command line in integration (otherwise it's not a representative test).

Tested: diffed the `helm template` output; verified prod config is unaffected.

#### Alternatives considered

Startup/liveness/readiness probes would be a more complete solution, but only if they're bug-free; otherwise it's likely to introduce more problems than it solves.

Ideally we'd use an operator (such as mongodb-kubernetes-operator) to handle the edge cases, but Mongo 2.6 is too old for that.

So, since this is really only meant to be a temporary installation until we get rid of router/router-api altogether, let's see how we get on with a crude but (hopefully) effective delay in the rolling update.