### PR TITLE
Add Cron Task for Travel Advice Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2911,6 +2911,10 @@ govukApplications:
 
   - name: travel-advice-publisher
     helmValues:
+      cronTasks:
+        - name: publish-scheduled-editions
+          task: "publish_scheduled_editions"
+          schedule: "29 5 * * *"
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
       ingress:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2975,6 +2975,10 @@ govukApplications:
 
   - name: travel-advice-publisher
     helmValues:
+      cronTasks:
+        - name: publish-scheduled-editions
+          task: "publish_scheduled_editions"
+          schedule: "29 5 * * *"
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
       ingress:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2931,6 +2931,10 @@ govukApplications:
 
   - name: travel-advice-publisher
     helmValues:
+      cronTasks:
+        - name: publish-scheduled-editions
+          task: "publish_scheduled_editions"
+          schedule: "29 5 * * *"
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
       ingress:


### PR DESCRIPTION
This is to publish any potentially unpublished editions that were scheduled for the past.

[Trello card](https://trello.com/c/UX0jNZC5/2419-cronjob-for-scheduling)

Rake task was added to the publisher here https://github.com/alphagov/travel-advice-publisher/pull/1859