### PR TITLE
Remove ingress for licensify feed

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1338,12 +1338,6 @@ govukApplications:
                 ]}}]
             hosts:
               - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
-        licensifyFeed:
-          ingress:
-            annotations:
-              <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-            hosts:
-              - name: licensify-feed.{{ .Values.k8sExternalDomainSuffix }}
         licensifyFrontend:
           ingress:
             annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1379,11 +1379,6 @@ govukApplications:
               - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
         licensifyFeed:
           enabled: false
-          ingress:
-            annotations:
-              <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-            hosts:
-              - name: licensify-feed.{{ .Values.k8sExternalDomainSuffix }}
         licensifyFrontend:
           ingress:
             annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1341,12 +1341,6 @@ govukApplications:
               <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
             hosts:
               - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
-        licensifyFeed:
-          ingress:
-            annotations:
-              <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-            hosts:
-              - name: licensify-feed.{{ .Values.k8sExternalDomainSuffix }}
         licensifyFrontend:
           ingress:
             annotations:

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -77,8 +77,7 @@ apps:
     port: 9940
     healthcheckPath: "/licence-management/feed/process-applications"
     ingress:
-      enabled: true
-      annotations: {}
+      enabled: false
     service:
       port: 80
     extraEnv:


### PR DESCRIPTION
Turns out we don't need and shouldn't have ingress to this application.