### PR TITLE
Switch off govuk-mirror-job in staging temporarily

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.govukEnvironment "staging" }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -116,3 +117,4 @@ spec:
                   # Upload file for checking mirror freshness
                   touch "/data/${WWW_DOMAIN}/last-updated.txt"
                   /s5cmd cp "/data/${WWW_DOMAIN}/last-updated.txt" "s3://${BUCKET_NAME}/${WWW_DOMAIN}/last-updated.txt"
+{{- end }}


### PR DESCRIPTION
During the same time period in which the govuk-mirror job runs, the post-sync workflow is triggered. This is to test if this might be due to the load from the govuk-mirror job. There's potential that extra load is causing pods to be terminated, which causes reconcilation activity in Argo CD, which then causes the post-sync workflow to be triggered.