### PR TITLE
Add secret for Notify API key in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1260,6 +1260,11 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-postgres
               key: DATABASE_URL
+        - name: GOVUK_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-notify
+              key: GOVUK_NOTIFY_API_KEY
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Stores the API key to allow GOV.UK Chat to send emails via Notify.

Just configured in integration now while we verify it works; will be
rolled out to staging/production at a later stage.

The secret has already been added in Secrets Manager.