### PR TITLE
Remove info-frontend

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -29,7 +29,7 @@ data:
   {{- end }}
   GOVUK_SIDEKIQ_JSON_LOGGING: "1"
   GOVUK_WEBSITE_ROOT: https://www.{{ .Values.externalDomainSuffix }}
-  PLEK_UNPREFIXABLE_HOSTS: account-api,asset-manager,feedback,imminence,info-frontend,licensify,local-links-manager,locations-api,search-api,signon
+  PLEK_UNPREFIXABLE_HOSTS: account-api,asset-manager,feedback,imminence,licensify,local-links-manager,locations-api,search-api,signon
   PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS: "true"
   PROMETHEUS_PUSHGATEWAY_URL: http://prometheus-pushgateway.monitoring.svc.cluster.local:9091
   RAILS_LOG_TO_STDOUT: "true"

--- a/charts/app-config/templates/signon-secrets-sync-configmap.yaml
+++ b/charts/app-config/templates/signon-secrets-sync-configmap.yaml
@@ -63,7 +63,6 @@ data:
       "frontend@alphagov.co.uk",
       "government-frontend@alphagov.co.uk",
       "hmrc-manuals-api@alphagov.co.uk",
-      "info-frontend@alphagov.co.uk",
       "local-links-manager@alphagov.co.uk",
       "manuals-publisher@alphagov.co.uk",
       "maslow@alphagov.co.uk",

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1284,8 +1284,6 @@ govukApplications:
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 
-  - name: info-frontend
-
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
@@ -1987,8 +1985,6 @@ govukApplications:
           value: "http://feedback"
         - name: BACKEND_URL_finder-frontend
           value: "http://finder-frontend"
-        - name: BACKEND_URL_info-frontend
-          value: "http://info-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
@@ -2037,8 +2033,6 @@ govukApplications:
           value: "http://feedback"
         - name: BACKEND_URL_finder-frontend
           value: "http://finder-frontend"
-        - name: BACKEND_URL_info-frontend
-          value: "http://info-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1336,8 +1336,6 @@ govukApplications:
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
 
-  - name: info-frontend
-
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
@@ -2064,8 +2062,6 @@ govukApplications:
           value: "http://feedback"
         - name: BACKEND_URL_finder-frontend
           value: "http://finder-frontend"
-        - name: BACKEND_URL_info-frontend
-          value: "http://info-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
@@ -2115,8 +2111,6 @@ govukApplications:
           value: "http://feedback"
         - name: BACKEND_URL_finder-frontend
           value: "http://finder-frontend"
-        - name: BACKEND_URL_info-frontend
-          value: "http://info-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1334,8 +1334,6 @@ govukApplications:
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
-  - name: info-frontend
-
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
@@ -2055,8 +2053,6 @@ govukApplications:
           value: "http://feedback"
         - name: BACKEND_URL_finder-frontend
           value: "http://finder-frontend"
-        - name: BACKEND_URL_info-frontend
-          value: "http://info-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
@@ -2106,8 +2102,6 @@ govukApplications:
           value: "http://feedback"
         - name: BACKEND_URL_finder-frontend
           value: "http://finder-frontend"
-        - name: BACKEND_URL_info-frontend
-          value: "http://info-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api


### PR DESCRIPTION
Info pages have been unpublished and thus info-frontend isn't serving any traffic regarding info pages.

We are seeing the odd request for legacy /needs pages [1] (~1 a day) which are being received by info-frontend. info-frontend doesn't know about these pages which result in 404 being returned. needs do not exist on the public facing website and only exist in the publishing stack (published by Maslow). After we remove info-frontend, these requests will return a 503, as the backend app serving the needs pages will no longer be available.

Returning 503s isn't ideal but we agreed [2] to is the best approach given:
- the traffic is tiny
- the traffic mainly comes from crawlers
- we will only return 503s up until we retire Maslow and then we'll return a normal 404

The alternative would be to unpublish the 679 editions / routes now in our publishing stack but we run the risk of strange behaviour / errors as we have inconsistent states between our apps.

Trello:
https://trello.com/c/NcSjgmmq/2385-remove-from-govuk-helm-charts

[1]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/goto/9f68346dc881bd4913aaeaf185522608?security_tenant=global
[2]: https://gds.slack.com/archives/C03D4A72HGE/p1709568749883129?thread_ts=1709556305.963639&cid=C03D4A72HGE