### PR TITLE
Reset Content Store `payload_version` to 0 in non-prod envs

### DIFF
--- a/charts/db-backup/scripts/content-store.sql
+++ b/charts/db-backup/scripts/content-store.sql
@@ -1,0 +1,17 @@
+-- sqlfluff:dialect:mysql
+
+-- Occasionally, Content Store and Publishing API can fall out of
+-- sync in non-production environments after the environment sync
+-- process has completed. Content Store can be a day 'ahead' of
+-- Publishing API.
+--
+-- Consequently, any publish events from Publishing API in the
+-- affected environment will be rejected by Content Store, if the
+-- `Event.maximum_id` in Publishing API is behind the
+-- `payload_version` of the `ContentItem` being updated in Content
+-- Store.
+--
+-- The pragmatic fix is to reset the `payload_version` in Content
+-- Store so that it can never be ahead of Publishing API.
+UPDATE content_items
+SET payload_version = 0;

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -334,6 +334,8 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
+        - op: transform
+          script: content-store.sql
         - op: backup
     draft-content-store-postgres:
       <<: *s5cmd-ram-workaround
@@ -342,6 +344,8 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
+        - op: transform
+          script: content-store.sql
         - op: backup
 
     content-tagger-postgres:


### PR DESCRIPTION
Occasionally, Content Store and Publishing API can fall out of sync in non-production environments after the environment sync process has completed. Content Store can be a day 'ahead' of Publishing API.

Consequently, any publish events from Publishing API in the affected environment will be rejected by Content Store, if the `Event.maximum_id` in Publishing API is behind the `payload_version` of the `ContentItem` being updated in Content Store.

The pragmatic fix is to reset the `payload_version` in Content Store so that it can never be ahead of Publishing API.