### PR TITLE
Change Integration cronjob to import snapshot from Prod instead of Staging

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -93,12 +93,12 @@ cronjobs:
           value: govuk-staging
         - name: SUBDOMAIN
           value: elasticsearch6
-    chat-engine-cp-stag:
+    chat-engine-cp-prod:
       schedule: "12 4 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO
-          value: govuk-staging
+          value: govuk-production
         - name: SUBDOMAIN
           value: chat-opensearch
         - name: SEARCH_USERNAME


### PR DESCRIPTION
### What
This is to change the snapshot restore cronjob to read from the Production S3 bucket instead of the Staging one

### Why
There have been a number of times when the snapshot imported from Staging into Integration has been corrupted somehow, resulting in the Integration Chat Opensearch Cluster Health going Red and the Integration Chat Service experiencing an outage. When the Test and Staging environments import snapshots from Production, this issue has not occurred.