### PR TITLE
Add inital delay for licensify probes

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -82,6 +82,7 @@ spec:
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30
+            initialDelaySeconds: 5
           readinessProbe:
             <<: *app-probe  # Intentionally same path as liveness.
             failureThreshold: 2


### PR DESCRIPTION
Let the app start before probing and failing healthchecks.