### PR TITLE
Set curl command with alias in `snapshot.sh`

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -28,27 +28,27 @@ EOF
 create () {
   : "${SNAPSHOT_NAME:?required}"
   local result
-  result=$($curl -XPUT "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME?wait_for_completion=true")
+  result=$(mycurl -XPUT "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME?wait_for_completion=true")
   echo "$result" | jq
   echo "$result" | jq -r .snapshot.state | grep -Fx "SUCCESS"
 }
 
 delete () {
   local result
-  result=$($curl -XDELETE "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME")
+  result=$(mycurl -XDELETE "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME")
   echo "$result" | jq -e .acknowledged >/dev/null
 }
 
 # List all snapshots in ascending date order (as returned by ES).
 list () {
-  $curl "$ES_URL/_snapshot/$SNAPSHOT_REPO/_all" | jq -e '.snapshots'
+  mycurl "$ES_URL/_snapshot/$SNAPSHOT_REPO/_all" | jq -e '.snapshots'
 }
 
 # Enable or disable automatic index creation on insert.
 # usage: set_auto_create_index true|false
 set_auto_create_index () {
   # TODO: use curl --json once available (requires curl >= 7.82).
-  $curl -XPUT "$ES_URL/_cluster/settings" -H 'Content-Type: application/json' \
+  mycurl -XPUT "$ES_URL/_cluster/settings" -H 'Content-Type: application/json' \
     -d '{ "persistent": { "action.auto_create_index": "'"$1"'" } }' >&2
 }
 
@@ -64,11 +64,11 @@ restore () {
   set_auto_create_index false
   trap 'set_auto_create_index true' EXIT HUP INT TERM
 
-  $curl -XDELETE "$ES_URL/*,-.*" >&2  # Delete all except system indices.
+  mycurl -XDELETE "$ES_URL/*,-.*" >&2  # Delete all except system indices.
   local result
   result=$(
     # TODO: use curl --json once available.
-    $curl -XPOST -H'Content-Type: application/json' -d'{"indices": "*,-.*"}' \
+    mycurl -XPOST -H'Content-Type: application/json' -d'{"indices": "*,-.*"}' \
       "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME/_restore"
   )
 
@@ -125,9 +125,13 @@ fi
 readonly GOVUK_ENVIRONMENT ES_URL SNAPSHOTS_TO_KEEP REQUEST_DEADLINE_SECONDS
 
 if [[ -n $SEARCH_USERNAME && -n $SEARCH_PASSWORD ]]; then
-  curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body --config /opt/etc/configfile"
+  mycurl () {
+    curl -Ssm"$REQUEST_DEADLINE_SECONDS" --fail-with-body -u "$SEARCH_USERNAME:$SEARCH_PASSWORD" "$@"
+  }
 else
-  curl="curl -Ssm$REQUEST_DEADLINE_SECONDS --fail-with-body"
+  mycurl () {
+    curl -Ssm"$REQUEST_DEADLINE_SECONDS" --fail-with-body "$@"
+  }
 fi
 
 [[ "${VERBOSE:-0}" -ge 1 ]] && set -x

--- a/charts/search-index-env-sync/templates/configmap.yaml
+++ b/charts/search-index-env-sync/templates/configmap.yaml
@@ -1,19 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "search-index-env-sync.fullname" . }}-script
+  name: {{ include "search-index-env-sync.fullname" . }}
   labels:
     {{- include "search-index-env-sync.labels" . | nindent 4 }}
 data:
   snapshot: |
     {{- $.Files.Get "snapshot.sh" | trim | nindent 4 }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "search-index-env-sync.fullname" . }}-config
-  labels:
-    {{- include "search-index-env-sync.labels" . | nindent 4 }}
-data:
-  configfile: |
-    -u $USERNAME:$PASSWORD

--- a/charts/search-index-env-sync/templates/cronjob.yaml
+++ b/charts/search-index-env-sync/templates/cronjob.yaml
@@ -46,12 +46,8 @@ spec:
           volumes:
             - name: scripts
               configMap:
-                name: {{ $fullName }}-script
+                name: {{ $fullName }}
                 defaultMode: 0555  # world-executable
-            - name: configs
-              configMap:
-                name: {{ $fullName }}-config
-                defaultMode: 0444
           containers:
             - name: main
               image: {{ $.Values.imageRef | quote }}
@@ -74,8 +70,5 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /opt/bin
-                  readOnly: true
-                - name: configs
-                  mountPath: /opt/etc
                   readOnly: true
 {{- end }}


### PR DESCRIPTION
Using environment variables in a config file for the curl command did not work as the env vars are not expanded when the command is run. Switching to using a function for curl instead to prevent authentication credentials being logged by the cronjob.