### PR TITLE
Use single mount point for asset-manager EFS volume in production

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -163,7 +163,7 @@ govukApplications:
               - path: /government/assets/
               - path: /media/
               - path: /auth/gds  # Viewing draft assets requires user auth.
-      assetManagerNFS: &assets-nfs assets.blue.integration.govuk-internal.digital
+      assetManagerNFS: &assets-nfs assets.integration.govuk-internal.digital
       clamMountConfigPath: /usr/local/etc
       nginxConfigMap:
         create: false

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -154,7 +154,7 @@ govukApplications:
               - path: /government/assets/
               - path: /media/
               - path: /auth/gds  # Viewing draft assets requires user auth.
-      assetManagerNFS: &assets-nfs assets.blue.production.govuk-internal.digital
+      assetManagerNFS: &assets-nfs "10.13.4.138"  # assets.production.govuk-internal.digital
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -162,7 +162,7 @@ govukApplications:
               - path: /government/assets/
               - path: /media/
               - path: /auth/gds  # Viewing draft assets requires user auth.
-      assetManagerNFS: &assets-nfs "10.12.26.144"  # assets.blue.staging.govuk-internal.digital
+      assetManagerNFS: &assets-nfs assets.staging.govuk-internal.digital
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf


### PR DESCRIPTION
https://github.com/alphagov/govuk-infrastructure/issues/1127