### PR TITLE
Enable ARM for Service Manual Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2443,6 +2443,7 @@ govukApplications:
 
   - name: service-manual-publisher
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       ingress:
         enabled: true


### PR DESCRIPTION
## What?
This switches Service Manual Publisher to run on ARM when running in the Integration environment.