### PR TITLE
Allow DB Backups to run on ARM

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -746,6 +746,7 @@ govukApplications:
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
     helmValues:
+      arch: arm64
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
       serviceAccount:
         annotations:

--- a/charts/db-backup/templates/_helpers.tpl
+++ b/charts/db-backup/templates/_helpers.tpl
@@ -49,6 +49,7 @@ Selector labels
 app: {{ include "db-backup.name" . }}
 app.kubernetes.io/name: {{ include "db-backup.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 {{- end }}
 
 {{/*

--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -115,5 +115,14 @@ spec:
                   readOnly: true
                 - name: tmp
                   mountPath: /tmp
+          {{- if eq "arm64" $.Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ $.Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ $.Values.arch }}
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -9,6 +9,8 @@ externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.
   deletionPolicy: Delete
 
+arch: amd64
+
 extraEnv:
   - name: GOGC
     value: "30"


### PR DESCRIPTION
## What?
DB Backups were one of the remaining stragglers not configured to run on ARM. The toolbox app is already built for ARM, so this shouldn't have any issues.