### PR TITLE
Add a healthcheck file for static assets

### DIFF
--- a/charts/generic-govuk-app/upload-static-error-pages.sh
+++ b/charts/generic-govuk-app/upload-static-error-pages.sh
@@ -8,5 +8,6 @@ OUTPUT_PATH=/tmp/output
 mkdir -p "${OUTPUT_PATH}"
 cd "${OUTPUT_PATH}"
 curl --fail-early -fo '#1.html' "${SERVICE}/templates/{${ERROR_PAGES_COMMA_SEPARATED}}.html.erb"
+touch healthcheck.html
 eval ls "{$ERROR_PAGES_COMMA_SEPARATED}.html" || (echo Failed to download one or more files.; exit 1)
 aws s3 sync . "s3://govuk-app-assets-${GOVUK_ENVIRONMENT}/error_pages/"


### PR DESCRIPTION
Description:
- Future PR will configure Fastly's backend for static S3 assets (those served by [www.gov.uk/assets/*](http://www.gov.uk/assets/*)) to point directly to the S3 bucket holding the static assets
- In order for this it requires a probe to poll an endpoint. Currently there is no suitable file on S3 so instead add a blank healthcheck.html file into the S3
govuk-app-assets-`${GOVUK_ENVIRONMENT}` bucket so that if that page can't be loaded Fastly knows to switch to the mirror
- See https://github.com/alphagov/govuk-fastly/issues/73