### PR TITLE
Updating Asset-manager chart to be PSS restricted compliant.

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -13,6 +13,7 @@ spec:
   securityContext:
     seccompProfile:
       type: RuntimeDefault
+    runAsNonRoot: true
     runAsUser: 1001
     runAsGroup: 1001
   containers:
@@ -31,6 +32,8 @@ spec:
           mountPath: {{ .Values.clamMountConfigPath }}
       securityContext:
         allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
         readOnlyRootFilesystem: true
   volumes:
     - name: clam-virus-db

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: &old-ec2-deploy-uid 2899
         runAsUser: 1001
         runAsGroup: 1001
@@ -119,6 +121,8 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
             readOnlyRootFilesystem: true
             # Asset Manager shares an NFS volume with its EC2 counterpart.
             runAsUser: *old-ec2-deploy-uid
@@ -159,6 +163,8 @@ spec:
             {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
             readOnlyRootFilesystem: true
           lifecycle:
             preStop:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -25,6 +25,8 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: &old-ec2-deploy-uid 2899
         runAsUser: 1001
         runAsGroup: 1001
@@ -102,6 +104,8 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
             readOnlyRootFilesystem: true
             # Asset Manager shares an NFS volume with its EC2 counterpart.
             runAsUser: *old-ec2-deploy-uid
@@ -126,4 +130,6 @@ spec:
               mountPath: {{ .Values.clamMountConfigPath }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Currently there is still the following errors, relating the the NFS mount.

```
Warning: would violate PodSecurity "restricted:latest": restricted volume types (volume "asset-manager-efs" uses restricted volume type "nfs") deployment.apps/asset-manager-pss created
Warning: would violate PodSecurity "restricted:latest": restricted volume types (volumes "asset-manager-efs", "clam-virus-db" use restricted volume type "nfs") deployment.apps/asset-manager-pss-worker created
Warning: would violate PodSecurity "restricted:latest": restricted volume types (volume "clam-virus-db" uses restricted volume type "nfs")
```

https://github.com/alphagov/govuk-helm-charts/issues/1883