### PR TITLE
Switch Signon to ARM in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2393,6 +2393,7 @@ govukApplications:
 
   - name: signon
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       workerEnabled: true
       ingress:


### PR DESCRIPTION
## What?
This switches Signon over to ARM in Integration now that we have ARM images available.

## Related

* https://github.com/alphagov/signon/pull/2832
* https://github.com/alphagov/signon/pull/2833