### PR TITLE
Add logging config for Licensify

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         - name: licensify-config
           secret:
             secretName: licensify-config
+        - name: logging-config
+          configMap:
+            name: licensify-logging-config
         - name: app-tmp
           emptyDir: {}
         - name: nginx-conf
@@ -61,6 +64,8 @@ spec:
               value: do-not-use
             - name: GDS_CONFIG_FILE
               value: /etc/licensing/config.properties
+            - name: LOGGING_CONFIG_FILE
+              value: ../../../app/conf/logging.xml
             {{- with $.Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}
@@ -88,6 +93,9 @@ spec:
             - name: licensify-config
               mountPath: "/etc/licensing"
               readOnly: true
+            - name: logging-config
+              mountPath: /app/conf/logging.xml
+              subPath: logging.xml
             - name: app-tmp
               mountPath: /tmp
         - name: nginx

--- a/charts/licensify/templates/logging-configmap.yaml
+++ b/charts/licensify/templates/logging-configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: licensify-logging-config
+data:
+  logging.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        </appender>
+
+        <logger name="application" level="INFO"/>
+        <logger name="akka" level="INFO"/>
+        <logger name="play" level="INFO"/>
+        <logger name="uk.gov" level="INFO"/>
+
+        <root level="INFO">
+            <appender-ref ref="STDOUT"/>
+        </root>
+
+    </configuration>


### PR DESCRIPTION
Logging for these applications is configured via XML file 😢. This might be overly verbose, but can turn it down after migration.