### PR TITLE
Scale up publishing-api workers in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1878,6 +1878,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      workerReplicaCount: 6
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
This increases the number of workers from 3 (the default) to 6. We've currently got a long backlog in the publishing-api queue, which is causing the publishing system to behave in surprising ways for publishers working on the general election (changes they expect to be automatic / near immediate being delayed by multiple hours).

The publishing-api database is only on about 20% CPU usage, and other metrics also look calm. So it doesn't seem like this will run into a database bottleneck.