### PR TITLE
Turn off debugging for authentication in `snapshot.sh`

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -126,7 +126,9 @@ readonly GOVUK_ENVIRONMENT ES_URL SNAPSHOTS_TO_KEEP REQUEST_DEADLINE_SECONDS
 
 if [[ -n $SEARCH_USERNAME && -n $SEARCH_PASSWORD ]]; then
   mycurl () {
+    set +x
     curl -Ssm"$REQUEST_DEADLINE_SECONDS" --fail-with-body -u "$SEARCH_USERNAME:$SEARCH_PASSWORD" "$@"
+    [[ "${VERBOSE:-0}" -ge 1 ]] && set -x
   }
 else
   mycurl () {


### PR DESCRIPTION
With debugging turned on, the username and password authentication for the Opensearch API are logged in clear text. This change aims to prevent this happening when the `curl` command is run.