### PR TITLE
Set up Discovery Engine secret for `search-admin`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2210,6 +2210,21 @@ govukApplications:
           value: *publishing-design-system-gtm-auth
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-design-system-gtm-preview
+        - name: GOOGLE_CLOUD_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: search-admin-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_CREDENTIALS
+        - name: DISCOVERY_ENGINE_ENGINE
+          valueFrom:
+            secretKeyRef:
+              name: search-admin-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_SERVING_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: search-admin-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-api
     helmValues:

--- a/charts/external-secrets/templates/search-admin/google-cloud-discovery-engine-configuration.yml
+++ b/charts/external-secrets/templates/search-admin/google-cloud-discovery-engine-configuration.yml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: search-admin-google-cloud-discovery-engine-configuration
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Configuration for Google Cloud Discovery Engine for search-admin
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-admin-google-cloud-discovery-engine-configuration
+  dataFrom:
+    - extract:
+        key: govuk/search-admin/google-cloud-discovery-engine-configuration


### PR DESCRIPTION
We will soon want to wire up `search-admin` to GCP Discovery Engine ("Vertex AI Search") in the same way we have done for `search-api-v2`. This integration will allow Search Admin to modify some resources on Discovery Engine to allow administrative users from the wider GOV.UK search team to make some modifications to configuration through the Search Admin UI.

- Add external secrets template for `search-admin` Discovery Engine configuration
- Update app config values to retrieve secrets as environment variables (in integration only for now to test it out)