### PR TITLE
Manually enable promotion/deploys for `search-admin`

### DIFF
--- a/charts/app-config/image-tags/production/search-admin
+++ b/charts/app-config/image-tags/production/search-admin
@@ -1,2 +1,3 @@
 image_tag: v135
-promote_deployment: false
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/image-tags/staging/search-admin
+++ b/charts/app-config/image-tags/staging/search-admin
@@ -1,3 +1,3 @@
 image_tag: v138
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true
 promote_deployment: true


### PR DESCRIPTION
The Github Action didn't work, so this manually re-enables automatic deploys and promotion for `search-admin` by adjusting the relevant values in the image tags.