### PR TITLE
Increase connect() deadline on nginx proxies + minor cleanup.

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -1,6 +1,4 @@
 {{- define "app-config.router-nginx-config" -}}
-user nginx;
-
 error_log  /dev/stderr warn;
 pid        /tmp/nginx.pid;
 

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -100,8 +100,8 @@ data:
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header GOVUK-Request-Id $govuk_request_id;
         proxy_redirect off;
-        proxy_connect_timeout 1s;
-        proxy_read_timeout 60;
+        proxy_connect_timeout {{ .Values.nginxProxyConnectTimeout }};
+        proxy_read_timeout    {{ .Values.nginxProxyReadTimeout }};
 
         access_log /dev/stdout json_event;
         error_log /dev/stderr;

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -41,8 +41,8 @@ nginxImage:
   pullPolicy: Always
   tag: stable
 nginxPort: 8080
-nginxProxyConnectTimeout: 1s
-nginxProxyReadTimeout: 15s
+nginxProxyConnectTimeout: 2s
+nginxProxyReadTimeout: 60s
 nginxConfigMap:
   create: true
 nginxExtraVolumeMounts: []

--- a/charts/generic-govuk-app/templates/nginx-configmap.yaml
+++ b/charts/generic-govuk-app/templates/nginx-configmap.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: nginx
 data:
   nginx.conf: |-
-
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
 
@@ -38,7 +37,6 @@ data:
 
       sendfile        on;
       keepalive_timeout  65;
-
 
       # Set GOVUK-Request-Id if not set
       map $http_govuk_request_id $govuk_request_id {

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -61,7 +61,7 @@ nginxImage:
   pullPolicy: Always
   tag: stable
 nginxPort: 8080
-nginxProxyConnectTimeout: 1s
+nginxProxyConnectTimeout: 2s
 nginxProxyReadTimeout: 15s
 nginxClientMaxBodySize: 1M
 nginxConfigMap:


### PR DESCRIPTION
- Increase the `connect()` deadline to 2s (which is still pretty short, but double what we had before).
- Delete the no-op `user` line which just causes nginx to emit warnings on startup when it fails calling `setuid()` (because it's already running as an unprivileged user).