### PR TITLE
Factor out AWS_REGION into env-configmap.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -13,6 +13,7 @@ metadata:
     kubernetes.io/description: >
       Environment variables applied to every GOV.UK app.
 data:
+  AWS_REGION: {{ .Values.awsRegion }}
   BOOTSNAP_READONLY: "1"
   GOVUK_APP_DOMAIN: ""
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.publishingDomainSuffix }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -193,8 +193,6 @@ govukApplications:
               key: MONGODB_URI
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-assets-integration
 
@@ -506,8 +504,6 @@ govukApplications:
             secretKeyRef:
               name: content-data-admin-aws
               key: secret_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_CSV_EXPORT_BUCKET_NAME
           value: govuk-integration-content-data-csvs
         - name: DATABASE_URL
@@ -643,8 +639,6 @@ govukApplications:
         hosts:
           - name: content-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
-        - name: AWS_REGION  # TODO: consider moving this to cm/govuk-apps-env?
-          value: eu-west-1
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1514,8 +1508,6 @@ govukApplications:
           value: "false"
         - name: AWS_S3_ASSET_BUCKET_NAME
           value: "govuk-app-assets-integration"
-        - name: AWS_REGION
-          value: "eu-west-1"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -1774,8 +1766,6 @@ govukApplications:
           value: *publishing-notify-template
         - name: REPORTS_S3_BUCKET_NAME
           value: govuk-integration-publisher-csvs
-        - name: AWS_REGION
-          value: eu-west-1
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-bootstrap-gtm-id
         - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
@@ -2194,8 +2184,6 @@ govukApplications:
         - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
           name: bulk-reindex-queue-listener
       extraEnv:
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-integration-search-relevancy
         - name: AWS_S3_SITEMAPS_BUCKET_NAME
@@ -2729,8 +2717,6 @@ govukApplications:
             secretKeyRef:
               name: specialist-publisher-aws
               key: secret_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-specialist-publisher-csvs
         - name: MONGODB_URI
@@ -2778,8 +2764,6 @@ govukApplications:
             secretKeyRef:
               name: support-aws
               key: access_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-support-api-csvs
         - name: AWS_SECRET_ACCESS_KEY
@@ -2855,8 +2839,6 @@ govukApplications:
             secretKeyRef:
               name: support-aws
               key: access_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-support-api-csvs
         - name: AWS_SECRET_ACCESS_KEY
@@ -2949,8 +2931,6 @@ govukApplications:
             secretKeyRef:
               name: signon-app-transition
               key: oauth_secret
-        - name: AWS_REGION
-          value: eu-west-1
         - name: BASIC_AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3145,8 +3125,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-whitehall-search-api
               key: bearer_token
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-whitehall-csvs
         - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -194,8 +194,6 @@ govukApplications:
           value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-assets-staging
 
@@ -508,8 +506,6 @@ govukApplications:
             secretKeyRef:
               name: content-data-admin-aws
               key: secret_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_CSV_EXPORT_BUCKET_NAME
           value: govuk-staging-content-data-csvs
         - name: DATABASE_URL
@@ -645,8 +641,6 @@ govukApplications:
         hosts:
           - name: content-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
-        - name: AWS_REGION  # TODO: consider moving this to cm/govuk-apps-env?
-          value: eu-west-1
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1526,8 +1520,6 @@ govukApplications:
           value: "false"
         - name: AWS_S3_ASSET_BUCKET_NAME
           value: "govuk-app-assets-staging"
-        - name: AWS_REGION
-          value: "eu-west-1"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -1776,8 +1768,6 @@ govukApplications:
           value: *publishing-notify-template
         - name: REPORTS_S3_BUCKET_NAME
           value: govuk-staging-publisher-csvs
-        - name: AWS_REGION
-          value: eu-west-1
 
   - name: publishing-api
     helmValues:
@@ -2216,8 +2206,6 @@ govukApplications:
         - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
           name: bulk-reindex-queue-listener
       extraEnv:
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-staging-search-relevancy
         - name: AWS_S3_SITEMAPS_BUCKET_NAME
@@ -2728,8 +2716,6 @@ govukApplications:
             secretKeyRef:
               name: specialist-publisher-aws
               key: secret_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-specialist-publisher-csvs
         - name: MONGODB_URI
@@ -2769,8 +2755,6 @@ govukApplications:
             secretKeyRef:
               name: support-aws
               key: access_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-support-api-csvs
         - name: AWS_SECRET_ACCESS_KEY
@@ -2846,8 +2830,6 @@ govukApplications:
             secretKeyRef:
               name: support-aws
               key: access_key
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-support-api-csvs
         - name: AWS_SECRET_ACCESS_KEY
@@ -2940,8 +2922,6 @@ govukApplications:
             secretKeyRef:
               name: signon-app-transition
               key: oauth_secret
-        - name: AWS_REGION
-          value: eu-west-1
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -3102,8 +3082,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-whitehall-search-api
               key: bearer_token
-        - name: AWS_REGION
-          value: eu-west-1
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-whitehall-csvs
         - name: GOVUK_NOTIFY_TEMPLATE_ID

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -5,6 +5,8 @@
 #
 # See values-${env}.yaml for per-environment and per-app values.
 
+awsRegion: eu-west-1
+
 appsNamespace: apps
 argoNamespace: cluster-services
 monitoringNamespace: monitoring


### PR DESCRIPTION
This was being duplicated a lot. There are few cases where it's legitimately not the same config item, but all these ones are.

I'll remove the duplicate env vars from prod in a separate PR.