### PR TITLE
Revert "Re-enable chat integration queue consumer"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1223,8 +1223,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#2220

Something went wrong and now I've got a bad index - need to stop this process to fix it.