### PR TITLE
Add places-manager app in staging

### DIFF
--- a/charts/app-config/image-tags/staging/places-manager
+++ b/charts/app-config/image-tags/staging/places-manager
@@ -1,0 +1,3 @@
+image_tag: v138
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/templates/places-manager-temp-service.yaml
+++ b/charts/app-config/templates/places-manager-temp-service.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Values.govukEnvironment "integration" }}
+{{ if eq .Values.govukEnvironment "production" }}
 # Temporary additional service name for places-manager/
 # imminence to allow a smooth switchover when we rename
 # the app. To be removed when the app is renamed fully

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1309,11 +1309,9 @@ govukApplications:
           alb.ingress.kubernetes.io/group.order: "110"
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "places-manager.{{ .Values.publishingDomainSuffix }}",
                 "imminence.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
-          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
           - name: imminence.{{ .Values.k8sExternalDomainSuffix }}
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 60s
@@ -1680,6 +1678,43 @@ govukApplications:
             secretKeyRef:
               name: maslow-docdb
               key: MONGODB_URI
+
+  - name: places-manager
+    helmValues:
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "110"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "places-manager.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: places-manager.{{ .Values.k8sExternalDomainSuffix }}
+      nginxClientMaxBodySize: *max-upload-size
+      nginxProxyReadTimeout: 60s
+      dbMigrationEnabled: true
+      workerEnabled: true
+      extraEnv:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: imminence-postgres
+              key: DATABASE_URL
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-imminence
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-imminence
+              key: oauth_secret
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+
 
   - name: publisher
     helmValues:


### PR DESCRIPTION
- Add the app, and remove the temporary service (frontend is temporarily pointed back to the old app, so at this point it's safe to remove the service, and necessary because otherwise it'll fight with the new app's default service)
 
https://trello.com/c/HAEH2bVF/4-rename-imminence