### PR TITLE
Revert "Revert "Re-enable chat integration queue consumer""

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1223,8 +1223,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#2222

Issue now resolved so this can be re-enabled.