### PR TITLE
Fix values on Kubescape 

### DIFF
--- a/charts/app-config/templates/kubescape.yaml
+++ b/charts/app-config/templates/kubescape.yaml
@@ -20,11 +20,11 @@ spec:
         - name: account
           value: "mgsQy3ett5"
         - name: clusterName
-          value: govuk-integration-new
+          value: "govuk-integration-new"
         - name: server
-          value: api.armosec.io
+          value: "api.armosec.io"
         - name: "credentials.cloudSecret"
-          value: false
+          value: "false"
   project: default
   syncPolicy:
     syncOptions:


### PR DESCRIPTION
Error:

`one or more objects failed to apply, reason: Application.argoproj.io "kubescape" is invalid: spec.source.helm.parameters[3].value: Invalid value: "boolean":`