### PR TITLE
Add parallel host names for Imminence in preparation for rename to Places Manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1265,9 +1265,11 @@ govukApplications:
           alb.ingress.kubernetes.io/group.order: "110"
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "places-manager.{{ .Values.publishingDomainSuffix }}",
                 "imminence.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
+          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
           - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
In preparation for renaming Imminence, test adding two host names in integration so we can see if this is a viable technique for making the switchover simpler.

https://trello.com/c/HAEH2bVF/2338-rename-imminence