### PR TITLE
Enable ARM64 for the link apps.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1451,6 +1451,7 @@ govukApplications:
 
   - name: link-checker-api
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
@@ -1491,6 +1492,7 @@ govukApplications:
 
   - name: local-links-manager
     helmValues:
+      arch: arm64
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
## What?
This enables ARM64 for the "links" apps:

* link-checker-api
* local-links-manager

(These apps may or may not be related in name only, but I'm trying to reduce the number of PRs needed to switch everything over!)