### PR TITLE
Set log level for email-alert-api back to default (info) in staging/prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -904,8 +904,6 @@ govukApplications:
           value: &frontend-notify-template cb633abc-6ae6-4843-ae6f-82ca500b6de2
         - name: GOVUK_NOTIFY_RECIPIENTS
           value: '*'
-        - name: RAILS_LOG_LEVEL
-          value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -908,8 +908,6 @@ govukApplications:
           value: &frontend-notify-template 2844a647-6bf1-4b01-a25c-569d2cc00849
         - name: GOVUK_NOTIFY_RECIPIENTS
           value: email-alert-api-staging@digital.cabinet-office.gov.uk
-        - name: RAILS_LOG_LEVEL
-          value: warn
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY


### PR DESCRIPTION
- This came up in a recent incident, where .info level logs were unavailable, slightly hindering the investigating team.
- email-alert-api has now had its in-app .info level logging audited and the worst offender has been removed, so should be safe to allow info level logging again. There's still the chance that a 3rd-party library might be dumping unnecessary logs, so worth keeping an eye on log volumes.