### PR TITLE
Changed the s3Directory name for govuk-chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1217,6 +1217,7 @@ govukApplications:
         hosts:
           - name: chat.{{ .Values.k8sExternalDomainSuffix }}
       uploadAssets:
+        s3Directory: chat
         path: /app/public/assets/chat
       extraEnv:
         - name: BASIC_AUTH_USERNAME


### PR DESCRIPTION
Since we have specified an asset path of '/chat' in govuk-chat, we have to manually specify the s3Directory to be `chat`, otherwise it defaults to the repo name: `govuk-chat`