### PR TITLE
Update outdated syntax in Prometheus rules

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -13,10 +13,12 @@ spec:
     - matchers:
         - name: severity
           value: page
+          matchType: =
       receiver: 'pagerduty'
     - matchers:
         - name: alertname
           value: SignonApiUserTokenExpirySoon
+          matchType: =
       receiver: 'slack-signon-token-expiry'
       repeatInterval: 1d
       groupWait: 12h
@@ -26,6 +28,7 @@ spec:
     - matchers:
         - name: alertname
           value: MirrorFreshnessAlert
+          matchType: =
       receiver: 'slack-mirror-freshness'
       repeatInterval: 1d
       groupWait: 12h
@@ -35,6 +38,7 @@ spec:
     - matchers:
       - name: destination
         value: slack-platform-engineering
+        matchType: =
       receiver: 'generic-slack-platform-engineering'
       repeatInterval: 1d
       groupWait: 12h
@@ -44,6 +48,7 @@ spec:
     - matchers:
       - name: destination
         value: slack-search-team
+        matchType: =
       receiver: 'slack-search-team'
       repeatInterval: 3h
       groupWait: 1m


### PR DESCRIPTION
Description:
- Looking through [this discussion](https://github.com/prometheus-operator/prometheus-operator/issues/4822#issuecomment-1680929406) it looks like adding `matchType: =` to the matchers removes the deprecation message
- Resolves https://github.com/alphagov/govuk-helm-charts/issues/1745