### PR TITLE
Add image references for govuk-mirror

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-mirror
+++ b/charts/app-config/image-tags/integration/govuk-mirror
@@ -1,0 +1,3 @@
+image_tag: v1
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/image-tags/production/govuk-mirror
+++ b/charts/app-config/image-tags/production/govuk-mirror
@@ -1,0 +1,3 @@
+image_tag: v1
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/image-tags/staging/govuk-mirror
+++ b/charts/app-config/image-tags/staging/govuk-mirror
@@ -1,0 +1,3 @@
+image_tag: v1
+automatic_deploys_enabled: true
+promote_deployment: true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1304,6 +1304,7 @@ govukApplications:
       - "content-store-postgresql-branch"
       - "search-api"
       - "search-api-learn-to-rank"
+      - "govuk-mirror"
     helmValues:
       govukMirrorSync:
         iamRoleArn: arn:aws:iam::210287912431:role/govuk-mirror-sync

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1242,6 +1242,7 @@ govukApplications:
       - "govuk-dependency-checker"
       - "search-api"
       - "search-api-learn-to-rank"
+      - "govuk-mirror"
     helmValues:
       govukMirrorSync:
         iamRoleArn: arn:aws:iam::172025368201:role/govuk-mirror-sync

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1244,6 +1244,7 @@ govukApplications:
       - "content-store-postgresql-branch"
       - "search-api"
       - "search-api-learn-to-rank"
+      - "govuk-mirror"
     helmValues:
       govukMirrorSync:
         iamRoleArn: arn:aws:iam::696911096973:role/govuk-mirror-sync

--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -39,7 +39,7 @@ spec:
               emptyDir: {}
           initContainers:
             - name: scrape
-              image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-mirror:latest
+              image: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/govuk-mirror:{{ .Values.images.GovukMirror.tag }}"
               imagePullPolicy: "Always"
               workingDir: /data
               resources:

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -29,6 +29,9 @@ images:
   SearchApiLearnToRank:
     repository: "search-api-learn-to-rank"
     tag: "release"
+  GovukMirror:
+    repository: "govuk-mirror"
+    tag: "release"
 
 govukMirrorSync:
   schedule: "0 0 * * *"


### PR DESCRIPTION
Previously the govuk-mirror job always used the "latest" image tag.