### PR TITLE
Add `search-api-v2` query failure AlertManager alert

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -11,3 +11,30 @@ groups:
           description: >-
             Invariant dataset '{{ $labels.dataset_name }}' has dropped below 100% recall (i.e. the
             expected results are not being returned for one or more queries in this dataset)
+
+      - alert: HighQueryFailureRate
+        expr: >-
+          sum(increase(http_requests_total{
+            namespace="apps",
+            job="search-api-v2",
+            controller="searches",
+            action="show",
+            status="200"
+          }[1m]))
+          /
+          sum(increase(http_requests_total{
+            namespace="apps",
+            job="search-api-v2",
+            controller="searches",
+            action="show"
+          }[1m]))
+          < 0.995
+        for: 10m
+        labels:
+          severity: critical
+          destination: slack-search-team
+        annotations:
+          summary: Elevated rate of query failures in search-api-v2
+          description: >-
+            The success rate of search requests to search-api-v2 has dropped below 99.5% for more
+            than 10 consecutive minutes.

--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -14,20 +14,20 @@ groups:
 
       - alert: HighQueryFailureRate
         expr: >-
-          sum(increase(http_requests_total{
+          sum(rate(http_requests_total{
             namespace="apps",
             job="search-api-v2",
             controller="searches",
             action="show",
             status="200"
-          }[1m]))
+          }[2m]))
           /
-          sum(increase(http_requests_total{
+          sum(rate(http_requests_total{
             namespace="apps",
             job="search-api-v2",
             controller="searches",
             action="show"
-          }[1m]))
+          }[2m]))
           < 0.995
         for: 10m
         labels:

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -34,3 +34,66 @@ tests:
               description: >-
                 Invariant dataset 'dataset1' has dropped below 100% recall (i.e. the expected
                 results are not being returned for one or more queries in this dataset)
+
+  - interval: 1m
+    input_series:
+      # Perfect 100% success
+      - series: >-
+          http_requests_total{
+          namespace="apps", job="search-api-v2", controller="searches", action="show", status="200"
+          }
+        values: '1000+100x15'
+      - series: >-
+          http_requests_total{
+          namespace="apps", job="search-api-v2", controller="searches", action="show", status="500"
+          }
+        values: '0x15'
+    alert_rule_test:
+      - alertname: HighQueryFailureRate
+        eval_time: 15m
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # consistent <99.5% success for 15 minutes
+      - series: >-
+          http_requests_total{
+          namespace="apps", job="search-api-v2", controller="searches", action="show", status="200"
+          }
+        values: '1000x15'
+      - series: >-
+          http_requests_total{
+          namespace="apps", job="search-api-v2", controller="searches", action="show", status="500"
+          }
+        values: '100+100x15'
+    alert_rule_test:
+      - alertname: HighQueryFailureRate
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              alertname: HighQueryFailureRate
+              severity: critical
+              destination: slack-search-team
+            exp_annotations:
+              summary: Elevated rate of query failures in search-api-v2
+              description: >-
+                The success rate of search requests to search-api-v2 has dropped below 99.5% for
+                more than 10 consecutive minutes.
+
+  - interval: 1m
+    input_series:
+      # brief but inconsistent blips
+      - series: >-
+          http_requests_total{
+          namespace="apps", job="search-api-v2", controller="searches", action="show", status="200"
+          }
+        values: '1000 1000 1000 900 1000 1000 1000 900 1000 1000 1000 1000 1000 0 1000'
+      - series: >-
+          http_requests_total{
+          namespace="apps", job="search-api-v2", controller="searches", action="show", status="500"
+          }
+        values: '0 0 0 100 0 0 0 100 0 0 0 0 0 1000 0'
+    alert_rule_test:
+      - alertname: HighQueryFailureRate
+        eval_time: 15m
+        exp_alerts: []


### PR DESCRIPTION
This adds a new alert for when the rate of successful `search-api-v2` queries drops below a certain threshold.