### PR TITLE
Remove defunct nodes from router-mongo rs in prod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2092,13 +2092,6 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
-    helmValues:  # TODO(#1668): remove overrides once defaults updated.
-      minReadySeconds: 60
-      args:
-        - --config
-        - /etc/mongo/mongodb.conf
-        - --replSet
-        - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo
 
   - name: search-admin
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2114,13 +2114,6 @@ govukApplications:
   - name: router-mongo
     chartPath: charts/router-mongo
     postSyncWorkflowEnabled: "false"
-    helmValues:  # TODO(#1668): remove overrides once defaults updated.
-      minReadySeconds: 60
-      args:
-        - --config
-        - /etc/mongo/mongodb.conf
-        - --replSet
-        - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo
 
   - name: search-admin
     helmValues:

--- a/charts/router-mongo/templates/statefulset.yaml
+++ b/charts/router-mongo/templates/statefulset.yaml
@@ -13,9 +13,7 @@ metadata:
 spec:
   serviceName: {{ $fullName }}
   replicas: {{ .Values.replicas }}
-  {{- with .Values.minReadySeconds }}
-  minReadySeconds: {{ . }}
-  {{- end }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
     matchLabels:
       {{- include "router-mongo.selectorLabels" $ | nindent 6 }}

--- a/charts/router-mongo/values.yaml
+++ b/charts/router-mongo/values.yaml
@@ -9,7 +9,7 @@ args:
   - --config
   - /etc/mongo/mongodb.conf
   - --replSet
-  - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo,router-backend-1,router-backend-2,router-backend-3
+  - production/router-mongo-0.router-mongo,router-mongo-1.router-mongo,router-mongo-2.router-mongo
 
 podSecurityContext:
   fsGroup: &uid 999
@@ -25,6 +25,7 @@ securityContext:
   runAsNonRoot: true
   runAsUser: *uid
 
+minReadySeconds: 60
 replicas: 3
 
 resources:


### PR DESCRIPTION
Like #1732 but in prod.

Tidy up the defaults for args and minReadySeconds now that the config is the same for all three clusters.

For #1668.