### PR TITLE
Add temporary additional service name for places-manager/imminence

### DIFF
--- a/charts/app-config/places-manager-temp-service.yaml
+++ b/charts/app-config/places-manager-temp-service.yaml
@@ -1,0 +1,20 @@
+# Temporary additional service name for places-manager/
+# imminence to allow a smooth switchover when we rename
+# the app. To be removed when the app is renamed fully
+# in the values-xxx.yaml files
+apiVersion: v1
+kind: Service
+metadata:
+  name: places-manager
+  labels:
+    app: places-manager
+    app.kubernetes.io/name: places-manager
+    app.kubernetes.io/component: app
+spec:
+  type: NodePort
+  ports:
+    - name: app
+      port: 80
+      targetPort: 8080
+  selector:
+    app: imminence


### PR DESCRIPTION
To enable a smooth transition from the old app name (imminence) to the new app name (places-manager) we need to run the two names in parallel for a short time. We've done this with the public hostnames since [PR 1960](https://github.com/alphagov/govuk-helm-charts/pull/1960), but for Frontend to be able to talk to the new name inside the cluster, we need to temporarily add a service pointing to the imminence app.

This will be removed once the app is properly renamed in govuk-helm-charts.

https://trello.com/c/HAEH2bVF/4-rename-imminence