### PR TITLE
Give Freshclam more memory - it got reaped

### DIFF
--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -68,10 +68,10 @@ workerResources:
 freshclamResources:
   limits:
     cpu: 1000m
-    memory: 200Mi
+    memory: 1Gi
   requests:
     cpu: 200m
-    memory: 200Mi
+    memory: 500Mi
 
 clamdResources:
   limits:


### PR DESCRIPTION
## What?
With the tight limit of 200Mi on the Freshclam spec, it was getting reaped by the OOM Killer. Let's double the request and give it a limit of 1Gi to see if this is enough breathing room.