### PR TITLE
Switch Bouncer to ARM on Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -244,6 +244,7 @@ govukApplications:
 
   - name: bouncer
     helmValues:
+      arch: arm64
       rails:
         enabled: false
       uploadAssets:


### PR DESCRIPTION
## What?
Bouncer will now run on ARM/Graviton on Integration.