### PR TITLE
Make Licensify config consistent with EC2

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1362,10 +1362,10 @@ govukApplications:
             - licensify-documentdb-0.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
             - licensify-documentdb-1.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
             - licensify-documentdb-2.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
-        baseUrl: https://licensify-admin.eks.integration.govuk.digital
+        adminBaseUrl: https://licensify-admin.eks.integration.govuk.digital
         frontendBaseUrl: https://licensify.eks.integration.govuk.digital
         signonBaseUrl: https://signon.integration.publishing.service.gov.uk
-        licenceFinderUrl: https://www-origin.integration.publishing.service.gov.uk/licence-finder
+        govukBaseUrl: https://www.integration.publishing.service.gov.uk
         performancePlatformUrl: >-
           https://www.integration.performance.service.gov.uk/data/licensing/application
         googleAnalytics:
@@ -1373,7 +1373,12 @@ govukApplications:
           domainAdmin: integration.publishing.service.gov.uk
           accountFrontend: UA-34519962-1
           domainFrontend: integration.publishing.service.gov.uk
-        noReplyMailAddress: noreply-licensing-preview@digital.cabinet-office.gov.uk
+        payments:
+          testMode: true
+        notify:
+          noReplyMailAddress: noreply-licensing-preview@digital.cabinet-office.gov.uk
+        uncollectedExpiry:
+          enabled: false
 
   - name: link-checker-api
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1407,11 +1407,11 @@ govukApplications:
             - licensify-documentdb-0.cafmt8xopqlp.eu-west-1.docdb.amazonaws.com
             - licensify-documentdb-1.cafmt8xopqlp.eu-west-1.docdb.amazonaws.com
             - licensify-documentdb-2.cafmt8xopqlp.eu-west-1.docdb.amazonaws.com
-        elmsPdfApiHost: https://gdsprodaws.aptosolutions.co.uk/GDSELMS-5/
-        baseUrl: https://licensify-admin.eks.production.govuk.digital
+        govukBaseUrl: https://www.gov.uk
         frontendBaseUrl: https://licensify.eks.production.govuk.digital
+        adminBaseUrl: https://licensify-admin.eks.production.govuk.digital
         signonBaseUrl: https://signon.publishing.service.gov.uk
-        licenceFinderUrl: https://www-origin.publishing.service.gov.uk/licence-finder
+        elmsPdfApiHost: https://gdsprodaws.aptosolutions.co.uk/GDSELMS-5/
         performancePlatformUrl: >-
           https://www.performance.service.gov.uk/data/licensing/application
         googleAnalytics:
@@ -1419,8 +1419,15 @@ govukApplications:
           domainAdmin: publishing.service.gov.uk
           accountFrontend: UA-26179049-1
           domainFrontend: www.gov.uk
-        noReplyMailAddress: noreply-licensing@digital.cabinet-office.gov.uk
-        paymentsTestMode: false
+        payments:
+          testMode: false
+        notify:
+          noReplyMailAddress: noreply-licensing@digital.cabinet-office.gov.uk
+          templateApplicatNone: f324cd8c-a0b1-48fa-b009-69bdf8ba81b0
+          templateApplicatOffline: bbbc408b-4276-498f-9d94-8f76663b258e
+          templateApplicatOnline: 8ca00761-7902-4ec3-89a2-e3aa006d3ed8
+          templateAuthority: 96af61a3-ffdc-419c-a814-9ce01a78a87f
+          templatePeriodic: a3a54578-2695-4953-9787-d7c73aaf08c0
 
   - name: link-checker-api
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1370,10 +1370,10 @@ govukApplications:
             - licensify-documentdb-0.ca5itorbs5wc.eu-west-1.docdb.amazonaws.com
             - licensify-documentdb-1.ca5itorbs5wc.eu-west-1.docdb.amazonaws.com
             - licensify-documentdb-2.ca5itorbs5wc.eu-west-1.docdb.amazonaws.com
-        baseUrl: https://licensify-admin.eks.staging.govuk.digital
+        adminBaseUrl: https://licensify-admin.eks.staging.govuk.digital
         frontendBaseUrl: https://licensify.eks.staging.govuk.digital
         signonBaseUrl: https://signon.staging.publishing.service.gov.uk
-        licenceFinderUrl: https://www-origin.staging.publishing.service.gov.uk/licence-finder
+        govukBaseUrl: https://www.staging.publishing.service.gov.uk
         performancePlatformUrl: >-
           https://www.staging.performance.service.gov.uk/data/licensing/application
         googleAnalytics:
@@ -1381,7 +1381,16 @@ govukApplications:
           domainAdmin: staging.publishing.service.gov.uk
           accountFrontend: UA-26179049-20
           domainFrontend: staging.publishing.service.gov.uk
-        noReplyMailAddress: noreply-licensing+staging@digital.cabinet-office.gov.uk
+        payments:
+          testMode: false
+        notify:
+          noReplyMailAddress: noreply-licensing+staging@digital.cabinet-office.gov.uk
+          emailOverrideRecipient: licensing-notifications+staging@digital.cabinet-office.gov.uk
+          templateApplicatNone: f324cd8c-a0b1-48fa-b009-69bdf8ba81b0
+          templateApplicatOffline: bbbc408b-4276-498f-9d94-8f76663b258e
+          templateApplicatOnline: 8ca00761-7902-4ec3-89a2-e3aa006d3ed8
+          templateAuthority: 96af61a3-ffdc-419c-a814-9ce01a78a87f
+          templatePeriodic: a3a54578-2695-4953-9787-d7c73aaf08c0
 
   - name: link-checker-api
     helmValues:

--- a/charts/licensify/templates/config-template-configmap.yaml
+++ b/charts/licensify/templates/config-template-configmap.yaml
@@ -4,9 +4,8 @@ metadata:
   name: licensify-config-template
 data:
   config.properties: |
-    {{ if .Values.config.clamAntivirusHost }}
+    # Virus scan config
     clam.antivirus.host={{ .Values.config.clamAntivirusHost }}
-    {{ end }}
     scheduled.virus.scan.cron.expression={{ .Values.config.scheduledVirusScanCronExpression }}
 
     # AWS Config
@@ -23,21 +22,19 @@ data:
     mongo.database.slaveok={{ .Values.config.mongo.dbSlaveOk }}
 
     # Elms config
-    places.api.url={{ .Values.config.placesApiUrl }}
-    feedActor={{ .Values.config.feedActor }}
+    govuk.url={{ .Values.config.govukBaseUrl }}/
     uploadUrlBase={{ .Values.config.frontendBaseUrl }}/
     elms.frontend.host={{ .Values.config.frontendBaseUrl }}/
-    elms.admin.host={{ .Values.config.baseUrl }}/
+    elms.admin.host={{ .Values.config.adminBaseUrl }}/
     elms.pdf.apihost={{ .Values.config.elmsPdfApiHost }}
-    elms.max.appProcessAttemptCount="{{ .Values.config.elmsMaxAppProcessAttemptCount }}"
-    govuk.url={{ .Values.config.frontendBaseUrl }}
+    elms.max.appProcessAttemptCount={{ .Values.config.elmsMaxAppProcessAttemptCount }}
 
     # Authorization config
     signon.url={{ .Values.config.signonBaseUrl }}
     access_token_url={{ .Values.config.signonBaseUrl }}/oauth/access_token
     authorization_url={{ .Values.config.signonBaseUrl }}/oauth/authorize
     user_details_url={{ .Values.config.signonBaseUrl }}/user.json
-    oauth_callback_url_override={{ .Values.config.baseUrl }}/licence-management/admin/oauth
+    oauth_callback_url_override={{ .Values.config.adminBaseUrl }}/licence-management/admin/oauth
     client_id={{ `{{ .client_id }}` }}
     client_secret={{ `{{ .client_secret }}` }}
 
@@ -48,42 +45,54 @@ data:
     googleAnalytics.domain.frontend={{ .Values.config.googleAnalytics.domainFrontend }}
 
     # Payment provider config
+    paymentsTestMode={{ .Values.config.payments.testMode }}
+
+    {{- if not .Values.config.payments.testMode }}
+    # Unsure if these are used
+    payment.bibit.formUrl={{ .Values.config.payments.bibitFormUrl }}
+    payment.capita.formUrl={{ .Values.config.payments.capitaFormUrl }}
+    payment.northgate.callback.override={{ .Values.config.payments.northgateCallbackOverride }}
+    payment.worldpay.formUrl={{ .Values.config.payments.worldpayFormUrl }}
+    {{- end }}
     worldpay.redirectUrl={{ .Values.config.frontendBaseUrl }}/apply-for-a-licence/payment/worldpayComplete
     worldpay.cancelled.redirectUrl={{ .Values.config.frontendBaseUrl }}/apply-for-a-licence/payment/worldpayCancelled
-    paymentsTestMode={{ .Values.config.paymentsTestMode }}
-    noReplyMailAddress={{ .Values.config.noReplyMailAddress }}
 
     # License Finder config
-    licenceFinderUrl={{ .Values.config.licenceFinderUrl }}
+    licencefinder.url={{ .Values.config.govukBaseUrl }}/licence-finder
+
+    # Notify config
+    noReplyMailAddress={{ .Values.config.notify.noReplyMailAddress }}
+    notify.key.api={{ `{{ .notify_key_api }}` }}
+    notify.template.applicant.none={{ .Values.config.notify.templateApplicatNone }}
+    notify.template.applicant.offline={{ .Values.config.notify.templateApplicatOffline }}
+    notify.template.applicant.online={{ .Values.config.notify.templateApplicatOnline }}
+    notify.template.authority={{ .Values.config.notify.templateAuthority }}
+    notify.template.periodic={{ .Values.config.notify.templatePeriodic }}
+
+    email.periodic.enabled={{ .Values.config.notify.emailPeriodicEnabled }}
+    notify.periodic.email.cron={{ .Values.config.notify.periodicEmailCron }}
+
+    {{- if .Values.config.notify.emailOverrideRecipient }}
+    email.override.recipient={{ .Values.config.notify.emailOverrideRecipient }}
+    {{- end }}
+
+    # Other config
+    licenceApplication.expirationPeriod={{ .Values.config.licenseApplicationExpirationPeriod }}
+
+    # Feed config
+    feedActor={{ .Values.config.feedActor }}
+    is.master.node={{ .Values.config.isMasterNode }}
+
+    {{- if .Values.config.uncollectedExpiry.enabled }}
+    uncollected.expiry.enabled={{ .Values.config.uncollectedExpiry.enabled }}
+    uncollected.expiry.cron={{ .Values.config.uncollectedExpiry.cron }}
+    uncollected.expiry.purge.days={{ .Values.config.uncollectedExpiry.purgeDays }}
+    uncollected.expiry.start.days={{ .Values.config.uncollectedExpiry.startDays }}
+    {{- end }}
 
     # Performance platform config
     performance.platform.service.url={{ .Values.config.performancePlatformUrl }}
     performance.platform.bearer.token={{ `{{ .performance_platform_bearer_token }}` }}
     performance.data.sender.cron.expression={{ .Values.config.performanceDataSenderCronExpression }}
 
-    # Notify config
-    notify.key.api={{ `{{ .notify_key_api }}` }}
-    {{ if .Values.config.notifyKeyService }}
-    notify.key.service={{ .Values.config.notifyKeyService }}
-    {{ end }}
-    {{ if .Values.config.notifyTemplateAuthority }}
-    notify.template.authority={{ .Values.config.notifyTemplateAuthority }}
-    {{ end }}
-
-    # Other config
-    app.timezone.id={{ .Values.config.appTimezoneId }}
-    is.master.node={{ .Values.config.isMasterNode }}
-
-    # Development config
-    {{ if .Values.config.isTest }}
-    is.test={{ .Values.config.isTest }}
-    {{ end }}
-    {{ if .Values.config.licenceApplicationPurgeExpiredAfter }}
-    licenceApplication.purgeExpiredAfter={{ .Values.config.licenceApplicationPurgeExpiredAfter }}
-    {{ end }}
-    {{ if .Values.config.pdfCacheSeconds }}
-    pdfCacheSeconds= {{ .Values.config.pdfCacheSeconds }}
-    {{ end }}
-    {{ if .Values.config.uncollectedExpiryEnabled }}
-    uncollected.expiry.enabled= {{ .Values.config.uncollectedExpiryEnabled }}
-    {{ end }}
+    places.api.url={{ .Values.config.placesApiUrl }}

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
           image: "{{ $appImage.repository }}:{{ $appImage.tag }}"
           imagePullPolicy: "IfNotPresent"
           env:
+            - name: LANG
+              value: en_GB.UTF-8
             - name: APP_PORT
               value: "{{ .port }}"
             - name: SBT_MODE

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -92,6 +92,7 @@ extraEnv: []
 
 config:
   clamAntivirusHost: clamav
+  scheduledVirusScanCronExpression: 0 0 16 * * ?
 
   mongo:
     dbHosts: []
@@ -104,28 +105,55 @@ config:
   elmsPdfApiHost: https://gdspreprodaws.aptosolutions.co.uk/GDSELMS-5/
   elmsMaxAppProcessAttemptCount: 6
 
-  baseUrl: https://licensify-admin
+  adminBaseUrl: https://licensify-admin
   frontendBaseUrl: https://licensify
   signonBaseUrl: https://signon
-  licenceFinderUrl: https://www.test.publishing.service.gov.uk/licence-finder
+  govukBaseUrl: https://www.test.publishing.service.gov.uk
 
-  placesApiUrl: http://places-api:9700/places
-
-  appTimezoneId: Europe/London
-  feedActor: true
+  licenseApplicationExpirationPeriod: 7
+  # Sets whether feed should be master node
   isMasterNode: true
-  paymentsTestMode: true
-  performanceDataSenderCronExpression: 0 0 1 * * ?
-  scheduledVirusScanCronExpression: 0 0 16 * * ?
+  feedActor: true
 
-  performancePlatformUrl: >-
-    https://performance/data/licensing/application
   googleAnalytics:
     accountAdmin: UA-XXXXXXXX-X
     domainAdmin: test.publishing.service.gov.uk
     accountFrontend: UA-XXXXXXXX-X
     domainFrontend: test.publishing.service.gov.uk
   noReplyMailAddress: test@example.com
+
+  uncollectedExpiry:
+    enabled: true
+    cron: 0 0 4 * * ?
+    purgeDays: 7
+    startDays: 90
+
+  payments:
+    testMode: false
+    bibitFormUrl: https://secure.wp3.rbsworldpay.com/jsp/merchant/xml/paymentService.jsp
+    capitaFormUrl: https://sbs.e-paycapita.com/portal/PortalServlet
+    northgateCallbackOverride: >-
+      https://online.ukwelcomes.businesslink.gov.uk/eff/action/northgateResponse
+    worldpayFormUrl: https://secure.worldpay.com/wcc/purchase
+
+  notify:
+    templateApplicatNone: test
+    templateApplicatOffline: test
+    templateApplicatOnline: test
+    templateAuthority: test
+    templatePeriodic: test
+    # Configures whether licensify should sends periodic emails to authorities
+    emailPeriodicEnabled: true
+    periodicEmailCron: 0 0 6 3 * ?
+    emailOverrideRecipient: ""
+
+  # Performance platform has been decomission useless config
+  performancePlatformUrl: >-
+    https://performance/data/licensing/application
+  performanceDataSenderCronExpression: 0 0 1 * * ?
+
+  placesApiUrl: http://places-api:9700/places
+
 
 images:
   nginx:


### PR DESCRIPTION
This adds in missing config options that are present in the configure of licensify on EC2 and tidies up the structure.