### PR TITLE
Reduce Licensify log verbosity + assorted trivial cleanups.

### DIFF
--- a/charts/licensify/templates/clamav/service.yaml
+++ b/charts/licensify/templates/clamav/service.yaml
@@ -12,6 +12,5 @@ spec:
     - name: app
       port: {{ $app.service.port }}
       targetPort: clamav
-      protocol: TCP
   selector:
     {{- include "licensify.selectorLabels" . | nindent 4 }}

--- a/charts/licensify/templates/config-externalsecret.yaml
+++ b/charts/licensify/templates/config-externalsecret.yaml
@@ -14,38 +14,38 @@ spec:
     template:
       engineVersion: v2
       templateFrom:
-      - target: Data
-        configMap:
-          name: licensify-config-template
-          items:
-          - key: config.properties
-            templateAs: Values
+        - target: Data
+          configMap:
+            name: licensify-config-template
+            items:
+              - key: config.properties
+                templateAs: Values
   data:
-  - secretKey: aws_access_key_id
-    remoteRef:
-      key: govuk/licensify
-      property: aws_access_key_id
-  - secretKey: aws_access_secret_key
-    remoteRef:
-      key: govuk/licensify
-      property: aws_access_secret_key
-  - secretKey: mongo_database_auth_password
-    remoteRef:
-      key: govuk/licensify
-      property: mongo_database_auth_password
-  - secretKey: client_id
-    remoteRef:
-      key: govuk/licensify
-      property: client_id
-  - secretKey: client_secret
-    remoteRef:
-      key: govuk/licensify
-      property: client_secret
-  - secretKey: performance_platform_bearer_token
-    remoteRef:
-      key: govuk/licensify
-      property: "performance_platform_bearer_token"
-  - secretKey: notify_key_api
-    remoteRef:
-      key: govuk/licensify
-      property: "notify_key_api"
+    - secretKey: aws_access_key_id
+      remoteRef:
+        key: govuk/licensify
+        property: aws_access_key_id
+    - secretKey: aws_access_secret_key
+      remoteRef:
+        key: govuk/licensify
+        property: aws_access_secret_key
+    - secretKey: mongo_database_auth_password
+      remoteRef:
+        key: govuk/licensify
+        property: mongo_database_auth_password
+    - secretKey: client_id
+      remoteRef:
+        key: govuk/licensify
+        property: client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: govuk/licensify
+        property: client_secret
+    - secretKey: performance_platform_bearer_token
+      remoteRef:
+        key: govuk/licensify
+        property: "performance_platform_bearer_token"
+    - secretKey: notify_key_api
+      remoteRef:
+        key: govuk/licensify
+        property: "notify_key_api"

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -1,8 +1,6 @@
 {{- range .Values.apps }}
 {{ $_ := set $.Values "appName" .name }}
 {{ $appImage := get $.Values.images (camelcase ( .useImage | default .name )) }}
-# TODO: Remove "if enabled" once live in production. This is to allow us to
-# disable feed in production before migration.
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/licensify/templates/logging-configmap.yaml
+++ b/charts/licensify/templates/logging-configmap.yaml
@@ -8,18 +8,14 @@ data:
   logging.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
     <configuration>
-
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
         </appender>
-
-        <logger name="application" level="INFO"/>
-        <logger name="akka" level="INFO"/>
-        <logger name="play" level="INFO"/>
-        <logger name="uk.gov" level="INFO"/>
-
-        <root level="INFO">
+        <logger name="application" level="WARN"/>
+        <logger name="akka" level="WARN"/>
+        <logger name="play" level="WARN"/>
+        <logger name="uk.gov" level="WARN"/>
+        <root level="WARN">
             <appender-ref ref="STDOUT"/>
         </root>
-
     </configuration>


### PR DESCRIPTION
The INFO logs are pretty noisy so this should be improve the signal-to-noise ratio.

Also fix some indentation (I think the linter might have given up the ghost at some point) and delete a stale TODO and a redundant default.