### PR TITLE
Disable mirror sync job from integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1313,24 +1313,6 @@ govukApplications:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5"
           project: chromium
-        - name: govuk-e2e-tests-mirror-s3
-          schedule: "*/30 7-19 * * 1-5"
-          project: mirrorS3
-        - name: govuk-e2e-tests-mirror-s3-replica
-          schedule: "*/30 7-19 * * 1-5"
-          project: mirrorS3Replica
-        - name: govuk-e2e-tests-mirror-gcs
-          schedule: "*/30 7-19 * * 1-5"
-          project: mirrorGCS
-
-  - name: govuk-jobs
-    chartPath: charts/govuk-jobs
-    postSyncWorkflowEnabled: "false"
-    imageValues:
-      - govuk-mirror
-    helmValues:
-      govukMirrorSync:
-        iamRoleArn: arn:aws:iam::210287912431:role/govuk-mirror-sync
 
   - name: hmrc-manuals-api
     helmValues:


### PR DESCRIPTION
Our Fastly CDN service for integration isn't configured to serve content from mirror in our integration environment. The staging enevironment is available to test mirror sync changes. This also remove smoke tests against the mirrors for integration (as the backend override is ignored).