### PR TITLE
Add cronjob for publishing finders on Specialist Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2656,6 +2656,10 @@ govukApplications:
             ]}}]
         hosts:
           - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
+      cronTasks:
+        - name: publish-finders
+          task: "publishing_api:publish_finders"
+          schedule: "49 7 * * 1-5"
       extraEnv:
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
Currently we have to manually publish pre-production flagged finders in integration. This cronTask will automate the process in integration.