### PR TITLE
Suppress connection logspew from router-mongo.

### DIFF
--- a/charts/router-mongo/mongodb.conf
+++ b/charts/router-mongo/mongodb.conf
@@ -4,3 +4,5 @@ replication:
   replSetName: production
 storage:
   dbPath: /data/db
+systemLog:
+  quiet: true


### PR DESCRIPTION
The [manual](https://www.mongodb.com/docs/v2.6/reference/configuration-options/#systemlog-options) recommends against this, but the logspew is really quite excessive and makes it difficult to see anything else that's going on without filtering. We're also paying to store and index this stuff.

It's also trivial to turn verbose logging back on at runtime as needed:

```js
db.adminCommand({setParameter: 1, quiet: 0});
```

For #1668.