### PR TITLE
Fix argo workflow job names

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
@@ -6,6 +6,8 @@ spec:
   event:
     selector: payload.environment != "" && payload.repoName != "" && payload.imageTag != "" && discriminator == "update-image-tag"
   submit:
+    metadata:
+      name: 'event.payload.repoName + "-" + event.payload.environment + "-deploy-image"'
     workflowTemplateRef:
       name: deploy-image
     arguments:

--- a/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
@@ -6,6 +6,8 @@ spec:
   event:
     selector: payload.application != "" && payload.repoName != "" && payload.imageTag != "" && discriminator == "post-sync"
   submit:
+    metadata:
+      name: 'event.payload.repoName + "-post-sync"'
     workflowTemplateRef:
       name: post-sync
     arguments:


### PR DESCRIPTION
This restores the workflow job naming to when we used Argo Events to trigger them.