### PR TITLE
Set the secure session flag for licensify

### DIFF
--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -44,6 +44,10 @@ apps:
       annotations: {}
     service:
       port: 80
+    extraEnv:
+      - name: JAVA_OPTIONS
+        value: >-
+          -Dsession.secure=true
 
   licensifyFeed:
     name: licensify-feed
@@ -70,6 +74,7 @@ apps:
     extraEnv:
       - name: JAVA_OPTIONS
         value: >-
+          -Dsession.secure=true
           -Dplay.http.session.sameSite=None
           -Dplay.akka.actor.retrieveBodyParserTimeout=30s
 


### PR DESCRIPTION
This is crucial to ensure the sessions produced by EKS and EC2 are the same.