### PR TITLE
Increase the preStop sleep from 15 to 60 seconds

### DIFF
--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -139,7 +139,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
+                command: ["sleep", "60"] # To allow time for ALB to deregister pod before termination
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}
@@ -183,7 +183,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
+                command: ["sleep", "60"] # To allow time for ALB to deregister pod before termination
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
During a recent terraform apply in integration which rolled the k8s nodes, we saw a number of 502 / 503 responses from the load balancers.

The theory is that this is due to kubernetes-sigs/aws-load-balancer-controller issue #2366 - pods and load balancers are updated at the same time, but load balancer updates don't happen instantly, so the load balancer may continue to send traffic to pods which are terminating.

[A comment on another issue](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2106#issuecomment-1155117280) suggests that 60 seconds is long enough to avoid any 502s, although the rest of the comments suggest "it depends" on various factors.

Whatever, 15 seconds does not seem to be long enough for us to be able to roll our nodes without serving some 502s, so we should try a higher value.

I guess higher values will result in slower deployments (not just node rollouts, but anything which requires pods to terminate and new pods to come up). 60 seconds still feels just about tolerable to me, but I don't think we'd want to go much higher than this.