### PR TITLE
Re-enable licensify feed in EKS for production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1349,8 +1349,6 @@ govukApplications:
                 ]}}]
             hosts:
               - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
-        licensifyFeed:
-          enabled: false
         licensifyFrontend:
           replicaCount: 3
           ingress:

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -3,7 +3,6 @@
 {{ $appImage := get $.Values.images (camelcase ( .useImage | default .name )) }}
 # TODO: Remove "if enabled" once live in production. This is to allow us to
 # disable feed in production before migration.
-{{- if .enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -138,5 +137,4 @@ spec:
               subPath: nginx.conf
             - name: nginx-tmp
               mountPath: /tmp
-{{- end }}
 {{- end }}


### PR DESCRIPTION
This deploys licensify-feed in EKS for production. Previously this was disabled in EKS, so we have only one instance of feed running in production (as it was already running in EC2).