### PR TITLE
Scale up `search-api-v2` replicas

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2301,6 +2301,7 @@ govukApplications:
   - name: search-api-v2
     helmValues:
       dbMigrationEnabled: false
+      replicaCount: 6
       uploadAssets:
         enabled: false
       workerEnabled: true


### PR DESCRIPTION
This increases the replicas for `search-api-v2` to be in line with those for `search-api` in anticipation of us going "fully" live shortly.

This can/should be reevaluated after a few days with full traffic to see if it needs adjusting - we may not need quite as much capacity as v1.