### PR TITLE
Create default RBAC resources for Argo Workflows

### DIFF
--- a/charts/argo-services/templates/argo-workflow-default-rb.yaml
+++ b/charts/argo-services/templates/argo-workflow-default-rb.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflow-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflow-default-role
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflow-default

--- a/charts/argo-services/templates/argo-workflow-default-role.yaml
+++ b/charts/argo-services/templates/argo-workflow-default-role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-workflow-default
+  annotations:
+    workflows.argoproj.io/description: |
+      Recomended minimum permissions for the `emissary` executor.
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtasksets
+      - workflowartifactgctasks
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtasksets/status
+      - workflowartifactgctasks/status
+    verbs:
+      - patch

--- a/charts/argo-services/templates/argo-workflow-default-sa.yaml
+++ b/charts/argo-services/templates/argo-workflow-default-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflows-default


### PR DESCRIPTION
Currently Argo Workflows use the default service account and the executor-role is bound to it. This makes it difficult to understand which service account and permissions are being used by workflows. These RBAC resources will replace the "executor" role and role bindings, which will be explicity defined as the workflow default service account.