### PR TITLE
Increase router nginx's client_max_body_size for licensify requests

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -134,6 +134,9 @@ http {
       proxy_set_header   X-Forwarded-Server $host;
       proxy_set_header   X-Forwarded-Host $proxy_add_x_forwarded_host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      # Allow large uploads to licensify-frontend
+      client_max_body_size 10M;
     }
 
     location /assets {


### PR DESCRIPTION
We allow files upto 10MB to be uploaded to licensify, however since moving to EKS  nginx at router has served 413 responses to users. The reason we're only seeing it since the migration, is that previously file upload request bypassed router completely. They were uploaded on a seperate `uploadlicence` domain that went directly to licensify frontend.

Tested in integration.