### PR TITLE
Remove long-lived IAM creds for support app in nonprod.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2729,18 +2729,8 @@ govukApplications:
         path: /app/public/assets/support
       workerEnabled: true
       extraEnv:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: access_key
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-support-api-csvs
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: secret_key
         - name: EMERGENCY_CONTACT_DETAILS
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2763,18 +2763,8 @@ govukApplications:
         path: /app/public/assets/support
       workerEnabled: true
       extraEnv:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: access_key
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-support-api-csvs
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: support-aws
-              key: secret_key
         - name: EMERGENCY_CONTACT_DETAILS
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
As of https://github.com/alphagov/support/pull/1300, the app is able to use more appropriate authn methods including EC2 instance profile creds and IRSA.

#1895