### PR TITLE
Set external-dns deployment strategy to recreate

### DIFF
--- a/charts/app-config/templates/external-dns.yaml
+++ b/charts/app-config/templates/external-dns.yaml
@@ -23,8 +23,6 @@ spec:
             eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.awsAccountId }}:role/external-dns-govuk
         automountServiceAccountToken: true
         revisionHistoryLimit: 10
-        deploymentStrategy:
-          type: RollingUpdate
         txtOwnerId: govuk
         domainFilters:
           - {{ .Values.k8sExternalDomainSuffix }}


### PR DESCRIPTION
Description:
- Default strategy is Recreate which is probably best. See discussion [here](https://github.com/kubernetes-sigs/external-dns/commit/3d343ae) which points out that a RollingUpdate strategy may result in pods racing each other to update DNS records