### PR TITLE
Enable govukchat-worker

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1219,9 +1219,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # Temporarily disabled until we have opensearch hooked up
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
- Opensearch is now available/reachable in integration, so this worker can be enabled again