### PR TITLE
Use a single mount point for asset-manager EFS volume in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -162,7 +162,7 @@ govukApplications:
               - path: /government/assets/
               - path: /media/
               - path: /auth/gds  # Viewing draft assets requires user auth.
-      assetManagerNFS: &assets-nfs assets.blue.staging.govuk-internal.digital
+      assetManagerNFS: &assets-nfs "10.12.26.144"  # assets.blue.staging.govuk-internal.digital
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf


### PR DESCRIPTION
This is to test swapping out the asset-manager EFS mount points in production without causing downtime. It will be reverted after testing is done.

alphagov/govuk-infrastructure#1127