### PR TITLE
Set up PodDisruptionBudgets for licensify-frontend.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -13,7 +13,7 @@ cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
 
 replicaCount: 3
 workerReplicaCount: 3
-podDisruptionBudget:
+podDisruptionBudget: &pdb
   maxUnavailable: 2
 
 _alb-ingress-defaults: &alb-ingress-defaults
@@ -1351,6 +1351,7 @@ govukApplications:
               - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
         licensifyFrontend:
           replicaCount: 3
+          podDisruptionBudget: *pdb
           ingress:
             annotations:
               <<: [*alb-ingress-group-backend, *alb-ingress-defaults]

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -13,7 +13,7 @@ cspReportURI: https://csp-reporter.staging.publishing.service.gov.uk/report
 
 replicaCount: 2
 workerReplicaCount: 2
-podDisruptionBudget:
+podDisruptionBudget: &pdb
   minAvailable: 1
 appResources:
   limits:
@@ -1348,6 +1348,7 @@ govukApplications:
             hosts:
               - name: licensify-admin.{{ .Values.k8sExternalDomainSuffix }}
         licensifyFrontend:
+          podDisruptionBudget: *pdb
           ingress:
             annotations:
               <<: [*alb-ingress-group-backend, *alb-ingress-defaults]

--- a/charts/licensify/templates/_helpers.tpl
+++ b/charts/licensify/templates/_helpers.tpl
@@ -1,8 +1,16 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "licensify.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
+{{- define "licensify.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -19,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "licensify.chart" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -27,13 +35,21 @@ Common labels
 */}}
 {{- define "licensify.labels" -}}
 helm.sh/chart: {{ include "licensify.chart" . }}
+{{ include "licensify.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: "licensify"
-app.kubernetes.io/name: {{ .Values.appName }}
-app.kubernetes.io/instance: {{ .Values.appName }}-{{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "licensify.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "licensify.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ .Values.appName }}
 {{- end }}
 
 {{/*
@@ -41,7 +57,7 @@ Create the name of the service account to use
 */}}
 {{- define "licensify.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "fullname" .) .Values.serviceAccount.name }}
+{{- default (include "licensify.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -5,21 +5,17 @@ kind: Deployment
 metadata:
   name: {{ $app.name }}
   labels:
-    {{- include "licensify.labels" . | nindent 4}}
-    app: {{ $app.name }}
-    app.kubernetes.io/component: app
+    {{- include "licensify.labels" . | nindent 4 }}
 spec:
   replicas: {{ $app.replicaCount }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: {{ $app.name }}
+      {{- include "licensify.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "licensify.labels" . | nindent 8}}
-        app: {{ $app.name }}
-        app.kubernetes.io/component: app
+        {{- include "licensify.labels" . | nindent 8 }}
     spec:
       securityContext:
         fsGroup: {{ .Values.securityContext.runAsGroup }}

--- a/charts/licensify/templates/clamav/service.yaml
+++ b/charts/licensify/templates/clamav/service.yaml
@@ -5,9 +5,7 @@ kind: Service
 metadata:
   name: {{ $app.name }}
   labels:
-    {{- include "licensify.labels" . | nindent 4}}
-    app: {{ $app.name }}
-    app.kubernetes.io/component: app
+    {{- include "licensify.labels" . | nindent 4 }}
 spec:
   type: {{ $app.service.type }}
   ports:
@@ -16,4 +14,4 @@ spec:
       targetPort: clamav
       protocol: TCP
   selector:
-    app: {{ $app.name }}
+    {{- include "licensify.selectorLabels" . | nindent 4 }}

--- a/charts/licensify/templates/config-externalsecret.yaml
+++ b/charts/licensify/templates/config-externalsecret.yaml
@@ -1,7 +1,9 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "fullname" . }}
+  name: {{ include "licensify.fullname" . }}
+  labels:
+    {{- include "licensify.labels" . | nindent 4 }}
 spec:
   refreshInterval: "1h"
   secretStoreRef:

--- a/charts/licensify/templates/config-template-configmap.yaml
+++ b/charts/licensify/templates/config-template-configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: licensify-config-template
+  labels:
+    {{- include "licensify.labels" . | nindent 4 }}
 data:
   config.properties: |
     # Virus scan config

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -9,21 +9,17 @@ kind: Deployment
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "licensify.labels" $ | nindent 4}}
-    app: {{ .name }}
-    app.kubernetes.io/component: app
+    {{- include "licensify.labels" $ | nindent 4 }}
 spec:
   replicas: {{ .replicaCount }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: {{ .name }}
+      {{- include "licensify.selectorLabels" $ | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "licensify.labels" $ | nindent 8}}
-        app: {{ .name }}
-        app.kubernetes.io/component: app
+        {{- include "licensify.labels" $ | nindent 8 }}
     spec:
       securityContext:
         fsGroup: {{ $.Values.securityContext.runAsGroup }}

--- a/charts/licensify/templates/envs-externalsecret.yaml
+++ b/charts/licensify/templates/envs-externalsecret.yaml
@@ -1,7 +1,9 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "fullname" . }}-envs
+  name: {{ include "licensify.fullname" . }}-envs
+  labels:
+    {{- include "licensify.labels" $ | nindent 4 }}
 spec:
   refreshInterval: "1h"
   secretStoreRef:

--- a/charts/licensify/templates/ingress.yaml
+++ b/charts/licensify/templates/ingress.yaml
@@ -8,9 +8,7 @@ kind: Ingress
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "licensify.labels" $ | nindent 4}}
-    app: {{ .name }}
-    app.kubernetes.io/component: app
+    {{- include "licensify.labels" $ | nindent 4 }}
   annotations:
     {{- (tpl (toYaml .ingress.annotations) $) | trim | nindent 4 }}
 spec:

--- a/charts/licensify/templates/logging-configmap.yaml
+++ b/charts/licensify/templates/logging-configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: licensify-logging-config
+  labels:
+    {{- include "licensify.labels" . | nindent 4 }}
 data:
   logging.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/charts/licensify/templates/nginx-configmap.yaml
+++ b/charts/licensify/templates/nginx-configmap.yaml
@@ -6,9 +6,7 @@ kind: ConfigMap
 metadata:
   name: {{ .name }}-nginx-conf
   labels:
-    {{- include "licensify.labels" $ | nindent 4}}
-    app: {{ .name }}
-    app.kubernetes.io/component: nginx
+    {{- include "licensify.labels" $ | nindent 4 }}
 data:
   nginx.conf: |-
     error_log  /dev/stderr warn;

--- a/charts/licensify/templates/pdb.yaml
+++ b/charts/licensify/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- range .Values.apps }}
+{{ $_ := set $.Values "appName" .name }}
+{{- if .podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "licensify.labels" $ | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "licensify.selectorLabels" $ | nindent 6 }}
+  {{- .podDisruptionBudget | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/licensify/templates/service.yaml
+++ b/charts/licensify/templates/service.yaml
@@ -6,9 +6,7 @@ kind: Service
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "licensify.labels" $ | nindent 4}}
-    app: {{ .name }}
-    app.kubernetes.io/component: app
+    {{- include "licensify.labels" $ | nindent 4 }}
 spec:
   type: NodePort
   ports:
@@ -16,5 +14,5 @@ spec:
       port: {{ .service.port }}
       targetPort: {{ $.Values.nginx.port }}
   selector:
-    app: {{ .name }}
+    {{- include "licensify.selectorLabels" $ | nindent 4 }}
 {{- end }}

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -36,6 +36,7 @@ apps:
     enabled: true
     useImage: licensify-backend
     replicaCount: 1
+    podDisruptionBudget: {}
     port: 9950
     healthcheckPath: "/"
     ingress:
@@ -52,6 +53,7 @@ apps:
     name: licensify-feed
     enabled: true
     replicaCount: 1
+    podDisruptionBudget: {}
     port: 9940
     healthcheckPath: "/licence-management/feed/process-applications"
     ingress:
@@ -63,6 +65,7 @@ apps:
     name: licensify-frontend
     enabled: true
     replicaCount: 2
+    podDisruptionBudget: {}
     port: 9903
     healthcheckPath: "/api/licences"
     ingress:


### PR DESCRIPTION
This helps prevent things like node upgrades from messing with our serving availability.

Fix up the label templates to make it easier to reason about labels vs. selector labels and minimise the chance of selector-related mistakes between pods and services, PDBs etc.