### PR TITLE
Remove unused `SUPPORT_BEARER_TOKEN` tokens

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -976,11 +976,6 @@ govukApplications:
           value: fee22233-2f28-4b0b-8b6c-4410979f2275
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
           value: eb9ba220-7d74-4aab-975a-bdbe718f69a3
-        - name: SUPPORT_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-feedback-support
-              key: bearer_token
         - name: SUPPORT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -985,11 +985,6 @@ govukApplications:
           value: e8b2d8a6-db5f-4346-9fbd-49b16b531e1c
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
           value: 54168fa9-3946-4860-a2f8-27ddbb14babe
-        - name: SUPPORT_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-feedback-support
-              key: bearer_token
         - name: SUPPORT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -991,11 +991,6 @@ govukApplications:
           value: 91ee838c-ef9c-4d10-b3d6-5f73441e08b7
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
           value: 9295dc76-91f2-4436-b2ca-4e69a6bc9f23
-        - name: SUPPORT_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-feedback-support
-              key: bearer_token
         - name: SUPPORT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The token [is no longer used](https://github.com/alphagov/feedback/pull/1835/files#diff-d3af66279f272ec6b619840dd8f8c200921e56303c094d5e6f8b8b355959b4d4L4).

Trello: https://trello.com/c/5MjV6r3T/3446-5-remove-feedbacks-dependency-on-support-app