### PR TITLE
Switch integration link-checker-api to use new Redis instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1415,8 +1415,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &link-checker-redis redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *link-checker-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This switches the web application in integration away from the shared Redis instance to a new dedicated instance for this app.

A later PR will switch the workers, once all the existing jobs have been processed.

[Trello card](https://trello.com/c/GAj8vwOU)