### PR TITLE
Fix quoting in Smokey workflow args.

### DIFF
--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -25,7 +25,7 @@ spec:
           - --profile={{ .Values.govukEnvironment }}
           - --strict-undefined
           - --tags=not @not{{ .Values.govukEnvironment }}
-          - --tags={{ `{{ inputs.parameters.extra-args }}` | quote }}
+          - --tags={{ `{{ inputs.parameters.extra-args }}` }}
         env:
           - name: BEARER_TOKEN
             valueFrom:


### PR DESCRIPTION
Turns out we don't want quotes around the `@app-foo` in `--tags=@app-foo`.

Tested: inspected `helm template` output and verified the cucumber args work as expected.