### PR TITLE
Fix the "deployed-to" image tagging script

### DIFF
--- a/charts/argo-services/scripts/add-tag-to-image.sh
+++ b/charts/argo-services/scripts/add-tag-to-image.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Add pull-through cache prefix
+REPOSITORY_NAME="github/alphagov/govuk/${REPOSITORY_NAME}"
+
 # Check if image is already tagged
 TAG_EXISTS=$(aws ecr describe-images \
   --registry-id "${AWS_ACCOUNT}" \


### PR DESCRIPTION
This fixes a step in the deployment pipeline that tags images that are referenced by the cluster with "deployed-to-<env>". Since implementing the pull-through cache, repository names are prefixed.