### PR TITLE
Create cronjob to import indices into Test Chat Opensearch on a daily basis

### DIFF
--- a/charts/external-secrets/templates/govuk-chat/opensearch-test.yaml
+++ b/charts/external-secrets/templates/govuk-chat/opensearch-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-opensearch-test
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      OpenSearch credentials for the GovUK Chat OpenSearch Test domain
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/opensearch-test

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -111,6 +111,24 @@ cronjobs:
             secretKeyRef:
               name: govuk-chat-opensearch
               key: password
+    test-chat-cp-prod:
+      schedule: "12 5 * * *"
+      args: [restore_latest]
+      extraEnv:
+        - name: SNAPSHOT_REPO
+          value: govuk-production
+        - name: SUBDOMAIN
+          value: chat-opensearch-test
+        - name: SEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch-test
+              key: username
+        - name: SEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-opensearch-test
+              key: password
 
 podSecurityContext:
   fsGroup: 1001


### PR DESCRIPTION
### What
Create a cronjob to import indices into the Test Chat Opensearch cluster on a daily basis
Configure access credentials in `external-secrets` for cronjob to use

### Why
This is to allow the Test Opensearch Cluster to import a snapshot of Prod indices on a daily basis