### PR TITLE
Increase ClamAV maximum number of files allowed

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -21,7 +21,7 @@ data:
     Foreground yes
     LogTime yes
     LogVerbose yes
-    MaxFiles 20000
+    MaxFiles 25000
     # Whitehall and Specialist Publisher allow up to 500 MB uploads. Keep in
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).


### PR DESCRIPTION
In https://github.com/alphagov/govuk-helm-charts/pull/1448/files, we increased the limits for files scanned by ClamAV in Asset Manager.

We have since had a user upload a PDF which (once expanded) has more than 20,000 files.

Therefore increasing the maximum limit to a size that accepts this document.  I've tested this manually on a Asset Manage worker to ensure this limit is sufficient for the file.

[Trello card](https://trello.com/c/ZSZlKf4x)