### PR TITLE
Temporarily roll manuals publisher back to AMD64

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1637,7 +1637,6 @@ govukApplications:
 
   - name: manuals-publisher
     helmValues:
-      arch: arm64
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
       ingress:


### PR DESCRIPTION
## What?
This temporarily returns manuals-publisher to AMD64 while we address the upload assets issue.