### PR TITLE
Re-enable Chat MQ consumer

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1219,8 +1219,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Now that we have extra RAM on the OpenSearch instance we believe we can now resume running this worker and not experience errors.