### PR TITLE
Fix secret reference in licensify deployment

### DIFF
--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: PLAY_HTTP_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .name }}-envs
+                  name: licensify-envs
                   key: {{ .name }}-play-secret-key
             {{- with $.Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}


### PR DESCRIPTION
We only have single secret for all deployments.