### PR TITLE
Put Asset Mgr on x86 Until ARM Builds fixed

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -135,7 +135,6 @@ govukApplications:
   - name: asset-manager
     chartPath: charts/asset-manager
     helmValues:
-      arch: arm64
       workerEnabled: true
       ingress:
         enabled: true


### PR DESCRIPTION
## What?
This launches Asset Manager back into x86 to give us time to unblock the ARM builds. We'll need to either build ClamAV for ARM, or de-couple ClamAV from the Build and use a standalone AV container (most likely).

## Related
* https://github.com/alphagov/asset-manager/pull/1391