### PR TITLE
Fix Mongo `self not present in the repl set` on startup.

### DIFF
--- a/charts/router-mongo/templates/service.yaml
+++ b/charts/router-mongo/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
       Headless service for the router-mongo statefulset.
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "router-mongo.selectorLabels" . | nindent 4 }}
   ports:


### PR DESCRIPTION
MongoDB replicaset members try to resolve their own hostname in DNS on startup and if they don't get an answer that matches what's in the replset config, they lameduck themselves and backoff/retry.

Kubernetes services treat DNS like a load balancer by default: a statefulset Pod is listed in DNS only while it is Ready and not otherwise.

This interacts poorly on startup, because the MongoDB pod tries to look up its own name before it's Ready, triggering the backoff/retry behaviour until eventually everything settles down.

MongoDB tracks the state of replicaset members itself, so in this case we don't want k8s to do anything fancy with DNS. We just want all the extant statefulset pods to be in DNS at all times, especially right after a new pod is created.