### PR TITLE
Automatically restart worker processes if a dependant secret/configmap changes

### DIFF
--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app: {{ $fullName }}-worker
     app.kubernetes.io/name: {{ $fullName }}-worker
     app.kubernetes.io/component: worker
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 2


### PR DESCRIPTION
This must've been missed when Reloader was first configured. 