### PR TITLE
Remove legacy preview routes for assets ingress

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1073,9 +1073,6 @@ govukApplications:
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-            pathType: ImplementationSpecific
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /media/*/*/preview
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
@@ -1135,9 +1132,6 @@ govukApplications:
                 "draft-assets*.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
-          - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-            pathType: ImplementationSpecific
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             path: /media/*/*/preview
             pathType: ImplementationSpecific

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1064,9 +1064,6 @@ govukApplications:
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-            pathType: ImplementationSpecific
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /media/*/*/preview
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
@@ -1135,9 +1132,6 @@ govukApplications:
                 "draft-assets*.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
-          - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-            pathType: ImplementationSpecific
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             path: /media/*/*/preview
             pathType: ImplementationSpecific

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1068,9 +1068,6 @@ govukApplications:
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-            pathType: ImplementationSpecific
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /media/*/*/preview
             pathType: ImplementationSpecific
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
@@ -1139,9 +1136,6 @@ govukApplications:
                 "draft-assets*.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
-          - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
-            path: /government/uploads/system/uploads/attachment_data/file/*/*/preview
-            pathType: ImplementationSpecific
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             path: /media/*/*/preview
             pathType: ImplementationSpecific


### PR DESCRIPTION
These paths are no-longer served by frontend. Removed in this PR: https://github.com/alphagov/frontend/pull/3886/files