### PR TITLE
Add parallel host names for Imminence in production/staging

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1312,9 +1312,11 @@ govukApplications:
           alb.ingress.kubernetes.io/group.order: "110"
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "places-manager.{{ .Values.publishingDomainSuffix }}",
                 "imminence.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
+          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
           - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 60s

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1308,9 +1308,11 @@ govukApplications:
           alb.ingress.kubernetes.io/group.order: "110"
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "places-manager.{{ .Values.publishingDomainSuffix }}",
                 "imminence.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
+          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
           - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION

In preparation for renaming Imminence, add place-manager as a host name in staging/production

https://trello.com/c/HAEH2bVF/2338-rename-imminence

(following on from testing in integration here: https://github.com/alphagov/govuk-helm-charts/pull/1958)