### PR TITLE
Flick Publisher to ARM on Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1708,6 +1708,7 @@ govukApplications:
 
   - name: publisher
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       workerEnabled: true
       cronTasks:


### PR DESCRIPTION
## What?
This gets Publisher running on ARM in Integration.

## Related

* https://github.com/alphagov/publisher/pull/2146