### PR TITLE
Manage Tempo with Argo

### DIFF
--- a/charts/monitoring-config/helm-versions/integration
+++ b/charts/monitoring-config/helm-versions/integration
@@ -2,3 +2,4 @@
 https://prometheus-community.github.io/helm-charts kube-prometheus-stack: "60.3.0"
 https://prometheus-community.github.io/helm-charts prometheus-pushgateway: "2.13.0"
 https://oauth2-proxy.github.io/manifests oauth2-proxy: "7.7.4"
+https://grafana.github.io/helm-charts tempo-distributed "1.11.0" 

--- a/charts/monitoring-config/helm-versions/production
+++ b/charts/monitoring-config/helm-versions/production
@@ -2,3 +2,4 @@
 https://prometheus-community.github.io/helm-charts kube-prometheus-stack: "60.3.0"
 https://prometheus-community.github.io/helm-charts prometheus-pushgateway: "2.13.0"
 https://oauth2-proxy.github.io/manifests oauth2-proxy: "7.7.4"
+https://grafana.github.io/helm-charts tempo-distributed "1.11.0" 

--- a/charts/monitoring-config/helm-versions/staging
+++ b/charts/monitoring-config/helm-versions/staging
@@ -2,3 +2,4 @@
 https://prometheus-community.github.io/helm-charts kube-prometheus-stack: "60.3.0"
 https://prometheus-community.github.io/helm-charts prometheus-pushgateway: "2.13.0"
 https://oauth2-proxy.github.io/manifests oauth2-proxy: "7.7.4"
+https://grafana.github.io/helm-charts tempo-distributed "1.11.0" 

--- a/charts/monitoring-config/templates/tempo/tempo-application.yaml
+++ b/charts/monitoring-config/templates/tempo/tempo-application.yaml
@@ -1,0 +1,27 @@
+{{ $baseValues := fromYaml (.Files.Get "tempo-values.yaml") }}
+{{ $envValues := fromYaml (.Files.Get (printf "tempo-values-%s.yaml" .Values.govukEnvironment)) }}
+{{ $mergedValues := toYaml (merge $envValues $baseValues) }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tempo
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+spec:
+  project: default
+  source:
+    {{- include "monitoring-config.helm-release"
+        ( merge (deepCopy .) (dict "repoURL" "https://grafana.github.io/helm-charts" "chart" "tempo-distributed") )
+        | nindent 4 }}
+    helm:
+      values: |
+        {{ $mergedValues | nindent 8 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.monitoringNamespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true

--- a/charts/monitoring-config/tempo-values-integration.yaml
+++ b/charts/monitoring-config/tempo-values-integration.yaml
@@ -1,0 +1,18 @@
+storage:
+  - trace:
+      - backend: s3
+        s3:
+          - bucket: govuk-integration-tempo
+            region: eu-west-1
+            endpoint: s3.dualstack.eu-west-1.amazonaws.com
+serviceAccount:
+  - name: tempo
+    annotations:
+      - eks.amazonaws.com/role-arn: "arn:aws:iam::210287912431:role/tempo-govuk"
+metricsGenerator:
+  - enabled: true
+    config:
+      - storage:
+          - remote_write:
+              - url: >
+                  http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values-production.yaml
+++ b/charts/monitoring-config/tempo-values-production.yaml
@@ -1,0 +1,22 @@
+storage:
+  - trace:
+      - backend: s3
+        s3:
+          - bucket: govuk-production-tempo
+            region: eu-west-1
+            endpoint: s3.dualstack.eu-west-1.amazonaws.com
+serviceAccount:
+  - name: tempo
+    annotations:
+      - eks.amazonaws.com/role-arn: "arn:aws:iam::172025368201:role/tempo-govuk"
+metricsGenerator:
+  - enabled: true
+    config:
+      - storage:
+          - remote_write:
+              - url: >
+                  http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
+              - url: >
+                  http://prometheus-kube-prometheus-stack-prometheus-1.kube-prometheus-stack-prometheus:9090/api/v1/write
+              - url: >
+                  http://prometheus-kube-prometheus-stack-prometheus-2.kube-prometheus-stack-prometheus:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values-staging.yaml
+++ b/charts/monitoring-config/tempo-values-staging.yaml
@@ -1,0 +1,20 @@
+storage:
+  - trace:
+      - backend: s3
+        s3:
+          - bucket: govuk-staging-tempo
+            region: eu-west-1
+            endpoint: s3.dualstack.eu-west-1.amazonaws.com
+serviceAccount:
+  - name: tempo
+    annotations:
+      - eks.amazonaws.com/role-arn: "arn:aws:iam::696911096973:role/tempo-govuk"
+metricsGenerator:
+  - enabled: true
+    config:
+      - storage:
+          - remote_write:
+              - url: >
+                  http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
+              - url: >
+                  http://prometheus-kube-prometheus-stack-prometheus-1.kube-prometheus-stack-prometheus:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values.yaml
+++ b/charts/monitoring-config/tempo-values.yaml
@@ -1,0 +1,22 @@
+reportingEnabled: false
+ingester:
+  - persistence:
+      - enabled: true
+        size: 30Gi
+        storageClass: ebs-gp3
+metaMonitoring:
+  - serviceMonitor:
+      - enabled: true
+        namespace: monitoring
+traces:
+  - otlp:
+      - grpc:
+          - enabled: true
+        http:
+          - enabled: true
+overrides:
+  - '*':
+      - ingestion_burst_size_bytes: 20000000
+        metrics_generator_processors:
+          - service-graphs
+          - span-metrics


### PR DESCRIPTION
This shifts the installing the Tempo chart from Terraform to ArgoCD.