### PR TITLE
Add Smokey labels to PodSpec Template

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -26,6 +26,13 @@ spec:
       activeDeadlineSeconds: 600
       backoffLimit: 0
       template:
+        metadata:
+          name: {{ .name }}
+          labels:
+            {{- include "smokey.labels" $ | nindent 12 }}
+            app: {{ .name }}
+            app.kubernetes.io/name: {{ .name }}
+            app.kubernetes.io/component: {{ .name }}
         spec:
           automountServiceAccountToken: false
           enableServiceLinks: false


### PR DESCRIPTION
## What?
At present, the Pods being generated by the Smokey Jobs don't have the correct labels. This is because the CronJob Template specifies a Job Template, that in-turn then specifies a Pod Template. Each one needs the correct set of labels defined.