### PR TITLE
Configure PodDisruptionBudget for router-mongo.

### DIFF
--- a/charts/router-mongo/templates/pdb.yaml
+++ b/charts/router-mongo/templates/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "router-mongo.fullname" $ }}
+  labels:
+    {{- include "router-mongo.labels" $ | nindent 4 }}
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      {{- include "router-mongo.selectorLabels" $ | nindent 6 }}


### PR DESCRIPTION
Same in all three clusters because recovering the cluster without quorum can sometimes be annoying even in nonprod. If it turns out to be more hassle than it's worth then we can parameterise it and relax the constraints in integration/staging.

Tested: applied via `helm template`, inspected the labels and verified that they match as expected:
```
NAME           MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
router-mongo   2               N/A               1                     3s
```