### PR TITLE
Add missing labels to Upload Asset Jobs

### DIFF
--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -18,6 +18,7 @@ spec:
   backoffLimit: 1
   template:
     metadata: 
+      name: {{ $fullName }}-upload-assets
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 4 }}
         app: {{ $fullName }}-upload-assets

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -17,6 +17,12 @@ spec:
   activeDeadlineSeconds: 900
   backoffLimit: 1
   template:
+    metadata: 
+      labels:
+        {{- include "generic-govuk-app.labels" . | nindent 4 }}
+        app: {{ $fullName }}-upload-assets
+        app.kubernetes.io/name: {{ $fullName }}-upload-assets
+        app.kubernetes.io/component: upload-assets
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -20,7 +20,7 @@ spec:
     metadata: 
       name: {{ $fullName }}-upload-assets
       labels:
-        {{- include "generic-govuk-app.labels" . | nindent 4 }}
+        {{- include "generic-govuk-app.labels" . | nindent 8 }}
         app: {{ $fullName }}-upload-assets
         app.kubernetes.io/name: {{ $fullName }}-upload-assets
         app.kubernetes.io/component: upload-assets


### PR DESCRIPTION
## What?
This adds a `template->metadata->labels` section to the `-upload-assets` Jobs.

## Why?
The jobs that were being created and displayed alongside other Pods had no corresponding labels, whereas other Jobs like DB Migrations were. This should hopefully fix that.