### PR TITLE
Rename `search-api-v2` quality monitoring task

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2233,8 +2233,8 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       cronTasks:
-        - name: quality-monitoring-result-invariants
-          task: "quality_monitoring:check_result_invariants"
+        - name: quality-monitoring-assert-invariants
+          task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *"  # 09:09am daily
           suspend: true  # Too noisy for integration to run on schedule, but can be run manually.
       extraEnv:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2298,8 +2298,8 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       cronTasks:
-        - name: quality-monitoring-result-invariants
-          task: "quality_monitoring:check_result_invariants"
+        - name: quality-monitoring-assert-invariants
+          task: "quality_monitoring:assert_invariants"
           schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm
       extraEnv:
         # Required for document sync worker to be able to export metrics

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2288,8 +2288,8 @@ govukApplications:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker
       cronTasks:
-        - name: quality-monitoring-result-invariants
-          task: "quality_monitoring:check_result_invariants"
+        - name: quality-monitoring-assert-invariants
+          task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *"  # 09:09am daily
           suspend: true  # Too noisy for staging to run on schedule, but can be run manually.
       extraEnv:


### PR DESCRIPTION
This has changed in the app and needs to be reflected in the cronTask.