### PR TITLE
Updating GOV.UK Generic chart to be PSS restricted compliant.

### DIFF
--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -21,6 +21,8 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
@@ -38,6 +40,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
       containers:
         - name: upload-assets
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
@@ -55,6 +59,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
       restartPolicy: Never
       volumes:
         - name: assets-to-upload

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -26,6 +26,8 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -65,6 +67,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -122,6 +124,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp
@@ -157,6 +161,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -26,6 +26,8 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -80,6 +82,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp


### PR DESCRIPTION
Adding:
```
            capabilities:
              drop: ["ALL"]

            seccompProfile:
              type: "RuntimeDefault"
```


Currently deploying application using the current chart will give the following warnings results:

```
Warning: would violate PodSecurity "restricted:latest": unrestricted capabilities (containers "app", "nginx" must set securityContext.capabilities.drop=["ALL"]) deployment.apps/transition-pss created
Warning: would violate PodSecurity "restricted:latest": unrestricted capabilities (container "worker" must set securityContext.capabilities.drop=["ALL"]) deployment.apps/transition-pss-worker created
Warning: would violate PodSecurity "restricted:latest": unrestricted capabilities (containers "copy-assets-for-upload", "upload-assets" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or containers "copy-assets-for-upload", "upload-assets" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost") job.batch/transition-pss-upload-assets created
Warning: would violate PodSecurity "restricted:latest": unrestricted capabilities (container "dbmigrate" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "dbmigrate" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

**After the applied changes the results are:**

```
deployment.apps/transition-pss created
deployment.apps/transition-pss-worker created
job.batch/transition-pss-upload-assets created
job.batch/transition-pss-dbmigrate created
```
**Warnings are corrected.**

All apps will need to be tested to ensure that the changes do not cause any issues.

I have tested one app which came up without errors, nevertheless this will need to be rolled out to Integration and staging to discover issues.