### PR TITLE
Clean up an obsolete TODO on probe config (no diff).

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           {{- with .Values.appProbes }}
             {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
-          startupProbe: &app-probe  # TODO: check the Rails apps aren't picky about the Host header.
+          startupProbe: &app-probe
             httpGet:
               path: /healthcheck/live
               port: http
@@ -114,9 +114,6 @@ spec:
             periodSeconds: 5
           readinessProbe:
             <<: *app-probe
-            httpGet:
-              path: /healthcheck/live  # TODO: fix readiness check so that we can use it here.
-              port: http
             failureThreshold: 2
             periodSeconds: 5
           {{- end }}


### PR DESCRIPTION
The probes are ok because the deployment is healthy; qed.

(We also don't intend to do anything fancy with the readiness probes any time soon.)