### PR TITLE
Use hostname for asset-manager EFS volume in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -154,7 +154,7 @@ govukApplications:
               - path: /government/assets/
               - path: /media/
               - path: /auth/gds  # Viewing draft assets requires user auth.
-      assetManagerNFS: &assets-nfs "10.13.31.41"  # assets.production.govuk-internal.digital
+      assetManagerNFS: &assets-nfs assets.production.govuk-internal.digital
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf


### PR DESCRIPTION
https://github.com/alphagov/govuk-infrastructure/issues/1127