### PR TITLE
Remove Perl usage from router-nginx config.

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -121,15 +121,8 @@ http {
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   Cookie '';
 
-      # If slug has trailing URL, direct after trimming.
-      location ~ ^\/(.+)\/$ {
-        rewrite ^\/(.+)\/$ $scheme://$host/$1 permanent;
-      }
-
-      # If slug has trailing fullstop, direct after trimming.
-      location ~ ^\/(.+)\.$ {
-        rewrite ^\/(.+)\.$ $scheme://$host/$1 permanent;
-      }
+      # Redirect to trim a (single) trailing slash or dot.
+      rewrite ^\/(.+)[/.]$ $scheme://$host/$1 permanent;
     }
 
     # Allow cookie headers to pass for services that require them
@@ -163,9 +156,7 @@ http {
       add_header "Access-Control-Allow-Headers" "origin, authorization";
     }
 
-    # Endpoint that isn't cached, which is used to assert that an external
-    # service can receive a response from GOV.UK origin on www hostname. It
-    # is intended for pingdom monitoring
+    # Uncacheable resource for use by external probers (Pingdom).
     location = /__canary__ {
       default_type application/json;
       add_header cache-control "max-age=0,no-store,no-cache";
@@ -181,7 +172,7 @@ http {
       root /usr/share/nginx/html;
     }
 
-    # 1stline use this URL in their zendesk template
+    # 1st-line User Support use this URL in their Zendesk email template.
     location = /static/gov.uk_logotype_crown.png {
       absolute_redirect off;
       return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;

--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -1,8 +1,6 @@
 {{- define "app-config.router-nginx-config" -}}
 user nginx;
 
-load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
-
 error_log  /dev/stderr warn;
 pid        /tmp/nginx.pid;
 
@@ -29,11 +27,6 @@ http {
 
   sendfile        on;
   keepalive_timeout  65;
-
-  perl_set $uri_lowercase 'sub {
-    my $r = shift;
-    return lc($r->uri);
-  }';
 
   # Set GOVUK-Request-Id if not set
   map $http_govuk_request_id $govuk_request_id {
@@ -127,13 +120,6 @@ http {
       proxy_set_header   X-Forwarded-Host $proxy_add_x_forwarded_host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   Cookie '';
-
-      # If slug is ALL CAPS then lowercase it, e.g.:
-      #   /GOVERNMENT/GUIDANCE -> /government/guidance
-      #   /GoVeRnMeNt/gUiDaNcE -> /GoVeRnMeNt/gUiDaNcE (but see next rule below)
-      location ~ ^\/[A-Z]+[A-Z\W\d]+$ {
-        rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
-      }
 
       # If slug has trailing URL, direct after trimming.
       location ~ ^\/(.+)\/$ {


### PR DESCRIPTION
Remove the last remaining Perl usage in Router's nginx.conf and drop the Perl module. The lowercase-all-caps-slugs functionality has [moved to Router](https://github.com/alphagov/router/pull/424) (for now).

While we're there, simplify the remaining rewrite rules.

Rollout: https://github.com/alphagov/router/pull/424 needs to be fully rolled out before merging this.