### PR TITLE
Add JAVA_OPTIONS for licensify frontend

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - name: GDS_CONFIG_FILE
               value: /etc/licensing/config.properties
             - name: LOGGING_CONFIG_FILE
-              value: ../../../app/conf/logging.xml
+              value: /app/conf/logging.xml
             {{- with $.Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               value: /etc/licensing/config.properties
             - name: LOGGING_CONFIG_FILE
               value: /app/conf/logging.xml
-            {{- with $.Values.extraEnv }}
+            {{- with .extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}
           ports:

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -79,6 +79,11 @@ apps:
       annotations: {}
     service:
       port: 80
+    extraEnv:
+      - name: JAVA_OPTIONS
+        value: >-
+          -Dplay.http.session.sameSite="None"
+          -Dplay.akka.actor.retrieveBodyParserTimeout="30 seconds"
 
 resources:
   limits:
@@ -87,8 +92,6 @@ resources:
   requests:
     cpu: 500m
     memory: 800Mi
-
-extraEnv: []
 
 config:
   clamAntivirusHost: clamav


### PR DESCRIPTION
This is extra config specific for licensify frontend. Pulled from puppet here:
https://github.com/alphagov/govuk-puppet/blob/5fe296410ed2a438acdc356b58fa72dd66fe0c21/modules/licensify/templates/gds-licensify-config.conf.erb#L23

This also fixes the file path for the logging config to be absolute, than a weird relative path.

This is possible due to these changes with image entrypoint:
https://github.com/alphagov/licensify/pull/645
