### PR TITLE
Update Kubeconform to use Kubernetes 1.29 schemas

### DIFF
--- a/kubernetes_version
+++ b/kubernetes_version
@@ -2,4 +2,4 @@
 # output in .github/workflows/ci.yml.
 #
 # Available schema versions: https://github.com/yannh/kubernetes-json-schema
-KUBERNETES_VERSION=1.28.6
+KUBERNETES_VERSION=1.29.0


### PR DESCRIPTION
Description:
- K8s has been updated to 1.29.0 in EKS so this change configures Kubeconform to use the 1.29.0 schemas