### PR TITLE
Add alerting for `search-api-v2` invariant tests

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -1,0 +1,13 @@
+groups:
+  - name: SearchApiV2
+    rules:
+      - alert: LowInvariantScore
+        expr: search_api_v2_quality_monitoring_score{dataset_type="invariants"} < 1
+        labels:
+          severity: warning
+          destination: slack-search-team
+        annotations:
+          summary: Low invariant recall score for '{{ $labels.dataset_name }}'
+          description: >-
+            Invariant dataset '{{ $labels.dataset_name }}' has dropped below 100% recall (i.e. the
+            expected results are not being returned for one or more queries in this dataset)

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -1,0 +1,36 @@
+rule_files:
+  - search_api_v2.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # Should alert (too low)
+      - series: >-
+          search_api_v2_quality_monitoring_score{dataset_name="dataset1", dataset_type="invariants"}
+        values: '0.9 0.99 1 0.95'
+      # Should not alert (perfect scores)
+      - series: >-
+          search_api_v2_quality_monitoring_score{dataset_name="dataset2", dataset_type="invariants"}
+        values: '1 1 1 1'
+      # Should not alert (wrong type)
+      - series: >-
+          search_api_v2_quality_monitoring_score{dataset_name="dataset3",
+          dataset_type="something_else"}
+        values: '0.1 0.2 0.3 0.4'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: LowInvariantScore
+        exp_alerts:
+          - exp_labels:
+              alertname: LowInvariantScore
+              dataset_name: "dataset1"
+              dataset_type: "invariants"
+              severity: "warning"
+              destination: "slack-search-team"
+            exp_annotations:
+              summary: "Low invariant recall score for 'dataset1'"
+              description: >-
+                Invariant dataset 'dataset1' has dropped below 100% recall (i.e. the expected
+                results are not being returned for one or more queries in this dataset)

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -41,6 +41,15 @@ spec:
       groupInterval: 12h
       activeTimeIntervals:
         - inhours
+    - matchers:
+      - name: destination
+        value: slack-search-team
+      receiver: 'slack-search-team'
+      repeatInterval: 3h
+      groupWait: 1m
+      groupInterval: 30m
+      activeTimeIntervals:
+        - inhours
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -95,6 +104,14 @@ spec:
       text: |-
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
       apiURL: *slack_api_url
+  - name: 'slack-search-team'
+    slackConfigs:
+    - channel: '#govuk-search-improvement-alerts'
+      sendResolved: true
+      iconURL: https://avatars3.githubusercontent.com/u/3380462
+      text: |-
+        {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
+      apiURL: *slack_api_url
   muteTimeIntervals:
   - name: inhours
     timeIntervals:
@@ -102,6 +119,6 @@ spec:
   - name: pagerduty_drill
     timeIntervals:
     - weekdays: ['wednesday']
-      times: 
+      times:
       - startTime: 10:00
         endTime: 10:03


### PR DESCRIPTION
These tests run against a number of datasets in `search-api-v2` to ensure that when searching for certain important queries, a set of expected results are returned, and publish a Prometheus gauge labelled by dataset name and type.

- Alert whenever the reported value of a dataset of type `invariant` drops below `1` (100%)
- Add routing destination for search team to general Alertmanager configuration