### PR TITLE
Add event binding and rbac resources for deploy image

### DIFF
--- a/charts/argo-services/templates/event-rbac.yaml
+++ b/charts/argo-services/templates/event-rbac.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflows-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflows-events
+subjects:
+- kind: ServiceAccount
+  name: argo-workflows-events
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-workflows-events
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workfloweventbindings
+  verbs:
+  - list
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflows-events
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-workflows-events.service-account-token
+  annotations:
+    kubernetes.io/service-account.name: argo-workflows-events
+type: kubernetes.io/service-account-token

--- a/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowEventBinding
+metadata:
+  name: deploy-image
+spec:
+  event:
+    selector: payload.environment != "" && payload.repoName != "" && payload.imageTag != "" && discriminator == "update-image-tag"
+  submit:
+    workflowTemplateRef:
+      name: deploy-image
+    arguments:
+      parameters:
+        - name: environment
+          valueFrom:
+            event: payload.environment
+        - name: repoName
+          valueFrom:
+            event: payload.repoName
+        - name: imageTag
+          valueFrom:
+            event: payload.imageTag
+        - name: promoteDeployment
+          valueFrom:
+            event: payload.promoteDeployment

--- a/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowEventBinding
+metadata:
+  name: post-sync
+spec:
+  event:
+    selector: payload.application != "" && payload.repoName != "" && payload.imageTag != "" && discriminator == "post-sync"
+  submit:
+    workflowTemplateRef:
+      name: post-sync
+    arguments:
+      parameters:
+        - name: application
+          valueFrom:
+            event: payload.application
+        - name: repoName
+          valueFrom:
+            event: payload.repoName
+        - name: imageTag
+          valueFrom:
+            event: payload.imageTag


### PR DESCRIPTION
This enables the deploy image workflow to be triggered using the Argo Workflows Event API, instead of via the Argo Events. Replacing usage of Argo Events will allow us to remove it from our cluster as a dependency.