### PR TITLE
Use /api/licences as healthcheck for licensify-frontend

### DIFF
--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -73,7 +73,7 @@ apps:
     enabled: true
     replicaCount: 1
     port: 9903
-    healthcheckPath: "/apply-for-a-licence"
+    healthcheckPath: "/api/licences"
     ingress:
       enabled: true
       annotations: {}


### PR DESCRIPTION
The previous path was a external redirect causing probe warnings. This path should return a 200.