### PR TITLE
Remove place-api and performance platform config from Licensify

### DIFF
--- a/charts/licensify/templates/config-template-configmap.yaml
+++ b/charts/licensify/templates/config-template-configmap.yaml
@@ -91,13 +91,3 @@ data:
     uncollected.expiry.purge.days={{ .Values.config.uncollectedExpiry.purgeDays }}
     uncollected.expiry.start.days={{ .Values.config.uncollectedExpiry.startDays }}
     {{- end }}
-
-    # TODO: remove dummy config for disused Performance Platform once
-    # https://github.com/alphagov/licensify/pull/651 lands.
-    performance.platform.service.url=http://localhost/
-    performance.platform.bearer.token=disused
-    performance.data.sender.cron.expression="0 0 1 * * ?"
-
-    # TODO: remove dummy config for disused Places API client once
-    # https://github.com/alphagov/licensify/pull/652 lands.
-    places.api.url=http://localhost/


### PR DESCRIPTION
This is no longer used as per:
- https://github.com/alphagov/licensify/pull/652
- https://github.com/alphagov/licensify/pull/651