### PR TITLE
Drop EKS suffix on environment names for Release notifications

### DIFF
--- a/charts/argo-services/templates/workflows/notify-release/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-release/workflow.yaml
@@ -26,7 +26,7 @@ spec:
            --json '{
               "repo": "alphagov/{{"{{inputs.parameters.repositoryName}}"}}",
               "deployment": {
-                "environment": "{{"{{inputs.parameters.environment}}"}} EKS",
+                "environment": "{{"{{inputs.parameters.environment}}"}}",
                 "deployed_sha": "{{"{{inputs.parameters.commitSha}}"}}",
                 "version": "{{"{{inputs.parameters.commitSha}}"}}"
               }


### PR DESCRIPTION
The environment names are being normalised in Release, and dropping support for the EKS suffix.

https://github.com/alphagov/release/pull/1408