### PR TITLE
Remove unused secret key for Licensify configmap

### DIFF
--- a/charts/licensify/templates/config-externalsecret.yaml
+++ b/charts/licensify/templates/config-externalsecret.yaml
@@ -47,7 +47,3 @@ spec:
     remoteRef:
       key: govuk/licensify
       property: "notify_key_api"
-  - secretKey: play_secret_key
-    remoteRef:
-      key: govuk/licensify
-      property: play_secret_key


### PR DESCRIPTION
This has been removed from the AWS Secret as it's been replaced with keys for each app instead (e.g. _frontend, _feed, _admin).