### PR TITLE
Manuals Publisher to ARM64 on Integration (retry)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1607,6 +1607,7 @@ govukApplications:
 
   - name: manuals-publisher
     helmValues:
+      arch: arm64
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
       ingress:


### PR DESCRIPTION
## What?
Now that most jobs are able to run on ARM, we can try to run Manuals Publisher on ARM64 again.