### PR TITLE
Use correct DGU domains and remove CloudFront tests in e2e tests

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -6,6 +6,7 @@ externalDomainSuffix: integration.publishing.service.gov.uk
 k8sExternalDomainSuffix: eks.integration.govuk.digital
 publishingDomainSuffix: integration.publishing.service.gov.uk
 assetsDomain: assets.integration.publishing.service.gov.uk
+dguDomain: integration.data.gov.uk
 
 awsAccountId: "210287912431"
 

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1311,15 +1311,6 @@ govukApplications:
         - name: govuk-e2e-tests-mirror-gcs
           schedule: "*/30 7-19 * * 1-5"
           project: mirrorGCS
-        - name: govuk-e2e-tests-cloudfront
-          schedule: "*/30 7-19 * * 1-5"
-          project: cloudfront
-          extraEnv:
-            - name: PUBLIC_DOMAIN
-              valueFrom:
-                secretKeyRef:
-                  key: FAILOVER_CDN_HOST
-                  name: smokey-failover-cdn-host
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -6,6 +6,7 @@ externalDomainSuffix: gov.uk
 k8sExternalDomainSuffix: eks.production.govuk.digital
 publishingDomainSuffix: publishing.service.gov.uk
 assetsDomain: assets.publishing.service.gov.uk
+dguDomain: data.gov.uk
 
 awsAccountId: "172025368201"
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -6,6 +6,7 @@ externalDomainSuffix: staging.publishing.service.gov.uk
 k8sExternalDomainSuffix: eks.staging.govuk.digital
 publishingDomainSuffix: staging.publishing.service.gov.uk
 assetsDomain: assets.staging.publishing.service.gov.uk
+dguDomain: staging.data.gov.uk
 
 awsAccountId: "696911096973"
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1314,15 +1314,6 @@ govukApplications:
         - name: govuk-e2e-tests-mirror-gcs
           schedule: "*/30 7-19 * * 1-5"
           project: mirrorGCS
-        - name: govuk-e2e-tests-cloudfront
-          schedule: "*/30 7-19 * * 1-5"
-          project: cloudfront
-          extraEnv:
-            - name: PUBLIC_DOMAIN
-              valueFrom:
-                secretKeyRef:
-                  key: FAILOVER_CDN_HOST
-                  name: smokey-failover-cdn-host
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter

--- a/charts/govuk-e2e-tests/templates/cronjob.yaml
+++ b/charts/govuk-e2e-tests/templates/cronjob.yaml
@@ -80,6 +80,8 @@ spec:
               value: www.{{ $.Values.externalDomainSuffix }}
             - name: PUBLISHING_DOMAIN
               value: {{ $.Values.publishingDomainSuffix }}
+            - name: DGU_DOMAIN
+              value: www.{{ $.Values.dguDomain }}
             - name: SIGNON_EMAIL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This set the correct DGU domains for each environment for the e2e tests.

This also disables the tests running against CloudFront CDN. Playwright doesn't support setting the
"Host" header for request and there's no forward proxy yet configured.