### PR TITLE
Add bucket value, delete legacy(?) AWS secrets

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -494,18 +494,10 @@ govukApplications:
             secretKeyRef:
               name: signon-app-content-data
               key: oauth_secret
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: content-data-admin-aws
-              key: access_key
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: content-data-admin-aws
-              key: secret_key
         - name: AWS_CSV_EXPORT_BUCKET_NAME
           value: govuk-integration-content-data-csvs
+        - name: AWS_SITEIMPROVE_SITEMAPS_BUCKET_NAME
+          value: govuk-integration-content-data-siteimprove-sitemaps
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
In integration, add a bucket name env var for generated siteimprove sitemaps in content-data-admin, also remove legacy AWS access envs to test if that will allow us to pick up the correct policy for writing to the sitemaps bucket.