### PR TITLE
Move up the arch label into the "define" block.

### DIFF
--- a/charts/generic-govuk-app/templates/_helpers.tpl
+++ b/charts/generic-govuk-app/templates/_helpers.tpl
@@ -40,8 +40,8 @@ helm.sh/chart: {{ include "generic-govuk-app.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
 app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+{{- end }}
 
 {{/*
 Selector labels


### PR DESCRIPTION
## What?
This moves the `arch` label so that it's actually _inside_ the labels block.

...oops.