### PR TITLE
Add publishing api secret envvar to government-frontend

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1167,6 +1167,11 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-government-frontend-publishing-api
+              key: bearer_token
 
   - name: draft-government-frontend
     repoName: government-frontend
@@ -1180,6 +1185,11 @@ govukApplications:
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-government-frontend-publishing-api
+              key: bearer_token
 
   - name: govuk-jobs
     chartPath: charts/govuk-jobs

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1194,6 +1194,11 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-government-frontend-publishing-api
+              key: bearer_token
 
   - name: draft-government-frontend
     repoName: government-frontend
@@ -1207,6 +1212,11 @@ govukApplications:
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-government-frontend-publishing-api
+              key: bearer_token
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1199,6 +1199,11 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-government-frontend-publishing-api
+              key: bearer_token
 
   - name: draft-government-frontend
     repoName: government-frontend
@@ -1212,6 +1217,11 @@ govukApplications:
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-government-frontend-publishing-api
+              key: bearer_token
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter


### PR DESCRIPTION
## Make sure the secrets with the matching names exist and are configured in SIgnon before this PR is merged.

Use PUBLISHING_API_BEARER_TOKEN envvar to propagate signon-token-government-frontend-publishing-api secret to government-frontend app.

This is required by the `publishing_api:publish_static_pages` rake task in government-frontend.

[Trello ticket](https://trello.com/c/R9OkZLQw/2362-missing-description-for-1-horse-guards-road-history-page-on-search-results-m-l)