### PR TITLE
Make Publishing API/Search API v2 sync job sync all

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1828,7 +1828,7 @@ govukApplications:
         # In non-production envs, run Search API v2 bulk import every week to bring it to parity
         # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_published_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
           schedule: "0 8 * * 0"  # every Sunday at 8am
       extraEnv:
         - name: GDS_SSO_OAUTH_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1809,7 +1809,7 @@ govukApplications:
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_published_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
           schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)
           suspend: true
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1805,7 +1805,7 @@ govukApplications:
         # In non-production envs, run Search API v2 bulk import every week to bring it to parity
         # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_published_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
           schedule: "0 8 * * 0"  # every Sunday at 8am
       extraEnv:
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
This was only syncing published content for efficiency reasons, but actually we want it to sync _everything_ including unpublished content, otherwise unpublished content won't get removed from the search engine (plus we don't need the efficiency anymore with the turbocharged workers!)

see: https://github.com/alphagov/publishing-api/blob/main/lib/tasks/queue.rake#L50