### PR TITLE
Make assets-upload job ARM supported...

### DIFF
--- a/charts/generic-govuk-app/templates/_helpers.tpl
+++ b/charts/generic-govuk-app/templates/_helpers.tpl
@@ -41,6 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 
 {{/*
 Selector labels

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -65,4 +65,13 @@ spec:
       volumes:
         - name: assets-to-upload
           emptyDir: {}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -21,7 +21,6 @@ spec:
         app: "{{ $fullName }}-{{ .name }}"
         app.kubernetes.io/name: "{{ $fullName }}-{{ .name }}"
         app.kubernetes.io/component: "{{ .name }}"
-        app.kubernetes.io/arch: {{ $.Values.arch }}
     spec:
       backoffLimit: 0
       template:
@@ -32,7 +31,6 @@ spec:
             app: "{{ $fullName }}-{{ .name }}"
             app.kubernetes.io/name: "{{ $fullName }}-{{ .name }}"
             app.kubernetes.io/component: "{{ .name }}"
-            app.kubernetes.io/arch: {{ $.Values.arch }}
         spec:
           automountServiceAccountToken: {{- if .serviceAccount }} true {{- else }} false {{- end }}
           enableServiceLinks: false

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -9,7 +9,6 @@ metadata:
     app: {{ $fullName }}-dbmigrate
     app.kubernetes.io/name: {{ $fullName }}-dbmigrate
     app.kubernetes.io/component: dbmigrate
-    app.kubernetes.io/arch: {{ .Values.arch }}
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:
@@ -23,7 +22,6 @@ spec:
         app: {{ $fullName }}-dbmigrate
         app.kubernetes.io/name: {{ $fullName }}-dbmigrate
         app.kubernetes.io/component: dbmigrate
-        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     app: {{ $fullName }}
     app.kubernetes.io/name: {{ $fullName }}
     app.kubernetes.io/component: app
-    app.kubernetes.io/arch: {{ .Values.arch }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
@@ -25,7 +24,6 @@ spec:
         app: {{ $fullName }}
         app.kubernetes.io/name: {{ $fullName }}
         app.kubernetes.io/component: app
-        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false

--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -52,4 +52,13 @@ spec:
             - name: tmp
               mountPath: /tmp
       restartPolicy: Never
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
 {{- end }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     app: {{ $fullName }}-worker
     app.kubernetes.io/name: {{ $fullName }}-worker
     app.kubernetes.io/component: worker
-    app.kubernetes.io/arch: {{ .Values.arch }}
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 2
@@ -23,7 +22,6 @@ spec:
         app: {{ $fullName }}-worker
         app.kubernetes.io/name: {{ $fullName }}-worker
         app.kubernetes.io/component: worker
-        app.kubernetes.io/arch: {{ .Values.arch }}
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false


### PR DESCRIPTION
## What?
This adds the necessary bits to get the `-upload-assets` jobs running on ARM. Hopefully alongside their deployments.

This also moves the "arch" label to _helpers so we don't have to specify it for every "generic GOV.UK app".