### PR TITLE
Run Smokey against failover CDN

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2496,8 +2496,6 @@ govukApplications:
 
   - name: smokey
     chartPath: charts/smokey
-    helmValues:
-      cronSchedule: "*/10 7-19 * * 1-5"
 
   - name: static
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2561,6 +2561,28 @@ govukApplications:
 
   - name: smokey
     chartPath: charts/smokey
+    helmValues:
+      cronJobs:
+        - name: smokey
+          schedule: "*/10 * * * *"
+          args:
+            - cucumber
+            - --profile={{ .Values.govukEnvironment }}
+            - --strict-undefined
+        - name: smokey-failover
+          schedule: "0 9 * * 1-5"
+          args:
+            - cucumber
+            - --strict-undefined
+            - --tags=not @notcloudfront
+          extraEnv:
+            - name: GOVUK_PROXY_PROFILE
+              value: failoverCDN
+            - name: FAILOVER_CDN_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: FAILOVER_CDN_HOST
+                  name: smokey-failover-cdn-host
 
   - name: static
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2535,8 +2535,6 @@ govukApplications:
 
   - name: smokey
     chartPath: charts/smokey
-    helmValues:
-      cronSchedule: "*/10 7-19 * * 1-5"
 
   - name: static
     helmValues:

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -1,15 +1,17 @@
+{{- range .Values.cronJobs }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: smokey
+  name: {{ .name }}
 spec:
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 3
   successfulJobsHistoryLimit: 3
-  schedule: {{ .Values.cronSchedule | quote }}
+  schedule: {{ .schedule | quote }}
   jobTemplate:
     metadata:
-      name: smokey
+      name: {{ .name }}
     spec:
       activeDeadlineSeconds: 600
       backoffLimit: 0
@@ -27,12 +29,11 @@ spec:
             name: tmp
           containers:
           - args:
-            - cucumber
-            - --profile={{ .Values.govukEnvironment }}
-            - --strict-undefined
-            - --tags=not @not{{ .Values.govukEnvironment }}
-            image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
-            name: smokey
+            {{- with .args }}
+              {{- tpl (toYaml .) $ | nindent 14 }}
+            {{- end }}
+            image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
+            name: {{ .name }}
             resources:
               limits:
                 cpu: "2"
@@ -53,21 +54,21 @@ spec:
                   key: bearer_token
                   name: signon-token-smokey-asset-manager
             - name: ENVIRONMENT
-              value: {{ .Values.govukEnvironment }}
+              value: {{ $.Values.govukEnvironment }}
             - name: GOVUK_APP_DOMAIN
               value: ""
             - name: GOVUK_APP_DOMAIN_EXTERNAL
-              value: {{ .Values.publishingDomainSuffix }}
+              value: {{ $.Values.publishingDomainSuffix }}
             - name: GOVUK_ASSET_ROOT
-              value: https://{{ .Values.assetsDomain }}
+              value: https://{{ $.Values.assetsDomain }}
             - name: GOVUK_WEBSITE_ROOT
-              value: https://www.{{ .Values.externalDomainSuffix }}
+              value: https://www.{{ $.Values.externalDomainSuffix }}
             - name: PLEK_SERVICE_ASSETS_URI
-              value: https://{{ .Values.assetsDomain }}
+              value: https://{{ $.Values.assetsDomain }}
             - name: PLEK_SERVICE_ASSETS_ORIGIN_URI
-              value: https://assets-origin.{{ .Values.publishingDomainSuffix }}
+              value: https://assets-origin.{{ $.Values.publishingDomainSuffix }}
             - name: PLEK_SERVICE_CONTENT_DATA_ADMIN_URI
-              value: https://content-data.{{ .Values.publishingDomainSuffix }}
+              value: https://content-data.{{ $.Values.publishingDomainSuffix }}
             - name: PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS
               value: "1"
             - name: SIGNON_EMAIL
@@ -81,17 +82,21 @@ spec:
                   key: password
                   name: smokey-signon-account
             - name: SENTRY_CURRENT_ENV
-              value: {{ .Values.govukEnvironment }}
+              value: {{ $.Values.govukEnvironment }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.repoName }}-sentry
+                  name: {{ $.Values.repoName }}-sentry
                   key: dsn
             - name: SENTRY_RELEASE
-              value: "{{ .Values.appImage.tag }}"
+              value: "{{ $.Values.appImage.tag }}"
             - name: SE_CACHE_PATH
               value: "/tmp/.cache/selenium"
             - name: XDG_CONFIG_HOME
               value: "/tmp/.chrome"
             - name: XDG_CACHE_HOME
               value: "/tmp/.chrome"
+            {{- with .extraEnv }}
+              {{- . | toYaml | nindent 12 }}
+            {{- end }}
+{{- end }}

--- a/charts/smokey/templates/secrets.yaml
+++ b/charts/smokey/templates/secrets.yaml
@@ -18,3 +18,22 @@ spec:
   dataFrom:
     - extract:
         key: govuk/smokey/signon-account
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: smokey-failover-cdn-host
+  annotations:
+    kubernetes.io/description: >
+      Of the form "secret.cloudfront.net", used in the Smokey failover CDN tests.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: smokey-failover-cdn-host
+  dataFrom:
+    - extract:
+        key: govuk/smokey/failover-cdn-host

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -4,7 +4,13 @@ k8sExternalDomainSuffix: eks.test.govuk.digital
 publishingDomainSuffix: test.publishing.service.gov.uk
 assetsDomain: assets.test.publishing.service.gov.uk
 
-cronSchedule: "*/10 * * * *"
+cronJobs:
+  - name: smokey
+    schedule: "*/10 7-19 * * 1-5"
+    args:
+      - cucumber
+      - --profile={{ .Values.govukEnvironment }}
+      - --strict-undefined
 
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey


### PR DESCRIPTION
In https://github.com/alphagov/smokey/pull/1221, Smokey was
configured to be able to run against the failover CDN (Cloudfront)
or against any of our [three mirrors](https://docs.publishing.service.gov.uk/manual/fall-back-to-mirror.html),
by means of a proxy that can be enabled and configured through
ENV variables.

Scenarios that should pass for the failover CDN are:
- Any scenarios NOT tagged `@notcloudfront`
Scenarios that should pass for the mirrors are:
- Any scenarios tagged `@worksonmirror`

We don't want to run these Smokeys as often as the 'main' Smokey
test suite, but we do want to periodically run them to ensure that
the failover solution and mirrors continue to work as expected.

For now, we'll just set up the failover CDN Smokey. In future,
it should be fairly straightforward to add the mirror tests
into the same cronjob.

Tested by running a modified snippet from the README:

```sh
cd charts/app-config

ENVIRONMENT=production
APP=smokey
helm template $USER-${APP?} ../smokey --values <(
  helm template . --values values-${ENVIRONMENT}.yaml |
  yq e '.|select(.metadata.name=="'$APP'").spec.source.helm.values'
) --set sentry.enabled=false --set rails.createKeyBaseSecret=false
```

...then looking for the `smokey-failover` cronjob in the output.
I also confirmed that no such job exists when swapping `ENVIRONMENT`
to `integration`.

Trello: https://trello.com/c/2XwAz6JD/3365-run-automatic-smokey-tests-against-the-standby-cdn-5