### PR TITLE
Add finder-frontend to draft stack

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1059,6 +1059,29 @@ govukApplications:
         - name: DISABLE_LTR_ON_PATHS
           value: /find-licences
 
+  - name: draft-finder-frontend
+    repoName: finder-frontend
+    helmValues:
+      arch: arm64
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+      uploadAssets:
+        enabled: false
+      cronTasks:
+        - name: registries-refresh
+          task: "registries:cache_refresh"
+          schedule: "15 * * * *"
+      extraEnv:
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-finder-frontend-email-alert-api
+              key: bearer_token
+
   - name: frontend
     helmValues:
       arch: arm64

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2146,6 +2146,8 @@ govukApplications:
           value: "http://draft-content-store"
         - name: BACKEND_URL_email-alert-frontend
           value: "http://draft-email-alert-frontend"
+        - name: BACKEND_URL_finder-frontend
+          value: "http://draft-finder-frontend"
         - name: BACKEND_URL_frontend
           value: "http://draft-frontend"
         - name: BACKEND_URL_government-frontend
@@ -2158,8 +2160,6 @@ govukApplications:
           value: "http://account-api"
         - name: BACKEND_URL_feedback
           value: "http://feedback"
-        - name: BACKEND_URL_finder-frontend
-          value: "http://finder-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2201,6 +2201,8 @@ govukApplications:
           value: "http://draft-content-store"
         - name: BACKEND_URL_email-alert-frontend
           value: "http://draft-email-alert-frontend"
+        - name: BACKEND_URL_finder-frontend
+          value: "http://draft-finder-frontend"
         - name: BACKEND_URL_frontend
           value: "http://draft-frontend"
         - name: BACKEND_URL_government-frontend
@@ -2213,8 +2215,6 @@ govukApplications:
           value: "http://account-api"
         - name: BACKEND_URL_feedback
           value: "http://feedback"
-        - name: BACKEND_URL_finder-frontend
-          value: "http://finder-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1116,6 +1116,28 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
+  - name: draft-finder-frontend
+    repoName: finder-frontend
+    helmValues:
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+      uploadAssets:
+        enabled: false
+      cronTasks:
+        - name: registries-refresh
+          task: "registries:cache_refresh"
+          schedule: "15 * * * *"
+      extraEnv:
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-finder-frontend-email-alert-api
+              key: bearer_token
+
   - name: draft-frontend
     repoName: frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1054,6 +1054,28 @@ govukApplications:
         - name: WEB_CONCURRENCY
           value: '4'
 
+  - name: draft-finder-frontend
+    repoName: finder-frontend
+    helmValues:
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+      uploadAssets:
+        enabled: false
+      cronTasks:
+        - name: registries-refresh
+          task: "registries:cache_refresh"
+          schedule: "15 * * * *"
+      extraEnv:
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-finder-frontend-email-alert-api
+              key: bearer_token
+
   - name: frontend
     helmValues:
       ingress:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2191,6 +2191,8 @@ govukApplications:
           value: "http://draft-content-store"
         - name: BACKEND_URL_email-alert-frontend
           value: "http://draft-email-alert-frontend"
+        - name: BACKEND_URL_finder-frontend
+          value: "http://draft-finder-frontend"
         - name: BACKEND_URL_frontend
           value: "http://draft-frontend"
         - name: BACKEND_URL_government-frontend
@@ -2203,8 +2205,6 @@ govukApplications:
           value: "http://account-api"
         - name: BACKEND_URL_feedback
           value: "http://feedback"
-        - name: BACKEND_URL_finder-frontend
-          value: "http://finder-frontend"
         - name: BACKEND_URL_licensify
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api


### PR DESCRIPTION
We're hoping to use the draft stack to support 'previews' of specialist finders, to avoid publishers having to use Integration for that. See commits for details.

Tested by [deploying as per README](https://github.com/alphagov/govuk-helm-charts?tab=readme-ov-file#installing-an-application-chart-without-argo-cd):

```
$ cd charts/app-config
$ ENVIRONMENT=integration
$ APP=draft-finder-frontend
$ USER=chrisashton
$ helm install $USER-${APP?} ../generic-govuk-app --values <(
  helm template . --values values-${ENVIRONMENT}.yaml |
  yq e '.|select(.metadata.name=="'$APP'").spec.source.helm.values'
) --set sentry.enabled=false --set rails.createKeyBaseSecret=false

NAME: chrisashton-draft-finder-frontend
LAST DEPLOYED: Mon Aug  5 15:47:51 2024
NAMESPACE: apps
STATUS: deployed
...
```

...and then confirming that the deployed app is talking to the draft content store:

```
$ k exec -it deploy/draft-content-store -- rails c
dcs$ content_item = ContentItem.find_by(content_id: "fef4ac7c-024a-4943-9f19-e85a8369a1f3")
dcs$ content_item.update(title: "DRAFT Competition and Markets Authority cases and projects")
dcs$ content.save!

$ k exec -it deploy/chrisashton-draft-finder-frontend -- rails c
dff$ ContentItem.from_content_store("/cma-cases")
#<ContentItem:0x0000ffff92fbdc08
 @content_item_hash=
  {"analytics_identifier"=>nil,
   "base_path"=>"/cma-cases",
    ...
     "schema_name"=>"finder",
   "title"=>"DRAFT Competition and Markets Authority cases and projects",
   "updated_at"=>"2024-08-05T15:50:59+01:00",
   "withdrawn_notice"=>{},
   "cache_control"=>{"max_age"=>"1", "public"=>true}}>
```

Trello: https://trello.com/c/cevf50zS/2451-spike-specialist-finder-previews-kick-off-needed