### PR TITLE
Add GTM config for search-admin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2168,6 +2168,12 @@ govukApplications:
             secretKeyRef:
               name: search-admin-mysql
               key: DATABASE_URL
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-design-system-gtm-id
+        - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
+          value: *publishing-design-system-gtm-auth
+        - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
+          value: *publishing-design-system-gtm-preview
 
   - name: search-api
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2172,6 +2172,8 @@ govukApplications:
             secretKeyRef:
               name: search-admin-mysql
               key: DATABASE_URL
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-design-system-gtm-id
 
   - name: search-api
     helmValues:


### PR DESCRIPTION
Support for this configuration is added in https://github.com/alphagov/search-admin/pull/1203

Search admin looks design-systemy, so using the design system GTM id. Technically search admin isn't part of publishing, but I think it makes sense to use the same GTM property.