### PR TITLE
Add severity

### DIFF
--- a/charts/monitoring-config/rules/mirrors.yaml
+++ b/charts/monitoring-config/rules/mirrors.yaml
@@ -8,6 +8,8 @@ groups:
       - alert: MirrorFreshnessAlert
         expr: |
           global:govuk_mirror_freshness_seconds > 172800
+        labels:
+          severity: warning
         annotations:
           summary: Mirror freshness has exceeded two days
           description: >-

--- a/charts/monitoring-config/rules/mirrors_tests.yaml
+++ b/charts/monitoring-config/rules/mirrors_tests.yaml
@@ -28,6 +28,7 @@ tests:
         exp_alerts:
           - exp_labels:
               backend: backend1
+              severity: warning
             exp_annotations:
               summary: Mirror freshness has exceeded two days
               description: The mirror hasn't been updated in more than two days

--- a/charts/monitoring-config/rules/signon.yaml
+++ b/charts/monitoring-config/rules/signon.yaml
@@ -9,6 +9,8 @@ groups:
         expr: |
           global:signon_api_user_token_expires_in_seconds < 1209600
         for: 1h
+        labels:
+          severity: warning
         annotations:
           summary: Signon API User token is due to expire soon
           description: >-


### PR DESCRIPTION
Adds `severity: warning` labels to a couple of alerts which were missing the label.

It's hard to filter metrics in prometheus if some of the metrics have a label, and others don't, because simple queries like `ALERTS{severity!="none"}` actually mean "alerts which have the severity label, but where it is not 'none'", which excludes the metrics which are missing the label.

This is the reason that the MirrorFreshness alerts are currently not appearing on the [Grafana alerts dashboard](https://grafana.eks.production.govuk.digital/d/edsqg54ha7h1cc/alerts?orgId=1)