### PR TITLE
Temporarily rolling govuk-chat backto AMD/x86

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1214,7 +1214,6 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      arch: arm64
       dbMigrationEnabled: true
       workerEnabled: true
       workers:


### PR DESCRIPTION
## What?
This rolls the GOV.UK Chat app back to AMD64 (x86-64) in Integration due to a hash mismatch when precompiling assets on the two different machine architectures.

FYI @kevindew.