### PR TITLE
Enable database migrations for Content Store

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -698,6 +698,7 @@ govukApplications:
 
   - name: content-store
     helmValues: &content-store
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
       cronTasks:
         - name: report-delays

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -686,6 +686,7 @@ govukApplications:
 
   - name: content-store
     helmValues: &content-store
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
       # TODO(chris.banks): tune these once we have some real-world usage data.
       replicaCount: 6

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -700,6 +700,7 @@ govukApplications:
 
   - name: content-store
     helmValues: &content-store
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
       replicaCount: 6
       cronTasks:


### PR DESCRIPTION
This allows us to run database migrations for Content Store, which are currently not being performed as we missed this configuration value.

[Trello card](https://trello.com/c/9ivR4TGQ)