### PR TITLE
Temporarily enable SLIMMER_WRAPPER_CHECK for frontend in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1119,6 +1119,8 @@ govukApplications:
               key: bearer_token
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: SLIMMER_WRAPPER_CHECK
+          value: 'true'
 
   - name: draft-frontend
     repoName: frontend


### PR DESCRIPTION
## What

Temporarily enable SLIMMER_WRAPPER_CHECK for frontend in production. The functionality was introduced to slimmer by [this PR](https://github.com/alphagov/slimmer/pull/321).

## Why

This is done in order to help investigating the exception raised in frontend only in production.
It should be disabled after the investigation is done.

Further info about the exception is in the following Trello ticket.

[Trello ticket](https://trello.com/c/iyPxdU09/2495-sentry-errors-investigate-fix-frontend-nomethoderror)