### PR TITLE
Add places manager app integration

### DIFF
--- a/charts/app-config/image-tags/integration/places-manager
+++ b/charts/app-config/image-tags/integration/places-manager
@@ -1,0 +1,3 @@
+image_tag: v138
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/templates/places-manager-temp-service.yaml
+++ b/charts/app-config/templates/places-manager-temp-service.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Values.govukEnvironment "integration" }}
 # Temporary additional service name for places-manager/
 # imminence to allow a smooth switchover when we rename
 # the app. To be removed when the app is renamed fully
@@ -18,3 +19,4 @@ spec:
       targetPort: 8080
   selector:
     app: imminence
+{{ end }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1368,11 +1368,9 @@ govukApplications:
           alb.ingress.kubernetes.io/group.order: "110"
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "places-manager.{{ .Values.publishingDomainSuffix }}",
                 "imminence.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
-          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
           - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 60s
@@ -1747,6 +1745,42 @@ govukApplications:
           value: *publishing-bootstrap-gtm-auth
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
+
+  - name: places-manager
+    helmValues:
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "110"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "places-manager.{{ .Values.publishingDomainSuffix }}",
+            ]}}]
+        hosts:
+          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
+      nginxClientMaxBodySize: *max-upload-size
+      nginxProxyReadTimeout: 60s
+      dbMigrationEnabled: true
+      workerEnabled: true
+      extraEnv:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: imminence-postgres
+              key: DATABASE_URL
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-imminence
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-imminence
+              key: oauth_secret
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
 
   - name: publisher
     helmValues:


### PR DESCRIPTION
Adds the app places-manager in integration, in parallel with imminence, and disables the additional service for places-name in integration. When in place, traffic from frontend and from the places-manager admin should go to the new app. 