### PR TITLE
Sync Publishing API data to Search API v2 weekly

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1753,10 +1753,11 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
+        # In non-production envs, run Search API v2 bulk import every week to bring it to parity
+        # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import
           task: "queue:requeue_all_the_published_things[bulk.search_api_v2_sync]"
-          schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)
-          suspend: true
+          schedule: "0 8 * * 0"  # every Sunday at 8am
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1799,10 +1799,11 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
+        # In non-production envs, run Search API v2 bulk import every week to bring it to parity
+        # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import
           task: "queue:requeue_all_the_published_things[bulk.search_api_v2_sync]"
-          schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)
-          suspend: true
+          schedule: "0 8 * * 0"  # every Sunday at 8am
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
Every night, Publishing API's database gets updated with the latest production state as part of the usual production DB sync. However, no messages are emitted to downstream systems that build up their state by applying events (like Search API v2) as part of that process, which means that they drift away from the current state of Publishing API over time.

This unsuspends the existing `search-api-v2-bulk-import` cronjob template we use to trigger one-off bulk synchronisation, and runs it on Sunday mornings so we start the working week with a reasonably fresh state of content.