### PR TITLE
Run freshclam with foreground and stdout args

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -20,6 +20,9 @@ spec:
       image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
       imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
       command: ["freshclam"]
+      args:
+        - "--foreground"
+        - "--stdout"
       {{ with .Values.freshclamResources }}
       resources:
         {{- . | toYaml | trim | nindent 8 }}


### PR DESCRIPTION
## What?
This adds some extra run-time arguments to the `freshclam` podspec template so that we are always running `freshclam` with `--foreground` and `--stdout`, as suggested by the official "unprivileged" entrypoint script.

### Related

* https://github.com/alphagov/asset-manager/pull/1413