### PR TITLE
Reinstate default replicaCount in prod and staging.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -11,6 +11,7 @@ awsAccountId: "172025368201"
 
 cspReportURI: https://csp-reporter.publishing.service.gov.uk/report
 
+replicaCount: 3
 workerReplicaCount: 3
 podDisruptionBudget: &pdb
   maxUnavailable: 2

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -11,6 +11,7 @@ awsAccountId: "696911096973"
 
 cspReportURI: https://csp-reporter.staging.publishing.service.gov.uk/report
 
+replicaCount: 2
 workerReplicaCount: 2
 podDisruptionBudget: &pdb
   minAvailable: 1


### PR DESCRIPTION
Looks like we accidentally these in d445927c :) No harm done.

This adds weight to the idea that we can probably drop to N+1 on a bunch of things (basically anything that's both non-public-facing and non-critical, i.e. not a problem if it's unavailable for a handful of minutes a month).

For now let's just put it back how it was though. That way we can be confident we won't be bitten by PDBs being out of spec etc.