### PR TITLE
Update Smokey templates for ARM64, add labels

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2641,6 +2641,8 @@ govukApplications:
 
   - name: smokey
     chartPath: charts/smokey
+    helmValues:
+      arch: arm64
 
   - name: static
     helmValues:

--- a/charts/smokey/templates/_helpers.tpl
+++ b/charts/smokey/templates/_helpers.tpl
@@ -22,7 +22,7 @@ helm.sh/chart: {{ include "smokey.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+app.kubernetes.io/arch: {{ .Values.arch }}
 {{- end }}
 
 {{/*

--- a/charts/smokey/templates/_helpers.tpl
+++ b/charts/smokey/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "smokey.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "smokey.chart" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "smokey.labels" -}}
+helm.sh/chart: {{ include "smokey.chart" . }}
+{{ include "smokey.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "smokey.selectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -3,9 +3,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "smokey.name" . }}
+  name: {{ include "smokey.name" $ }}
   labels:
-    {{- include "smokey.labels" . | nindent 4 }}
+    {{- include "smokey.labels" $ | nindent 4 }}
     app: {{ .name }}
     app.kubernetes.io/name: {{ .name }}
     app.kubernetes.io/component: {{ .name }}
@@ -18,7 +18,7 @@ spec:
     metadata:
       name: {{ .name }}
       labels:
-        {{- include "smokey.labels" . | nindent 8 }}
+        {{- include "smokey.labels" $ | nindent 8 }}
         app: {{ .name }}
         app.kubernetes.io/name: {{ .name }}
         app.kubernetes.io/component: {{ .name }}
@@ -109,13 +109,13 @@ spec:
             {{- with .extraEnv }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- if eq "arm64" .Values.arch }}
+          {{- if eq "arm64" $.Values.arch }}
           tolerations:
             - key: arch
               operator: Equal
-              value: {{ .Values.arch }}
+              value: {{ $.Values.arch }}
               effect: NoSchedule
           nodeSelector:
-            kubernetes.io/arch: {{ .Values.arch }}
+            kubernetes.io/arch: {{ $.Values.arch }}
           {{- end }}
 {{- end }}

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{- include "smokey.name" . -}}
+  name: {{ include "smokey.name" . }}
   labels:
     {{- include "smokey.labels" . | nindent 4 }}
     app: {{ .name }}

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -3,7 +3,12 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .name }}
+  name: {{- include "smokey.name" . -}}
+  labels:
+    {{- include "smokey.labels" . | nindent 4 }}
+    app: {{ .name }}
+    app.kubernetes.io/name: {{ .name }}
+    app.kubernetes.io/component: {{ .name }}
 spec:
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 3
@@ -12,6 +17,11 @@ spec:
   jobTemplate:
     metadata:
       name: {{ .name }}
+      labels:
+        {{- include "smokey.labels" . | nindent 8 }}
+        app: {{ .name }}
+        app.kubernetes.io/name: {{ .name }}
+        app.kubernetes.io/component: {{ .name }}
     spec:
       activeDeadlineSeconds: 600
       backoffLimit: 0
@@ -99,4 +109,13 @@ spec:
             {{- with .extraEnv }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}
 {{- end }}

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -7,6 +7,9 @@ spec:
   arguments:
     parameters:
       - name: extra-args
+  workflowMetadata:
+    labels:
+      {{- include "smokey.labels" . | nindent 6 }}
   templates:
     - name: smoke-test
       inputs:
@@ -66,3 +69,12 @@ spec:
             value: "/tmp/.chrome"
           - name: XDG_CACHE_HOME
             value: "/tmp/.chrome"
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -12,6 +12,7 @@ cronJobs:
       - --profile={{ .Values.govukEnvironment }}
       - --strict-undefined
 
+arch: amd64
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey
   tag: latest


### PR DESCRIPTION
## What?
This aims to add the necessary ARM64 stuff to Smokey, including the arch labels to make ARM-powered pods/jobs easier to identify.

I have also tried to add this to the Argo `WorkflowTemplate` but haven't needed to touch these up to now, so would appreciate an extra thorough review of this part!