### PR TITLE
2nd line drill update content store staging replica count to 7

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -702,7 +702,7 @@ govukApplications:
     helmValues: &content-store
       dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
-      replicaCount: 6
+      replicaCount: 7
       cronTasks:
         - name: report-delays
           task: "publishing_delay_report:report_delays"


### PR DESCRIPTION
Description:
- As part of the 2nd line drill we are testing updating the content store in staging replica count to 7