### PR TITLE
Update Licensify domains to use EKS instance in production

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -50,9 +50,4 @@ data:
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}
   PLEK_SERVICE_DRAFT_ASSETS_URI: https://draft-assets.{{ .Values.publishingDomainSuffix }}
 
-  {{- if ne .Values.govukEnvironment "production" }}
   PLEK_SERVICE_LICENSIFY_URI: http://licensify-frontend.licensify
-  {{- else }}
-  # Services which remain in EC2 for a while after "MVP launch".
-  PLEK_SERVICE_LICENSIFY_URI: https://licensify.{{ .Values.govukEnvironment }}.{{ .Values.ec2InternalDomainSuffix }}
-  {{- end }}

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2057,7 +2057,7 @@ govukApplications:
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
         - name: BACKEND_URL_licensify
-          value: "https://licensify.production.govuk-internal.digital"
+          value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
 
@@ -2108,7 +2108,7 @@ govukApplications:
         - name: BACKEND_URL_info-frontend
           value: "http://info-frontend"
         - name: BACKEND_URL_licensify
-          value: "https://licensify.production.govuk-internal.digital"
+          value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
 


### PR DESCRIPTION
This switches Licensify to be served from EKS in production. (Second attempt).