### PR TITLE
Use ghcr.io pull through cache for integration/staging

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
         {{- else }}
         appImage:
-          {{- if .useImagePullThroughCache }}
+          {{- if ne $.Values.govukEnvironment "production" }}
           repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/{{ $reponame }}
           {{- else }}
           repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/{{ $reponame }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1912,7 +1912,6 @@ govukApplications:
           value: "true"
 
   - name: release
-    useImagePullThroughCache: true
     helmValues:
       arch: arm64
       dbMigrationEnabled: true


### PR DESCRIPTION
This updates the image reference for apps to use the ghcr.io pull through cache in ECR.

Checked that all images in use for integration and staging are built and pushed to ghcr.io