### PR TITLE
Update curl in snapshot.sh to work with username/password authentication

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -122,7 +122,11 @@ fi
 : "${REQUEST_DEADLINE_SECONDS:=900}"  # Keep this > ES's 30s timeout to preserve error messages.
 readonly GOVUK_ENVIRONMENT ES_URL SNAPSHOTS_TO_KEEP REQUEST_DEADLINE_SECONDS
 
-curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body"
+if [[ -n $SEARCH_USERNAME && -n $SEARCH_PASSWORD ]]; then
+  curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body -u \"$SEARCH_USERNAME:$SEARCH_PASSWORD\""
+else
+  curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body"
+fi
 
 [[ "${VERBOSE:-0}" -ge 1 ]] && set -x
 $subcommand

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -23,6 +23,16 @@ cronjobs:
       extraEnv:
         - name: SUBDOMAIN
           value: chat-opensearch
+        - name: SEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: username
+        - name: SEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: password
 
   staging:
     blue-es6-cp-prod:  # This would be too long as blue-elasticsearch6-domain-cp-prod
@@ -47,12 +57,32 @@ cronjobs:
           value: govuk-production
         - name: SUBDOMAIN
           value: chat-opensearch
+        - name: SEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: username
+        - name: SEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: password
     chat-engine-snapshot:
       schedule: "12 3 * * *"
       args: [create_and_clean_up]
       extraEnv:
         - name: SUBDOMAIN
           value: chat-opensearch
+        - name: SEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: username
+        - name: SEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: password
 
   integration:
     blue-es6-cp-stag:  # This would be too long as blue-elasticsearch6-domain-cp-stag
@@ -71,6 +101,16 @@ cronjobs:
           value: govuk-staging
         - name: SUBDOMAIN
           value: chat-opensearch
+        - name: SEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: username
+        - name: SEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch
+              key: password
 
 podSecurityContext:
   fsGroup: 1001


### PR DESCRIPTION
This change allows the existing Elasticsearch snapshots to continue as they were, but allow
the Opensearch snapshots to be created by the same script with basic username/password
authentication, if env vars `SEARCH_USERNAME` & `SEARCH_PASSWORD` are provided in
`values.yaml`.