### PR TITLE
Provision standalone Redis instance in production for link-checker-api

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1450,6 +1450,11 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &link-checker-redis redis://shared-redis-govuk.eks.production.govuk-internal.digital
+          workers: *link-checker-redis
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This creates the standalone instance of Redis in production for Link Checker API.

Later commits will switch the application away from the shared instance.

[Trello card](https://trello.com/c/eqvVgy68)