### PR TITLE
Add shared secret key for Licensify

### DIFF
--- a/charts/licensify/templates/config-externalsecret.yaml
+++ b/charts/licensify/templates/config-externalsecret.yaml
@@ -47,3 +47,7 @@ spec:
     remoteRef:
       key: govuk/licensify
       property: "notify_key_api"
+  - secretKey: play_secret_key
+    remoteRef:
+      key: govuk/licensify
+      property: play_secret_key

--- a/charts/licensify/templates/config-template-configmap.yaml
+++ b/charts/licensify/templates/config-template-configmap.yaml
@@ -4,6 +4,9 @@ metadata:
   name: licensify-config-template
 data:
   config.properties: |
+    # Play config
+    play.http.secret.key={{ `{{ .play_secret_key }}` }}
+
     # Virus scan config
     clam.antivirus.host={{ .Values.config.clamAntivirusHost }}
     scheduled.virus.scan.cron.expression={{ .Values.config.scheduledVirusScanCronExpression }}


### PR DESCRIPTION
This ensures the same key is used by pods (e.g. multiple pods when rolling out).