### PR TITLE
Modify `curl` command in `snapshot.sh` for `search-index-env-sync`

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -125,7 +125,7 @@ fi
 readonly GOVUK_ENVIRONMENT ES_URL SNAPSHOTS_TO_KEEP REQUEST_DEADLINE_SECONDS
 
 if [[ -n $SEARCH_USERNAME && -n $SEARCH_PASSWORD ]]; then
-  curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body -u $SEARCH_USERNAME:$SEARCH_PASSWORD"
+  curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body --config /opt/etc/configfile"
 else
   curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body"
 fi

--- a/charts/search-index-env-sync/templates/configmap.yaml
+++ b/charts/search-index-env-sync/templates/configmap.yaml
@@ -1,9 +1,19 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "search-index-env-sync.fullname" . }}
+  name: {{ include "search-index-env-sync.fullname" . }}-script
   labels:
     {{- include "search-index-env-sync.labels" . | nindent 4 }}
 data:
   snapshot: |
     {{- $.Files.Get "snapshot.sh" | trim | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "search-index-env-sync.fullname" . }}-config
+  labels:
+    {{- include "search-index-env-sync.labels" . | nindent 4 }}
+data:
+  configfile: |
+    -u $USERNAME:$PASSWORD

--- a/charts/search-index-env-sync/templates/cronjob.yaml
+++ b/charts/search-index-env-sync/templates/cronjob.yaml
@@ -46,8 +46,12 @@ spec:
           volumes:
             - name: scripts
               configMap:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-script
                 defaultMode: 0555  # world-executable
+            - name: configs
+              configMap:
+                name: {{ $fullName }}-config
+                defaultMode: 0444
           containers:
             - name: main
               image: {{ $.Values.imageRef | quote }}
@@ -70,5 +74,8 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /opt/bin
+                  readOnly: true
+                - name: configs
+                  mountPath: /opt/etc
                   readOnly: true
 {{- end }}


### PR DESCRIPTION
The way the `curl` command currently works in the script, both username and password for the basic authentication go into the cronjob log. This change aims to fix that by using a config file rather than having the authentication directly in the command.