### PR TITLE
Write timestamp to last-updated.txt for GCS mirror

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -114,5 +114,5 @@ spec:
                   /s5cmd sync --size-only "/data/${ASSETS_DOMAIN}" "s3://${BUCKET_NAME}/"
 
                   # Upload file for checking mirror freshness
-                  touch "/data/${WWW_DOMAIN}/last-updated.txt"
+                  date "+%Y-%m-%d %H:%M:%S" > "/data/${WWW_DOMAIN}/last-updated.txt"
                   /s5cmd cp "/data/${WWW_DOMAIN}/last-updated.txt" "s3://${BUCKET_NAME}/${WWW_DOMAIN}/last-updated.txt"


### PR DESCRIPTION
This fixes the govuk_mirror_last_updated_time metric for GCS mirrors. Google Storage Transfer copies files from our S3 Mirror bucket, however ignores files where content hasn't changed. This updates the last-updated.txt file to have changing content.