### PR TITLE
Switch Gov Frontend to ARM

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1167,6 +1167,7 @@ govukApplications:
 
   - name: government-frontend
     helmValues:
+      arch: arm64
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital


### PR DESCRIPTION
## What?
This switches government-frontend over to ARM64 on Integration.

Only merge this once the multi-arch builds have been enabled.

## Related

* https://github.com/alphagov/government-frontend/pull/3172