### PR TITLE
Switch staging link-checker-api workers to use new Redis instance

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1447,8 +1447,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This switches the workers in staging away from the shared Redis instance to a new dedicated instance for this app.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/2249.

[Trello card](https://trello.com/c/eqvVgy68)