### PR TITLE
Remove support-api's long-lived IAM creds in nonprod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2804,18 +2804,8 @@ govukApplications:
           task: "anonymous_feedback_deduplication:recent"
           schedule: "*/5 * * * *"
       extraEnv:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: access_key
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-support-api-csvs
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: secret_key
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2838,18 +2838,8 @@ govukApplications:
           task: "anonymous_feedback_deduplication:recent"
           schedule: "*/5 * * * *"
       extraEnv:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: access_key
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-support-api-csvs
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: secret_key
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
See:
- https://github.com/alphagov/support-api/pull/911
- https://github.com/alphagov/govuk-helm-charts/issues/1895