### PR TITLE
Switch integration link-checker-api workers to use new Redis instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1414,8 +1414,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This switches the workers in integration away from the shared Redis instance to a new dedicated instance for this app.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/2186 and all jobs in the old shared instance being completed.

[Trello card](https://trello.com/c/GAj8vwOU)