### PR TITLE
Fix permissions for add-tag-to-image workflow

### DIFF
--- a/charts/argo-services/templates/workflows/add-tag-to-image/rbac.yaml
+++ b/charts/argo-services/templates/workflows/add-tag-to-image/rbac.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.name }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.iamRoleArn }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflow-default
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.name }}

--- a/charts/argo-services/templates/workflows/add-tag-to-image/service-account.yaml
+++ b/charts/argo-services/templates/workflows/add-tag-to-image/service-account.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.name }}
-  annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.iamRoleServiceAccounts.tagImageWorkflow.iamRoleArn }}


### PR DESCRIPTION
The workflow uses a non-default workflow, hence needs the base permissions provided by the default role to operate the workflow.

The existing service account is unchanged, just the file has been renamed.