### PR TITLE
Add Toleration and Node Selector for ARM64 apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1810,7 +1810,8 @@ govukApplications:
 
   - name: release
     helmValues:
-      appImage.arch: arm64
+      appImage:
+        arch: arm64
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2845,7 +2846,8 @@ govukApplications:
 
   - name: transition
     helmValues:
-      appImage.arch: arm64
+      appImage:
+        arch: arm64
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1810,6 +1810,7 @@ govukApplications:
 
   - name: release
     helmValues:
+      appImage.arch: arm64
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2844,6 +2845,7 @@ govukApplications:
 
   - name: transition
     helmValues:
+      appImage.arch: arm64
       ingress:
         enabled: true
         annotations:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -180,4 +180,13 @@ spec:
             preStop:
               exec:
                 command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
+      {{- if eq "arm64" .Values.appImage.arch }}
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -45,6 +45,7 @@ appImage:
   repository: ""  # Dummy value, overridden in ArgoCD config.
   pullPolicy: Always
   tag: latest
+  arch: amd64
 appPort: 3000
 # appExtraVolumeMounts defines VolumeMounts on the app container (in both
 # deployment.yaml and worker-deployment.yaml).


### PR DESCRIPTION
## What?
This adds a `appImage.arch` value to our Helm Charts and a condition in the Chart template to add the necessary Pod Node Toleration and Node Selector for scheduling known supported ARM64 images onto Graviton instances. This should also prevent AMD64/x86 images from being scheduled onto ARM nodes and vice-versa.

We then apply this value to the `release` and `transition` apps for testing.

If we wanted to change this in the future so we can schedule/select certain apps to run on specialised GPU/ML hardware, that's something we can add down the line without too much difficulty - but for now, this should keep our app configuration a bit simpler.