### PR TITLE
Scale search-api-v2-worker back in.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2238,7 +2238,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 25
+      workerReplicaCount: 3
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2305,7 +2305,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 25
+      workerReplicaCount: 3
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2293,7 +2293,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 25
+      workerReplicaCount: 3
       workers:
         - command: ['bin/rake', 'document_sync_worker:run']
           name: document-sync-worker


### PR DESCRIPTION
[Max instantaneous CPU utilisation](https://grafana.eks.production.govuk.digital/goto/criZ6j-IR) has been < 8% for the last 30 days.

Scale them back to ~12% of their current replica count, which should still be plenty.