### PR TITLE
Suspend database backup / restore in staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -259,7 +259,7 @@ cronjobs:
 
   staging:
     authenticating-proxy-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "23 1 * * 1-5"
       db: authenticating_proxy_production
       operations:
@@ -268,7 +268,7 @@ cronjobs:
         - op: backup
 
     govuk-chat-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "47 1 * * 1-5"
       db: govuk_chat_production
       operations:
@@ -286,7 +286,7 @@ cronjobs:
         - op: backup
 
     collections-publisher-mysql:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "21 1 * * 1-5"
       db: collections_publisher_production
       operations:
@@ -295,7 +295,7 @@ cronjobs:
         - op: backup
 
     contacts-admin-mysql:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "49 1 * * 1-5"
       db: contacts_production
       operations:
@@ -304,7 +304,7 @@ cronjobs:
         - op: backup
 
     content-data-admin-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "4 1 * * 1-5"
       db: content_data_admin_production
       operations:
@@ -313,7 +313,7 @@ cronjobs:
         - op: backup
 
     content-data-api-postgresql-primary:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "35 1 * * 6"
       host: blue-content-data-api-postgresql-primary-postgres
       db: content_performance_manager_production
@@ -324,7 +324,7 @@ cronjobs:
         - op: backup
 
     content-publisher-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "9 1 * * 1-5"
       db: content_publisher_production
       operations:
@@ -336,7 +336,7 @@ cronjobs:
 
     content-store-postgres:
       <<: *s5cmd-ram-workaround
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       db: content_store_production
       schedule: "06 22 * * 1-5"
       operations:
@@ -345,7 +345,7 @@ cronjobs:
         - op: backup
     draft-content-store-postgres:
       <<: *s5cmd-ram-workaround
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       db: draft_content_store_production
       schedule: "16 22 * * 1-5"
       operations:
@@ -354,7 +354,7 @@ cronjobs:
         - op: backup
 
     content-tagger-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "31 1 * * 1-5"
       db: content_tagger_production
       operations:
@@ -363,7 +363,7 @@ cronjobs:
         - op: backup
 
     email-alert-api-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "54 1 * * 1-5"
       db: email-alert-api_production
       operations:
@@ -374,7 +374,7 @@ cronjobs:
         - op: backup
 
     imminence-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "18 1 * * 1-5"
       db: imminence_production
       operations:
@@ -383,7 +383,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "43 1 * * 1-5"
       db: link_checker_api_production
       operations:
@@ -392,7 +392,7 @@ cronjobs:
         - op: backup
 
     local-links-manager-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "8 1 * * 1-5"
       db: local-links-manager_production
       operations:
@@ -401,7 +401,7 @@ cronjobs:
         - op: backup
 
     locations-api-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "32 1 * * 1-5"
       db: locations_api_production
       operations:
@@ -411,7 +411,7 @@ cronjobs:
 
     publishing-api-postgres:
       <<: *s5cmd-ram-workaround
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "36 1 * * 1-5"
       db: publishing_api_production
       operations:
@@ -431,7 +431,7 @@ cronjobs:
 
     router-mongo:
       <<: *mongo-resources
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "23 0 * * 1-5"
       operations:
         - op: restore
@@ -446,7 +446,7 @@ cronjobs:
           db: router
 
     search-admin-mysql:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "56 1 * * 1-5"
       db: search_admin_production
       operations:
@@ -455,7 +455,7 @@ cronjobs:
         - op: backup
 
     service-manual-publisher-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "49 1 * * 1-5"
       db: service-manual-publisher_production
       operations:
@@ -465,7 +465,7 @@ cronjobs:
 
     shared-documentdb:
       <<: *mongo-resources
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "13 1 * * 1-5"
       operations:
         - op: restore
@@ -503,7 +503,7 @@ cronjobs:
           db: govuk_assets_production
 
     signon-mysql:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "3 1 * * 1-5"
       db: signon_production
       operations:
@@ -511,7 +511,7 @@ cronjobs:
           bucket: s3://govuk-production-database-backups
 
     support-api-postgres:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "38 1 * * 1-5"
       db: support_contacts_production
       operations:
@@ -520,7 +520,7 @@ cronjobs:
         - op: backup
 
     transition-postgresql-primary:
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "24 1 * * 1-5"
       db: transition_production
       dbms: postgres
@@ -531,7 +531,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
+      suspend: true  # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "28 1 * * 1-5"
       db: whitehall_production
       operations:

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -259,6 +259,7 @@ cronjobs:
 
   staging:
     authenticating-proxy-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "23 1 * * 1-5"
       db: authenticating_proxy_production
       operations:
@@ -267,6 +268,7 @@ cronjobs:
         - op: backup
 
     govuk-chat-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "47 1 * * 1-5"
       db: govuk_chat_production
       operations:
@@ -284,6 +286,7 @@ cronjobs:
         - op: backup
 
     collections-publisher-mysql:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "21 1 * * 1-5"
       db: collections_publisher_production
       operations:
@@ -292,6 +295,7 @@ cronjobs:
         - op: backup
 
     contacts-admin-mysql:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "49 1 * * 1-5"
       db: contacts_production
       operations:
@@ -300,6 +304,7 @@ cronjobs:
         - op: backup
 
     content-data-admin-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "4 1 * * 1-5"
       db: content_data_admin_production
       operations:
@@ -308,6 +313,7 @@ cronjobs:
         - op: backup
 
     content-data-api-postgresql-primary:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "35 1 * * 6"
       host: blue-content-data-api-postgresql-primary-postgres
       db: content_performance_manager_production
@@ -318,6 +324,7 @@ cronjobs:
         - op: backup
 
     content-publisher-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "9 1 * * 1-5"
       db: content_publisher_production
       operations:
@@ -329,6 +336,7 @@ cronjobs:
 
     content-store-postgres:
       <<: *s5cmd-ram-workaround
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       db: content_store_production
       schedule: "06 22 * * 1-5"
       operations:
@@ -337,6 +345,7 @@ cronjobs:
         - op: backup
     draft-content-store-postgres:
       <<: *s5cmd-ram-workaround
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       db: draft_content_store_production
       schedule: "16 22 * * 1-5"
       operations:
@@ -345,6 +354,7 @@ cronjobs:
         - op: backup
 
     content-tagger-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "31 1 * * 1-5"
       db: content_tagger_production
       operations:
@@ -353,6 +363,7 @@ cronjobs:
         - op: backup
 
     email-alert-api-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "54 1 * * 1-5"
       db: email-alert-api_production
       operations:
@@ -363,6 +374,7 @@ cronjobs:
         - op: backup
 
     imminence-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "18 1 * * 1-5"
       db: imminence_production
       operations:
@@ -371,6 +383,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "43 1 * * 1-5"
       db: link_checker_api_production
       operations:
@@ -379,6 +392,7 @@ cronjobs:
         - op: backup
 
     local-links-manager-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "8 1 * * 1-5"
       db: local-links-manager_production
       operations:
@@ -387,6 +401,7 @@ cronjobs:
         - op: backup
 
     locations-api-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "32 1 * * 1-5"
       db: locations_api_production
       operations:
@@ -396,6 +411,7 @@ cronjobs:
 
     publishing-api-postgres:
       <<: *s5cmd-ram-workaround
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "36 1 * * 1-5"
       db: publishing_api_production
       operations:
@@ -415,6 +431,7 @@ cronjobs:
 
     router-mongo:
       <<: *mongo-resources
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "23 0 * * 1-5"
       operations:
         - op: restore
@@ -429,6 +446,7 @@ cronjobs:
           db: router
 
     search-admin-mysql:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "56 1 * * 1-5"
       db: search_admin_production
       operations:
@@ -437,6 +455,7 @@ cronjobs:
         - op: backup
 
     service-manual-publisher-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "49 1 * * 1-5"
       db: service-manual-publisher_production
       operations:
@@ -446,6 +465,7 @@ cronjobs:
 
     shared-documentdb:
       <<: *mongo-resources
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "13 1 * * 1-5"
       operations:
         - op: restore
@@ -483,6 +503,7 @@ cronjobs:
           db: govuk_assets_production
 
     signon-mysql:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "3 1 * * 1-5"
       db: signon_production
       operations:
@@ -490,6 +511,7 @@ cronjobs:
           bucket: s3://govuk-production-database-backups
 
     support-api-postgres:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "38 1 * * 1-5"
       db: support_contacts_production
       operations:
@@ -498,6 +520,7 @@ cronjobs:
         - op: backup
 
     transition-postgresql-primary:
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "24 1 * * 1-5"
       db: transition_production
       dbms: postgres
@@ -508,6 +531,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
+      suspend: true # Temporarily suspended to preview history mode (richard.towers 2024-06-17)
       schedule: "28 1 * * 1-5"
       db: whitehall_production
       operations:


### PR DESCRIPTION
This is to allow us to preview "history mode" ahead of the general election. We're suspending restores so that we've got time to evaluate the impact of history mode (i.e. which pages will it / won't it affect, and will they look correct).

I only really need to suspend the restores, but the config doesn't separate out the ops into separately suspendable tasks, so it's easier to just suspend the backups too. Backups in staging are not really important.