### PR TITLE
Add template for Notify API key

### DIFF
--- a/charts/external-secrets/templates/govuk-chat/notify.yaml
+++ b/charts/external-secrets/templates/govuk-chat/notify.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-notify
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      The GOV.UK Notify API key belonging to GOV.UK Chat.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: govuk-chat-notify
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/notify


### PR DESCRIPTION
The env var was added to the integration values file but this template
file is needed to map the value to the AWS secrets manager secret.