### PR TITLE
Switch production link-checker-api workers to use new Redis instance

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1452,8 +1452,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This switches the workers in production away from the shared Redis instance to a new dedicated instance for this app.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/2252.

[Trello card](https://trello.com/c/eqvVgy68)