### PR TITLE
Removing Account as declaring credentials.cloudsecret=false:

### DIFF
--- a/charts/app-config/templates/kubescape.yaml
+++ b/charts/app-config/templates/kubescape.yaml
@@ -16,9 +16,6 @@ spec:
       valueFiles:
         - values.yaml
       parameters:
-        # Dummy value account string for testing purpose
-        - name: account
-          value: "mgsQy3ett5"
         - name: clusterName
           value: "govuk-integration-new"
         - name: server


### PR DESCRIPTION
As stated in Kubescape values.yaml:
https://github.com/kubescape/helm-charts/blob/128c77523ef5499982686cf158e0f5b66020963f/charts/kubescape-operator/values.yaml#L49

Extract:
`# The chart will create a secret with the "account" and "access-key", in case you have a pre-created secret, use "credentials.cloudSecret" instead `