### PR TITLE
Fix Tempo helm chart values

### DIFF
--- a/charts/monitoring-config/tempo-values-integration.yaml
+++ b/charts/monitoring-config/tempo-values-integration.yaml
@@ -14,5 +14,5 @@ metricsGenerator:
   config:
     storage:
       remote_write:
-        - url: >
+        - url: >-
             http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values-production.yaml
+++ b/charts/monitoring-config/tempo-values-production.yaml
@@ -14,9 +14,9 @@ metricsGenerator:
   config:
     storage:
       remote_write:
-        - url: >
+        - url: >-
             http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
-        - url: >
+        - url: >-
             http://prometheus-kube-prometheus-stack-prometheus-1.kube-prometheus-stack-prometheus:9090/api/v1/write
-        - url: >
+        - url: >-
             http://prometheus-kube-prometheus-stack-prometheus-2.kube-prometheus-stack-prometheus:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values-staging.yaml
+++ b/charts/monitoring-config/tempo-values-staging.yaml
@@ -14,7 +14,7 @@ metricsGenerator:
   config:
     storage:
       remote_write:
-        - url: >
+        - url: >-
             http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
-        - url: >
+        - url: >-
             http://prometheus-kube-prometheus-stack-prometheus-1.kube-prometheus-stack-prometheus:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values.yaml
+++ b/charts/monitoring-config/tempo-values.yaml
@@ -14,7 +14,7 @@ traces:
       enabled: true
     http:
       enabled: true
-overrides:
+overrides: |
   '*':
     ingestion_burst_size_bytes: 20000000
     metrics_generator_processors:

--- a/charts/monitoring-config/tempo-values.yaml
+++ b/charts/monitoring-config/tempo-values.yaml
@@ -14,9 +14,11 @@ traces:
       enabled: true
     http:
       enabled: true
-overrides: |
-  '*':
-    ingestion_burst_size_bytes: 20000000
-    metrics_generator_processors:
-      - service-graphs
-      - span-metrics
+global_overrides:
+  defaults:
+    ingestion:
+      burst_size_bytes: 32000000  # 32Mb
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics


### PR DESCRIPTION
This fixes the remote_write URLs to not include a newline and update the format of the overrides section.

Tested in integration.