### PR TITLE
Remove old unused image tag files

### DIFF
--- a/charts/app-config/image-tags/integration/content-store-postgresql-branch
+++ b/charts/app-config/image-tags/integration/content-store-postgresql-branch
@@ -1,3 +1,0 @@
-image_tag: release-32b571ac7449c018866c35b836a0ac2af1726e6e
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/app-config/image-tags/integration/content-store-proxy
+++ b/charts/app-config/image-tags/integration/content-store-proxy
@@ -1,3 +1,0 @@
-image_tag: release-7c53014ffcbf05343996aa99edb006784545415d
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/app-config/image-tags/integration/licensify
+++ b/charts/app-config/image-tags/integration/licensify
@@ -1,5 +1,0 @@
-# This is a placeholder to prevent licensify promotion check failures during
-# post sync workflow for licensify-frontend, licensify-feed and licensify-backend.
-# The workflow expects the image tag file name to match the ArgoCD App name.
-automatic_deploys_enabled: false
-promote_deployment: false

--- a/charts/app-config/image-tags/integration/licensify-admin
+++ b/charts/app-config/image-tags/integration/licensify-admin
@@ -1,3 +1,0 @@
-image_tag: release-fd5aef7a641ff92029d81edfc372b98d1611bb14
-automatic_deploys_enabled: false
-promote_deployment: false

--- a/charts/app-config/image-tags/integration/signon-resources
+++ b/charts/app-config/image-tags/integration/signon-resources
@@ -1,2 +1,0 @@
-image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
-automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/production/content-store-postgresql-branch
+++ b/charts/app-config/image-tags/production/content-store-postgresql-branch
@@ -1,3 +1,0 @@
-image_tag: release-32b571ac7449c018866c35b836a0ac2af1726e6e
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/app-config/image-tags/production/content-store-proxy
+++ b/charts/app-config/image-tags/production/content-store-proxy
@@ -1,3 +1,0 @@
-image_tag: release-3931565a459a1938f99312f35dc6182892944576
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/app-config/image-tags/production/licensify
+++ b/charts/app-config/image-tags/production/licensify
@@ -1,5 +1,0 @@
-# This is a placeholder to prevent licensify promotion check failures during
-# post sync workflow for licensify-frontend, licensify-feed and licensify-backend.
-# The workflow expects the image tag file name to match the ArgoCD App name.
-automatic_deploys_enabled: false
-promote_deployment: false

--- a/charts/app-config/image-tags/production/signon-resources
+++ b/charts/app-config/image-tags/production/signon-resources
@@ -1,2 +1,0 @@
-image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
-automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/content-store-postgresql-branch
+++ b/charts/app-config/image-tags/staging/content-store-postgresql-branch
@@ -1,3 +1,0 @@
-image_tag: release-32b571ac7449c018866c35b836a0ac2af1726e6e
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/app-config/image-tags/staging/content-store-proxy
+++ b/charts/app-config/image-tags/staging/content-store-proxy
@@ -1,3 +1,0 @@
-image_tag: release-3931565a459a1938f99312f35dc6182892944576
-automatic_deploys_enabled: true
-promote_deployment: false

--- a/charts/app-config/image-tags/staging/licensify
+++ b/charts/app-config/image-tags/staging/licensify
@@ -1,5 +1,0 @@
-# This is a placeholder to prevent licensify promotion check failures during
-# post sync workflow for licensify-frontend, licensify-feed and licensify-backend.
-# The workflow expects the image tag file name to match the ArgoCD App name.
-automatic_deploys_enabled: false
-promote_deployment: false

--- a/charts/app-config/image-tags/staging/signon-resources
+++ b/charts/app-config/image-tags/staging/signon-resources
@@ -1,2 +1,0 @@
-image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
-automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/test/signon-resources
+++ b/charts/app-config/image-tags/test/signon-resources
@@ -1,2 +1,0 @@
-image_tag: bfafc5fff8a2541bbc5611667b8aa4d108f305b9
-automatic_deploys_enabled: true


### PR DESCRIPTION
These apps are no longer deployed or were never used.

licensify-(backend|feed|frontend) are used instead of licensify or licensify-admin.