### PR TITLE
Improve Search quality monitoring alerts

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -2,15 +2,10 @@ groups:
   - name: SearchApiV2
     rules:
       - alert: LowInvariantScore
-        expr: search_api_v2_quality_monitoring_score{dataset_type="invariants"} < 1
+        expr: search_api_v2_quality_monitoring_score{dataset_type="invariants"} < 0.95
         labels:
           severity: warning
-          destination: slack-search-team
-        annotations:
-          summary: Low invariant recall score for '{{ $labels.dataset_name }}'
-          description: >-
-            Invariant dataset '{{ $labels.dataset_name }}' has dropped below 100% recall (i.e. the
-            expected results are not being returned for one or more queries in this dataset)
+          destination: slack-search-quality-monitoring
 
       - alert: HighQueryFailureRate
         expr: >-

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -6,21 +6,35 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      # Should alert (too low)
+      # Should alert (below threshold)
       - series: >-
-          search_api_v2_quality_monitoring_score{dataset_name="dataset1", dataset_type="invariants"}
-        values: '0.9 0.99 1 0.95'
-      # Should not alert (perfect scores)
+          search_api_v2_quality_monitoring_score{dataset_name="dataset1",
+          dataset_type="invariants"}
+        values: '0.94 0.94 0.94 0.94 0.94'
+      # Should not alert (at threshold)
       - series: >-
-          search_api_v2_quality_monitoring_score{dataset_name="dataset2", dataset_type="invariants"}
-        values: '1 1 1 1'
-      # Should not alert (wrong type)
+          search_api_v2_quality_monitoring_score{dataset_name="dataset2",
+          dataset_type="invariants"}
+        values: '0.95 0.95 0.95 0.95 0.95'
+      # Should not alert (above threshold)
       - series: >-
           search_api_v2_quality_monitoring_score{dataset_name="dataset3",
+          dataset_type="invariants"}
+        values: '0.96 0.96 0.96 0.96 0.96'
+      # Should not alert (wrong type)
+      - series: >-
+          search_api_v2_quality_monitoring_score{dataset_name="dataset4",
           dataset_type="something_else"}
-        values: '0.1 0.2 0.3 0.4'
+        values: '0.90 0.90 0.90 0.90 0.90'
+      # Should alert (drops below threshold)
+      - series: >-
+          search_api_v2_quality_monitoring_score{dataset_name="dataset5",
+          dataset_type="invariants"}
+        values: '0.96 0.95 0.94 0.94 0.94'
+
+
     alert_rule_test:
-      - eval_time: 4m
+      - eval_time: 5m
         alertname: LowInvariantScore
         exp_alerts:
           - exp_labels:
@@ -28,12 +42,13 @@ tests:
               dataset_name: "dataset1"
               dataset_type: "invariants"
               severity: "warning"
-              destination: "slack-search-team"
-            exp_annotations:
-              summary: "Low invariant recall score for 'dataset1'"
-              description: >-
-                Invariant dataset 'dataset1' has dropped below 100% recall (i.e. the expected
-                results are not being returned for one or more queries in this dataset)
+              destination: "slack-search-quality-monitoring"
+          - exp_labels:
+              alertname: LowInvariantScore
+              dataset_name: "dataset5"
+              dataset_type: "invariants"
+              severity: "warning"
+              destination: "slack-search-quality-monitoring"
 
   - interval: 1m
     input_series:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -58,6 +58,16 @@ spec:
       groupInterval: 30m
       activeTimeIntervals:
         - inhours
+    - matchers:
+      - name: destination
+        value: slack-search-quality-monitoring
+        matchType: =
+      receiver: slack-search-quality-monitoring
+      repeatInterval: 24h
+      groupWait: 5m
+      groupInterval: 30m
+      activeTimeIntervals:
+        - inhours
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -122,6 +132,27 @@ spec:
       iconURL: https://avatars3.githubusercontent.com/u/3380462
       text: |-
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
+      apiURL: *slack_api_url
+  - name: slack-search-quality-monitoring
+    slackConfigs:
+    - channel: '#govuk-search-improvement'
+      sendResolved: true
+      iconEmoji: '{{ if eq .Status "firing" }}:warning:{{ else }}:white_check_mark:{{ end }}'
+      color: '{{ if eq .Status "firing" }}#FFFF00{{ else }}#36a64f{{ end }}'
+      title: Quality monitoring warning
+      text: >-
+        {{ if eq .Status "firing" }}
+          {{ len .Alerts.Firing }} invariant dataset(s) have scores lower than 95%:
+          {{ range .Alerts }}
+            • {{ .Labels.dataset_name }}: {{ printf "%.2f" (mul .Value 100) }}%
+          {{ end }}
+        {{ else }}
+        All invariant datasets have returned to normal levels (95% or above).
+        {{ end }}
+      actions:
+      - type: button
+        text: 'View logs in Kibana'
+        url: "https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-quality-monitoring-assert-invariants),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-quality-monitoring-assert-invariants)))),sort:!())"
       apiURL: *slack_api_url
   muteTimeIntervals:
   - name: inhours


### PR DESCRIPTION
- Change alerting treshold to 95% to reduce noise caused by daily fluctuations
- Remove unnecessary alert rule annotations
- Set up dedicated route and receiver for quality monitoring alerts, going to the main team channel and with a pretty formatted message