### PR TITLE
Add ARM support to Workers, Migrations, plus...

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -135,6 +135,7 @@ govukApplications:
   - name: asset-manager
     chartPath: charts/asset-manager
     helmValues:
+      arch: arm64
       workerEnabled: true
       ingress:
         enabled: true
@@ -844,6 +845,7 @@ govukApplications:
 
   - name: email-alert-api
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
@@ -1037,6 +1039,7 @@ govukApplications:
 
   - name: finder-frontend
     helmValues:
+      arch: arm64
       cronTasks:
         - name: registries-refresh
           task: "registries:cache_refresh"
@@ -1211,6 +1214,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       workerEnabled: true
       ingress:
@@ -1307,6 +1311,7 @@ govukApplications:
 
   - name: hmrc-manuals-api
     helmValues:
+      arch: arm64
       nginxClientMaxBodySize: 2M
       ingress:
         enabled: true

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ $fullName }}-dbmigrate
     app.kubernetes.io/name: {{ $fullName }}-dbmigrate
     app.kubernetes.io/component: dbmigrate
+    app.kubernetes.io/arch: {{ .Values.arch }}
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:
@@ -22,6 +23,7 @@ spec:
         app: {{ $fullName }}-dbmigrate
         app.kubernetes.io/name: {{ $fullName }}-dbmigrate
         app.kubernetes.io/component: dbmigrate
+        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
@@ -75,4 +77,13 @@ spec:
             {{- with .Values.appExtraVolumeMounts }}
               {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ $fullName }}-worker
     app.kubernetes.io/name: {{ $fullName }}-worker
     app.kubernetes.io/component: worker
+    app.kubernetes.io/arch: {{ .Values.arch }}
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 2
@@ -22,6 +23,7 @@ spec:
         app: {{ $fullName }}-worker
         app.kubernetes.io/name: {{ $fullName }}-worker
         app.kubernetes.io/component: worker
+        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
@@ -91,4 +93,13 @@ spec:
               {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
         {{- end }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
## What?
This enables ARM support for workers, DB Migrations, plus the following apps:

* asset-manager
* email-alert-api
* finder-frontend
* govuk-chat
* hmrc-manuals-api

## Related

* https://github.com/alphagov/asset-manager/pull/1367
* https://github.com/alphagov/email-alert-api/pull/2144
* https://github.com/alphagov/finder-frontend/pull/3341
* https://github.com/alphagov/govuk-chat/pull/172
* https://github.com/alphagov/hmrc-manuals-api/pull/953