### PR TITLE
Promote integration deploys in chat

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-chat
+++ b/charts/app-config/image-tags/integration/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v304
-promote_deployment: false
+promote_deployment: true
 automatic_deploys_enabled: true


### PR DESCRIPTION
A manual deploy, to fix a failed deploy, seems to have changed this boolean from a false to a true. So we seem to have lost automatic deploys 🤷