### PR TITLE
Add TODOs for cleaning up a deleted env var.

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -18,6 +18,7 @@ data:
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
+  # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
   GOVUK_PROMETHEUS_EXPORTER: "true"
   GOVUK_PERSONALISATION_FEEDBACK_URI: https://signin.account.gov.uk/support
   {{- if eq .Values.govukEnvironment "production" }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -951,6 +951,7 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-service-email-alert-api
               key: bearer_token
+        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force
         - name: RABBITMQ_URL
@@ -2242,7 +2243,7 @@ govukApplications:
           schedule: "09 9 * * *"  # 09:09am daily
           suspend: true  # Too noisy for integration to run on schedule, but can be run manually.
       extraEnv:
-        # Required for document sync worker to be able to export metrics
+        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -960,6 +960,7 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-service-email-alert-api
               key: bearer_token
+        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force
         - name: RABBITMQ_URL
@@ -2314,7 +2315,7 @@ govukApplications:
           task: "quality_monitoring:assert_invariants"
           schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm
       extraEnv:
-        # Required for document sync worker to be able to export metrics
+        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -966,6 +966,7 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-service-email-alert-api
               key: bearer_token
+        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force
         - name: RABBITMQ_URL
@@ -2305,7 +2306,7 @@ govukApplications:
           schedule: "09 9 * * *"  # 09:09am daily
           suspend: true  # Too noisy for staging to run on schedule, but can be run manually.
       extraEnv:
-        # Required for document sync worker to be able to export metrics
+        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME


### PR DESCRIPTION
https://github.com/alphagov/govuk_app_config/pull/361 removes the `GOVUK_PROMETHEUS_EXPORTER` env var, so once that lands in all its consumer apps we can delete it from the config.