### PR TITLE
Fix mirror freshness alertmanager config

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -102,7 +102,10 @@ spec:
 
         *Environment:* {{ .Values.govukEnvironment }}
 
-        *Mirror*: {{ "{{ .Labels.backend }}" }}
+        *Mirrors*:
+        {{ "{{ range .Alerts -}}" }}
+          • backend: {{ "`{{ .Labels.backend }}`" }}
+        {{ "{{ end }}" }}
       apiURL: *slack_api_url
   - name: 'generic-slack-platform-engineering'
     slackConfigs:


### PR DESCRIPTION
We're getting these errors at the moment:

    ts=2024-07-25T09:27:39.522Z caller=dispatch.go:353 level=error component=dispatcher msg="Notify for alerts failed" num_alerts=3 err="monitoring/alertmanagerconfig-general/slack-mirror-freshness/slack[0]: notify retry canceled due to unrecoverable error after 1 attempts: template: :3:20: executing \"\" at <.Labels.backend>: can't evaluate field Labels in type *template.Data"

Judging from the other examples in this file, we need to range over .Alerts first.

There are like, so many curly brackets in these templates, so I'm really not sure whether I'm getting the syntax right. I'll keep an eye on the logs. Hopefully this is the one.