### PR TITLE
Set curl command with alias in `snapshot.sh`

### DIFF
--- a/charts/search-index-env-sync/templates/configmap.yaml
+++ b/charts/search-index-env-sync/templates/configmap.yaml
@@ -1,19 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "search-index-env-sync.fullname" . }}-script
+  name: {{ include "search-index-env-sync.fullname" . }}
   labels:
     {{- include "search-index-env-sync.labels" . | nindent 4 }}
 data:
   snapshot: |
     {{- $.Files.Get "snapshot.sh" | trim | nindent 4 }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "search-index-env-sync.fullname" . }}-config
-  labels:
-    {{- include "search-index-env-sync.labels" . | nindent 4 }}
-data:
-  configfile: |
-    -u $USERNAME:$PASSWORD

--- a/charts/search-index-env-sync/templates/cronjob.yaml
+++ b/charts/search-index-env-sync/templates/cronjob.yaml
@@ -46,12 +46,8 @@ spec:
           volumes:
             - name: scripts
               configMap:
-                name: {{ $fullName }}-script
+                name: {{ $fullName }}
                 defaultMode: 0555  # world-executable
-            - name: configs
-              configMap:
-                name: {{ $fullName }}-config
-                defaultMode: 0444
           containers:
             - name: main
               image: {{ $.Values.imageRef | quote }}
@@ -74,8 +70,5 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /opt/bin
-                  readOnly: true
-                - name: configs
-                  mountPath: /opt/etc
                   readOnly: true
 {{- end }}


### PR DESCRIPTION
Using environment variables in a config file for the curl command did not work as the env vars are not expanded when the command is run. Switching to using alias for curl instead to prevent authentication credentials being logged by the cronjob.