### PR TITLE
The upload-assets job image change got missed out

### DIFF
--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -44,7 +44,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: upload-assets
-          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox:latest
           command:
             - aws
             - s3


### PR DESCRIPTION
## What?
This one is on me - I forgot to hit "save" when updating the image names used for the `toolbox` (formerly `github-cli`) image.