### PR TITLE
Put Chat back on ARM

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1216,6 +1216,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
+      arch: arm64
       dbMigrationEnabled: true
       workerEnabled: true
       workers:


### PR DESCRIPTION
## What?
There were some issues with the upload jobs not running on the same Arch as our main app deployments. This has since been fixed and now Chat is the only remaining app on Integration still running on AMD64.