### PR TITLE
Disable renovate in govuk-infrastructure

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   config.json: |-
     {
-      "repositories": ["alphagov/govuk-helm-charts", "alphagov/govuk-infrastructure"]
+      "repositories": ["alphagov/govuk-helm-charts"]
     }


### PR DESCRIPTION
It is managing too many dependencies that all have to be merged manually at the moment