### PR TITLE
Increase replicaCount from 6 to 7

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -702,7 +702,7 @@ govukApplications:
     helmValues: &content-store
       dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
-      replicaCount: 6
+      replicaCount: 7
       cronTasks:
         - name: report-delays
           task: "publishing_delay_report:report_delays"


### PR DESCRIPTION
# What
Update the content store replica count in staging from 6 to 7

# Why
As part of the 2nd line drill for scaling up an application

https://docs.publishing.service.gov.uk/manual/2nd-line-drills.html#drill-scaling-up-an-application 

[Trello card](https://trello.com/c/CcTbU73I/2285-2nd-line-drill)