### PR TITLE
Add Google Tag Manager to Support

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2773,6 +2773,12 @@ govukApplications:
             secretKeyRef:
               name: support-zendesk
               key: ticket_email
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
+        - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
+          value: *publishing-bootstrap-gtm-auth
+        - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
+          value: *publishing-bootstrap-gtm-preview
 
   - name: support-api
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2846,6 +2846,8 @@ govukApplications:
             secretKeyRef:
               name: support-zendesk
               key: ticket_email
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
 
   - name: support-api
     helmValues:


### PR DESCRIPTION
This allows us to enable basic GA4 tracking for the Support app.

In Integration we also set the `GOOGLE_TAG_MANAGER_AUTH` and `GOOGLE_TAG_MANAGER_PREVIEW` variables so that we can test the configuration before proceeding to Production.

Trello card: https://trello.com/c/owLrfsOP/3473-implement-tracking-in-ga4-for-support-3