### PR TITLE
Switch staging link-checker-api to use new Redis instance

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1448,8 +1448,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &link-checker-redis redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *link-checker-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This switches the web application in staging away from the shared Redis instance to a new dedicated instance for this app.

A later PR will switch the workers, once all the existing jobs have been processed.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/2248.

[Trello card](https://trello.com/c/eqvVgy68)