### PR TITLE
Clean up temp dnsConfig on Router(-API) in prod.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1955,9 +1955,6 @@ govukApplications:
 
   - name: router-api
     helmValues: &router-api
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.production.govuk-internal.digital
       uploadAssets:
         enabled: false
       extraEnv:
@@ -2008,9 +2005,6 @@ govukApplications:
         enabled: false
       uploadAssets:
         enabled: false
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.production.govuk-internal.digital
       appResources:
         limits:
           cpu: 4
@@ -2118,9 +2112,6 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
-      dnsConfig:  # TODO: remove dnsConfig once MongoDB migrated to DocDB.
-        searches:
-          - blue.production.govuk-internal.digital
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false

--- a/charts/router-mongo/templates/statefulset.yaml
+++ b/charts/router-mongo/templates/statefulset.yaml
@@ -35,11 +35,6 @@ spec:
       enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 12 }}
-      # TODO: remove dnsConfig once #1668 is done.
-      dnsConfig:
-        searches:
-          - {{ $fullName }}.{{ .Release.Namespace }}.svc.cluster.local
-          - blue.{{ $.Values.govukEnvironment }}.govuk-internal.digital
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
This was for the Puppet->k8s migration in #1668 and no longer necessary.

Tested: #1749 in staging/integration + tested the statefulset change separately in staging (verified that the Mongo replset stays up during the rollout and nodes can still resolve their own names).