### PR TITLE
Remove support-api's long-lived IAM creds in prod.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2881,18 +2881,8 @@ govukApplications:
           task: "anonymous_feedback_deduplication:recent"
           schedule: "*/5 * * * *"
       extraEnv:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: access_key
         - name: AWS_S3_BUCKET_NAME
           value: govuk-production-support-api-csvs
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: secret_key
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
See:

- #1896
- #1895
- https://github.com/alphagov/support-api/pull/911

Tested: verified that the same setup in staging was able to upload a report to S3 using instance profile creds.