### PR TITLE
Use HTTP 1.1 for proxing requests

### DIFF
--- a/charts/licensify/templates/nginx-configmap.yaml
+++ b/charts/licensify/templates/nginx-configmap.yaml
@@ -105,6 +105,8 @@ data:
         add_header X-Robots-Tag "noindex";
 
         location / {
+          proxy_http_version 1.1;
+
           proxy_set_header   Host $http_host;
           proxy_set_header   X-Real-IP $remote_addr;
           proxy_set_header GOVUK-Request-Id $govuk_request_id;


### PR DESCRIPTION
This is because licensify need to support chunked responses. https://medium.com/@yatskevich/chunked-responses-with-nginx-and-play-framework-3ffada39ea0c