### PR TITLE
Disable indexing of site search through robots.txt

### DIFF
--- a/charts/app-config/www-production-robots.txt
+++ b/charts/app-config/www-production-robots.txt
@@ -2,6 +2,8 @@ User-agent: *
 Disallow: /*/print$
 # Don't allow indexing of user needs pages
 Disallow: /info/*
+# Don't allow indexing of site search
+Disallow: /search/all*
 Sitemap: https://www.gov.uk/sitemap.xml
 
 # https://ahrefs.com/robot/ crawls the site frequently


### PR DESCRIPTION
There has been a significant increase in traffic from crawlers to our site search, often with nonsensical queries. These results aren't useful for crawling purposes, and all of our pages that can be found through search form part of the sitemap anyway, so it doesn't even help search engines with page discovery.