### PR TITLE
Run 2 support-api workers instead of 3.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2867,6 +2867,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 2
       cronTasks:
         - name: feedback-deduplication-nightly
           task: "anonymous_feedback_deduplication:nightly"


### PR DESCRIPTION
These are [woefully undertutilised](https://grafana.eks.production.govuk.digital/goto/Ni3R2kJIg) and not mission-critical, so N+1 should be more than adequate.