### PR TITLE
Scrape `/metrics` from kube-apiserver.

### DIFF
--- a/charts/monitoring-config/templates/kube-apiserver.yaml
+++ b/charts/monitoring-config/templates/kube-apiserver.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-apiserver
+  namespace: monitoring
+spec:
+  endpoints:
+    - port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        serverName: kubernetes
+  namespaceSelector:
+    matchNames:
+      - default
+  jobLabel: component
+  selector:
+    matchLabels:
+      component: apiserver
+      provider: kubernetes


### PR DESCRIPTION
We don't run the control plane, but it's occasionally useful to be able to see apiserver metrics (like when argocd-server misbehaves).

Tested: via `kubectl apply` in the integration cluster: [targets](https://prometheus.eks.integration.govuk.digital/targets?search=&scrapePool=serviceMonitor%2Fmonitoring%2Fkube-apiserver%2F0)