### PR TITLE
Clean up temporary dnsConfig on Router(-API) in nonprod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1894,9 +1894,6 @@ govukApplications:
 
   - name: router-api
     helmValues: &router-api
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.integration.govuk-internal.digital
       uploadAssets:
         enabled: false
       extraEnv:
@@ -1947,9 +1944,6 @@ govukApplications:
         enabled: false
       uploadAssets:
         enabled: false
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:
@@ -2049,9 +2043,6 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.integration.govuk-internal.digital
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1912,9 +1912,6 @@ govukApplications:
 
   - name: router-api
     helmValues: &router-api
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.staging.govuk-internal.digital
       uploadAssets:
         enabled: false
       extraEnv:
@@ -1965,9 +1962,6 @@ govukApplications:
         enabled: false
       uploadAssets:
         enabled: false
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.staging.govuk-internal.digital
       appResources:
         limits:
           cpu: 4
@@ -2075,9 +2069,6 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.staging.govuk-internal.digital
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false


### PR DESCRIPTION
This was for the Puppet->k8s migration in #1668 and no longer necessary.

Just non-prod first, just in case I've missed something.