### PR TITLE
Attempt to re-enable ARM64 on Smokey.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2642,7 +2642,7 @@ govukApplications:
   - name: smokey
     chartPath: charts/smokey
     helmValues:
-      arch: amd64
+      arch: arm64
 
   - name: static
     helmValues:

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -107,17 +107,19 @@ spec:
             - name: SE_AVOID_BROWSER_DOWNLOAD
               value: true
             - name: SE_OS
-              value: "linux"
+              value: linux
             - name: XDG_CONFIG_HOME
               value: "/tmp/.chrome"
             - name: XDG_CACHE_HOME
               value: "/tmp/.chrome"
+            {{- if eq "arm64" $.Values.arch }}
+            - name: SE_ARCH
+              value: arm64
+            {{- end }}
             {{- with .extraEnv }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}
           {{- if eq "arm64" $.Values.arch }}
-            - name: SE_ARCH
-              value: arm64
           tolerations:
             - key: arch
               operator: Equal

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -103,9 +103,9 @@ spec:
             - name: SE_CACHE_PATH
               value: "/tmp/.cache/selenium"
             - name: SE_AVOID_STATS
-              value: true
+              value: "true"
             - name: SE_AVOID_BROWSER_DOWNLOAD
-              value: true
+              value: "true"
             - name: SE_OS
               value: linux
             - name: XDG_CONFIG_HOME

--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -102,6 +102,12 @@ spec:
               value: "{{ $.Values.appImage.tag }}"
             - name: SE_CACHE_PATH
               value: "/tmp/.cache/selenium"
+            - name: SE_AVOID_STATS
+              value: true
+            - name: SE_AVOID_BROWSER_DOWNLOAD
+              value: true
+            - name: SE_OS
+              value: "linux"
             - name: XDG_CONFIG_HOME
               value: "/tmp/.chrome"
             - name: XDG_CACHE_HOME
@@ -110,6 +116,8 @@ spec:
               {{- . | toYaml | nindent 12 }}
             {{- end }}
           {{- if eq "arm64" $.Values.arch }}
+            - name: SE_ARCH
+              value: arm64
           tolerations:
             - key: arch
               operator: Equal


### PR DESCRIPTION
## What?
We've made a few changes to the Smokey app. We will also attempt to switch Smokey over to ARM on Integration and see if we have any further errors.