### PR TITLE
Use official Kubernetes external-dns chart instead of Bitnami

### DIFF
--- a/charts/app-config/helm-versions/integration
+++ b/charts/app-config/helm-versions/integration
@@ -2,6 +2,6 @@
 https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.29.1"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.36.0"
 https://charts.dexidp.io dex: "0.17.0"
-https://charts.bitnami.com/bitnami external-dns: "7.1.2"
+https://kubernetes-sigs.github.io/external-dns external-dns: "1.14.4"
 https://charts.external-secrets.io external-secrets: "0.9.14"
 https://stakater.github.io/stakater-charts reloader: "1.0.79"

--- a/charts/app-config/helm-versions/production
+++ b/charts/app-config/helm-versions/production
@@ -2,6 +2,6 @@
 https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.29.1"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.36.0"
 https://charts.dexidp.io dex: "0.17.0"
-https://charts.bitnami.com/bitnami external-dns: "7.1.2"
+https://kubernetes-sigs.github.io/external-dns external-dns: "1.14.4"
 https://charts.external-secrets.io external-secrets: "0.9.14"
 https://stakater.github.io/stakater-charts reloader: "1.0.79"

--- a/charts/app-config/helm-versions/staging
+++ b/charts/app-config/helm-versions/staging
@@ -2,6 +2,6 @@
 https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.29.1"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.36.0"
 https://charts.dexidp.io dex: "0.17.0"
-https://charts.bitnami.com/bitnami external-dns: "7.1.2"
+https://kubernetes-sigs.github.io/external-dns external-dns: "1.14.4"
 https://charts.external-secrets.io external-secrets: "0.9.14"
 https://stakater.github.io/stakater-charts reloader: "1.0.79"

--- a/charts/app-config/templates/external-dns.yaml
+++ b/charts/app-config/templates/external-dns.yaml
@@ -7,23 +7,29 @@ spec:
   project: default
   source:
     {{- include "app-config.helm-release"
-        ( merge (deepCopy .) (dict "repoURL" "https://charts.bitnami.com/bitnami" "chart" "external-dns") )
+        ( merge (deepCopy .) (dict "repoURL" "https://kubernetes-sigs.github.io/external-dns" "chart" "external-dns") )
         | nindent 4 }}
     helm:
       values: |
-        aws:
-          region: eu-west-1
-          zoneType: public
+        provider: aws
+        env:
+          - name: AWS_DEFAULT_REGION
+            value: eu-west-1
+        extraArgs:
+          - --aws-zone-type=public
         serviceAccount:
           name: external-dns
           annotations:
             eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.awsAccountId }}:role/external-dns-govuk
+        automountServiceAccountToken: true
+        revisionHistoryLimit: 10
+        strategy:
+          type: RollingUpdate
         txtOwnerId: govuk
         domainFilters:
           - {{ .Values.k8sExternalDomainSuffix }}
         interval: 5m
         triggerLoopOnEvent: true
-        replicaCount: {{ .Values.replicaCount | default 1 }}
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Values.argoNamespace }}

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -11,7 +11,6 @@ awsAccountId: "172025368201"
 
 cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
 
-replicaCount: 3
 workerReplicaCount: 3
 podDisruptionBudget: &pdb
   maxUnavailable: 2

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -11,7 +11,6 @@ awsAccountId: "696911096973"
 
 cspReportURI: https://csp-reporter.staging.publishing.service.gov.uk/report
 
-replicaCount: 2
 workerReplicaCount: 2
 podDisruptionBudget: &pdb
   minAvailable: 1


### PR DESCRIPTION
Description:
- Official Kubernetes external-dns chart is located [here](https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns)
- Previously in production we were running 3 but the bitnami chart doesn’t have any leader selection so all external-dnspods were running thinking they were the only one. Kubernetes external-dns doesn’t support multiple replicas so removing this entirely. See the discussion [here](https://github.com/kubernetes-sigs/external-dns/issues/2430)
- PR closes https://github.com/alphagov/govuk-helm-charts/issues/1744