### PR TITLE
Refactor `search-index-env-sync` to work with multiple clusters

### DIFF
--- a/charts/search-index-env-sync/Chart.yaml
+++ b/charts/search-index-env-sync/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: search-index-env-sync
-description: Cronjobs for copying Elasticsearch indices from prod to non-prod
+description: Cronjobs for copying Elasticsearch and Opensearch indices from prod to non-prod
 type: application
-version: 1.0.0
+version: 2.0.0

--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -96,7 +96,7 @@ cleanup () {
 }
 
 create_and_clean_up () {
-  SNAPSHOT_NAME=$(date +%Y-%m-%d%H:%M:%S)-elasticsearch6 create
+  SNAPSHOT_NAME=$(date +%Y-%m-%d%H:%M:%S)-$SUBDOMAIN create
   SNAPSHOT_REPO="govuk-$GOVUK_ENVIRONMENT" cleanup
 }
 
@@ -111,8 +111,8 @@ if ! echo '[true]' | jq -e '.[-1]' >/dev/null 2>&1; then
   exit 69  # EX_UNAVAILABLE
 fi
 
-if [[ -n "$GOVUK_ENVIRONMENT" ]]; then
-  : "${ES_URL:=https://elasticsearch6.$GOVUK_ENVIRONMENT.govuk-internal.digital}"
+if [[ -n "$GOVUK_ENVIRONMENT" && -n "$SUBDOMAIN" ]]; then
+  : "${ES_URL:=https://$SUBDOMAIN.$GOVUK_ENVIRONMENT.govuk-internal.digital}"
   : "${SNAPSHOT_REPO:=govuk-$GOVUK_ENVIRONMENT}"
 fi
 

--- a/charts/search-index-env-sync/templates/cronjob.yaml
+++ b/charts/search-index-env-sync/templates/cronjob.yaml
@@ -1,12 +1,12 @@
 {{- $_ := .Values.govukEnvironment | required "govukEnvironment is required" }}
 {{- $fullName := include "search-index-env-sync.fullname" . }}
-{{- range get .Values.cronjobs .Values.govukEnvironment }}
-  {{- $jobName := printf "%s-%s" $fullName .name }}
+{{- range $jobName, $job := get .Values.cronjobs .Values.govukEnvironment }}
+  {{- $jobFullName := printf "%s-%s" $fullName $jobName }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ $jobName }}
+  name: {{ $jobFullName }}
   labels:
     {{- include "search-index-env-sync.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $jobName }}
@@ -23,10 +23,10 @@ metadata:
       These jobs are not involved in making backups for disaster recovery
       purposes; those are handled separately within AWS Managed Elasticsearch.
 spec:
-  schedule: {{ .schedule | quote }}
+  schedule: {{ $job.schedule | quote }}
   jobTemplate:
     metadata:
-      name: {{ $jobName }}
+      name: {{ $jobFullName }}
       labels:
         {{- include "search-index-env-sync.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/component: {{ $jobName }}
@@ -34,7 +34,7 @@ spec:
       backoffLimit: 0
       template:
         metadata:
-          name: {{ $jobName }}
+          name: {{ $jobFullName }}
           labels:
             {{- include "search-index-env-sync.selectorLabels" $ | nindent 12 }}
             app.kubernetes.io/component: {{ $jobName }}
@@ -54,13 +54,13 @@ spec:
               command:
                 - /opt/bin/snapshot
               args:
-                {{- toYaml .args | nindent 16 }}
+                {{- toYaml $job.args | nindent 16 }}
               env:
                 - name: GOVUK_ENVIRONMENT
                   value: {{ $.Values.govukEnvironment | required "govukEnvironment is required" }}
                 - name: VERBOSE
                   value: "1"
-                {{- with .extraEnv }}
+                {{- with $job.extraEnv }}
                   {{- toYaml . | nindent 16 }}
                 {{- end }}
               resources:

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -11,26 +11,66 @@ govukEnvironment: staging
 
 cronjobs:
   production:
-    - name: snapshot
+    blue-es6-snapshot:  # This would be too long as blue-elasticsearch6-domain-snapshot
       schedule: "21 1 * * *"
       args: [create_and_clean_up]
+      extraEnv:
+        - name: SUBDOMAIN
+          value: elasticsearch6
+    chat-engine-snapshot:
+      schedule: "12 1 * * *"
+      args: [create_and_clean_up]
+      extraEnv:
+        - name: SUBDOMAIN
+          value: chat-opensearch
+
   staging:
-    - name: copy-from-prod  # These names have to be fairly short :(
+    blue-es6-cp-prod:  # This would be too long as blue-elasticsearch6-domain-cp-prod
       schedule: "37 1 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO
           value: govuk-production
-    - name: snapshot
+        - name: SUBDOMAIN
+          value: elasticsearch6
+    blue-es6-snapshot:  # This would be too long as blue-elasticsearch6-domain-snapshot
       schedule: "37 2 * * *"
       args: [create_and_clean_up]
+      extraEnv:
+        - name: SUBDOMAIN
+          value: elasticsearch6
+    chat-engine-cp-prod:
+      schedule: "12 2 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-production
+        - name: SUBDOMAIN
+          value: chat-opensearch
+    chat-engine-snapshot:
+      schedule: "12 3 * * *"
+      args: [create_and_clean_up]
+      extraEnv:
+        - name: SUBDOMAIN
+          value: chat-opensearch
+
   integration:
-    - name: copy-from-stag
+    blue-es6-cp-stag:  # This would be too long as blue-elasticsearch6-domain-cp-stag
       schedule: "17 6 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO
           value: govuk-staging
+        - name: SUBDOMAIN
+          value: elasticsearch6
+    chat-engine-cp-stag:
+      schedule: "12 4 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-staging
+        - name: SUBDOMAIN
+          value: chat-opensearch
 
 podSecurityContext:
   fsGroup: 1001


### PR DESCRIPTION
Refactor `search-index-env-sync` Helm chart to work with multiple clusters of differing types (ElasticSearch and OpenSearch). This is required as there are now 2 clusters (`blue-elasticsearch6-domain` and `chat-engine`) and both of them need to have their indices replicated from Production to Staging and Integration each night.