### PR TITLE
Hook `search-api-v2` up to shared Redis

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2242,6 +2242,8 @@ govukApplications:
           value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2314,6 +2314,8 @@ govukApplications:
           value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2305,6 +2305,8 @@ govukApplications:
           value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Adds `REDIS_URL` env variable pointing to the shared Redis to the `search-api-v2` app across environments for use in an upcoming sync-related locking/mutex feature.

This isn't ideal, and in the future we will want to disentangle the myriad use cases of that shared Redis instance, but this'll do for the short term.

c.f. https://gds.slack.com/archives/C013F737737/p1709897264741419