### PR TITLE
Drop SignonApiUserTokenExpirySoon for staging.

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -19,6 +19,9 @@ spec:
         - name: alertname
           value: SignonApiUserTokenExpirySoon
           matchType: =
+        - name: environment
+          value: integration|production
+          matchType: =~
       receiver: 'slack-signon-token-expiry'
       repeatInterval: 1d
       groupWait: 12h


### PR DESCRIPTION
The horrible, toily `SignonApiUserTokenExpirySoon` Slack alerts are not applicable in the staging cluster because staging Signon's database is copied nightly from production.

This whole source of toil needs to be thrown in the bin with extreme prejudice, but that's another matter.