### PR TITLE
Report publishing-api metrics to prometheus hourly

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1852,6 +1852,9 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
+        - name: metrics-report-to-prometheus
+          task: "metrics:report_to_prometheus"
+          schedule: "22 * * * *"  # every hour, at 22 minutes past the hour
         # In non-production envs, run Search API v2 bulk import every week to bring it to parity
         # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1892,6 +1892,9 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
+        - name: metrics-report-to-prometheus
+          task: "metrics:report_to_prometheus"
+          schedule: "22 * * * *"  # every hour, at 22 minutes past the hour
         - name: search-api-v2-bulk-import
           task: "queue:requeue_all_the_ever_published_things[bulk.search_api_v2_sync]"
           schedule: "0 0 1 11 *"  # arbitrary value (only used as a template but field is required)

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1886,6 +1886,9 @@ govukApplications:
         - name: events-export
           task: "events:export_to_s3"
           schedule: "38 5 * * 0"
+        - name: metrics-report-to-prometheus
+          task: "metrics:report_to_prometheus"
+          schedule: "22 * * * *"  # every hour, at 22 minutes past the hour
         # In non-production envs, run Search API v2 bulk import every week to bring it to parity
         # with Publishing API state (which gets refreshed from production DB every night).
         - name: search-api-v2-bulk-import


### PR DESCRIPTION
22 minutes past the hour is a random choice. Choosing a random value rather than 0 to avoid a situation where everything happens exactly on the hour causing load spikes.

Depends on https://github.com/alphagov/publishing-api/pull/2828