### PR TITLE
Re-enable queue consumers for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1241,8 +1241,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1245,8 +1245,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1248,8 +1248,8 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
-        # - command: ['rake', 'message_queue:published_documents_consumer']
-        #   name: published-documents-consumer
+        - command: ['rake', 'message_queue:published_documents_consumer']
+          name: published-documents-consumer
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
We now have OpenAI credits again and can turn these back on.