### PR TITLE
Work around gotcha in `appImage` value.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1812,8 +1812,7 @@ govukApplications:
 
   - name: release
     helmValues:
-      appImage:
-        arch: arm64
+      arch: arm64
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2848,8 +2847,7 @@ govukApplications:
 
   - name: transition
     helmValues:
-      appImage:
-        arch: arm64
+      arch: arm64
       ingress:
         enabled: true
         annotations:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -180,13 +180,13 @@ spec:
             preStop:
               exec:
                 command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
-      {{- if eq "arm64" .Values.appImage.arch }}
+      {{- if eq "arm64" .Values.arch }}
       tolerations:
-      - key: "kubernetes.io/arch"
-        operator: "Equal"
-        value: "arm64"
-        effect: "NoSchedule"
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: {{ .Values.arch }}
       {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -41,11 +41,14 @@ cronTasks: []
 extraVolumes: []
 
 repoName: "example"  # Dummy value, overridden in ArgoCD config.
+# arch determines whether the app should schedule on amd64 or arm64 nodes.
+# TODO: remove `arch` once the ARM migration is complete and we're not longer
+# running mixed-arch clusters.
+arch: amd64
 appImage:
   repository: ""  # Dummy value, overridden in ArgoCD config.
   pullPolicy: Always
   tag: latest
-  arch: amd64
 appPort: 3000
 # appExtraVolumeMounts defines VolumeMounts on the app container (in both
 # deployment.yaml and worker-deployment.yaml).


### PR DESCRIPTION
Turns out the `appImage` Helm value is a bit of a confusing special case cos it gets mangled through app-config/templates/govuk-application.yaml. At least it was confusing to me, anyway.

So setting anything under `appImage` in `helmValues` in `values-*.yaml` shadows the `appImage` value object that comes out of charts/app-config, removing the rest of the info about the app image. Confusing.

Simpler to make `arch` a top-level value in charts/generic-govuk-app. Also kinda makes sense cos `arch` is really about a scheduling-constraint so affects the whole pod/deployment and not just the app image (even though it is arguably a property of the app image).