### PR TITLE
Enable ARM64 for Whitehall in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3069,6 +3069,7 @@ govukApplications:
   - name: whitehall-admin
     repoName: whitehall
     helmValues:
+      arch: arm64
       securityContext:
         # Use the same uid/gid for NFS permissions as the old stack, so that
         # files uploaded by whitehall-admin on k8s can be processed by


### PR DESCRIPTION
## What?
What it says on the tin. Run the ARM64 flavour of Whitehall in Integration.