### PR TITLE
Fix remote_write URLs for Tempo

### DIFF
--- a/charts/monitoring-config/tempo-values-integration.yaml
+++ b/charts/monitoring-config/tempo-values-integration.yaml
@@ -15,4 +15,4 @@ metricsGenerator:
     storage:
       remote_write:
         - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
+            http://prometheus-kube-prometheus-stack-prometheus-0.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values-production.yaml
+++ b/charts/monitoring-config/tempo-values-production.yaml
@@ -15,8 +15,8 @@ metricsGenerator:
     storage:
       remote_write:
         - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
+            http://prometheus-kube-prometheus-stack-prometheus-0.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write
         - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-1.kube-prometheus-stack-prometheus:9090/api/v1/write
+            http://prometheus-kube-prometheus-stack-prometheus-1.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write
         - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-2.kube-prometheus-stack-prometheus:9090/api/v1/write
+            http://prometheus-kube-prometheus-stack-prometheus-2.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write

--- a/charts/monitoring-config/tempo-values-staging.yaml
+++ b/charts/monitoring-config/tempo-values-staging.yaml
@@ -15,6 +15,6 @@ metricsGenerator:
     storage:
       remote_write:
         - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-0.kube-prometheus-stack-prometheus:9090/api/v1/write
+            http://prometheus-kube-prometheus-stack-prometheus-0.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write
         - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-1.kube-prometheus-stack-prometheus:9090/api/v1/write
+            http://prometheus-kube-prometheus-stack-prometheus-1.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write


### PR DESCRIPTION
These URLs need to reference the headless service "prometheus-operated" to be able to resolve individual pod IPs. This service is already created in the kube-prom-stack chart. Using the FQDN, as short domain didn't seem to resolve.