### PR TITLE
Only publish pre-production finders on cronjob

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2789,8 +2789,8 @@ govukApplications:
         hosts:
           - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
       cronTasks:
-        - name: publish-finders
-          task: "publishing_api:publish_finders"
+        - name: publish-pre-production-finders
+          task: "publishing_api:publish_pre_production_finders"
           schedule: "55 8 * * 1-5"
       extraEnv:
         - name: ASSET_MANAGER_BEARER_TOKEN


### PR DESCRIPTION
The purpose of republishing on integration is to have pre-production finders ready to test, without a developer having to intervene.

However, republishing all finders puts ~300,000 documents on the low priority Publishing API Sidekiq queue, meaning Integration is busy processing that queue from around 09:55 until 16:00. This means that during working hours, publishing teams are unable to use Integration to test anything that depends on dependency resolution.

Republishing only the pre-production finders will massively reduce the amount of items put onto the queue.

---

Dependent on https://github.com/alphagov/specialist-publisher/pull/2693

Trello: https://trello.com/c/yPEWns6H/2738-make-daily-finder-cronjob-only-republish-pre-production-finders