### PR TITLE
Suspend search-index-env-sync cron in integration.

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -53,7 +53,6 @@ snapshot_valid () {
 restore () {
   snapshot_valid
   $curl -XDELETE "$ES_URL/*,-.*" >&2  # Delete all except system indices.
-  sleep 20  # TODO: use ?wait_for_active_shards=all once our ES version supports it.
   local result
   result=$(
     # TODO: use curl --json once available.

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -26,6 +26,7 @@ cronjobs:
       args: [create_and_clean_up]
   integration:
     - name: copy-from-stag
+      suspend: true
       schedule: "17 6 * * *"
       args: [restore_latest]
       extraEnv:


### PR DESCRIPTION
Now that site search no longer uses Elasticsearch, there's little reason to copy the Elasticsearch indices from staging to production every day.

The job has lately started flaking because (for as yet unknown reasons) the search-api-worker deployment seems to be doing a lot of inserts which re-create the index in between the `DELETE` and the `POST _restore` (even if we issue them in immediate succession). This leaves the integration environment in a non-working state every few days, which is way worse than some data being a bit stale (that probably nobody even needs anyway).

There are a few features that still use Elasticsearch, such as [finders], but at this point it's likely that the disadvantages of clobbering the integration indices every morning outweigh the advantages.

It's easy enough to run the job on-demand (from the ⋮ menu -> Create job in the [Argo CD web UI](https://argo.eks.integration.govuk.digital/applications/cluster-services/search-index-env-sync?view=tree&node=batch%2FCronJob%2Fapps%2Fsearch-index-env-sync-copy-from-stag%2F0), or from the [command line](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_job/)) if it's needed.

Also remove the delay between the delete and the restore, since we now know this exacerbates the race condition rather than mitigating it.

[finders]: https://github.com/alphagov/finder-frontend#live-examples