### PR TITLE
Switch Support to ARM in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2719,6 +2719,7 @@ govukApplications:
 
   - name: support
     helmValues:
+      arch: arm64
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
## What?
This will flick the Support app over to ARM in Integration only.

## Related

* https://github.com/alphagov/support/pull/1336