### PR TITLE
Remove kubernetes.io from the taint key.

### DIFF
--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -182,7 +182,7 @@ spec:
                 command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
       {{- if eq "arm64" .Values.arch }}
       tolerations:
-        - key: kubernetes.io/arch
+        - key: arch
           operator: Equal
           value: {{ .Values.arch }}
           effect: NoSchedule


### PR DESCRIPTION
## What?
This removes `kubernetes.io` from the taint key as per our changes to the node taints.

## Related

* https://github.com/alphagov/govuk-infrastructure/pull/1264