### PR TITLE
Disable GOV.UK Chat message queue workers and auto deploys

### DIFF
--- a/charts/app-config/image-tags/production/govuk-chat
+++ b/charts/app-config/image-tags/production/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v257
 promote_deployment: true
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/app-config/image-tags/staging/govuk-chat
+++ b/charts/app-config/image-tags/staging/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v257
 promote_deployment: true
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1223,8 +1223,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1228,8 +1228,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1231,8 +1231,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
These have been temporarily disabled to try minimise the errors that occur while we run a reindex of the GOV.UK Chat search database.