### PR TITLE
Give Smokey WF same as Jobs to prevent OOM Reaping

### DIFF
--- a/charts/smokey/templates/cronjob.yaml
+++ b/charts/smokey/templates/cronjob.yaml
@@ -51,13 +51,10 @@ spec:
             {{- end }}
             image: "{{ $.Values.appImage.repository }}:{{ $.Values.appImage.tag }}"
             name: {{ .name }}
+            {{- with $.Values.appResources }}
             resources:
-              limits:
-                cpu: "2"
-                memory: 2Gi
-              requests:
-                cpu: "1"
-                memory: 2Gi
+              {{- . | toYaml | trim | nindent 14 }}
+            {{- end }}
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -69,6 +69,13 @@ spec:
             value: "/tmp/.chrome"
           - name: XDG_CACHE_HOME
             value: "/tmp/.chrome"
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "1"
+            memory: 2Gi
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch

--- a/charts/smokey/templates/workflow-templates/smoke-test.yaml
+++ b/charts/smokey/templates/workflow-templates/smoke-test.yaml
@@ -69,13 +69,10 @@ spec:
             value: "/tmp/.chrome"
           - name: XDG_CACHE_HOME
             value: "/tmp/.chrome"
+        {{- with .Values.appResources }}
         resources:
-          limits:
-            cpu: "2"
-            memory: 2Gi
-          requests:
-            cpu: "1"
-            memory: 2Gi
+          {{- . | toYaml | trim | nindent 10 }}
+        {{- end }}
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch

--- a/charts/smokey/values.yaml
+++ b/charts/smokey/values.yaml
@@ -17,6 +17,14 @@ appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/smokey
   tag: latest
 
+appResources:
+  limits:
+    cpu: "2"
+    memory: 2Gi
+  requests:
+    cpu: "1"
+    memory: 2Gi
+
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.
   deletionPolicy: Delete


### PR DESCRIPTION
## What?
This gives the Smokey job triggered by Argo Workflows the same resource limits as the other CronJob template in the hopes of resolving the "OOMKilled" errors.