### PR TITLE
Change redis URL for the chat app to the dedicated redis cluster

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1294,7 +1294,7 @@ govukApplications:
               name: signon-app-chat
               key: oauth_secret
         - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+          value: redis://chat-redis.eks.integration.govuk-internal.digital
 
   - name: govuk-jobs
     chartPath: charts/govuk-jobs


### PR DESCRIPTION
In order to reduce the blast radius of the GOV.UK chat app we now use a dedicated redis cluster for it.