### PR TITLE
Add MIRROR_AVAILABILITY_URL for govuk-exporter

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1310,6 +1310,8 @@ govukApplications:
       extraEnv:
         - name: MIRROR_FRESHNESS_URL
           value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
+        - name: MIRROR_AVAILABILITY_URL
+          value: https://www.{{ .Values.externalDomainSuffix }}
         - name: BACKENDS
           value: "mirrorS3,mirrorS3Replica,mirrorGCS"
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1313,6 +1313,8 @@ govukApplications:
       extraEnv:
         - name: MIRROR_FRESHNESS_URL
           value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
+        - name: MIRROR_AVAILABILITY_URL
+          value: https://www.{{ .Values.externalDomainSuffix }}
         - name: BACKENDS
           value: "mirrorS3,mirrorGCS"
 

--- a/charts/govuk-exporter/values.yaml
+++ b/charts/govuk-exporter/values.yaml
@@ -27,6 +27,8 @@ resources:
 extraEnv:
   - name: MIRROR_FRESHNESS_URL
     value: ""
+  - name: MIRROR_AVAILABILITY_URL
+    value: ""
   - name: BACKENDS
     value: ""
   - name: REFRESH_INTERVAL


### PR DESCRIPTION
This specifies which URL the exporter should use to monitor the availability of the mirrors from.