### PR TITLE
Run short-url-manager on ARM in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2716,6 +2716,7 @@ govukApplications:
 
   - name: short-url-manager
     helmValues:
+      arch: arm64
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
## What?
This switches the Short URL Manager to run on ARM/Graviton in Integration