### PR TITLE
Re-enable tracing in production

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -42,14 +42,11 @@ data:
   GOVUK_DATA_SYNC_PERIOD: "22:0-8:0"
   {{- end }}
 
-  {{- if ne .Values.govukEnvironment "production" }}
-  # TODO(#1827): fix OTel nil dereference so we can re-enable it in production.
   ENABLE_OPEN_TELEMETRY: "true"
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo-distributor.monitoring.svc.cluster.local:4318"
   OTEL_TRACES_SAMPLER: "traceidratio"
   OTEL_TRACES_SAMPLER_ARG: '0.001'
   OTEL_RUBY_INSTRUMENTATION_RACK_CONFIG_OPTS: "untraced_endpoints=/healthcheck/live"
-  {{- end }}
 
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}
   PLEK_SERVICE_DRAFT_ASSETS_URI: https://draft-assets.{{ .Values.publishingDomainSuffix }}


### PR DESCRIPTION
This was previously disable due to a bug causing the OpenTel SDK to produce significant numbers of error logs. This bug has been fixed in https://github.com/alphagov/govuk_app_config/pull/372.