### PR TITLE
Add replicas for Licensify frontend

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1347,6 +1347,7 @@ govukApplications:
         licensifyFeed:
           enabled: false
         licensifyFrontend:
+          replicaCount: 3
           ingress:
             annotations:
               <<: [*alb-ingress-group-backend, *alb-ingress-defaults]

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -73,7 +73,7 @@ apps:
   licensifyFrontend:
     name: licensify-frontend
     enabled: true
-    replicaCount: 1
+    replicaCount: 2
     port: 9903
     healthcheckPath: "/api/licences"
     ingress:


### PR DESCRIPTION
Noticed that we had 2 instances of licenisfy-frontend running in Production. So should be able to run replicas for it here too.