### PR TITLE
Define `ZENDESK_CLIENT_{USERNAME|PASSWORD}` for Feedback

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1013,6 +1013,16 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+        - name: ZENDESK_CLIENT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: support-zendesk
+              key: username
+        - name: ZENDESK_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: support-zendesk
+              key: password
 
   - name: finder-frontend
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1022,6 +1022,16 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+        - name: ZENDESK_CLIENT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: support-zendesk
+              key: username
+        - name: ZENDESK_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: support-zendesk
+              key: password
 
   - name: finder-frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1028,6 +1028,16 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+        - name: ZENDESK_CLIENT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: support-zendesk
+              key: username
+        - name: ZENDESK_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: support-zendesk
+              key: password
 
   - name: finder-frontend
     helmValues:


### PR DESCRIPTION
See https://github.com/alphagov/feedback/pull/1835

The no-longer-used `SUPPORT_BEARER_TOKEN` token will be removed once the Zendesk client based approach has been deployed.

Trello: https://trello.com/c/5MjV6r3T/3446-5-remove-feedbacks-dependency-on-support-app