### PR TITLE
Prevent post-sync deployments when nothing changes

### DIFF
--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -33,5 +33,6 @@ trigger.deployment: |
     when: "app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'"
 trigger.on-deployed: |
   - send: ["send-argo-events-webhook"]
+    oncePer: 'app.status.operationState.syncResult.revision'
     when: "app.status.operationState.phase in ['Succeeded'] and app.status.health.status
       == 'Healthy' and app.metadata.annotations['postSyncWorkflowEnabled'] == 'true' "


### PR DESCRIPTION
This sets a condition to prevent triggering the post-sync workflow when there is no configuration changes. The post-sync notification was being sent when an Application was being sync, even if there wasn't a configuration change (due to a change in the cluster).