### PR TITLE
Add flag to use image pull through from ghcr.io

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -39,7 +39,11 @@ spec:
         {{- end }}
         {{- else }}
         appImage:
+          {{- if .useImagePullThroughCache }}
+          repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/{{ $reponame }}
+          {{- else }}
           repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/{{ $reponame }}
+          {{- end }}
           tag: {{ $imageTag }}
           pullPolicy: {{ .appImagePullPolicy | default "IfNotPresent" }}
         {{- end }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1928,6 +1928,7 @@ govukApplications:
           value: "true"
 
   - name: release
+    useImagePullThroughCache: true
     helmValues:
       arch: arm64
       dbMigrationEnabled: true


### PR DESCRIPTION
This is switches the image repository to the ECR repository configured to pull through images from ghcr.io.

Only enabling in Release for testing.