### PR TITLE
Change search bulk resync task on Publishing API

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1863,7 +1863,7 @@ govukApplications:
         # In non-production envs, run Search API v2 bulk import every week to bring it to parity
         # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_ever_published_things[bulk.search_api_v2_sync]"
           schedule: "0 8 * * 0"  # every Sunday at 8am
       extraEnv:
         - name: GDS_SSO_OAUTH_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1809,7 +1809,7 @@ govukApplications:
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_ever_published_things[bulk.search_api_v2_sync]"
           schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)
           suspend: true
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1805,7 +1805,7 @@ govukApplications:
         # In non-production envs, run Search API v2 bulk import every week to bring it to parity
         # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import
-          task: "queue:requeue_all_the_things[bulk.search_api_v2_sync]"
+          task: "queue:requeue_all_the_ever_published_things[bulk.search_api_v2_sync]"
           schedule: "0 8 * * 0"  # every Sunday at 8am
       extraEnv:
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
When syncing content data for `search-api-v2`, we want to use a new, subtly different Rake task on `publishing-api` that requeues _all_ content that has ever been published (including content that has since been unpublished), not just currently live content.

This means unpublishing messages will be sent for content that is no longer live but for whatever reason failed to be deleted from the search datastore in real time, meaning the sync should actually bring the two systems to 100% parity (famous last distributed systems words).

c.f. https://github.com/alphagov/publishing-api/pull/2725