### PR TITLE
Remove references to disused `notreplatforming` label.

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
             - cucumber
             - --profile={{ .Values.govukEnvironment }}
             - --strict-undefined
-            - --tags=not @notreplatforming and not @not{{ .Values.govukEnvironment }}
+            - --tags=not @not{{ .Values.govukEnvironment }}
             image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
             name: smokey
             resources:

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -21,11 +21,11 @@ spec:
       container:
         image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
         command:
-          - bundle
-          - exec
-          - >-
-            cucumber --profile={{ .Values.govukEnvironment }} --strict-undefined --tags='not
-            @notreplatforming' --tags='not @not{{ .Values.govukEnvironment }}' --tags="{{"{{ inputs.parameters.extra-args }}"}}"
+          - cucumber
+          - --profile={{ .Values.govukEnvironment }}
+          - --strict-undefined
+          - --tags=not @not{{ .Values.govukEnvironment }}
+          - --tags={{ `{{ inputs.parameters.extra-args }}` | quote }}
         env:
           - name: BEARER_TOKEN
             valueFrom:


### PR DESCRIPTION
Also clean up the cucumber args in the Workflow template.