### PR TITLE
Remove SLIMMER_WRAPPER_CHECK environment variable

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1117,8 +1117,6 @@ govukApplications:
               key: bearer_token
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: SLIMMER_WRAPPER_CHECK
-          value: 'true'
 
   - name: draft-frontend
     repoName: frontend


### PR DESCRIPTION
This reverts commit feb83945a8bd1023039d42deb39ec60180d11d4c.

## What

This variable is no longer necessary as it was only used for selectively enabling the wrapper check for the error investigation purposes. This envvar will no longer be used in Slimmer after [this PR](https://github.com/alphagov/slimmer/pull/334) is merged.

## Why

[Trello card](https://trello.com/c/iyPxdU09/2495-sentry-errors-investigate-fix-frontend-nomethoderror)



