### PR TITLE
Add placeholder image tag file for Licensify apps

### DIFF
--- a/charts/app-config/image-tags/integration/licensify
+++ b/charts/app-config/image-tags/integration/licensify
@@ -1,0 +1,5 @@
+# This is a placeholder to prevent licensify promotion check failures during
+# post sync workflow for licensify-frontend, licensify-feed and licensify-backend.
+# The workflow expects the image tag file name to match the ArgoCD App name.
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/app-config/image-tags/production/licensify
+++ b/charts/app-config/image-tags/production/licensify
@@ -1,0 +1,5 @@
+# This is a placeholder to prevent licensify promotion check failures during
+# post sync workflow for licensify-frontend, licensify-feed and licensify-backend.
+# The workflow expects the image tag file name to match the ArgoCD App name.
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/app-config/image-tags/staging/licensify
+++ b/charts/app-config/image-tags/staging/licensify
@@ -1,0 +1,5 @@
+# This is a placeholder to prevent licensify promotion check failures during
+# post sync workflow for licensify-frontend, licensify-feed and licensify-backend.
+# The workflow expects the image tag file name to match the ArgoCD App name.
+automatic_deploys_enabled: false
+promote_deployment: false


### PR DESCRIPTION
The post sync workflow currently fails for the licensify-frontend, licensify-feed and licensify-admin apps. This is becuase the workflow expects the image tag file to match the ArgoCD App name. However this is "licensify" for all three apps, becuase they are all deployments within the same ArgoCD App. This will supress the deployment failures, but doesn't matter as we want it to be a no-op anyway.