### PR TITLE
Remove unused arguments from post-sync workflow

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -15,9 +15,6 @@ spec:
   arguments:
     parameters:
       - name: application
-      - name: commitSha
-      - name: argoUrl
-      - name: slackChannel
       - name: repoName
       - name: imageTag
   templates:


### PR DESCRIPTION
This arguments aren't used.