### PR TITLE
Increase publisher nginx read timeout to 30s

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1657,6 +1657,7 @@ govukApplications:
             ]}}]
         hosts:
           - name: publisher.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 30s
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1706,6 +1706,7 @@ govukApplications:
             ]}}]
         hosts:
           - name: publisher.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 30s
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1702,6 +1702,7 @@ govukApplications:
             ]}}]
         hosts:
           - name: publisher.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 30s
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
https://trello.com/c/v2WB7RzB/187-504-error-when-searching-and-filtering-in-mainstream-publisher-5631736

The longest search on the publications page is timing out at ~15 seconds, after looking at indexes and hitting issues with the differences between mongo locally and documentdb, decided that increasing the nginx timeout past the default 15s is a sensible first option that unblocks users. 