### PR TITLE
Temporarily disable published-documents-consumer worker

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1219,8 +1219,9 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # Temporarily disabled until we have opensearch hooked up
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Until we have opensearch hooked up