### PR TITLE
Add Google Tag Manager to Content Data

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -664,11 +664,11 @@ govukApplications:
         # These GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: GOOGLE_TAG_MANAGER_ID
-          value: &publishing-design-system-gtm-id GTM-P93SHJ4Z
+          value: *publishing-design-system-gtm-id
         - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
-          value: &publishing-design-system-gtm-auth 8jHx-VNEguw67iX9TBC6_g
+          value: *publishing-design-system-gtm-auth
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
-          value: &publishing-design-system-gtm-preview env-50
+          value: *publishing-design-system-gtm-preview
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -484,6 +484,12 @@ govukApplications:
           value: GTM-NZG8SF2
         - name: GOOGLE_TAG_MANAGER_PREVIEW
           value: env-7
+        - name: GOOGLE_TAG_MANAGER_GA4_ID
+          value: &publishing-design-system-gtm-id GTM-P93SHJ4Z
+        - name: GOOGLE_TAG_MANAGER_GA4_AUTH  # Non-prod only
+          value: &publishing-design-system-gtm-auth 8jHx-VNEguw67iX9TBC6_g
+        - name: GOOGLE_TAG_MANAGER_GA4_PREVIEW  # Non-prod only
+          value: &publishing-design-system-gtm-preview env-50
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -478,6 +478,8 @@ govukApplications:
         # https://www.github.com/alphagov/govuk-puppet/pull/8041
         - name: GOOGLE_TAG_MANAGER_ID
           value: GTM-NZG8SF2
+        - name: GOOGLE_TAG_MANAGER_GA4_ID
+          value: &publishing-design-system-gtm-id GTM-P93SHJ4Z
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -660,7 +660,7 @@ govukApplications:
         # These GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
         - name: GOOGLE_TAG_MANAGER_ID
-          value: &publishing-design-system-gtm-id GTM-P93SHJ4Z
+          value: *publishing-design-system-gtm-id
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This allows us to enable basic GA4 tracking for the Support app.

In Integration we also set the `GOOGLE_TAG_MANAGER_GA4_AUTH` and `GOOGLE_TAG_MANAGER_GA4_PREVIEW` variables so that we can test the configuration before proceeding to Production.

Trello card: https://trello.com/c/NxwdsJb2/3475-implement-tracking-in-ga4-for-content-data-admin-3