### PR TITLE
Update image name for static error job

### DIFF
--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -30,7 +30,7 @@ spec:
           emptyDir: {}
       containers:
         - name: upload-static-error-pages
-          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github-cli:latest
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox:latest
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## What?
This is a small one - also updating the Static Error Job page to use the new/correct toolbox image name.