### PR TITLE
Add `arch` label to Deploys for easier filtering

### DIFF
--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ $fullName }}
     app.kubernetes.io/name: {{ $fullName }}
     app.kubernetes.io/component: app
+    app.kubernetes.io/arch: {{ .Values.arch }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
@@ -24,6 +25,7 @@ spec:
         app: {{ $fullName }}
         app.kubernetes.io/name: {{ $fullName }}
         app.kubernetes.io/component: app
+        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false


### PR DESCRIPTION
## What?
This adds a label to deployments (and their pods) to show us the system architecture behind the pod. This will either be `amd64` or `arm64`.

## Why?
At present, to find/filter apps based on arch, you first have to `k get nodes -o wide`, get the name of the node, then `k get pods --field-selector spec.nodeName=blah` which can get a bit repetitive and tiresome in a world where we don't want to worry about the nodes too much. With this new label set we should be able to list, sort and filter stuff by its architecture.