### PR TITLE
Add `search-api-v2` quality cronTask to all envs

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2293,6 +2293,10 @@ govukApplications:
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
+      cronTasks:
+        - name: quality-monitoring-result-invariants
+          task: "quality_monitoring:check_result_invariants"
+          schedule: "09 9 * * *"  # 09:09am daily
       extraEnv:
         # Required for document sync worker to be able to export metrics
         - name: GOVUK_PROMETHEUS_EXPORTER

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2286,6 +2286,11 @@ govukApplications:
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
+      cronTasks:
+        - name: quality-monitoring-result-invariants
+          task: "quality_monitoring:check_result_invariants"
+          schedule: "09 9 * * *"  # 09:09am daily
+          suspend: true  # Too noisy for staging to run on schedule, but can be run manually.
       extraEnv:
         # Required for document sync worker to be able to export metrics
         - name: GOVUK_PROMETHEUS_EXPORTER


### PR DESCRIPTION
This adds the `quality-monitoring-result-invariants` tasks to staging (suspended like in integration to avoid noise) and production (running on a daily schedule).