### PR TITLE
Toleration Outside nested "range" loop

### DIFF
--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -115,6 +115,7 @@ spec:
                   readOnly: true
                 - name: tmp
                   mountPath: /tmp
+  {{- end }}
           {{- if eq "arm64" $.Values.arch }}
           tolerations:
             - key: arch
@@ -124,5 +125,4 @@ spec:
           nodeSelector:
             kubernetes.io/arch: {{ $.Values.arch }}
           {{- end }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
## What?
So apparently the toleration config isn't valid. This might be because of the nested "range" loop that flicks between `initContainers` and `containers` which might be throwing things off.

Sooo... we'll move the toleration so it sits just outside the second range. (It needs to be at the same nested level as volumes/containers.)