### PR TITLE
Combine the two promtool check jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           format: github
 
-  promcheck:
+  promtool:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,14 +76,8 @@ jobs:
         uses: ./.github/actions/promtool
         with:
           args: >
-            check rules $(find charts/monitoring-config/rules -name *.yaml -not -name *_tests.yaml)
-
-  promtest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
+            check rules $(find charts/monitoring-config/rules -name '*.yaml' \
+              -not -name '*_tests.yaml')
       - name: Run promtool tests
         uses: ./.github/actions/promtool
         with:


### PR DESCRIPTION
These are both < 1s so running two jobs doesn't buy us much. There's maybe a tiny bit of benefit to having them both run independently, but it doesn't seem worth the duplication in this case IMHO.