### PR TITLE
Disable govuk-chat queue consumers.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1224,8 +1224,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1229,8 +1229,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1232,8 +1232,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        - command: ['rake', 'message_queue:published_documents_consumer']
-          name: published-documents-consumer
+        # - command: ['rake', 'message_queue:published_documents_consumer']
+        #   name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Currently GOV.UK Chat is not operational due to a lack of OpenAI credits. Therefore I'm turning off these queue consumers that are only going to raise errors. I plan to re-enable them once we have OpenAI credits again.