### PR TITLE
Fix Licensify env vars

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
               value: /etc/licensing/config.properties
             - name: LOGGING_CONFIG_FILE
               value: /app/conf/logging.xml
+            {{- with $.Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
             {{- with .extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -85,6 +85,8 @@ apps:
           -Dplay.http.session.sameSite="None"
           -Dplay.akka.actor.retrieveBodyParserTimeout="30 seconds"
 
+extraEnv: []
+
 resources:
   limits:
     cpu: 1

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -82,8 +82,8 @@ apps:
     extraEnv:
       - name: JAVA_OPTIONS
         value: >-
-          -Dplay.http.session.sameSite="None"
-          -Dplay.akka.actor.retrieveBodyParserTimeout="30 seconds"
+          -Dplay.http.session.sameSite=None
+          -Dplay.akka.actor.retrieveBodyParserTimeout=30s
 
 extraEnv: []
 


### PR DESCRIPTION
Accidentally removed the common env vars for AWS region and S3 bucket. Also fixes templating of the JAVA_OPTIONS