### PR TITLE
Run integration ES restore outside off-peak window.

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -53,7 +53,7 @@ snapshot_valid () {
 restore () {
   snapshot_valid
   $curl -XDELETE "$ES_URL/*,-.*" >&2  # Delete all except system indices.
-  sleep 20  # TODO: use ?wait_for_shards=all once our ES version supports it.
+  sleep 20  # TODO: use ?wait_for_active_shards=all once our ES version supports it.
   local result
   result=$(
     # TODO: use curl --json once available.

--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -53,7 +53,7 @@ snapshot_valid () {
 restore () {
   snapshot_valid
   $curl -XDELETE "$ES_URL/*,-.*" >&2  # Delete all except system indices.
-  sleep 2  # TODO: use ?wait_for_shards=all once our ES version supports it.
+  sleep 20  # TODO: use ?wait_for_shards=all once our ES version supports it.
   local result
   result=$(
     # TODO: use curl --json once available.

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -26,7 +26,7 @@ cronjobs:
       args: [create_and_clean_up]
   integration:
     - name: copy-from-stag
-      schedule: "53 2 * * *"
+      schedule: "17 6 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO


### PR DESCRIPTION
Still don't know for sure why the Elasticsearch restore cron is flaking in the integration cluster (having worked reliably for months), so try a couple more stabs in the dark to see if the problem goes away.

I haven't been able to repro the flake, even though it's happened now 3 nights in a row on the real integration cronjob (but only in integration) :/

If it's still flakey after this then we'll take a step back and consider alternatives (or maybe delve in to find out exactly why it's flaking, but that's probably a big timesink for what's already a bit of a whacky and non-essential cronjob).

- Wait longer between issuing the delete and issuing the restore. Just a hunch (e.g. maybe integration is slower than the other clusters for some reason?)
- Change the cron schedule to avoid the AWS maintenance window (20:00-06:00 UTC) for the integration ES cluster. Also just a hunch.

Previous attempt: #1912.