### PR TITLE
Add GTM config for signon and transition

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2541,6 +2541,12 @@ govukApplications:
               key: DEVISE_SECRET_KEY
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-design-system-gtm-id
+        - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
+          value: *publishing-design-system-gtm-auth
+        - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
+          value: *publishing-design-system-gtm-preview
 
   - name: smartanswers
     repoName: smart-answers

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2985,6 +2985,12 @@ govukApplications:
               key: DATABASE_URL
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
+        - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
+          value: *publishing-bootstrap-gtm-auth
+        - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
+          value: *publishing-bootstrap-gtm-preview
 
   - name: travel-advice-publisher
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2536,6 +2536,8 @@ govukApplications:
               key: DEVISE_SECRET_KEY
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-design-system-gtm-id
 
   - name: smartanswers
     repoName: smart-answers

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2965,6 +2965,8 @@ govukApplications:
               key: DATABASE_URL
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
 
   - name: travel-advice-publisher
     helmValues:


### PR DESCRIPTION
Support for this configuration is added in https://github.com/alphagov/signon/pull/2841 and https://github.com/alphagov/transition/pull/1577

Signon is design system, but Transition is still bootstrap, so using the GTM IDs for each respectively.