### PR TITLE
Move Licensify into separate namespace

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -58,5 +58,8 @@ spec:
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/managed-by: {{ $.Values.argoNamespace | default $.Release.Namespace }}
 ---
 {{ end }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1285,6 +1285,7 @@ govukApplications:
 
   - name: licensify
     chartPath: charts/licensify
+    appsNamespace: licensify
     imageValues:
       - "licensify-admin"
       - "licensify-backend"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1329,6 +1329,7 @@ govukApplications:
 
   - name: licensify
     chartPath: charts/licensify
+    appsNamespace: licensify
     imageValues:
       - "licensify-admin"
       - "licensify-backend"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1327,6 +1327,7 @@ govukApplications:
 
   - name: licensify
     chartPath: charts/licensify
+    appsNamespace: licensify
     imageValues:
       - "licensify-admin"
       - "licensify-backend"


### PR DESCRIPTION
This allows us to restrict access for third parties to just the Licensify resources. This should also keep the Argo Application resource in the apps namespace.

As per [the docs](https://argocd-operator.readthedocs.io/en/latest/usage/deploy-to-different-namespaces/), they suggest that namespaces created by Argo require the "managed-by' annotation. Also useful anyway to keep track of what created the ns.