### PR TITLE
Disable automatic deployments for govuk-replatform-test-app in integration

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-replatform-test-app
+++ b/charts/app-config/image-tags/integration/govuk-replatform-test-app
@@ -1,3 +1,3 @@
 image_tag: v22
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false
 promote_deployment: true


### PR DESCRIPTION
Description:
- To demonstrate how to disable automatic deployments for `govuk-replatform-test` app in integration