### PR TITLE
Add external secrets for govuk-chat

### DIFF
--- a/charts/external-secrets/templates/govuk-chat/basic-auth.yaml
+++ b/charts/external-secrets/templates/govuk-chat/basic-auth.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-basic-auth
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for basic HTTP authentication to govuk-chat.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/basic-auth

--- a/charts/external-secrets/templates/govuk-chat/chat-api.yaml
+++ b/charts/external-secrets/templates/govuk-chat/chat-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-chat-api
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for working with Python Chat API: https://github.com/alphagov/govuk-chat-api.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/chat-api

--- a/charts/external-secrets/templates/govuk-chat/open-ai.yaml
+++ b/charts/external-secrets/templates/govuk-chat/open-ai.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-open-ai
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for connecting to openAI API.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/open-ai

--- a/charts/external-secrets/templates/govuk-chat/postgres.yaml
+++ b/charts/external-secrets/templates/govuk-chat/postgres.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-postgres
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for govuk-chat Postgres DB hosted in RDS.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: govuk-chat-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/govuk_chat_production'
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/postgres

--- a/charts/external-secrets/templates/govuk-chat/rabbitmq.yaml
+++ b/charts/external-secrets/templates/govuk-chat/rabbitmq.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-rabbitmq
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      RabbitMQ connection string for govuk-chat. Fields in SecretsManager
+      are username, password, host, port.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: govuk-chat-rabbitmq
+    template:
+      data:
+        RABBITMQ_URL: '{{ $.Files.Get "externalsecrets-templates/amqp-conn-string.tpl" | trim }}'
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/rabbitmq


### PR DESCRIPTION
Added seperate files/sercrets for basic-auth, chat-api, postgres, open-ai and rabbitMQ as an initial setup.

RabbitMQ has been added as a placeholder for now in the secrets-manager, will update it once we add the service

Trello card: https://trello.com/c/ewV5ilJ6/1229-initial-terraform-for-integration-environment 