### PR TITLE
Use the regular nginx image instead of the Perl one.

### DIFF
--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -39,7 +39,7 @@ appProbes: {}
 nginxImage:
   repository: public.ecr.aws/nginx/nginx
   pullPolicy: Always
-  tag: stable-perl
+  tag: stable
 nginxPort: 8080
 nginxProxyConnectTimeout: 1s
 nginxProxyReadTimeout: 15s

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -59,7 +59,7 @@ appProbes: {}
 nginxImage:
   repository: public.ecr.aws/nginx/nginx
   pullPolicy: Always
-  tag: stable-perl
+  tag: stable
 nginxPort: 8080
 nginxProxyConnectTimeout: 1s
 nginxProxyReadTimeout: 15s


### PR DESCRIPTION
As of #1764, we no longer need the Perl module \o/