### PR TITLE
Update k8s version for schema validation.

### DIFF
--- a/kubernetes_version
+++ b/kubernetes_version
@@ -2,4 +2,4 @@
 # output in .github/workflows/ci.yml.
 #
 # Available schema versions: https://github.com/yannh/kubernetes-json-schema
-KUBERNETES_VERSION=1.29.0
+KUBERNETES_VERSION=1.30.2


### PR DESCRIPTION
We're currently running 1.30 in all three clusters.