### PR TITLE
Add env var for Notify template ID

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1265,6 +1265,8 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-notify
               key: GOVUK_NOTIFY_API_KEY
+        - name: GOVUK_NOTIFY_TEMPLATE_ID
+          value: 346cdea0-9d4e-4de1-a528-cded6713bc61
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Allows govuk-chat to know which Notify template to use.

Template [here](https://www.notifications.service.gov.uk/services/f88223b5-7a5c-4b05-9f06-5c65d4769c78/templates/346cdea0-9d4e-4de1-a528-cded6713bc61)