### PR TITLE
Switch production link-checker-api to use new Redis instance

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1453,8 +1453,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &link-checker-redis redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *link-checker-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This switches the web application in production away from the shared Redis instance to a new dedicated instance for this app.

A later PR will switch the workers, once all the existing jobs have been processed.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/2251.

[Trello card](https://trello.com/c/eqvVgy68)