### PR TITLE
Reset cache max-age to 5 minutes

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -723,7 +723,7 @@ govukApplications:
               name: signon-app-content-store
               key: oauth_secret
         - name: DEFAULT_TTL
-          value: "1"
+          value: "300"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -723,7 +723,7 @@ govukApplications:
               name: signon-app-content-store
               key: oauth_secret
         - name: DEFAULT_TTL
-          value: "1"
+          value: "300"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -727,7 +727,7 @@ govukApplications:
               name: signon-app-content-store
               key: oauth_secret
         - name: DEFAULT_TTL
-          value: "1"
+          value: "300"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Currently, the cache max age for pages rendered by frontend's content items controller is 1 second:

    $ curl -sI https://www.gov.uk | grep -i cache-control
    cache-control: max-age=1, public

It's supposed to be 5 minutes, as per [RFC 144][0]

It's pretty surprising that the cache control header in content store ends up affecting the cache control header in the frontend response, but this [appears to be deliberate][1].

This value [used to be set to 300][2], but it regressed as part of the content-store postgres migration. It's an error carried forward from [this commit][3].

Fixing this should improve our cache hit rate, resulting in less load on our frontends and faster response times for users.

[0] - https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md
[1] - https://github.com/alphagov/frontend/blob/main/app/controllers/content_items_controller.rb#L48-L51
[2] - https://github.com/alphagov/govuk-helm-charts/blob/36fd274b9864f570acd43a82864bb5c722345a1d/charts/app-config/values-production.yaml#L683-L684
[3] - https://github.com/alphagov/govuk-helm-charts/blame/9ed49761654e38c2410a91094ad45e1f46711746/charts/app-config/values-production.yaml#L725