### PR TITLE
Remove legacy request accessible env vars from feedback

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -969,10 +969,6 @@ govukApplications:
   - name: feedback
     helmValues:
       extraEnv:
-        - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-          value: 93109fea-34d9-4c38-ac7e-1ebc75e7416b
-        - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
-          value: 47cef7ea-0849-48aa-9676-0ee0f7baa4ae
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: fee22233-2f28-4b0b-8b6c-4410979f2275
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -978,10 +978,6 @@ govukApplications:
   - name: feedback
     helmValues:
       extraEnv:
-        - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-          value: b5baae45-0a68-4b63-91a1-66b05640d27e
-        - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
-          value: ceefedd7-3214-4774-8b57-f27c89aac90d
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: e8b2d8a6-db5f-4346-9fbd-49b16b531e1c
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -984,10 +984,6 @@ govukApplications:
   - name: feedback
     helmValues:
       extraEnv:
-        - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID
-          value: d33f7857-7514-4458-81b9-0995f48e2ac5
-        - name: GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID
-          value: b67971ed-a249-4afa-b05e-9adad9da551a
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: 91ee838c-ef9c-4d10-b3d6-5f73441e08b7
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID


### PR DESCRIPTION
Remove env vars for reply ids and template ids that aren't used by feedback any more:

https://trello.com/c/1kfu8Ltc/12-remove-request-accessible-format-legacy-code

https://github.com/alphagov/feedback/pull/1849