### PR TITLE
Change publish finders cronjob to run later

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2793,7 +2793,7 @@ govukApplications:
       cronTasks:
         - name: publish-finders
           task: "publishing_api:publish_finders"
-          schedule: "49 7 * * 1-5"
+          schedule: "55 8 * * 1-5"
       extraEnv:
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
This rake task ensures pre-production finders in integration are published and made available for user testing.
Noticed that unpublished finders are still not published in the morning. Getting it to run later to ensure that other jobs like index sync are done.

[Trello](https://trello.com/c/e0KYS9mQ/2584-farming-grant-options-breadcrumb-not-showing-not-able-to-save-documents)