### PR TITLE
Re-enable GOV.UK Chat changes following reindex setup

### DIFF
--- a/charts/app-config/image-tags/production/govuk-chat
+++ b/charts/app-config/image-tags/production/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v259
 promote_deployment: false
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/govuk-chat
+++ b/charts/app-config/image-tags/staging/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v259
 promote_deployment: true
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1228,8 +1228,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1231,8 +1231,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Now that the new indices are created we can re-enable automatic deploys and the worker processes.