### PR TITLE
Allow Cron Jobs to run on ARM.

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -21,6 +21,7 @@ spec:
         app: "{{ $fullName }}-{{ .name }}"
         app.kubernetes.io/name: "{{ $fullName }}-{{ .name }}"
         app.kubernetes.io/component: "{{ .name }}"
+        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       backoffLimit: 0
       template:
@@ -31,6 +32,7 @@ spec:
             app: "{{ $fullName }}-{{ .name }}"
             app.kubernetes.io/name: "{{ $fullName }}-{{ .name }}"
             app.kubernetes.io/component: "{{ .name }}"
+            app.kubernetes.io/arch: {{ .Values.arch }}
         spec:
           automountServiceAccountToken: {{- if .serviceAccount }} true {{- else }} false {{- end }}
           enableServiceLinks: false
@@ -101,4 +103,13 @@ spec:
                 {{- with $.Values.appExtraVolumeMounts }}
                   {{- . | toYaml | trim | nindent 16 }}
                 {{- end }}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}
 {{- end }}


### PR DESCRIPTION
## What?
We've switched a large handful of apps over to ARM now on Integration, but none of the Cron Jobs have switched over yet. This should catch quite a few of them.