### PR TITLE
Add govuk_content_production back into backup config.

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -219,6 +219,8 @@ cronjobs:
         - op: backup
           db: travel_advice_publisher_production
         - op: backup
+          db: govuk_content_production
+        - op: backup
           db: govuk_assets_production
 
     signon-mysql:
@@ -441,6 +443,9 @@ cronjobs:
           db: short_url_manager_production
         - op: restore
           bucket: s3://govuk-production-database-backups
+          db: govuk_content_production
+        - op: restore
+          bucket: s3://govuk-production-database-backups
           db: travel_advice_publisher_production
         - op: backup
           db: maslow_production
@@ -450,6 +455,8 @@ cronjobs:
           db: short_url_manager_production
         - op: backup
           db: travel_advice_publisher_production
+        - op: backup
+          db: govuk_content_production
         - op: restore
           bucket: s3://govuk-production-database-backups
           db: govuk_assets_production
@@ -677,6 +684,9 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-staging-database-backups
           db: travel_advice_publisher_production
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
+          db: govuk_content_production
         - op: backup
           db: maslow_production
         - op: backup
@@ -685,6 +695,8 @@ cronjobs:
           db: short_url_manager_production
         - op: backup
           db: travel_advice_publisher_production
+        - op: backup
+          db: govuk_content_production
         - op: restore
           bucket: s3://govuk-staging-database-backups
           db: govuk_assets_production


### PR DESCRIPTION
It turns out this MongoDB/DocumentDB database was only *mostly* owned by content-store (which was migrated to Postgres). It's still accessed by publisher, specialist-publisher and service-manual-publisher.

Need to tease out what on earth is going on with these three apps and figure out how bad the situation is and how to fix it, but that's a different matter. For now, just keep backing this stuff up so at least we're not SOL if we lose prod.