### PR TITLE
Add ability to create redis instances in generic-govuk-app chart

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1426,6 +1426,11 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &link-checker-redis redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+          workers: *link-checker-redis
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
@@ -1457,9 +1462,6 @@ govukApplications:
             secretKeyRef:
               name: link-checker-api-postgres
               key: DATABASE_URL
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-
   - name: local-links-manager
     helmValues:
       arch: arm64

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
   selector:
     matchLabels:
       app: {{ $fullName }}
-      app.kubernetes.io/component: app
   template:
     metadata:
       labels:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     matchLabels:
       app: {{ $fullName }}
+      app.kubernetes.io/component: app
   template:
     metadata:
       labels:
@@ -94,6 +95,10 @@ spec:
                   key: dsn
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_URL
+              value: {{ .Values.redis.redisUrlOverride.app | default (printf "redis://%s-redis" $fullName) }}
             {{- end }}
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}

--- a/charts/generic-govuk-app/templates/redis-configmap.yaml
+++ b/charts/generic-govuk-app/templates/redis-configmap.yaml
@@ -1,0 +1,25 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-redis-conf
+  labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: redis
+data:
+  redis.conf: |-
+    bind 0.0.0.0
+    port 6379
+
+    protected-mode no
+
+    daemonize no
+
+    # Use AOF for persistence
+    dir /data
+    appendonly yes
+    save ""
+{{ end }}

--- a/charts/generic-govuk-app/templates/redis-deployment.yaml
+++ b/charts/generic-govuk-app/templates/redis-deployment.yaml
@@ -1,0 +1,90 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-redis
+  labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: redis
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $fullName }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "generic-govuk-app.labels" . | nindent 8 }}
+        app: {{ $fullName }}
+        app.kubernetes.io/name: {{ $fullName }}
+        app.kubernetes.io/component: redis
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-redis-conf
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-redis
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          command: ["redis-server", "/etc/redis/redis.conf"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          livenessProbe: &redisProbe
+            tcpSocket:
+              port: 6379
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            <<: *redisProbe
+          startupProbe:
+            <<: *redisProbe
+            failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis.conf
+            - name: storage
+              mountPath: /data
+          resources:
+            {{- .Values.redis.resources | toYaml | trim | nindent 12 }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+{{ end }}

--- a/charts/generic-govuk-app/templates/redis-deployment.yaml
+++ b/charts/generic-govuk-app/templates/redis-deployment.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ $fullName }}-redis
   labels:
     {{- include "generic-govuk-app.labels" . | nindent 4 }}
-    app: {{ $fullName }}
-    app.kubernetes.io/name: {{ $fullName }}
+    app: {{ $fullName }}-redis
+    app.kubernetes.io/name: {{ $fullName }}-redis
     app.kubernetes.io/component: redis
   annotations:
     reloader.stakater.com/auto: "true"
@@ -16,14 +16,14 @@ spec:
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: {{ $fullName }}
+      app: {{ $fullName }}-redis
       app.kubernetes.io/component: redis
   template:
     metadata:
       labels:
         {{- include "generic-govuk-app.labels" . | nindent 8 }}
-        app: {{ $fullName }}
-        app.kubernetes.io/name: {{ $fullName }}
+        app: {{ $fullName }}-redis
+        app.kubernetes.io/name: {{ $fullName }}-redis
         app.kubernetes.io/component: redis
     spec:
       automountServiceAccountToken: false

--- a/charts/generic-govuk-app/templates/redis-pvc.yaml
+++ b/charts/generic-govuk-app/templates/redis-pvc.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-redis
+  labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: redis
+spec:
+  storageClassName: {{ .Values.redis.storageClassName }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.redis.storage }}
+{{ end }}

--- a/charts/generic-govuk-app/templates/redis-service.yaml
+++ b/charts/generic-govuk-app/templates/redis-service.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-redis
+  labels:
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: redis
+spec:
+  type: NodePort
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+  selector:
+    app: {{ $fullName }}
+    app.kubernetes.io/component: redis
+{{ end }}

--- a/charts/generic-govuk-app/templates/service.yaml
+++ b/charts/generic-govuk-app/templates/service.yaml
@@ -21,3 +21,4 @@ spec:
       targetPort: {{ .Values.nginxPort }}
   selector:
     app: {{ $fullName }}
+    app.kubernetes.io/component: app

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -72,6 +72,10 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ $.Values.appImage.tag }}"
             {{- end }}
+            {{- if $.Values.redis.enabled }}
+            - name: REDIS_URL
+              value: {{ $.Values.redis.redisUrlOverride.workers | default (printf "redis://%s-redis" $fullName) }}
+            {{- end }}
             {{- with $.Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -20,6 +20,27 @@ workers:
   - command: ["sidekiq", "-C", "config/sidekiq.yml"]
     name: worker
 
+# redis.enabled controls whether a Redis database is set up for the app
+# REDIS_URL is automatically set unless redis.redisUrlOverride values are provided
+redis:
+  enabled: false
+  image:
+    repository: redis
+    tag: "7.2"
+    pullPolicy: Always
+  storageClassName: ebs-gp3
+  storage: 10Gi
+  resources:
+    limits:
+      cpu: 1
+      memory: 1000Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
+  redisUrlOverride:
+    app: ""
+    workers: ""
+
 # dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
 dbMigrationEnabled: false
 dbMigrationCommand: ["rails", "db:migrate"]


### PR DESCRIPTION
Adds the ability to create redis servers in the generic-govuk-app chart, and creates a test Redis server for link-checker-api in integration

#2098 