### PR TITLE
Actually scrape pushgateway.

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/pushgateway-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/pushgateway-application.yaml
@@ -11,6 +11,8 @@ spec:
         | nindent 4 }}
     helm:
       values: |
+        serviceMonitor:
+          enabled: true
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
Seems we weren't scraping it before. Didn't show up under `/targets`.

Bit odd though. Suspect I'm still missing something cos seems unlikely this would have been set up without attempting to use it. Let's see if this helps.