### PR TITLE
Run failover CDN tests in staging instead of integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1322,15 +1322,6 @@ govukApplications:
         - name: govuk-e2e-tests-mirror-gcs
           schedule: "*/30 7-19 * * 1-5"
           project: mirrorGCS
-        - name: govuk-e2e-tests-mirror-cloudfront
-          schedule: "*/30 7-19 * * 1-5"
-          project: cloudfront
-          extraEnv:
-            - name: PUBLIC_DOMAIN
-              valueFrom:
-                secretKeyRef:
-                  key: FAILOVER_CDN_HOST
-                  name: smokey-failover-cdn-host
 
   - name: govuk-jobs
     chartPath: charts/govuk-jobs

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1322,6 +1322,15 @@ govukApplications:
         - name: govuk-e2e-tests-mirror-gcs
           schedule: "*/30 7-19 * * 1-5"
           project: mirrorGCS
+        - name: govuk-e2e-tests-mirror-cloudfront
+          schedule: "*/30 7-19 * * 1-5"
+          project: cloudfront
+          extraEnv:
+            - name: PUBLIC_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  key: FAILOVER_CDN_HOST
+                  name: smokey-failover-cdn-host
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter


### PR DESCRIPTION
We don't have a Cloudfront distrubution setup for integration, only staging and production.