### PR TITLE
Reduce content-store staging replica count to 6

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -702,7 +702,7 @@ govukApplications:
     helmValues: &content-store
       dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
-      replicaCount: 7
+      replicaCount: 6
       cronTasks:
         - name: report-delays
           task: "publishing_delay_report:report_delays"


### PR DESCRIPTION
Description:
- As part of the 2nd line drill we are reducing the count back to the original state