### PR TITLE
Wait a little bit longer for healthcheck on licenisfy

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
           readinessProbe:
             <<: *app-probe  # Intentionally same path as liveness.
             failureThreshold: 2


### PR DESCRIPTION
Still seeing some occasions where the healthchecks happen before the app is ready and are coming back unhealthy.