### PR TITLE
Pause deployments on asset manager

### DIFF
--- a/charts/app-config/image-tags/production/asset-manager
+++ b/charts/app-config/image-tags/production/asset-manager
@@ -1,3 +1,3 @@
 image_tag: v204
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false
 promote_deployment: false

--- a/charts/app-config/image-tags/staging/asset-manager
+++ b/charts/app-config/image-tags/staging/asset-manager
@@ -1,3 +1,3 @@
 image_tag: v204
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false
 promote_deployment: false


### PR DESCRIPTION
After an incident with virus scanning newly uploaded documents, we have rolled back the changes and we are pausing deployments on asset manager until we are confident the issue is fixed.