### PR TITLE
Dial down the log verbosity on cluster-autoscaler.

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -25,6 +25,7 @@ spec:
           balance-similar-node-groups: true
           scale-down-utilization-threshold: "0.55"
           skip-nodes-with-local-storage: false
+          v: "0"
         replicaCount: {{ .Values.replicaCount }}
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
It's pretty noisy right now on `--v=4`. [Docs recommend](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-increase-the-information-that-the-ca-is-logging) 0 or 1 to see normal activity, so let's go with that.