### PR TITLE
Remove "rummager" token from Search Admin env

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2086,11 +2086,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-search-admin-publishing-api
               key: bearer_token
-        - name: RUMMAGER_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-search-admin-search-api
-              key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: GOVUK_NOTIFY_API_KEY

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2157,11 +2157,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-search-admin-publishing-api
               key: bearer_token
-        - name: RUMMAGER_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-search-admin-search-api
-              key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: GOVUK_NOTIFY_API_KEY

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2147,11 +2147,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-search-admin-publishing-api
               key: bearer_token
-        - name: RUMMAGER_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-search-admin-search-api
-              key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: GOVUK_NOTIFY_API_KEY


### PR DESCRIPTION
The API on Rummager (aka `search-api` v1) is no longer accessed by `search-admin` and the API token can be removed from its environment configuration.