### PR TITLE
Add quality monitoring cronTask for `search-api-v2`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2232,6 +2232,11 @@ govukApplications:
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
+      cronTasks:
+        - name: quality-monitoring-check-result-invariants
+          task: "rake quality_monitoring:check_result_invariants"
+          schedule: "09 9 * * *"  # 09:09am daily
+          suspend: true  # Too noisy for integration to run on schedule, but can be run manually.
       extraEnv:
         # Required for document sync worker to be able to export metrics
         - name: GOVUK_PROMETHEUS_EXPORTER


### PR DESCRIPTION
This adds (in integration for testing, and suspended because it might be quite noisy in non-production environments) a cronTask to run a set of quality tests on `search-api-v2`.