### PR TITLE
Use kubedns, not CloudFlare, for nginx's async resolver.

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -210,9 +210,7 @@ data:
           # want to unset a request header sent TO S3 by nginx.
           proxy_set_header Authorization "";
 
-          # Add CloudFlare and Google DNS server to avoid "no resolver defined to resolve"
-          # errors when trying to connect to S3.
-          resolver 1.1.1.1 8.8.8.8 8.8.4.4;
+          resolver kube-dns.kube-system.svc.cluster.local.;
 
           # Download the file and send it to client
           proxy_pass $download_url;


### PR DESCRIPTION
This should help to reduce the annoying GuardDuty alerts that Cybersecurity team spend time manually forwarding to us.

#### Alternatives considered

We could configure a VPC endpoint for S3 with a fixed IP address and point nginx at that, avoiding the need for nginx to use its weird resolver implementation, but that just seems complicated.