### PR TITLE
Remove unnecessary comment

### DIFF
--- a/charts/db-backup/scripts/whitehall.sql
+++ b/charts/db-backup/scripts/whitehall.sql
@@ -1,8 +1,5 @@
 -- sqlfluff:dialect:mysql
 
--- This is a SQL port of
--- https://github.com/alphagov/whitehall/blob/main/script/scrub-database
-
 SET @lipsum_line = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
 SET @lipsum_slug = 'lorem-ipsum-dolor-sit-amet-elit-';
 SET @lipsum_body


### PR DESCRIPTION
The link 404s as the file has been deleted - so we'd probably want to link to a previous commit version instead:
https://github.com/alphagov/whitehall/blob/942744666bd6eabac4f552baa082a44659d5a749/script/scrub-database

But that commit is 10 years old and the reason the file was deleted is that the contents were ported over to
https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk_env_sync/files/transformation_sql/sanitise_whitehall.sql, which would probably be a better place to link to.

But then there's little value in linking to the govuk-puppet equivalent of all the new infrastructure. Suggest we just bin this.