### PR TITLE
1597 - Update other CRD kubeconform schemas

### DIFF
--- a/schemas/appproject_v1alpha1.json
+++ b/schemas/appproject_v1alpha1.json
@@ -67,7 +67,7 @@
             "description": "ApplicationDestination holds information about the application's destination",
             "properties": {
               "name": {
-                "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+                "description": "Name is an alternate way of specifying the target cluster by its symbolic name. This must be set if Server is not set.",
                 "type": "string"
               },
               "namespace": {
@@ -75,7 +75,7 @@
                 "type": "string"
               },
               "server": {
-                "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+                "description": "Server specifies the URL of the target cluster's Kubernetes control plane API. This must be set if Name is not set.",
                 "type": "string"
               }
             },
@@ -157,6 +157,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "permitOnlyProjectScopedClusters": {
+          "description": "PermitOnlyProjectScopedClusters determines whether destinations can only reference clusters which are project-scoped",
+          "type": "boolean"
+        },
         "roles": {
           "description": "Roles are user defined RBAC roles associated with this project",
           "items": {
@@ -233,6 +237,13 @@
             ],
             "type": "object",
             "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "sourceNamespaces": {
+          "description": "SourceNamespaces defines the namespaces application resources are allowed to be created in",
+          "items": {
+            "type": "string"
           },
           "type": "array"
         },

--- a/schemas/clusterexternalsecret_v1beta1.json
+++ b/schemas/clusterexternalsecret_v1beta1.json
@@ -15,6 +15,25 @@
     "spec": {
       "description": "ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.",
       "properties": {
+        "externalSecretMetadata": {
+          "description": "The metadata of the external secrets to be created",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "externalSecretName": {
           "description": "The name of the external secrets to be created defaults to the name of the ClusterExternalSecret",
           "type": "string"
@@ -33,11 +52,21 @@
                       "conversionStrategy": {
                         "default": "Default",
                         "description": "Used to define a conversion Strategy",
+                        "enum": [
+                          "Default",
+                          "Unicode"
+                        ],
                         "type": "string"
                       },
                       "decodingStrategy": {
                         "default": "None",
                         "description": "Used to define a decoding Strategy",
+                        "enum": [
+                          "Auto",
+                          "Base64",
+                          "Base64URL",
+                          "None"
+                        ],
                         "type": "string"
                       },
                       "key": {
@@ -45,7 +74,12 @@
                         "type": "string"
                       },
                       "metadataPolicy": {
+                        "default": "None",
                         "description": "Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None",
+                        "enum": [
+                          "None",
+                          "Fetch"
+                        ],
                         "type": "string"
                       },
                       "property": {
@@ -72,7 +106,7 @@
                     "maxProperties": 1,
                     "properties": {
                       "generatorRef": {
-                        "description": "GeneratorRef points to a generator custom resource in",
+                        "description": "GeneratorRef points to a generator custom resource. \n Deprecated: The generatorRef is not implemented in .data[]. this will be removed with v1.",
                         "properties": {
                           "apiVersion": {
                             "default": "generators.external-secrets.io/v1alpha1",
@@ -137,11 +171,21 @@
                       "conversionStrategy": {
                         "default": "Default",
                         "description": "Used to define a conversion Strategy",
+                        "enum": [
+                          "Default",
+                          "Unicode"
+                        ],
                         "type": "string"
                       },
                       "decodingStrategy": {
                         "default": "None",
                         "description": "Used to define a decoding Strategy",
+                        "enum": [
+                          "Auto",
+                          "Base64",
+                          "Base64URL",
+                          "None"
+                        ],
                         "type": "string"
                       },
                       "key": {
@@ -149,7 +193,12 @@
                         "type": "string"
                       },
                       "metadataPolicy": {
+                        "default": "None",
                         "description": "Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None",
+                        "enum": [
+                          "None",
+                          "Fetch"
+                        ],
                         "type": "string"
                       },
                       "property": {
@@ -173,11 +222,21 @@
                       "conversionStrategy": {
                         "default": "Default",
                         "description": "Used to define a conversion Strategy",
+                        "enum": [
+                          "Default",
+                          "Unicode"
+                        ],
                         "type": "string"
                       },
                       "decodingStrategy": {
                         "default": "None",
                         "description": "Used to define a decoding Strategy",
+                        "enum": [
+                          "Auto",
+                          "Base64",
+                          "Base64URL",
+                          "None"
+                        ],
                         "type": "string"
                       },
                       "name": {
@@ -228,6 +287,20 @@
                           ],
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "transform": {
+                          "description": "Used to apply string transformation on the secrets. The resulting key will be the output of the template applied by the operation.",
+                          "properties": {
+                            "template": {
+                              "description": "Used to define the template to apply on the secret name. `.value ` will specify the secret name in the template.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "template"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "type": "object",
@@ -240,7 +313,7 @@
                     "maxProperties": 1,
                     "properties": {
                       "generatorRef": {
-                        "description": "GeneratorRef points to a generator custom resource in",
+                        "description": "GeneratorRef points to a generator custom resource.",
                         "properties": {
                           "apiVersion": {
                             "default": "generators.external-secrets.io/v1alpha1",
@@ -361,6 +434,19 @@
                     },
                     "engineVersion": {
                       "default": "v2",
+                      "description": "EngineVersion specifies the template engine version that should be used to compile/execute the template specified in .data and .templateFrom[].",
+                      "enum": [
+                        "v1",
+                        "v2"
+                      ],
+                      "type": "string"
+                    },
+                    "mergePolicy": {
+                      "default": "Replace",
+                      "enum": [
+                        "Replace",
+                        "Merge"
+                      ],
                       "type": "string"
                     },
                     "metadata": {
@@ -384,8 +470,6 @@
                     },
                     "templateFrom": {
                       "items": {
-                        "maxProperties": 1,
-                        "minProperties": 1,
                         "properties": {
                           "configMap": {
                             "properties": {
@@ -393,6 +477,14 @@
                                 "items": {
                                   "properties": {
                                     "key": {
+                                      "type": "string"
+                                    },
+                                    "templateAs": {
+                                      "default": "Values",
+                                      "enum": [
+                                        "Values",
+                                        "KeysAndValues"
+                                      ],
                                       "type": "string"
                                     }
                                   },
@@ -415,12 +507,23 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "literal": {
+                            "type": "string"
+                          },
                           "secret": {
                             "properties": {
                               "items": {
                                 "items": {
                                   "properties": {
                                     "key": {
+                                      "type": "string"
+                                    },
+                                    "templateAs": {
+                                      "default": "Values",
+                                      "enum": [
+                                        "Values",
+                                        "KeysAndValues"
+                                      ],
                                       "type": "string"
                                     }
                                   },
@@ -442,6 +545,15 @@
                             ],
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "target": {
+                            "default": "Data",
+                            "enum": [
+                              "Data",
+                              "Annotations",
+                              "Labels"
+                            ],
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -509,14 +621,20 @@
           "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
+        "namespaces": {
+          "description": "Choose namespaces by name. This field is ORed with anything that NamespaceSelector ends up choosing.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "refreshTime": {
-          "description": "The time in which the controller should reconcile it's objects and recheck namespaces for labels.",
+          "description": "The time in which the controller should reconcile its objects and recheck namespaces for labels.",
           "type": "string"
         }
       },
       "required": [
-        "externalSecretSpec",
-        "namespaceSelector"
+        "externalSecretSpec"
       ],
       "type": "object",
       "additionalProperties": false
@@ -545,6 +663,10 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "externalSecretName": {
+          "description": "ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret",
+          "type": "string"
         },
         "failedNamespaces": {
           "description": "Failed namespaces are the namespaces that failed to apply an ExternalSecret",

--- a/schemas/clustersecretstore_v1beta1.json
+++ b/schemas/clustersecretstore_v1beta1.json
@@ -15,8 +15,71 @@
     "spec": {
       "description": "SecretStoreSpec defines the desired state of SecretStore.",
       "properties": {
+        "conditions": {
+          "description": "Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore",
+          "items": {
+            "description": "ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.",
+            "properties": {
+              "namespaceSelector": {
+                "description": "Choose namespace using a labelSelector",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "namespaces": {
+                "description": "Choose namespaces by name",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "controller": {
-          "description": "Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property",
+          "description": "Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters ES based on this property",
           "type": "string"
         },
         "provider": {
@@ -34,8 +97,71 @@
                 "authSecretRef": {
                   "description": "Auth configures how the operator authenticates with Akeyless.",
                   "properties": {
+                    "kubernetesAuth": {
+                      "description": "Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.",
+                      "properties": {
+                        "accessID": {
+                          "description": "the Akeyless Kubernetes auth-method access-id",
+                          "type": "string"
+                        },
+                        "k8sConfName": {
+                          "description": "Kubernetes-auth configuration name in Akeyless-Gateway",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountRef": {
+                          "description": "Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.",
+                          "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "The name of the ServiceAccount resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "accessID",
+                        "k8sConfName"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "secretRef": {
-                      "description": "AkeylessAuthSecretRef AKEYLESS_ACCESS_TYPE_PARAM: AZURE_OBJ_ID OR GCP_AUDIENCE OR ACCESS_KEY OR KUB_CONFIG_NAME.",
+                      "description": "Reference to a Secret that contains the details to authenticate with Akeyless.",
                       "properties": {
                         "accessID": {
                           "description": "The SecretAccessID is used for authentication",
@@ -99,8 +225,41 @@
                       "additionalProperties": false
                     }
                   },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caBundle": {
+                  "description": "PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.",
+                  "format": "byte",
+                  "type": "string"
+                },
+                "caProvider": {
+                  "description": "The provider for the CA bundle to use to validate Akeyless Gateway certificate.",
+                  "properties": {
+                    "key": {
+                      "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the object located at the provider type.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    }
+                  },
                   "required": [
-                    "secretRef"
+                    "name",
+                    "type"
                   ],
                   "type": "object",
                   "additionalProperties": false
@@ -119,6 +278,31 @@
                 "auth": {
                   "description": "AlibabaAuth contains a secretRef for credentials.",
                   "properties": {
+                    "rrsa": {
+                      "description": "Authenticate against Alibaba using RRSA.",
+                      "properties": {
+                        "oidcProviderArn": {
+                          "type": "string"
+                        },
+                        "oidcTokenFilePath": {
+                          "type": "string"
+                        },
+                        "roleArn": {
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "oidcProviderArn",
+                        "oidcTokenFilePath",
+                        "roleArn",
+                        "sessionName"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "secretRef": {
                       "description": "AlibabaAuthSecretRef holds secret references for Alibaba credentials.",
                       "properties": {
@@ -169,14 +353,8 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "secretRef"
-                  ],
                   "type": "object",
                   "additionalProperties": false
-                },
-                "endpoint": {
-                  "type": "string"
                 },
                 "regionID": {
                   "description": "Alibaba Region to be used for the provider",
@@ -193,6 +371,13 @@
             "aws": {
               "description": "AWS configures this store to sync secrets using AWS Secret Manager provider",
               "properties": {
+                "additionalRoles": {
+                  "description": "AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "auth": {
                   "description": "Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
                   "properties": {
@@ -202,6 +387,13 @@
                         "serviceAccountRef": {
                           "description": "A reference to a ServiceAccount resource.",
                           "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "name": {
                               "description": "The name of the ServiceAccount resource being referred to.",
                               "type": "string"
@@ -261,6 +453,25 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "sessionTokenSecretRef": {
+                          "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "type": "object",
@@ -270,13 +481,33 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "externalID": {
+                  "description": "AWS External ID set on assumed IAM roles",
+                  "type": "string"
+                },
                 "region": {
                   "description": "AWS Region to be used for the provider",
                   "type": "string"
                 },
                 "role": {
-                  "description": "Role is a Role ARN which the SecretManager provider will assume",
+                  "description": "Role is a Role ARN which the provider will assume",
                   "type": "string"
+                },
+                "secretsManager": {
+                  "description": "SecretsManager defines how the provider behaves when interacting with AWS SecretsManager",
+                  "properties": {
+                    "forceDeleteWithoutRecovery": {
+                      "description": "Specifies whether to delete the secret without any recovery window. You can't use both this parameter and RecoveryWindowInDays in the same call. If you don't use either, then by default Secrets Manager uses a 30 day recovery window. see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery",
+                      "type": "boolean"
+                    },
+                    "recoveryWindowInDays": {
+                      "description": "The number of days from 7 to 30 that Secrets Manager waits before permanently deleting the secret. You can't use both this parameter and ForceDeleteWithoutRecovery in the same call. If you don't use either, then by default Secrets Manager uses a 30 day recovery window. see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "service": {
                   "description": "Service defines which service should be used to fetch the secrets",
@@ -285,6 +516,33 @@
                     "ParameterStore"
                   ],
                   "type": "string"
+                },
+                "sessionTags": {
+                  "description": "AWS STS assume role session tags",
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "transitiveTagKeys": {
+                  "description": "AWS STS assume role transitive session tags. Required when multiple rules are used with the provider",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "required": [
@@ -339,10 +597,6 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "clientId",
-                    "clientSecret"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -351,13 +605,50 @@
                   "description": "Auth type defines how to authenticate to the keyvault service. Valid values are: - \"ServicePrincipal\" (default): Using a service principal (tenantId, clientId, clientSecret) - \"ManagedIdentity\": Using Managed Identity assigned to the pod (see aad-pod-identity)",
                   "enum": [
                     "ServicePrincipal",
-                    "ManagedIdentity"
+                    "ManagedIdentity",
+                    "WorkloadIdentity"
+                  ],
+                  "type": "string"
+                },
+                "environmentType": {
+                  "default": "PublicCloud",
+                  "description": "EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud",
+                  "enum": [
+                    "PublicCloud",
+                    "USGovernmentCloud",
+                    "ChinaCloud",
+                    "GermanCloud"
                   ],
                   "type": "string"
                 },
                 "identityId": {
                   "description": "If multiple Managed Identity is assigned to the pod, you can select the one to be used",
                   "type": "string"
+                },
+                "serviceAccountRef": {
+                  "description": "ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "tenantId": {
                   "description": "TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.",
@@ -370,6 +661,336 @@
               },
               "required": [
                 "vaultUrl"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "conjur": {
+              "description": "Conjur configures this store to sync secrets using conjur provider",
+              "properties": {
+                "auth": {
+                  "properties": {
+                    "apikey": {
+                      "properties": {
+                        "account": {
+                          "type": "string"
+                        },
+                        "apiKeyRef": {
+                          "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "userRef": {
+                          "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "account",
+                        "apiKeyRef",
+                        "userRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jwt": {
+                      "properties": {
+                        "account": {
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Conjur using the JWT authentication method.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountRef": {
+                          "description": "Optional ServiceAccountRef specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.",
+                          "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "The name of the ServiceAccount resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceID": {
+                          "description": "The conjur authn jwt webservice id",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "account",
+                        "serviceID"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caBundle": {
+                  "type": "string"
+                },
+                "caProvider": {
+                  "description": "Used to provide custom certificate authority (CA) certificates for a secret store. The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.",
+                  "properties": {
+                    "key": {
+                      "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the object located at the provider type.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "auth",
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "delinea": {
+              "description": "Delinea DevOps Secrets Vault https://docs.delinea.com/online-help/products/devops-secrets-vault/current",
+              "properties": {
+                "clientId": {
+                  "description": "ClientID is the non-secret part of the credential.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clientSecret": {
+                  "description": "ClientSecret is the secret part of the credential.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenant": {
+                  "description": "Tenant is the chosen hostname / site name.",
+                  "type": "string"
+                },
+                "tld": {
+                  "description": "TLD is based on the server location that was chosen during provisioning. If unset, defaults to \"com\".",
+                  "type": "string"
+                },
+                "urlTemplate": {
+                  "description": "URLTemplate If unset, defaults to \"https://%s.secretsvaultcloud.%s/v1/%s%s\".",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "clientId",
+                "clientSecret",
+                "tenant"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "doppler": {
+              "description": "Doppler configures this store to sync secrets using the Doppler provider",
+              "properties": {
+                "auth": {
+                  "description": "Auth configures how the Operator authenticates with the Doppler API",
+                  "properties": {
+                    "secretRef": {
+                      "properties": {
+                        "dopplerToken": {
+                          "description": "The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "dopplerToken"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "config": {
+                  "description": "Doppler config (required if not using a Service Token)",
+                  "type": "string"
+                },
+                "format": {
+                  "description": "Format enables the downloading of secrets as a file (string)",
+                  "enum": [
+                    "json",
+                    "dotnet-json",
+                    "env",
+                    "yaml",
+                    "docker"
+                  ],
+                  "type": "string"
+                },
+                "nameTransformer": {
+                  "description": "Environment variable compatible name transforms that change secret names to a different format",
+                  "enum": [
+                    "upper-camel",
+                    "camel",
+                    "lower-snake",
+                    "tf-var",
+                    "dotnet-env",
+                    "lower-kebab"
+                  ],
+                  "type": "string"
+                },
+                "project": {
+                  "description": "Doppler project (required if not using a Service Token)",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "auth"
               ],
               "type": "object",
               "additionalProperties": false
@@ -390,6 +1011,7 @@
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "Deprecated: ValueMap is deprecated and is intended to be removed in the future, use the `value` field instead.",
                         "type": "object"
                       },
                       "version": {
@@ -456,6 +1078,13 @@
                         "serviceAccountRef": {
                           "description": "A reference to a ServiceAccount resource.",
                           "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "name": {
                               "description": "The name of the ServiceAccount resource being referred to.",
                               "type": "string"
@@ -493,7 +1122,7 @@
               "additionalProperties": false
             },
             "gitlab": {
-              "description": "GItlab configures this store to sync secrets using Gitlab Variables provider",
+              "description": "GitLab configures this store to sync secrets using GitLab Variables provider",
               "properties": {
                 "auth": {
                   "description": "Auth configures how secret-manager authenticates with a GitLab instance.",
@@ -530,6 +1159,21 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "environment": {
+                  "description": "Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)",
+                  "type": "string"
+                },
+                "groupIDs": {
+                  "description": "GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "inheritFromGroups": {
+                  "description": "InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.",
+                  "type": "boolean"
+                },
                 "projectID": {
                   "description": "ProjectID specifies a project where secrets are located.",
                   "type": "string"
@@ -550,7 +1194,30 @@
               "properties": {
                 "auth": {
                   "description": "Auth configures how secret-manager authenticates with the IBM secrets manager.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
+                    "containerAuth": {
+                      "description": "IBM Container-based auth with IAM Trusted Profile.",
+                      "properties": {
+                        "iamEndpoint": {
+                          "type": "string"
+                        },
+                        "profile": {
+                          "description": "the IBM Trusted Profile",
+                          "type": "string"
+                        },
+                        "tokenLocation": {
+                          "description": "Location the token is mounted on the pod",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "profile"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "secretRef": {
                       "properties": {
                         "secretApiKeySecretRef": {
@@ -577,9 +1244,6 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "secretRef"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -590,6 +1254,39 @@
               },
               "required": [
                 "auth"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "keepersecurity": {
+              "description": "KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider",
+              "properties": {
+                "authRef": {
+                  "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the Secret resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "folderID": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authRef",
+                "folderID"
               ],
               "type": "object",
               "additionalProperties": false
@@ -650,25 +1347,25 @@
                     "serviceAccount": {
                       "description": "points to a service account that should be used for authentication",
                       "properties": {
-                        "serviceAccount": {
-                          "description": "A reference to a ServiceAccount resource.",
-                          "properties": {
-                            "name": {
-                              "description": "The name of the ServiceAccount resource being referred to.",
-                              "type": "string"
-                            },
-                            "namespace": {
-                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
-                              "type": "string"
-                            }
+                        "audiences": {
+                          "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                          "items": {
+                            "type": "string"
                           },
-                          "required": [
-                            "name"
-                          ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "The name of the ServiceAccount resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -719,7 +1416,7 @@
                       "description": "see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider",
                       "properties": {
                         "key": {
-                          "description": "The key the value inside of the provider type to use, only used with \"Secret\" type",
+                          "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
                           "type": "string"
                         },
                         "name": {
@@ -727,7 +1424,7 @@
                           "type": "string"
                         },
                         "namespace": {
-                          "description": "The namespace the Provider type is in.",
+                          "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
                           "type": "string"
                         },
                         "type": {
@@ -758,6 +1455,68 @@
               },
               "required": [
                 "auth"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "onepassword": {
+              "description": "OnePassword configures this store to sync secrets using the 1Password Cloud provider",
+              "properties": {
+                "auth": {
+                  "description": "Auth defines the information necessary to authenticate against OnePassword Connect Server",
+                  "properties": {
+                    "secretRef": {
+                      "description": "OnePasswordAuthSecretRef holds secret references for 1Password credentials.",
+                      "properties": {
+                        "connectTokenSecretRef": {
+                          "description": "The ConnectToken is used for authentication to a 1Password Connect Server.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "connectTokenSecretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "connectHost": {
+                  "description": "ConnectHost defines the OnePassword Connect Server to connect to",
+                  "type": "string"
+                },
+                "vaults": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "description": "Vaults defines which OnePassword vaults to search in which order",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "auth",
+                "connectHost",
+                "vaults"
               ],
               "type": "object",
               "additionalProperties": false
@@ -834,9 +1593,52 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "compartment": {
+                  "description": "Compartment is the vault compartment OCID. Required for PushSecret",
+                  "type": "string"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the OCID of the encryption key within the vault. Required for PushSecret",
+                  "type": "string"
+                },
+                "principalType": {
+                  "description": "The type of principal to use for authentication. If left blank, the Auth struct will determine the principal type. This optional field must be specified if using workload identity.",
+                  "enum": [
+                    "",
+                    "UserPrincipal",
+                    "InstancePrincipal",
+                    "Workload"
+                  ],
+                  "type": "string"
+                },
                 "region": {
                   "description": "Region is the region where vault is located.",
                   "type": "string"
+                },
+                "serviceAccountRef": {
+                  "description": "ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "vault": {
                   "description": "Vault is the vault's OCID of the specific vault where secret is located.",
@@ -846,6 +1648,149 @@
               "required": [
                 "region",
                 "vault"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scaleway": {
+              "description": "Scaleway",
+              "properties": {
+                "accessKey": {
+                  "description": "AccessKey is the non-secret part of the api key.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "apiUrl": {
+                  "description": "APIURL is the url of the api to use. Defaults to https://api.scaleway.com",
+                  "type": "string"
+                },
+                "projectId": {
+                  "description": "ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone",
+                  "type": "string"
+                },
+                "secretKey": {
+                  "description": "SecretKey is the non-secret part of the api key.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "accessKey",
+                "projectId",
+                "region",
+                "secretKey"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "senhasegura": {
+              "description": "Senhasegura configures this store to sync secrets using senhasegura provider",
+              "properties": {
+                "auth": {
+                  "description": "Auth defines parameters to authenticate in senhasegura",
+                  "properties": {
+                    "clientId": {
+                      "type": "string"
+                    },
+                    "clientSecretSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "clientId",
+                    "clientSecretSecretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ignoreSslCertificate": {
+                  "default": false,
+                  "description": "IgnoreSslCertificate defines if SSL certificate must be ignored",
+                  "type": "boolean"
+                },
+                "module": {
+                  "description": "Module defines which senhasegura module should be used to get secrets",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "URL of senhasegura",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "auth",
+                "module",
+                "url"
               ],
               "type": "object",
               "additionalProperties": false
@@ -867,6 +1812,25 @@
                         "roleId": {
                           "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
                           "type": "string"
+                        },
+                        "roleRef": {
+                          "description": "Reference to a key in a Secret that contains the App Role ID used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role id.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "secretRef": {
                           "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
@@ -890,7 +1854,6 @@
                       },
                       "required": [
                         "path",
-                        "roleId",
                         "secretRef"
                       ],
                       "type": "object",
@@ -941,9 +1904,186 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "iam": {
+                      "description": "Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials AWS IAM authentication method",
+                      "properties": {
+                        "externalID": {
+                          "description": "AWS External ID set on assumed IAM roles",
+                          "type": "string"
+                        },
+                        "jwt": {
+                          "description": "Specify a service account with IRSA enabled",
+                          "properties": {
+                            "serviceAccountRef": {
+                              "description": "A reference to a ServiceAccount resource.",
+                              "properties": {
+                                "audiences": {
+                                  "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "The name of the ServiceAccount resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "description": "Path where the AWS auth method is enabled in Vault, e.g: \"aws\"",
+                          "type": "string"
+                        },
+                        "region": {
+                          "description": "AWS region",
+                          "type": "string"
+                        },
+                        "role": {
+                          "description": "This is the AWS role to be assumed before talking to vault",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Specify credentials in a Secret object",
+                          "properties": {
+                            "accessKeyIDSecretRef": {
+                              "description": "The AccessKeyID is used for authentication",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the Secret resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretAccessKeySecretRef": {
+                              "description": "The SecretAccessKey is used for authentication",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the Secret resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sessionTokenSecretRef": {
+                              "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the Secret resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "vaultAwsIamServerID": {
+                          "description": "X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws",
+                          "type": "string"
+                        },
+                        "vaultRole": {
+                          "description": "Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "vaultRole"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "jwt": {
                       "description": "Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method",
                       "properties": {
+                        "kubernetesServiceAccountToken": {
+                          "description": "Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.",
+                          "properties": {
+                            "audiences": {
+                              "description": "Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "expirationSeconds": {
+                              "description": "Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "serviceAccountRef": {
+                              "description": "Service account field containing the name of a kubernetes ServiceAccount.",
+                              "properties": {
+                                "audiences": {
+                                  "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "The name of the ServiceAccount resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "serviceAccountRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "path": {
                           "default": "jwt",
                           "description": "Path where the JWT authentication backend is mounted in Vault, e.g: \"jwt\"",
@@ -954,7 +2094,7 @@
                           "type": "string"
                         },
                         "secretRef": {
-                          "description": "SecretRef to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method",
+                          "description": "Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.",
                           "properties": {
                             "key": {
                               "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1013,6 +2153,13 @@
                         "serviceAccountRef": {
                           "description": "Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.",
                           "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "name": {
                               "description": "The name of the ServiceAccount resource being referred to.",
                               "type": "string"
@@ -1093,6 +2240,45 @@
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "userPass": {
+                      "description": "UserPass authenticates with Vault by passing username/password pair",
+                      "properties": {
+                        "path": {
+                          "default": "user",
+                          "description": "Path where the UserPassword authentication backend is mounted in Vault, e.g: \"user\"",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "SecretRef to a key in a Secret resource containing password for the user used to authenticate with Vault using the UserPass authentication method",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "username": {
+                          "description": "Username is a user name used to authenticate using the UserPass Vault authentication method",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "username"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -1107,7 +2293,7 @@
                   "description": "The provider for the CA bundle to use to validate Vault server certificate.",
                   "properties": {
                     "key": {
-                      "description": "The key the value inside of the provider type to use, only used with \"Secret\" type",
+                      "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
                       "type": "string"
                     },
                     "name": {
@@ -1115,7 +2301,7 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "The namespace the Provider type is in.",
+                      "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
                       "type": "string"
                     },
                     "type": {
@@ -1289,6 +2475,72 @@
               "type": "object",
               "additionalProperties": false
             },
+            "yandexcertificatemanager": {
+              "description": "YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider",
+              "properties": {
+                "apiEndpoint": {
+                  "description": "Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')",
+                  "type": "string"
+                },
+                "auth": {
+                  "description": "Auth defines the information necessary to authenticate against Yandex Certificate Manager",
+                  "properties": {
+                    "authorizedKeySecretRef": {
+                      "description": "The authorized key used for authentication",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caProvider": {
+                  "description": "The provider for the CA bundle to use to validate Yandex.Cloud server certificate.",
+                  "properties": {
+                    "certSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "auth"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "yandexlockbox": {
               "description": "YandexLockbox configures this store to sync secrets using Yandex Lockbox provider",
               "properties": {
@@ -1359,6 +2611,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "refreshInterval": {
+          "description": "Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.",
+          "type": "integer"
+        },
         "retrySettings": {
           "description": "Used to configure http retries if failed",
           "properties": {
@@ -1383,6 +2639,10 @@
     "status": {
       "description": "SecretStoreStatus defines the observed state of the SecretStore.",
       "properties": {
+        "capabilities": {
+          "description": "SecretStoreCapabilities defines the possible operations a SecretStore can do.",
+          "type": "string"
+        },
         "conditions": {
           "items": {
             "properties": {

--- a/schemas/clusterworkflowtemplate_v1alpha1.json
+++ b/schemas/clusterworkflowtemplate_v1alpha1.json
@@ -621,6 +621,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -669,6 +705,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -710,6 +790,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -749,6 +832,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -885,6 +971,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -1218,6 +1478,42 @@
           "type": "object",
           "additionalProperties": false
         },
+        "artifactGC": {
+          "properties": {
+            "podMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "strategy": {
+              "enum": [
+                "",
+                "OnWorkflowCompletion",
+                "OnWorkflowDeletion",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "configMap": {
@@ -1314,6 +1610,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -1362,6 +1694,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -1403,6 +1779,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -1442,6 +1821,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -1578,6 +1960,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -1933,9 +2489,6 @@
                 "additionalProperties": false
               }
             },
-            "required": [
-              "template"
-            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -3073,6 +3626,47 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blob": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blob",
+                    "container",
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "gcs": {
                   "properties": {
                     "bucket": {
@@ -3108,6 +3702,9 @@
                 },
                 "git": {
                   "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
                     "depth": {
                       "format": "int64",
                       "type": "integer"
@@ -3147,6 +3744,9 @@
                     },
                     "revision": {
                       "type": "string"
+                    },
+                    "singleBranch": {
+                      "type": "boolean"
                     },
                     "sshPrivateKeySecret": {
                       "properties": {
@@ -3280,6 +3880,180 @@
                 },
                 "http": {
                   "properties": {
+                    "auth": {
+                      "properties": {
+                        "basicAuth": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clientCert": {
+                          "properties": {
+                            "clientCertSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauth2": {
+                          "properties": {
+                            "clientIDSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientSecretSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpointParams": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tokenURLSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "headers": {
                       "items": {
                         "properties": {
@@ -5575,6 +6349,42 @@
                                 "archiveLogs": {
                                   "type": "boolean"
                                 },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "artifactory": {
                                   "properties": {
                                     "passwordSecret": {
@@ -5623,6 +6433,50 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
                                 "from": {
                                   "type": "string"
                                 },
@@ -5664,6 +6518,9 @@
                                 },
                                 "git": {
                                   "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
                                     "depth": {
                                       "format": "int64",
                                       "type": "integer"
@@ -5703,6 +6560,9 @@
                                     },
                                     "revision": {
                                       "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
                                     },
                                     "sshPrivateKeySecret": {
                                       "properties": {
@@ -5839,6 +6699,180 @@
                                 },
                                 "http": {
                                   "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "headers": {
                                       "items": {
                                         "properties": {
@@ -6226,6 +7260,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -6274,6 +7344,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -6315,6 +7429,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -6354,6 +7471,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -6490,6 +7610,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -6845,9 +8139,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "template"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -6979,6 +8270,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7027,6 +8354,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7068,6 +8439,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7107,6 +8481,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7243,6 +8620,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7550,6 +9101,16 @@
               "properties": {
                 "body": {
                   "type": "string"
+                },
+                "bodyFrom": {
+                  "properties": {
+                    "bytes": {
+                      "format": "byte",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "headers": {
                   "items": {
@@ -8628,6 +10189,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -8676,6 +10273,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -8717,6 +10358,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -8756,6 +10400,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -8892,6 +10539,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -9423,6 +11244,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -9471,6 +11328,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -9512,6 +11413,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -9551,6 +11455,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -9687,6 +11594,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -10059,6 +12140,812 @@
                 },
                 "manifest": {
                   "type": "string"
+                },
+                "manifestFrom": {
+                  "properties": {
+                    "artifact": {
+                      "properties": {
+                        "archive": {
+                          "properties": {
+                            "none": {
+                              "type": "object"
+                            },
+                            "tar": {
+                              "properties": {
+                                "compressionLevel": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "zip": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "archiveLogs": {
+                          "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "artifactory": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "fromExpression": {
+                          "type": "string"
+                        },
+                        "gcs": {
+                          "properties": {
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "serviceAccountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
+                            "depth": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "disableSubmodules": {
+                              "type": "boolean"
+                            },
+                            "fetch": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "insecureIgnoreHostKey": {
+                              "type": "boolean"
+                            },
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
+                            },
+                            "sshPrivateKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repo"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "globalName": {
+                          "type": "string"
+                        },
+                        "hdfs": {
+                          "properties": {
+                            "addresses": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "force": {
+                              "type": "boolean"
+                            },
+                            "hdfsUser": {
+                              "type": "string"
+                            },
+                            "krbCCacheSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbConfigConfigMap": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbKeytabSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbRealm": {
+                              "type": "string"
+                            },
+                            "krbServicePrincipalName": {
+                              "type": "string"
+                            },
+                            "krbUsername": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "http": {
+                          "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headers": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        },
+                        "oss": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "type": "boolean"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "lifecycleRule": {
+                              "properties": {
+                                "markDeletionAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "markInfrequentAccessAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "securityToken": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "raw": {
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurseMode": {
+                          "type": "boolean"
+                        },
+                        "s3": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "properties": {
+                                "objectLocking": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "encryptionOptions": {
+                              "properties": {
+                                "enableEncryption": {
+                                  "type": "boolean"
+                                },
+                                "kmsEncryptionContext": {
+                                  "type": "string"
+                                },
+                                "kmsKeyId": {
+                                  "type": "string"
+                                },
+                                "serverSideCustomerKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "insecure": {
+                              "type": "boolean"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "roleARN": {
+                              "type": "string"
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "subPath": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "artifact"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mergeStrategy": {
                   "type": "string"
@@ -14035,6 +16922,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -14070,6 +16998,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -14109,6 +17040,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -14242,6 +17176,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -16537,6 +19645,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -16585,6 +19729,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -16626,6 +19814,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -16665,6 +19856,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -16801,6 +19995,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -17188,6 +20556,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -17236,6 +20640,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -17277,6 +20725,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -17316,6 +20767,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -17452,6 +20906,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -17807,9 +21435,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17941,6 +21566,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -17989,6 +21650,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -18030,6 +21735,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -18069,6 +21777,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -18205,6 +21916,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -18512,6 +22397,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -19590,6 +23485,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -19638,6 +23569,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -19679,6 +23654,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -19718,6 +23696,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -19854,6 +23835,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -20385,6 +24540,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -20433,6 +24624,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -20474,6 +24709,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -20513,6 +24751,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -20649,6 +24890,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -21021,6 +25436,812 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"

--- a/schemas/cronworkflow_v1alpha1.json
+++ b/schemas/cronworkflow_v1alpha1.json
@@ -650,6 +650,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -698,6 +734,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -739,6 +819,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -778,6 +861,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -914,6 +1000,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -1247,6 +1507,42 @@
               "type": "object",
               "additionalProperties": false
             },
+            "artifactGC": {
+              "properties": {
+                "podMetadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "strategy": {
+                  "enum": [
+                    "",
+                    "OnWorkflowCompletion",
+                    "OnWorkflowDeletion",
+                    "Never"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "artifactRepositoryRef": {
               "properties": {
                 "configMap": {
@@ -1343,6 +1639,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -1391,6 +1723,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -1432,6 +1808,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -1471,6 +1850,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -1607,6 +1989,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -1962,9 +2518,6 @@
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "template"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -3102,6 +3655,47 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "azure": {
+                      "properties": {
+                        "accountKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "blob": {
+                          "type": "string"
+                        },
+                        "container": {
+                          "type": "string"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "blob",
+                        "container",
+                        "endpoint"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "gcs": {
                       "properties": {
                         "bucket": {
@@ -3137,6 +3731,9 @@
                     },
                     "git": {
                       "properties": {
+                        "branch": {
+                          "type": "string"
+                        },
                         "depth": {
                           "format": "int64",
                           "type": "integer"
@@ -3176,6 +3773,9 @@
                         },
                         "revision": {
                           "type": "string"
+                        },
+                        "singleBranch": {
+                          "type": "boolean"
                         },
                         "sshPrivateKeySecret": {
                           "properties": {
@@ -3309,6 +3909,180 @@
                     },
                     "http": {
                       "properties": {
+                        "auth": {
+                          "properties": {
+                            "basicAuth": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientCert": {
+                              "properties": {
+                                "clientCertSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "oauth2": {
+                              "properties": {
+                                "clientIDSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientSecretSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpointParams": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "scopes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tokenURLSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "headers": {
                           "items": {
                             "properties": {
@@ -5604,6 +6378,42 @@
                                     "archiveLogs": {
                                       "type": "boolean"
                                     },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "artifactory": {
                                       "properties": {
                                         "passwordSecret": {
@@ -5652,6 +6462,50 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
                                     "from": {
                                       "type": "string"
                                     },
@@ -5693,6 +6547,9 @@
                                     },
                                     "git": {
                                       "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
                                         "depth": {
                                           "format": "int64",
                                           "type": "integer"
@@ -5732,6 +6589,9 @@
                                         },
                                         "revision": {
                                           "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
                                         },
                                         "sshPrivateKeySecret": {
                                           "properties": {
@@ -5868,6 +6728,180 @@
                                     },
                                     "http": {
                                       "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "headers": {
                                           "items": {
                                             "properties": {
@@ -6255,6 +7289,42 @@
                                           "archiveLogs": {
                                             "type": "boolean"
                                           },
+                                          "artifactGC": {
+                                            "properties": {
+                                              "podMetadata": {
+                                                "properties": {
+                                                  "annotations": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "labels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "serviceAccountName": {
+                                                "type": "string"
+                                              },
+                                              "strategy": {
+                                                "enum": [
+                                                  "",
+                                                  "OnWorkflowCompletion",
+                                                  "OnWorkflowDeletion",
+                                                  "Never"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "artifactory": {
                                             "properties": {
                                               "passwordSecret": {
@@ -6303,6 +7373,50 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
+                                          "azure": {
+                                            "properties": {
+                                              "accountKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "blob": {
+                                                "type": "string"
+                                              },
+                                              "container": {
+                                                "type": "string"
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "blob",
+                                              "container",
+                                              "endpoint"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "deleted": {
+                                            "type": "boolean"
+                                          },
                                           "from": {
                                             "type": "string"
                                           },
@@ -6344,6 +7458,9 @@
                                           },
                                           "git": {
                                             "properties": {
+                                              "branch": {
+                                                "type": "string"
+                                              },
                                               "depth": {
                                                 "format": "int64",
                                                 "type": "integer"
@@ -6383,6 +7500,9 @@
                                               },
                                               "revision": {
                                                 "type": "string"
+                                              },
+                                              "singleBranch": {
+                                                "type": "boolean"
                                               },
                                               "sshPrivateKeySecret": {
                                                 "properties": {
@@ -6519,6 +7639,180 @@
                                           },
                                           "http": {
                                             "properties": {
+                                              "auth": {
+                                                "properties": {
+                                                  "basicAuth": {
+                                                    "properties": {
+                                                      "passwordSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "usernameSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientCert": {
+                                                    "properties": {
+                                                      "clientCertSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientKeySecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "oauth2": {
+                                                    "properties": {
+                                                      "clientIDSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientSecretSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "endpointParams": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "scopes": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "tokenURLSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "headers": {
                                                 "items": {
                                                   "properties": {
@@ -6874,9 +8168,6 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": [
-                                "template"
-                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -7008,6 +8299,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -7056,6 +8383,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -7097,6 +8468,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -7136,6 +8510,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -7272,6 +8649,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -7579,6 +9130,16 @@
                   "properties": {
                     "body": {
                       "type": "string"
+                    },
+                    "bodyFrom": {
+                      "properties": {
+                        "bytes": {
+                          "format": "byte",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "headers": {
                       "items": {
@@ -8657,6 +10218,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -8705,6 +10302,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -8746,6 +10387,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -8785,6 +10429,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -8921,6 +10568,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -9452,6 +11273,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -9500,6 +11357,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -9541,6 +11442,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -9580,6 +11484,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -9716,6 +11623,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -10088,6 +12169,812 @@
                     },
                     "manifest": {
                       "type": "string"
+                    },
+                    "manifestFrom": {
+                      "properties": {
+                        "artifact": {
+                          "properties": {
+                            "archive": {
+                              "properties": {
+                                "none": {
+                                  "type": "object"
+                                },
+                                "tar": {
+                                  "properties": {
+                                    "compressionLevel": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "zip": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "archiveLogs": {
+                              "type": "boolean"
+                            },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "artifactory": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
+                            "from": {
+                              "type": "string"
+                            },
+                            "fromExpression": {
+                              "type": "string"
+                            },
+                            "gcs": {
+                              "properties": {
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "serviceAccountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "git": {
+                              "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
+                                "depth": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "disableSubmodules": {
+                                  "type": "boolean"
+                                },
+                                "fetch": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "insecureIgnoreHostKey": {
+                                  "type": "boolean"
+                                },
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "revision": {
+                                  "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
+                                },
+                                "sshPrivateKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "globalName": {
+                              "type": "string"
+                            },
+                            "hdfs": {
+                              "properties": {
+                                "addresses": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "force": {
+                                  "type": "boolean"
+                                },
+                                "hdfsUser": {
+                                  "type": "string"
+                                },
+                                "krbCCacheSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbConfigConfigMap": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbKeytabSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbRealm": {
+                                  "type": "string"
+                                },
+                                "krbServicePrincipalName": {
+                                  "type": "string"
+                                },
+                                "krbUsername": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "http": {
+                              "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "url": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            },
+                            "oss": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "createBucketIfNotPresent": {
+                                  "type": "boolean"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "lifecycleRule": {
+                                  "properties": {
+                                    "markDeletionAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "markInfrequentAccessAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "securityToken": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "raw": {
+                              "properties": {
+                                "data": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "data"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "recurseMode": {
+                              "type": "boolean"
+                            },
+                            "s3": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "createBucketIfNotPresent": {
+                                  "properties": {
+                                    "objectLocking": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "encryptionOptions": {
+                                  "properties": {
+                                    "enableEncryption": {
+                                      "type": "boolean"
+                                    },
+                                    "kmsEncryptionContext": {
+                                      "type": "string"
+                                    },
+                                    "kmsKeyId": {
+                                      "type": "string"
+                                    },
+                                    "serverSideCustomerKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "roleARN": {
+                                  "type": "string"
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "subPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "artifact"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "mergeStrategy": {
                       "type": "string"
@@ -14064,6 +16951,47 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "gcs": {
                         "properties": {
                           "bucket": {
@@ -14099,6 +17027,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -14138,6 +17069,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -14271,6 +17205,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -16566,6 +19674,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -16614,6 +19758,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -16655,6 +19843,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -16694,6 +19885,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -16830,6 +20024,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -17217,6 +20585,42 @@
                                             "archiveLogs": {
                                               "type": "boolean"
                                             },
+                                            "artifactGC": {
+                                              "properties": {
+                                                "podMetadata": {
+                                                  "properties": {
+                                                    "annotations": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "labels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "serviceAccountName": {
+                                                  "type": "string"
+                                                },
+                                                "strategy": {
+                                                  "enum": [
+                                                    "",
+                                                    "OnWorkflowCompletion",
+                                                    "OnWorkflowDeletion",
+                                                    "Never"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "artifactory": {
                                               "properties": {
                                                 "passwordSecret": {
@@ -17265,6 +20669,50 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
+                                            "azure": {
+                                              "properties": {
+                                                "accountKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "blob": {
+                                                  "type": "string"
+                                                },
+                                                "container": {
+                                                  "type": "string"
+                                                },
+                                                "endpoint": {
+                                                  "type": "string"
+                                                },
+                                                "useSDKCreds": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "blob",
+                                                "container",
+                                                "endpoint"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "deleted": {
+                                              "type": "boolean"
+                                            },
                                             "from": {
                                               "type": "string"
                                             },
@@ -17306,6 +20754,9 @@
                                             },
                                             "git": {
                                               "properties": {
+                                                "branch": {
+                                                  "type": "string"
+                                                },
                                                 "depth": {
                                                   "format": "int64",
                                                   "type": "integer"
@@ -17345,6 +20796,9 @@
                                                 },
                                                 "revision": {
                                                   "type": "string"
+                                                },
+                                                "singleBranch": {
+                                                  "type": "boolean"
                                                 },
                                                 "sshPrivateKeySecret": {
                                                   "properties": {
@@ -17481,6 +20935,180 @@
                                             },
                                             "http": {
                                               "properties": {
+                                                "auth": {
+                                                  "properties": {
+                                                    "basicAuth": {
+                                                      "properties": {
+                                                        "passwordSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "usernameSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientCert": {
+                                                      "properties": {
+                                                        "clientCertSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientKeySecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "oauth2": {
+                                                      "properties": {
+                                                        "clientIDSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientSecretSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "endpointParams": {
+                                                          "items": {
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "scopes": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "tokenURLSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
                                                 "headers": {
                                                   "items": {
                                                     "properties": {
@@ -17836,9 +21464,6 @@
                                     "additionalProperties": false
                                   }
                                 },
-                                "required": [
-                                  "template"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -17970,6 +21595,42 @@
                               "archiveLogs": {
                                 "type": "boolean"
                               },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "artifactory": {
                                 "properties": {
                                   "passwordSecret": {
@@ -18018,6 +21679,50 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
                               "from": {
                                 "type": "string"
                               },
@@ -18059,6 +21764,9 @@
                               },
                               "git": {
                                 "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
                                   "depth": {
                                     "format": "int64",
                                     "type": "integer"
@@ -18098,6 +21806,9 @@
                                   },
                                   "revision": {
                                     "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
                                   },
                                   "sshPrivateKeySecret": {
                                     "properties": {
@@ -18234,6 +21945,180 @@
                               },
                               "http": {
                                 "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "headers": {
                                     "items": {
                                       "properties": {
@@ -18541,6 +22426,16 @@
                     "properties": {
                       "body": {
                         "type": "string"
+                      },
+                      "bodyFrom": {
+                        "properties": {
+                          "bytes": {
+                            "format": "byte",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -19619,6 +23514,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -19667,6 +23598,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -19708,6 +23683,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -19747,6 +23725,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -19883,6 +23864,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -20414,6 +24569,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -20462,6 +24653,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -20503,6 +24738,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -20542,6 +24780,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -20678,6 +24919,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -21050,6 +25465,812 @@
                       },
                       "manifest": {
                         "type": "string"
+                      },
+                      "manifestFrom": {
+                        "properties": {
+                          "artifact": {
+                            "properties": {
+                              "archive": {
+                                "properties": {
+                                  "none": {
+                                    "type": "object"
+                                  },
+                                  "tar": {
+                                    "properties": {
+                                      "compressionLevel": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "zip": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "archiveLogs": {
+                                "type": "boolean"
+                              },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "artifactory": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "fromExpression": {
+                                "type": "string"
+                              },
+                              "gcs": {
+                                "properties": {
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "git": {
+                                "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "depth": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "disableSubmodules": {
+                                    "type": "boolean"
+                                  },
+                                  "fetch": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "insecureIgnoreHostKey": {
+                                    "type": "boolean"
+                                  },
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "repo": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
+                                  },
+                                  "sshPrivateKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "repo"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "hdfs": {
+                                "properties": {
+                                  "addresses": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "hdfsUser": {
+                                    "type": "string"
+                                  },
+                                  "krbCCacheSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbConfigConfigMap": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbKeytabSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbRealm": {
+                                    "type": "string"
+                                  },
+                                  "krbServicePrincipalName": {
+                                    "type": "string"
+                                  },
+                                  "krbUsername": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "mode": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "oss": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "type": "boolean"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "lifecycleRule": {
+                                    "properties": {
+                                      "markDeletionAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "markInfrequentAccessAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "securityToken": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "raw": {
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "data"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurseMode": {
+                                "type": "boolean"
+                              },
+                              "s3": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "properties": {
+                                      "objectLocking": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "encryptionOptions": {
+                                    "properties": {
+                                      "enableEncryption": {
+                                        "type": "boolean"
+                                      },
+                                      "kmsEncryptionContext": {
+                                        "type": "string"
+                                      },
+                                      "kmsKeyId": {
+                                        "type": "string"
+                                      },
+                                      "serverSideCustomerKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "insecure": {
+                                    "type": "boolean"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "roleARN": {
+                                    "type": "string"
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "subPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "artifact"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "mergeStrategy": {
                         "type": "string"

--- a/schemas/secretstore_v1beta1.json
+++ b/schemas/secretstore_v1beta1.json
@@ -15,8 +15,71 @@
     "spec": {
       "description": "SecretStoreSpec defines the desired state of SecretStore.",
       "properties": {
+        "conditions": {
+          "description": "Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore",
+          "items": {
+            "description": "ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.",
+            "properties": {
+              "namespaceSelector": {
+                "description": "Choose namespace using a labelSelector",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "namespaces": {
+                "description": "Choose namespaces by name",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "controller": {
-          "description": "Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property",
+          "description": "Used to select the correct ESO controller (think: ingress.ingressClassName) The ESO controller is instantiated with a specific controller name and filters ES based on this property",
           "type": "string"
         },
         "provider": {
@@ -34,8 +97,71 @@
                 "authSecretRef": {
                   "description": "Auth configures how the operator authenticates with Akeyless.",
                   "properties": {
+                    "kubernetesAuth": {
+                      "description": "Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.",
+                      "properties": {
+                        "accessID": {
+                          "description": "the Akeyless Kubernetes auth-method access-id",
+                          "type": "string"
+                        },
+                        "k8sConfName": {
+                          "description": "Kubernetes-auth configuration name in Akeyless-Gateway",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountRef": {
+                          "description": "Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.",
+                          "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "The name of the ServiceAccount resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "accessID",
+                        "k8sConfName"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "secretRef": {
-                      "description": "AkeylessAuthSecretRef AKEYLESS_ACCESS_TYPE_PARAM: AZURE_OBJ_ID OR GCP_AUDIENCE OR ACCESS_KEY OR KUB_CONFIG_NAME.",
+                      "description": "Reference to a Secret that contains the details to authenticate with Akeyless.",
                       "properties": {
                         "accessID": {
                           "description": "The SecretAccessID is used for authentication",
@@ -99,8 +225,41 @@
                       "additionalProperties": false
                     }
                   },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caBundle": {
+                  "description": "PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates are used to validate the TLS connection.",
+                  "format": "byte",
+                  "type": "string"
+                },
+                "caProvider": {
+                  "description": "The provider for the CA bundle to use to validate Akeyless Gateway certificate.",
+                  "properties": {
+                    "key": {
+                      "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the object located at the provider type.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    }
+                  },
                   "required": [
-                    "secretRef"
+                    "name",
+                    "type"
                   ],
                   "type": "object",
                   "additionalProperties": false
@@ -119,6 +278,31 @@
                 "auth": {
                   "description": "AlibabaAuth contains a secretRef for credentials.",
                   "properties": {
+                    "rrsa": {
+                      "description": "Authenticate against Alibaba using RRSA.",
+                      "properties": {
+                        "oidcProviderArn": {
+                          "type": "string"
+                        },
+                        "oidcTokenFilePath": {
+                          "type": "string"
+                        },
+                        "roleArn": {
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "oidcProviderArn",
+                        "oidcTokenFilePath",
+                        "roleArn",
+                        "sessionName"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "secretRef": {
                       "description": "AlibabaAuthSecretRef holds secret references for Alibaba credentials.",
                       "properties": {
@@ -169,14 +353,8 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "secretRef"
-                  ],
                   "type": "object",
                   "additionalProperties": false
-                },
-                "endpoint": {
-                  "type": "string"
                 },
                 "regionID": {
                   "description": "Alibaba Region to be used for the provider",
@@ -193,6 +371,13 @@
             "aws": {
               "description": "AWS configures this store to sync secrets using AWS Secret Manager provider",
               "properties": {
+                "additionalRoles": {
+                  "description": "AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "auth": {
                   "description": "Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
                   "properties": {
@@ -202,6 +387,13 @@
                         "serviceAccountRef": {
                           "description": "A reference to a ServiceAccount resource.",
                           "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "name": {
                               "description": "The name of the ServiceAccount resource being referred to.",
                               "type": "string"
@@ -261,6 +453,25 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "sessionTokenSecretRef": {
+                          "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "type": "object",
@@ -270,13 +481,33 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "externalID": {
+                  "description": "AWS External ID set on assumed IAM roles",
+                  "type": "string"
+                },
                 "region": {
                   "description": "AWS Region to be used for the provider",
                   "type": "string"
                 },
                 "role": {
-                  "description": "Role is a Role ARN which the SecretManager provider will assume",
+                  "description": "Role is a Role ARN which the provider will assume",
                   "type": "string"
+                },
+                "secretsManager": {
+                  "description": "SecretsManager defines how the provider behaves when interacting with AWS SecretsManager",
+                  "properties": {
+                    "forceDeleteWithoutRecovery": {
+                      "description": "Specifies whether to delete the secret without any recovery window. You can't use both this parameter and RecoveryWindowInDays in the same call. If you don't use either, then by default Secrets Manager uses a 30 day recovery window. see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery",
+                      "type": "boolean"
+                    },
+                    "recoveryWindowInDays": {
+                      "description": "The number of days from 7 to 30 that Secrets Manager waits before permanently deleting the secret. You can't use both this parameter and ForceDeleteWithoutRecovery in the same call. If you don't use either, then by default Secrets Manager uses a 30 day recovery window. see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "service": {
                   "description": "Service defines which service should be used to fetch the secrets",
@@ -285,6 +516,33 @@
                     "ParameterStore"
                   ],
                   "type": "string"
+                },
+                "sessionTags": {
+                  "description": "AWS STS assume role session tags",
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "transitiveTagKeys": {
+                  "description": "AWS STS assume role transitive session tags. Required when multiple rules are used with the provider",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "required": [
@@ -339,10 +597,6 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "clientId",
-                    "clientSecret"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -351,13 +605,50 @@
                   "description": "Auth type defines how to authenticate to the keyvault service. Valid values are: - \"ServicePrincipal\" (default): Using a service principal (tenantId, clientId, clientSecret) - \"ManagedIdentity\": Using Managed Identity assigned to the pod (see aad-pod-identity)",
                   "enum": [
                     "ServicePrincipal",
-                    "ManagedIdentity"
+                    "ManagedIdentity",
+                    "WorkloadIdentity"
+                  ],
+                  "type": "string"
+                },
+                "environmentType": {
+                  "default": "PublicCloud",
+                  "description": "EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud",
+                  "enum": [
+                    "PublicCloud",
+                    "USGovernmentCloud",
+                    "ChinaCloud",
+                    "GermanCloud"
                   ],
                   "type": "string"
                 },
                 "identityId": {
                   "description": "If multiple Managed Identity is assigned to the pod, you can select the one to be used",
                   "type": "string"
+                },
+                "serviceAccountRef": {
+                  "description": "ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "tenantId": {
                   "description": "TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.",
@@ -370,6 +661,336 @@
               },
               "required": [
                 "vaultUrl"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "conjur": {
+              "description": "Conjur configures this store to sync secrets using conjur provider",
+              "properties": {
+                "auth": {
+                  "properties": {
+                    "apikey": {
+                      "properties": {
+                        "account": {
+                          "type": "string"
+                        },
+                        "apiKeyRef": {
+                          "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "userRef": {
+                          "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "account",
+                        "apiKeyRef",
+                        "userRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jwt": {
+                      "properties": {
+                        "account": {
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Conjur using the JWT authentication method.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountRef": {
+                          "description": "Optional ServiceAccountRef specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.",
+                          "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "The name of the ServiceAccount resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceID": {
+                          "description": "The conjur authn jwt webservice id",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "account",
+                        "serviceID"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caBundle": {
+                  "type": "string"
+                },
+                "caProvider": {
+                  "description": "Used to provide custom certificate authority (CA) certificates for a secret store. The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.",
+                  "properties": {
+                    "key": {
+                      "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the object located at the provider type.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "auth",
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "delinea": {
+              "description": "Delinea DevOps Secrets Vault https://docs.delinea.com/online-help/products/devops-secrets-vault/current",
+              "properties": {
+                "clientId": {
+                  "description": "ClientID is the non-secret part of the credential.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clientSecret": {
+                  "description": "ClientSecret is the secret part of the credential.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenant": {
+                  "description": "Tenant is the chosen hostname / site name.",
+                  "type": "string"
+                },
+                "tld": {
+                  "description": "TLD is based on the server location that was chosen during provisioning. If unset, defaults to \"com\".",
+                  "type": "string"
+                },
+                "urlTemplate": {
+                  "description": "URLTemplate If unset, defaults to \"https://%s.secretsvaultcloud.%s/v1/%s%s\".",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "clientId",
+                "clientSecret",
+                "tenant"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "doppler": {
+              "description": "Doppler configures this store to sync secrets using the Doppler provider",
+              "properties": {
+                "auth": {
+                  "description": "Auth configures how the Operator authenticates with the Doppler API",
+                  "properties": {
+                    "secretRef": {
+                      "properties": {
+                        "dopplerToken": {
+                          "description": "The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "dopplerToken"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "config": {
+                  "description": "Doppler config (required if not using a Service Token)",
+                  "type": "string"
+                },
+                "format": {
+                  "description": "Format enables the downloading of secrets as a file (string)",
+                  "enum": [
+                    "json",
+                    "dotnet-json",
+                    "env",
+                    "yaml",
+                    "docker"
+                  ],
+                  "type": "string"
+                },
+                "nameTransformer": {
+                  "description": "Environment variable compatible name transforms that change secret names to a different format",
+                  "enum": [
+                    "upper-camel",
+                    "camel",
+                    "lower-snake",
+                    "tf-var",
+                    "dotnet-env",
+                    "lower-kebab"
+                  ],
+                  "type": "string"
+                },
+                "project": {
+                  "description": "Doppler project (required if not using a Service Token)",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "auth"
               ],
               "type": "object",
               "additionalProperties": false
@@ -390,6 +1011,7 @@
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "Deprecated: ValueMap is deprecated and is intended to be removed in the future, use the `value` field instead.",
                         "type": "object"
                       },
                       "version": {
@@ -456,6 +1078,13 @@
                         "serviceAccountRef": {
                           "description": "A reference to a ServiceAccount resource.",
                           "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "name": {
                               "description": "The name of the ServiceAccount resource being referred to.",
                               "type": "string"
@@ -493,7 +1122,7 @@
               "additionalProperties": false
             },
             "gitlab": {
-              "description": "GItlab configures this store to sync secrets using Gitlab Variables provider",
+              "description": "GitLab configures this store to sync secrets using GitLab Variables provider",
               "properties": {
                 "auth": {
                   "description": "Auth configures how secret-manager authenticates with a GitLab instance.",
@@ -530,6 +1159,21 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "environment": {
+                  "description": "Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)",
+                  "type": "string"
+                },
+                "groupIDs": {
+                  "description": "GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "inheritFromGroups": {
+                  "description": "InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.",
+                  "type": "boolean"
+                },
                 "projectID": {
                   "description": "ProjectID specifies a project where secrets are located.",
                   "type": "string"
@@ -550,7 +1194,30 @@
               "properties": {
                 "auth": {
                   "description": "Auth configures how secret-manager authenticates with the IBM secrets manager.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
+                    "containerAuth": {
+                      "description": "IBM Container-based auth with IAM Trusted Profile.",
+                      "properties": {
+                        "iamEndpoint": {
+                          "type": "string"
+                        },
+                        "profile": {
+                          "description": "the IBM Trusted Profile",
+                          "type": "string"
+                        },
+                        "tokenLocation": {
+                          "description": "Location the token is mounted on the pod",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "profile"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "secretRef": {
                       "properties": {
                         "secretApiKeySecretRef": {
@@ -577,9 +1244,6 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "secretRef"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -590,6 +1254,39 @@
               },
               "required": [
                 "auth"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "keepersecurity": {
+              "description": "KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider",
+              "properties": {
+                "authRef": {
+                  "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the Secret resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "folderID": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authRef",
+                "folderID"
               ],
               "type": "object",
               "additionalProperties": false
@@ -650,25 +1347,25 @@
                     "serviceAccount": {
                       "description": "points to a service account that should be used for authentication",
                       "properties": {
-                        "serviceAccount": {
-                          "description": "A reference to a ServiceAccount resource.",
-                          "properties": {
-                            "name": {
-                              "description": "The name of the ServiceAccount resource being referred to.",
-                              "type": "string"
-                            },
-                            "namespace": {
-                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
-                              "type": "string"
-                            }
+                        "audiences": {
+                          "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                          "items": {
+                            "type": "string"
                           },
-                          "required": [
-                            "name"
-                          ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "The name of the ServiceAccount resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -719,7 +1416,7 @@
                       "description": "see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider",
                       "properties": {
                         "key": {
-                          "description": "The key the value inside of the provider type to use, only used with \"Secret\" type",
+                          "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
                           "type": "string"
                         },
                         "name": {
@@ -727,7 +1424,7 @@
                           "type": "string"
                         },
                         "namespace": {
-                          "description": "The namespace the Provider type is in.",
+                          "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
                           "type": "string"
                         },
                         "type": {
@@ -758,6 +1455,68 @@
               },
               "required": [
                 "auth"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "onepassword": {
+              "description": "OnePassword configures this store to sync secrets using the 1Password Cloud provider",
+              "properties": {
+                "auth": {
+                  "description": "Auth defines the information necessary to authenticate against OnePassword Connect Server",
+                  "properties": {
+                    "secretRef": {
+                      "description": "OnePasswordAuthSecretRef holds secret references for 1Password credentials.",
+                      "properties": {
+                        "connectTokenSecretRef": {
+                          "description": "The ConnectToken is used for authentication to a 1Password Connect Server.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "connectTokenSecretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "connectHost": {
+                  "description": "ConnectHost defines the OnePassword Connect Server to connect to",
+                  "type": "string"
+                },
+                "vaults": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "description": "Vaults defines which OnePassword vaults to search in which order",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "auth",
+                "connectHost",
+                "vaults"
               ],
               "type": "object",
               "additionalProperties": false
@@ -834,9 +1593,52 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "compartment": {
+                  "description": "Compartment is the vault compartment OCID. Required for PushSecret",
+                  "type": "string"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the OCID of the encryption key within the vault. Required for PushSecret",
+                  "type": "string"
+                },
+                "principalType": {
+                  "description": "The type of principal to use for authentication. If left blank, the Auth struct will determine the principal type. This optional field must be specified if using workload identity.",
+                  "enum": [
+                    "",
+                    "UserPrincipal",
+                    "InstancePrincipal",
+                    "Workload"
+                  ],
+                  "type": "string"
+                },
                 "region": {
                   "description": "Region is the region where vault is located.",
                   "type": "string"
+                },
+                "serviceAccountRef": {
+                  "description": "ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "vault": {
                   "description": "Vault is the vault's OCID of the specific vault where secret is located.",
@@ -846,6 +1648,149 @@
               "required": [
                 "region",
                 "vault"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scaleway": {
+              "description": "Scaleway",
+              "properties": {
+                "accessKey": {
+                  "description": "AccessKey is the non-secret part of the api key.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "apiUrl": {
+                  "description": "APIURL is the url of the api to use. Defaults to https://api.scaleway.com",
+                  "type": "string"
+                },
+                "projectId": {
+                  "description": "ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone",
+                  "type": "string"
+                },
+                "secretKey": {
+                  "description": "SecretKey is the non-secret part of the api key.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "SecretRef references a key in a secret that will be used as value.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "value": {
+                      "description": "Value can be specified directly to set a value without using a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "accessKey",
+                "projectId",
+                "region",
+                "secretKey"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "senhasegura": {
+              "description": "Senhasegura configures this store to sync secrets using senhasegura provider",
+              "properties": {
+                "auth": {
+                  "description": "Auth defines parameters to authenticate in senhasegura",
+                  "properties": {
+                    "clientId": {
+                      "type": "string"
+                    },
+                    "clientSecretSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "clientId",
+                    "clientSecretSecretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ignoreSslCertificate": {
+                  "default": false,
+                  "description": "IgnoreSslCertificate defines if SSL certificate must be ignored",
+                  "type": "boolean"
+                },
+                "module": {
+                  "description": "Module defines which senhasegura module should be used to get secrets",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "URL of senhasegura",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "auth",
+                "module",
+                "url"
               ],
               "type": "object",
               "additionalProperties": false
@@ -867,6 +1812,25 @@
                         "roleId": {
                           "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
                           "type": "string"
+                        },
+                        "roleRef": {
+                          "description": "Reference to a key in a Secret that contains the App Role ID used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role id.",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "secretRef": {
                           "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
@@ -890,7 +1854,6 @@
                       },
                       "required": [
                         "path",
-                        "roleId",
                         "secretRef"
                       ],
                       "type": "object",
@@ -941,9 +1904,186 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "iam": {
+                      "description": "Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials AWS IAM authentication method",
+                      "properties": {
+                        "externalID": {
+                          "description": "AWS External ID set on assumed IAM roles",
+                          "type": "string"
+                        },
+                        "jwt": {
+                          "description": "Specify a service account with IRSA enabled",
+                          "properties": {
+                            "serviceAccountRef": {
+                              "description": "A reference to a ServiceAccount resource.",
+                              "properties": {
+                                "audiences": {
+                                  "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "The name of the ServiceAccount resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "description": "Path where the AWS auth method is enabled in Vault, e.g: \"aws\"",
+                          "type": "string"
+                        },
+                        "region": {
+                          "description": "AWS region",
+                          "type": "string"
+                        },
+                        "role": {
+                          "description": "This is the AWS role to be assumed before talking to vault",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Specify credentials in a Secret object",
+                          "properties": {
+                            "accessKeyIDSecretRef": {
+                              "description": "The AccessKeyID is used for authentication",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the Secret resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretAccessKeySecretRef": {
+                              "description": "The SecretAccessKey is used for authentication",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the Secret resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sessionTokenSecretRef": {
+                              "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the Secret resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "vaultAwsIamServerID": {
+                          "description": "X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws",
+                          "type": "string"
+                        },
+                        "vaultRole": {
+                          "description": "Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "vaultRole"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "jwt": {
                       "description": "Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method",
                       "properties": {
+                        "kubernetesServiceAccountToken": {
+                          "description": "Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.",
+                          "properties": {
+                            "audiences": {
+                              "description": "Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "expirationSeconds": {
+                              "description": "Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "serviceAccountRef": {
+                              "description": "Service account field containing the name of a kubernetes ServiceAccount.",
+                              "properties": {
+                                "audiences": {
+                                  "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "The name of the ServiceAccount resource being referred to.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "serviceAccountRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "path": {
                           "default": "jwt",
                           "description": "Path where the JWT authentication backend is mounted in Vault, e.g: \"jwt\"",
@@ -954,7 +2094,7 @@
                           "type": "string"
                         },
                         "secretRef": {
-                          "description": "SecretRef to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method",
+                          "description": "Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.",
                           "properties": {
                             "key": {
                               "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1013,6 +2153,13 @@
                         "serviceAccountRef": {
                           "description": "Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.",
                           "properties": {
+                            "audiences": {
+                              "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "name": {
                               "description": "The name of the ServiceAccount resource being referred to.",
                               "type": "string"
@@ -1093,6 +2240,45 @@
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "userPass": {
+                      "description": "UserPass authenticates with Vault by passing username/password pair",
+                      "properties": {
+                        "path": {
+                          "default": "user",
+                          "description": "Path where the UserPassword authentication backend is mounted in Vault, e.g: \"user\"",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "SecretRef to a key in a Secret resource containing password for the user used to authenticate with Vault using the UserPass authentication method",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "username": {
+                          "description": "Username is a user name used to authenticate using the UserPass Vault authentication method",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "username"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -1107,7 +2293,7 @@
                   "description": "The provider for the CA bundle to use to validate Vault server certificate.",
                   "properties": {
                     "key": {
-                      "description": "The key the value inside of the provider type to use, only used with \"Secret\" type",
+                      "description": "The key where the CA certificate can be found in the Secret or ConfigMap.",
                       "type": "string"
                     },
                     "name": {
@@ -1115,7 +2301,7 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "The namespace the Provider type is in.",
+                      "description": "The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.",
                       "type": "string"
                     },
                     "type": {
@@ -1289,6 +2475,72 @@
               "type": "object",
               "additionalProperties": false
             },
+            "yandexcertificatemanager": {
+              "description": "YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider",
+              "properties": {
+                "apiEndpoint": {
+                  "description": "Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')",
+                  "type": "string"
+                },
+                "auth": {
+                  "description": "Auth defines the information necessary to authenticate against Yandex Certificate Manager",
+                  "properties": {
+                    "authorizedKeySecretRef": {
+                      "description": "The authorized key used for authentication",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caProvider": {
+                  "description": "The provider for the CA bundle to use to validate Yandex.Cloud server certificate.",
+                  "properties": {
+                    "certSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "auth"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "yandexlockbox": {
               "description": "YandexLockbox configures this store to sync secrets using Yandex Lockbox provider",
               "properties": {
@@ -1359,6 +2611,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "refreshInterval": {
+          "description": "Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.",
+          "type": "integer"
+        },
         "retrySettings": {
           "description": "Used to configure http retries if failed",
           "properties": {
@@ -1383,6 +2639,10 @@
     "status": {
       "description": "SecretStoreStatus defines the observed state of the SecretStore.",
       "properties": {
+        "capabilities": {
+          "description": "SecretStoreCapabilities defines the possible operations a SecretStore can do.",
+          "type": "string"
+        },
         "conditions": {
           "items": {
             "properties": {

--- a/schemas/workflow_v1alpha1.json
+++ b/schemas/workflow_v1alpha1.json
@@ -621,6 +621,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -669,6 +705,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -710,6 +790,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -749,6 +832,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -885,6 +971,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -1218,6 +1478,42 @@
           "type": "object",
           "additionalProperties": false
         },
+        "artifactGC": {
+          "properties": {
+            "podMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "strategy": {
+              "enum": [
+                "",
+                "OnWorkflowCompletion",
+                "OnWorkflowDeletion",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "configMap": {
@@ -1314,6 +1610,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -1362,6 +1694,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -1403,6 +1779,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -1442,6 +1821,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -1578,6 +1960,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -1933,9 +2489,6 @@
                 "additionalProperties": false
               }
             },
-            "required": [
-              "template"
-            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -3073,6 +3626,47 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blob": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blob",
+                    "container",
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "gcs": {
                   "properties": {
                     "bucket": {
@@ -3108,6 +3702,9 @@
                 },
                 "git": {
                   "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
                     "depth": {
                       "format": "int64",
                       "type": "integer"
@@ -3147,6 +3744,9 @@
                     },
                     "revision": {
                       "type": "string"
+                    },
+                    "singleBranch": {
+                      "type": "boolean"
                     },
                     "sshPrivateKeySecret": {
                       "properties": {
@@ -3280,6 +3880,180 @@
                 },
                 "http": {
                   "properties": {
+                    "auth": {
+                      "properties": {
+                        "basicAuth": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clientCert": {
+                          "properties": {
+                            "clientCertSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauth2": {
+                          "properties": {
+                            "clientIDSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientSecretSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpointParams": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tokenURLSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "headers": {
                       "items": {
                         "properties": {
@@ -5575,6 +6349,42 @@
                                 "archiveLogs": {
                                   "type": "boolean"
                                 },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "artifactory": {
                                   "properties": {
                                     "passwordSecret": {
@@ -5623,6 +6433,50 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
                                 "from": {
                                   "type": "string"
                                 },
@@ -5664,6 +6518,9 @@
                                 },
                                 "git": {
                                   "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
                                     "depth": {
                                       "format": "int64",
                                       "type": "integer"
@@ -5703,6 +6560,9 @@
                                     },
                                     "revision": {
                                       "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
                                     },
                                     "sshPrivateKeySecret": {
                                       "properties": {
@@ -5839,6 +6699,180 @@
                                 },
                                 "http": {
                                   "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "headers": {
                                       "items": {
                                         "properties": {
@@ -6226,6 +7260,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -6274,6 +7344,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -6315,6 +7429,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -6354,6 +7471,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -6490,6 +7610,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -6845,9 +8139,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "template"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -6979,6 +8270,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7027,6 +8354,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7068,6 +8439,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7107,6 +8481,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7243,6 +8620,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7550,6 +9101,16 @@
               "properties": {
                 "body": {
                   "type": "string"
+                },
+                "bodyFrom": {
+                  "properties": {
+                    "bytes": {
+                      "format": "byte",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "headers": {
                   "items": {
@@ -8628,6 +10189,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -8676,6 +10273,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -8717,6 +10358,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -8756,6 +10400,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -8892,6 +10539,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -9423,6 +11244,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -9471,6 +11328,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -9512,6 +11413,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -9551,6 +11455,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -9687,6 +11594,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -10059,6 +12140,812 @@
                 },
                 "manifest": {
                   "type": "string"
+                },
+                "manifestFrom": {
+                  "properties": {
+                    "artifact": {
+                      "properties": {
+                        "archive": {
+                          "properties": {
+                            "none": {
+                              "type": "object"
+                            },
+                            "tar": {
+                              "properties": {
+                                "compressionLevel": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "zip": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "archiveLogs": {
+                          "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "artifactory": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "fromExpression": {
+                          "type": "string"
+                        },
+                        "gcs": {
+                          "properties": {
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "serviceAccountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
+                            "depth": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "disableSubmodules": {
+                              "type": "boolean"
+                            },
+                            "fetch": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "insecureIgnoreHostKey": {
+                              "type": "boolean"
+                            },
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
+                            },
+                            "sshPrivateKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repo"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "globalName": {
+                          "type": "string"
+                        },
+                        "hdfs": {
+                          "properties": {
+                            "addresses": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "force": {
+                              "type": "boolean"
+                            },
+                            "hdfsUser": {
+                              "type": "string"
+                            },
+                            "krbCCacheSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbConfigConfigMap": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbKeytabSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbRealm": {
+                              "type": "string"
+                            },
+                            "krbServicePrincipalName": {
+                              "type": "string"
+                            },
+                            "krbUsername": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "http": {
+                          "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headers": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        },
+                        "oss": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "type": "boolean"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "lifecycleRule": {
+                              "properties": {
+                                "markDeletionAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "markInfrequentAccessAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "securityToken": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "raw": {
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurseMode": {
+                          "type": "boolean"
+                        },
+                        "s3": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "properties": {
+                                "objectLocking": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "encryptionOptions": {
+                              "properties": {
+                                "enableEncryption": {
+                                  "type": "boolean"
+                                },
+                                "kmsEncryptionContext": {
+                                  "type": "string"
+                                },
+                                "kmsKeyId": {
+                                  "type": "string"
+                                },
+                                "serverSideCustomerKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "insecure": {
+                              "type": "boolean"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "roleARN": {
+                              "type": "string"
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "subPath": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "artifact"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mergeStrategy": {
                   "type": "string"
@@ -14035,6 +16922,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -14070,6 +16998,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -14109,6 +17040,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -14242,6 +17176,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -16537,6 +19645,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -16585,6 +19729,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -16626,6 +19814,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -16665,6 +19856,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -16801,6 +19995,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -17188,6 +20556,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -17236,6 +20640,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -17277,6 +20725,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -17316,6 +20767,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -17452,6 +20906,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -17807,9 +21435,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17941,6 +21566,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -17989,6 +21650,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -18030,6 +21735,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -18069,6 +21777,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -18205,6 +21916,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -18512,6 +22397,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -19590,6 +23485,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -19638,6 +23569,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -19679,6 +23654,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -19718,6 +23696,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -19854,6 +23835,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -20385,6 +24540,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -20433,6 +24624,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -20474,6 +24709,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -20513,6 +24751,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -20649,6 +24890,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -21021,6 +25436,812 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -25802,6 +31023,27 @@
     },
     "status": {
       "properties": {
+        "artifactGCStatus": {
+          "properties": {
+            "notSpecified": {
+              "type": "boolean"
+            },
+            "podsRecouped": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            },
+            "strategiesProcessed": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "artifactRepository": {
@@ -25851,6 +31093,46 @@
                       "additionalProperties": false
                     }
                   },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blobNameFormat": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "container",
+                    "endpoint"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -26259,6 +31541,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -26307,6 +31625,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -26348,6 +31710,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -26387,6 +31752,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -26523,6 +31891,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -26918,6 +32460,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -26966,6 +32544,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -27007,6 +32629,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -27046,6 +32671,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -27182,6 +32810,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -27618,6 +33420,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -27666,6 +33504,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -27707,6 +33589,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -27746,6 +33631,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -27882,6 +33770,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -29987,6 +36049,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -30022,6 +36125,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -30061,6 +36167,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -30194,6 +36303,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -32489,6 +38772,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -32537,6 +38856,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -32578,6 +38941,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -32617,6 +38983,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -32753,6 +39122,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -33140,6 +39683,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -33188,6 +39767,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -33229,6 +39852,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -33268,6 +39894,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -33404,6 +40033,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -33759,9 +40562,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -33893,6 +40693,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -33941,6 +40777,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -33982,6 +40862,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -34021,6 +40904,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -34157,6 +41043,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -34464,6 +41524,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -35542,6 +42612,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -35590,6 +42696,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -35631,6 +42781,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -35670,6 +42823,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -35806,6 +42962,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -36337,6 +43667,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -36385,6 +43751,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -36426,6 +43836,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -36465,6 +43878,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -36601,6 +44017,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -36973,6 +44563,812 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -40923,6 +49319,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -40971,6 +49403,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -41012,6 +49488,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -41051,6 +49530,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -41187,6 +49669,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -41520,6 +50176,42 @@
               "type": "object",
               "additionalProperties": false
             },
+            "artifactGC": {
+              "properties": {
+                "podMetadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "strategy": {
+                  "enum": [
+                    "",
+                    "OnWorkflowCompletion",
+                    "OnWorkflowDeletion",
+                    "Never"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "artifactRepositoryRef": {
               "properties": {
                 "configMap": {
@@ -41616,6 +50308,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -41664,6 +50392,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -41705,6 +50477,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -41744,6 +50519,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -41880,6 +50658,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -42235,9 +51187,6 @@
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "template"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -43375,6 +52324,47 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "azure": {
+                      "properties": {
+                        "accountKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "blob": {
+                          "type": "string"
+                        },
+                        "container": {
+                          "type": "string"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "blob",
+                        "container",
+                        "endpoint"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "gcs": {
                       "properties": {
                         "bucket": {
@@ -43410,6 +52400,9 @@
                     },
                     "git": {
                       "properties": {
+                        "branch": {
+                          "type": "string"
+                        },
                         "depth": {
                           "format": "int64",
                           "type": "integer"
@@ -43449,6 +52442,9 @@
                         },
                         "revision": {
                           "type": "string"
+                        },
+                        "singleBranch": {
+                          "type": "boolean"
                         },
                         "sshPrivateKeySecret": {
                           "properties": {
@@ -43582,6 +52578,180 @@
                     },
                     "http": {
                       "properties": {
+                        "auth": {
+                          "properties": {
+                            "basicAuth": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientCert": {
+                              "properties": {
+                                "clientCertSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "oauth2": {
+                              "properties": {
+                                "clientIDSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientSecretSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpointParams": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "scopes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tokenURLSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "headers": {
                           "items": {
                             "properties": {
@@ -45877,6 +55047,42 @@
                                     "archiveLogs": {
                                       "type": "boolean"
                                     },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "artifactory": {
                                       "properties": {
                                         "passwordSecret": {
@@ -45925,6 +55131,50 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
                                     "from": {
                                       "type": "string"
                                     },
@@ -45966,6 +55216,9 @@
                                     },
                                     "git": {
                                       "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
                                         "depth": {
                                           "format": "int64",
                                           "type": "integer"
@@ -46005,6 +55258,9 @@
                                         },
                                         "revision": {
                                           "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
                                         },
                                         "sshPrivateKeySecret": {
                                           "properties": {
@@ -46141,6 +55397,180 @@
                                     },
                                     "http": {
                                       "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "headers": {
                                           "items": {
                                             "properties": {
@@ -46528,6 +55958,42 @@
                                           "archiveLogs": {
                                             "type": "boolean"
                                           },
+                                          "artifactGC": {
+                                            "properties": {
+                                              "podMetadata": {
+                                                "properties": {
+                                                  "annotations": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "labels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "serviceAccountName": {
+                                                "type": "string"
+                                              },
+                                              "strategy": {
+                                                "enum": [
+                                                  "",
+                                                  "OnWorkflowCompletion",
+                                                  "OnWorkflowDeletion",
+                                                  "Never"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "artifactory": {
                                             "properties": {
                                               "passwordSecret": {
@@ -46576,6 +56042,50 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
+                                          "azure": {
+                                            "properties": {
+                                              "accountKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "blob": {
+                                                "type": "string"
+                                              },
+                                              "container": {
+                                                "type": "string"
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "blob",
+                                              "container",
+                                              "endpoint"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "deleted": {
+                                            "type": "boolean"
+                                          },
                                           "from": {
                                             "type": "string"
                                           },
@@ -46617,6 +56127,9 @@
                                           },
                                           "git": {
                                             "properties": {
+                                              "branch": {
+                                                "type": "string"
+                                              },
                                               "depth": {
                                                 "format": "int64",
                                                 "type": "integer"
@@ -46656,6 +56169,9 @@
                                               },
                                               "revision": {
                                                 "type": "string"
+                                              },
+                                              "singleBranch": {
+                                                "type": "boolean"
                                               },
                                               "sshPrivateKeySecret": {
                                                 "properties": {
@@ -46792,6 +56308,180 @@
                                           },
                                           "http": {
                                             "properties": {
+                                              "auth": {
+                                                "properties": {
+                                                  "basicAuth": {
+                                                    "properties": {
+                                                      "passwordSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "usernameSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientCert": {
+                                                    "properties": {
+                                                      "clientCertSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientKeySecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "oauth2": {
+                                                    "properties": {
+                                                      "clientIDSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientSecretSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "endpointParams": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "scopes": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "tokenURLSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "headers": {
                                                 "items": {
                                                   "properties": {
@@ -47147,9 +56837,6 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": [
-                                "template"
-                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -47281,6 +56968,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -47329,6 +57052,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -47370,6 +57137,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -47409,6 +57179,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -47545,6 +57318,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -47852,6 +57799,16 @@
                   "properties": {
                     "body": {
                       "type": "string"
+                    },
+                    "bodyFrom": {
+                      "properties": {
+                        "bytes": {
+                          "format": "byte",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "headers": {
                       "items": {
@@ -48930,6 +58887,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -48978,6 +58971,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -49019,6 +59056,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -49058,6 +59098,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -49194,6 +59237,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -49725,6 +59942,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -49773,6 +60026,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -49814,6 +60111,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -49853,6 +60153,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -49989,6 +60292,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -50361,6 +60838,812 @@
                     },
                     "manifest": {
                       "type": "string"
+                    },
+                    "manifestFrom": {
+                      "properties": {
+                        "artifact": {
+                          "properties": {
+                            "archive": {
+                              "properties": {
+                                "none": {
+                                  "type": "object"
+                                },
+                                "tar": {
+                                  "properties": {
+                                    "compressionLevel": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "zip": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "archiveLogs": {
+                              "type": "boolean"
+                            },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "artifactory": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
+                            "from": {
+                              "type": "string"
+                            },
+                            "fromExpression": {
+                              "type": "string"
+                            },
+                            "gcs": {
+                              "properties": {
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "serviceAccountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "git": {
+                              "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
+                                "depth": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "disableSubmodules": {
+                                  "type": "boolean"
+                                },
+                                "fetch": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "insecureIgnoreHostKey": {
+                                  "type": "boolean"
+                                },
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "revision": {
+                                  "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
+                                },
+                                "sshPrivateKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "globalName": {
+                              "type": "string"
+                            },
+                            "hdfs": {
+                              "properties": {
+                                "addresses": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "force": {
+                                  "type": "boolean"
+                                },
+                                "hdfsUser": {
+                                  "type": "string"
+                                },
+                                "krbCCacheSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbConfigConfigMap": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbKeytabSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbRealm": {
+                                  "type": "string"
+                                },
+                                "krbServicePrincipalName": {
+                                  "type": "string"
+                                },
+                                "krbUsername": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "http": {
+                              "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "url": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            },
+                            "oss": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "createBucketIfNotPresent": {
+                                  "type": "boolean"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "lifecycleRule": {
+                                  "properties": {
+                                    "markDeletionAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "markInfrequentAccessAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "securityToken": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "raw": {
+                              "properties": {
+                                "data": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "data"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "recurseMode": {
+                              "type": "boolean"
+                            },
+                            "s3": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "createBucketIfNotPresent": {
+                                  "properties": {
+                                    "objectLocking": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "encryptionOptions": {
+                                  "properties": {
+                                    "enableEncryption": {
+                                      "type": "boolean"
+                                    },
+                                    "kmsEncryptionContext": {
+                                      "type": "string"
+                                    },
+                                    "kmsKeyId": {
+                                      "type": "string"
+                                    },
+                                    "serverSideCustomerKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "roleARN": {
+                                  "type": "string"
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "subPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "artifact"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "mergeStrategy": {
                       "type": "string"
@@ -54337,6 +65620,47 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "gcs": {
                         "properties": {
                           "bucket": {
@@ -54372,6 +65696,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -54411,6 +65738,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -54544,6 +65874,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -56839,6 +68343,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -56887,6 +68427,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -56928,6 +68512,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -56967,6 +68554,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -57103,6 +68693,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -57490,6 +69254,42 @@
                                             "archiveLogs": {
                                               "type": "boolean"
                                             },
+                                            "artifactGC": {
+                                              "properties": {
+                                                "podMetadata": {
+                                                  "properties": {
+                                                    "annotations": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "labels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "serviceAccountName": {
+                                                  "type": "string"
+                                                },
+                                                "strategy": {
+                                                  "enum": [
+                                                    "",
+                                                    "OnWorkflowCompletion",
+                                                    "OnWorkflowDeletion",
+                                                    "Never"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "artifactory": {
                                               "properties": {
                                                 "passwordSecret": {
@@ -57538,6 +69338,50 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
+                                            "azure": {
+                                              "properties": {
+                                                "accountKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "blob": {
+                                                  "type": "string"
+                                                },
+                                                "container": {
+                                                  "type": "string"
+                                                },
+                                                "endpoint": {
+                                                  "type": "string"
+                                                },
+                                                "useSDKCreds": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "blob",
+                                                "container",
+                                                "endpoint"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "deleted": {
+                                              "type": "boolean"
+                                            },
                                             "from": {
                                               "type": "string"
                                             },
@@ -57579,6 +69423,9 @@
                                             },
                                             "git": {
                                               "properties": {
+                                                "branch": {
+                                                  "type": "string"
+                                                },
                                                 "depth": {
                                                   "format": "int64",
                                                   "type": "integer"
@@ -57618,6 +69465,9 @@
                                                 },
                                                 "revision": {
                                                   "type": "string"
+                                                },
+                                                "singleBranch": {
+                                                  "type": "boolean"
                                                 },
                                                 "sshPrivateKeySecret": {
                                                   "properties": {
@@ -57754,6 +69604,180 @@
                                             },
                                             "http": {
                                               "properties": {
+                                                "auth": {
+                                                  "properties": {
+                                                    "basicAuth": {
+                                                      "properties": {
+                                                        "passwordSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "usernameSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientCert": {
+                                                      "properties": {
+                                                        "clientCertSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientKeySecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "oauth2": {
+                                                      "properties": {
+                                                        "clientIDSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientSecretSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "endpointParams": {
+                                                          "items": {
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "scopes": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "tokenURLSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
                                                 "headers": {
                                                   "items": {
                                                     "properties": {
@@ -58109,9 +70133,6 @@
                                     "additionalProperties": false
                                   }
                                 },
-                                "required": [
-                                  "template"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -58243,6 +70264,42 @@
                               "archiveLogs": {
                                 "type": "boolean"
                               },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "artifactory": {
                                 "properties": {
                                   "passwordSecret": {
@@ -58291,6 +70348,50 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
                               "from": {
                                 "type": "string"
                               },
@@ -58332,6 +70433,9 @@
                               },
                               "git": {
                                 "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
                                   "depth": {
                                     "format": "int64",
                                     "type": "integer"
@@ -58371,6 +70475,9 @@
                                   },
                                   "revision": {
                                     "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
                                   },
                                   "sshPrivateKeySecret": {
                                     "properties": {
@@ -58507,6 +70614,180 @@
                               },
                               "http": {
                                 "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "headers": {
                                     "items": {
                                       "properties": {
@@ -58814,6 +71095,16 @@
                     "properties": {
                       "body": {
                         "type": "string"
+                      },
+                      "bodyFrom": {
+                        "properties": {
+                          "bytes": {
+                            "format": "byte",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -59892,6 +72183,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -59940,6 +72267,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -59981,6 +72352,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -60020,6 +72394,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -60156,6 +72533,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -60687,6 +73238,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -60735,6 +73322,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -60776,6 +73407,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -60815,6 +73449,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -60951,6 +73588,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -61323,6 +74134,812 @@
                       },
                       "manifest": {
                         "type": "string"
+                      },
+                      "manifestFrom": {
+                        "properties": {
+                          "artifact": {
+                            "properties": {
+                              "archive": {
+                                "properties": {
+                                  "none": {
+                                    "type": "object"
+                                  },
+                                  "tar": {
+                                    "properties": {
+                                      "compressionLevel": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "zip": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "archiveLogs": {
+                                "type": "boolean"
+                              },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "artifactory": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "fromExpression": {
+                                "type": "string"
+                              },
+                              "gcs": {
+                                "properties": {
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "git": {
+                                "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "depth": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "disableSubmodules": {
+                                    "type": "boolean"
+                                  },
+                                  "fetch": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "insecureIgnoreHostKey": {
+                                    "type": "boolean"
+                                  },
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "repo": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
+                                  },
+                                  "sshPrivateKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "repo"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "hdfs": {
+                                "properties": {
+                                  "addresses": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "hdfsUser": {
+                                    "type": "string"
+                                  },
+                                  "krbCCacheSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbConfigConfigMap": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbKeytabSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbRealm": {
+                                    "type": "string"
+                                  },
+                                  "krbServicePrincipalName": {
+                                    "type": "string"
+                                  },
+                                  "krbUsername": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "mode": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "oss": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "type": "boolean"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "lifecycleRule": {
+                                    "properties": {
+                                      "markDeletionAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "markInfrequentAccessAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "securityToken": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "raw": {
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "data"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurseMode": {
+                                "type": "boolean"
+                              },
+                              "s3": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "properties": {
+                                      "objectLocking": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "encryptionOptions": {
+                                    "properties": {
+                                      "enableEncryption": {
+                                        "type": "boolean"
+                                      },
+                                      "kmsEncryptionContext": {
+                                        "type": "string"
+                                      },
+                                      "kmsKeyId": {
+                                        "type": "string"
+                                      },
+                                      "serverSideCustomerKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "insecure": {
+                                    "type": "boolean"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "roleARN": {
+                                    "type": "string"
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "subPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "artifact"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "mergeStrategy": {
                         "type": "string"

--- a/schemas/workflowtemplate_v1alpha1.json
+++ b/schemas/workflowtemplate_v1alpha1.json
@@ -621,6 +621,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -669,6 +705,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -710,6 +790,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -749,6 +832,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -885,6 +971,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -1218,6 +1478,42 @@
           "type": "object",
           "additionalProperties": false
         },
+        "artifactGC": {
+          "properties": {
+            "podMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "strategy": {
+              "enum": [
+                "",
+                "OnWorkflowCompletion",
+                "OnWorkflowDeletion",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "configMap": {
@@ -1314,6 +1610,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -1362,6 +1694,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -1403,6 +1779,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -1442,6 +1821,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -1578,6 +1960,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -1933,9 +2489,6 @@
                 "additionalProperties": false
               }
             },
-            "required": [
-              "template"
-            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -3073,6 +3626,47 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blob": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blob",
+                    "container",
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "gcs": {
                   "properties": {
                     "bucket": {
@@ -3108,6 +3702,9 @@
                 },
                 "git": {
                   "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
                     "depth": {
                       "format": "int64",
                       "type": "integer"
@@ -3147,6 +3744,9 @@
                     },
                     "revision": {
                       "type": "string"
+                    },
+                    "singleBranch": {
+                      "type": "boolean"
                     },
                     "sshPrivateKeySecret": {
                       "properties": {
@@ -3280,6 +3880,180 @@
                 },
                 "http": {
                   "properties": {
+                    "auth": {
+                      "properties": {
+                        "basicAuth": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clientCert": {
+                          "properties": {
+                            "clientCertSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauth2": {
+                          "properties": {
+                            "clientIDSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientSecretSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpointParams": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tokenURLSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "headers": {
                       "items": {
                         "properties": {
@@ -5575,6 +6349,42 @@
                                 "archiveLogs": {
                                   "type": "boolean"
                                 },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "artifactory": {
                                   "properties": {
                                     "passwordSecret": {
@@ -5623,6 +6433,50 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
                                 "from": {
                                   "type": "string"
                                 },
@@ -5664,6 +6518,9 @@
                                 },
                                 "git": {
                                   "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
                                     "depth": {
                                       "format": "int64",
                                       "type": "integer"
@@ -5703,6 +6560,9 @@
                                     },
                                     "revision": {
                                       "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
                                     },
                                     "sshPrivateKeySecret": {
                                       "properties": {
@@ -5839,6 +6699,180 @@
                                 },
                                 "http": {
                                   "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "headers": {
                                       "items": {
                                         "properties": {
@@ -6226,6 +7260,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -6274,6 +7344,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -6315,6 +7429,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -6354,6 +7471,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -6490,6 +7610,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -6845,9 +8139,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "template"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -6979,6 +8270,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7027,6 +8354,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7068,6 +8439,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7107,6 +8481,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7243,6 +8620,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7550,6 +9101,16 @@
               "properties": {
                 "body": {
                   "type": "string"
+                },
+                "bodyFrom": {
+                  "properties": {
+                    "bytes": {
+                      "format": "byte",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "headers": {
                   "items": {
@@ -8628,6 +10189,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -8676,6 +10273,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -8717,6 +10358,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -8756,6 +10400,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -8892,6 +10539,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -9423,6 +11244,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -9471,6 +11328,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -9512,6 +11413,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -9551,6 +11455,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -9687,6 +11594,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -10059,6 +12140,812 @@
                 },
                 "manifest": {
                   "type": "string"
+                },
+                "manifestFrom": {
+                  "properties": {
+                    "artifact": {
+                      "properties": {
+                        "archive": {
+                          "properties": {
+                            "none": {
+                              "type": "object"
+                            },
+                            "tar": {
+                              "properties": {
+                                "compressionLevel": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "zip": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "archiveLogs": {
+                          "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "artifactory": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "fromExpression": {
+                          "type": "string"
+                        },
+                        "gcs": {
+                          "properties": {
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "serviceAccountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
+                            "depth": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "disableSubmodules": {
+                              "type": "boolean"
+                            },
+                            "fetch": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "insecureIgnoreHostKey": {
+                              "type": "boolean"
+                            },
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
+                            },
+                            "sshPrivateKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repo"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "globalName": {
+                          "type": "string"
+                        },
+                        "hdfs": {
+                          "properties": {
+                            "addresses": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "force": {
+                              "type": "boolean"
+                            },
+                            "hdfsUser": {
+                              "type": "string"
+                            },
+                            "krbCCacheSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbConfigConfigMap": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbKeytabSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbRealm": {
+                              "type": "string"
+                            },
+                            "krbServicePrincipalName": {
+                              "type": "string"
+                            },
+                            "krbUsername": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "http": {
+                          "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headers": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        },
+                        "oss": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "type": "boolean"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "lifecycleRule": {
+                              "properties": {
+                                "markDeletionAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "markInfrequentAccessAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "securityToken": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "raw": {
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurseMode": {
+                          "type": "boolean"
+                        },
+                        "s3": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "properties": {
+                                "objectLocking": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "encryptionOptions": {
+                              "properties": {
+                                "enableEncryption": {
+                                  "type": "boolean"
+                                },
+                                "kmsEncryptionContext": {
+                                  "type": "string"
+                                },
+                                "kmsKeyId": {
+                                  "type": "string"
+                                },
+                                "serverSideCustomerKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "insecure": {
+                              "type": "boolean"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "roleARN": {
+                              "type": "string"
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "subPath": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "artifact"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mergeStrategy": {
                   "type": "string"
@@ -14035,6 +16922,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -14070,6 +16998,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -14109,6 +17040,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -14242,6 +17176,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -16537,6 +19645,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -16585,6 +19729,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -16626,6 +19814,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -16665,6 +19856,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -16801,6 +19995,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -17188,6 +20556,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -17236,6 +20640,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -17277,6 +20725,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -17316,6 +20767,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -17452,6 +20906,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -17807,9 +21435,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17941,6 +21566,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -17989,6 +21650,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -18030,6 +21735,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -18069,6 +21777,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -18205,6 +21916,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -18512,6 +22397,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -19590,6 +23485,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -19638,6 +23569,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -19679,6 +23654,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -19718,6 +23696,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -19854,6 +23835,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -20385,6 +24540,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -20433,6 +24624,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -20474,6 +24709,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -20513,6 +24751,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -20649,6 +24890,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -21021,6 +25436,812 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"


### PR DESCRIPTION
Description:
- Updates the CRD schemas for [argo-workflows](https://github.com/argoproj/argo-workflows/), [argo-events](https://github.com/argoproj/argo-events) and [argo-cd](https://github.com/argoproj/argo-cd)
- By running the [Python script](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) and passing in the relevant CRD the Kubeconform schemas were generated
- To review check out the branch and run the kubeconform tests