### PR TITLE
Make `search-api-v2` invariant checks more frequent

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2301,7 +2301,7 @@ govukApplications:
       cronTasks:
         - name: quality-monitoring-result-invariants
           task: "quality_monitoring:check_result_invariants"
-          schedule: "09 9 * * *"  # 09:09am daily
+          schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm
       extraEnv:
         # Required for document sync worker to be able to export metrics
         - name: GOVUK_PROMETHEUS_EXPORTER


### PR DESCRIPTION
During our launch and for a while after, we want these checks to be more frequent so we are alerted more quickly to any developing issues. We may turn this down again once everything has settled in and we are confident in the performance.