### PR TITLE
Run Publishing API as ARM on Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1826,6 +1826,7 @@ govukApplications:
 
   - name: publishing-api
     helmValues:
+      arch: arm64
       nginxClientMaxBodySize: 2M
       dbMigrationEnabled: true
       uploadAssets:


### PR DESCRIPTION
## What?
This flips Publishing API on Integration to run on ARM. This should hopefully catch the Jobs too now that the CronJob template has been updated.