### PR TITLE
Update the name used for toolbox image.

### DIFF
--- a/charts/argo-services/templates/workflows/add-tag-to-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/add-tag-to-image/workflow.yaml
@@ -23,7 +23,7 @@ spec:
           - name: referenceTag
           - name: newTag
       script:
-        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox:latest
         command: [/bin/bash]
         env:
           - name: AWS_DEFAULT_REGION

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -61,7 +61,7 @@ spec:
         - name: environment
         - name: repoName
       script:
-        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox:latest
         command: [/bin/bash]
         env:
           - name: ENVIRONMENT

--- a/charts/argo-services/templates/workflows/set-automatic-deploys/workflow.yaml
+++ b/charts/argo-services/templates/workflows/set-automatic-deploys/workflow.yaml
@@ -18,7 +18,7 @@ spec:
           - name: automaticDeploysEnabled
             default: "true"
       script:
-        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox:latest
         command: [/bin/bash]
         env:
           - name: GIT_NAME

--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -20,7 +20,7 @@ spec:
           - name: promoteDeployment
             default: "false"
       script:
-        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox:latest
         command: [/bin/bash]
         env:
           - name: GIT_NAME


### PR DESCRIPTION
## What?
Some time ago, the `github-cli` image was re-named to `toolbox` but this was never updated in the Helm Charts.

This means that our "toolbox" has not been pulling the latest version for quite some time! Let's fix that.