### PR TITLE
Scale up publishing-api workers again

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1878,7 +1878,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
-      workerReplicaCount: 6
+      workerReplicaCount: 12
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
We went from 3 workers to 6 in https://github.com/alphagov/govuk-helm-charts/pull/2153.

Database CPU still looks comfortable, at around 37%. We still have a massive queue backlog.

Let's see what happens with 12 workers instead of 6 :)