### PR TITLE
Deploy Draft Gov Frontend to ARM

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1180,6 +1180,7 @@ govukApplications:
   - name: draft-government-frontend
     repoName: government-frontend
     helmValues:
+      arch: arm64
       rails:
         createKeyBaseSecret: false
       sentry:


### PR DESCRIPTION
## What?
Draft Gov Frontend pulls from the same repo as regular Government Frontend, so we should just be able to flick this over.