### PR TITLE
Add new Helm chart to create index snapshots of the Chat Opensearch clusters

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -286,6 +286,11 @@ govukApplications:
             proxy_pass https://www.gov.uk/apply-for-a-licence/payment/worldpayCallback;
           }
 
+  - name: chat-opensearch-index-sync
+    # See ../chat-opensearch-index-sync/values.yaml for job configuration.
+    chartPath: charts/chat-opensearch-index-sync
+    postSyncWorkflowEnabled: "false"
+
   - name: collections
     helmValues:
       arch: arm64

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -276,6 +276,11 @@ govukApplications:
             proxy_pass https://www.gov.uk/apply-for-a-licence/payment/worldpayCallback;
           }
 
+  - name: chat-opensearch-index-sync
+    # See ../chat-opensearch-index-sync/values.yaml for job configuration.
+    chartPath: charts/chat-opensearch-index-sync
+    postSyncWorkflowEnabled: "false"
+
   - name: collections
     helmValues:
       replicaCount: 4

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -283,6 +283,11 @@ govukApplications:
             proxy_pass https://www.gov.uk/apply-for-a-licence/payment/worldpayCallback;
           }
 
+  - name: chat-opensearch-index-sync
+    # See ../chat-opensearch-index-sync/values.yaml for job configuration.
+    chartPath: charts/chat-opensearch-index-sync
+    postSyncWorkflowEnabled: "false"
+
   - name: collections
     helmValues:
       appResources:

--- a/charts/chat-opensearch-index-sync/Chart.yaml
+++ b/charts/chat-opensearch-index-sync/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: chat-opensearch-index-sync
+description: Cronjobs for copying Opensearch indices from prod to non-prod
+type: application
+version: 1.0.0

--- a/charts/chat-opensearch-index-sync/snapshot.sh
+++ b/charts/chat-opensearch-index-sync/snapshot.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -euo pipefail
+export LC_ALL=C.UTF-8  # Prevent i18n from affecting command outputs (e.g. `type`).
+
+usage () {
+  cat >&2 <<EOF
+
+$self is a tool for creating and restoring Elasticsearch/Opensearch snapshots
+in order to copy indices between clusters/environments.
+
+Usage examples:
+
+GOVUK_ENVIRONMENT=production $self create_and_clean_up
+GOVUK_ENVIRONMENT=staging SNAPSHOT_REPO=govuk-integration) $self restore_latest
+
+export ES_URL=https://elasticsearch.example.com SNAPSHOT_REPO=myrepo
+$self list
+SNAPSHOT_NAME=foo $self create
+SNAPSHOT_NAME=foo $self restore
+SNAPSHOT_NAME=foo $self delete
+
+Either GOVUK_ENVIRONMENT, or both ES_URL and SNAPSHOT_REPO must be provided.
+
+EOF
+  exit 64  # EX_USAGE; see sysexits(3).
+}
+
+create () {
+  : "${SNAPSHOT_NAME:?required}"
+  local result
+  result=$($curl -XPUT "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME?wait_for_completion=true")
+  echo "$result" | jq
+  echo "$result" | jq -r .snapshot.state | grep -Fx "SUCCESS"
+}
+
+delete () {
+  local result
+  result=$($curl -XDELETE "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME")
+  echo "$result" | jq -e .acknowledged >/dev/null
+}
+
+# List all snapshots in ascending date order (as returned by ES).
+list () {
+  $curl "$ES_URL/_snapshot/$SNAPSHOT_REPO/_all" | jq -e '.snapshots'
+}
+
+# Enable or disable automatic index creation on insert.
+# usage: set_auto_create_index true|false
+set_auto_create_index () {
+  # TODO: use curl --json once available (requires curl >= 7.82).
+  $curl -XPUT "$ES_URL/_cluster/settings" -H 'Content-Type: application/json' \
+    -d '{ "persistent": { "action.auto_create_index": "'"$1"'" } }' >&2
+}
+
+snapshot_valid () {
+  : "${SNAPSHOT_NAME:?required}"
+  list | jq -r '. | map(select(.state == "SUCCESS"))[].snapshot' \
+    | grep -Fx "$SNAPSHOT_NAME"
+}
+
+restore () {
+  snapshot_valid
+
+  set_auto_create_index false
+  trap 'set_auto_create_index true' EXIT HUP INT TERM
+
+  $curl -XDELETE "$ES_URL/*,-.*" >&2  # Delete all except system indices.
+  local result
+  result=$(
+    # TODO: use curl --json once available.
+    $curl -XPOST -H'Content-Type: application/json' -d'{"indices": "*,-.*"}' \
+      "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME/_restore"
+  )
+
+  echo "$result" | jq -e .accepted >/dev/null
+}
+
+latest_successful () {
+  list | jq -r '. | map(select(.state == "SUCCESS"))[-1].snapshot'
+}
+
+restore_latest () {
+  SNAPSHOT_NAME=$(latest_successful) restore
+}
+
+# List all completed snapshots except for the n most recent.
+snapshots_to_delete () {
+  list | \
+    jq -r '. | map(select(.state == "SUCCESS"))[:-'"$SNAPSHOTS_TO_KEEP"'][].snapshot'
+}
+
+cleanup () {
+  for snap in $(snapshots_to_delete); do
+    SNAPSHOT_NAME=$snap delete || true  # Continue on error.
+  done
+}
+
+create_and_clean_up () {
+  SNAPSHOT_NAME=$(date +%Y-%m-%d%H:%M:%S)-chat-opensearch create
+  SNAPSHOT_REPO="govuk-$GOVUK_ENVIRONMENT" cleanup
+}
+
+
+self=$(basename "$0")
+subcommand=${1:-}
+[[ $(type -t "$subcommand") == function ]] || usage
+
+# We need a version of jq that understands negative slice offsets and -e (--exit-status).
+if ! echo '[true]' | jq -e '.[-1]' >/dev/null 2>&1; then
+  echo >&2 "$self: compatible version of jq not found; please install jq >=1.5"
+  exit 69  # EX_UNAVAILABLE
+fi
+
+if [[ -n "$GOVUK_ENVIRONMENT" ]]; then
+  : "${ES_URL:=https://chat-opensearch.$GOVUK_ENVIRONMENT.govuk-internal.digital}"
+  : "${SNAPSHOT_REPO:=govuk-$GOVUK_ENVIRONMENT}"
+fi
+
+: "${ES_URL:?required}"
+: "${SNAPSHOT_REPO:?required}"
+: "${SNAPSHOTS_TO_KEEP:=1}"
+: "${REQUEST_DEADLINE_SECONDS:=900}"  # Keep this > ES's 30s timeout to preserve error messages.
+readonly GOVUK_ENVIRONMENT ES_URL SNAPSHOTS_TO_KEEP REQUEST_DEADLINE_SECONDS
+
+curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body"
+
+[[ "${VERBOSE:-0}" -ge 1 ]] && set -x
+$subcommand

--- a/charts/chat-opensearch-index-sync/templates/_helpers.tpl
+++ b/charts/chat-opensearch-index-sync/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chat-opensearch-index-sync.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chat-opensearch-index-sync.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chat-opensearch-index-sync.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chat-opensearch-index-sync.labels" -}}
+helm.sh/chart: {{ include "chat-opensearch-index-sync.chart" . }}
+{{ include "chat-opensearch-index-sync.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chat-opensearch-index-sync.selectorLabels" -}}
+app: {{ include "chat-opensearch-index-sync.name" . }}
+app.kubernetes.io/name: {{ include "chat-opensearch-index-sync.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/chat-opensearch-index-sync/templates/configmap.yaml
+++ b/charts/chat-opensearch-index-sync/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chat-opensearch-index-sync.fullname" . }}
+  labels:
+    {{- include "chat-opensearch-index-sync.labels" . | nindent 4 }}
+data:
+  snapshot: |
+    {{- $.Files.Get "snapshot.sh" | trim | nindent 4 }}

--- a/charts/chat-opensearch-index-sync/templates/cronjob.yaml
+++ b/charts/chat-opensearch-index-sync/templates/cronjob.yaml
@@ -1,0 +1,74 @@
+{{- $_ := .Values.govukEnvironment | required "govukEnvironment is required" }}
+{{- $fullName := include "chat-opensearch-index-sync.fullname" . }}
+{{- range get .Values.cronjobs .Values.govukEnvironment }}
+  {{- $jobName := printf "%s-%s" $fullName .name }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $jobName }}
+  labels:
+    {{- include "chat-opensearch-index-sync.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+  annotations:
+    kubernetes.io/description: >
+      The {{ $fullName }}-* jobs copy OpenSearch indices between environments
+      via OpenSearch snapshots, so that the website search feature works in
+      staging and integration.
+
+      OpenSearch handles the actual transfer of the index shards to/from the
+      snapshot repositories in S3. This job just makes HTTP requests to
+      OpenSearch to initiate the snapshot and restore.
+
+      These jobs are not involved in making backups for disaster recovery
+      purposes; those are handled separately within AWS OpenSearch Service.
+spec:
+  schedule: {{ .schedule | quote }}
+  jobTemplate:
+    metadata:
+      name: {{ $jobName }}
+      labels:
+        {{- include "chat-opensearch-index-sync.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: {{ $jobName }}
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          name: {{ $jobName }}
+          labels:
+            {{- include "chat-opensearch-index-sync.selectorLabels" $ | nindent 12 }}
+            app.kubernetes.io/component: {{ $jobName }}
+        spec:
+          enableServiceLinks: false
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          restartPolicy: Never
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ $fullName }}
+                defaultMode: 0555  # world-executable
+          containers:
+            - name: main
+              image: {{ $.Values.imageRef | quote }}
+              command:
+                - /opt/bin/snapshot
+              args:
+                {{- toYaml .args | nindent 16 }}
+              env:
+                - name: GOVUK_ENVIRONMENT
+                  value: {{ $.Values.govukEnvironment | required "govukEnvironment is required" }}
+                - name: VERBOSE
+                  value: "1"
+                {{- with .extraEnv }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
+              resources:
+                {{- $.Values.resources | toYaml | nindent 16 }}
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /opt/bin
+                  readOnly: true
+{{- end }}

--- a/charts/chat-opensearch-index-sync/values.yaml
+++ b/charts/chat-opensearch-index-sync/values.yaml
@@ -1,0 +1,55 @@
+# Default values for chat-opensearch-index-sync.
+
+nameOverride: ""
+fullnameOverride: ""
+imageRef: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/toolbox"
+
+# govukEnvironment determines which set of cronjobs to use from `cronjobs`
+# below. When running under Argo CD, the ../app-config chart passes the
+# appropriate value for govukEnvironment by default.
+govukEnvironment: staging
+
+cronjobs:
+  production:
+    - name: snapshot
+      schedule: "12 1 * * *"
+      args: [create_and_clean_up]
+  staging:
+    - name: copy-from-prod  # These names have to be fairly short :(
+      schedule: "12 2 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-production
+    - name: snapshot
+      schedule: "12 3 * * *"
+      args: [create_and_clean_up]
+  integration:
+    - name: copy-from-stag
+      schedule: "12 4 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-staging
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi


### PR DESCRIPTION
This is to configure daily snapshots of the Chat Opensearch clusters and to sync them from Production to Staging to Integration.