### PR TITLE
Use x86 for govuk-e2e-tests in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1309,7 +1309,6 @@ govukApplications:
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
     helmValues:
-      arch: arm64
       cronJobs:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5"


### PR DESCRIPTION
We don't have arm nodes in staging yet.