### PR TITLE
Re-enable continuous deployment for Asset Manager

### DIFF
--- a/charts/app-config/image-tags/production/asset-manager
+++ b/charts/app-config/image-tags/production/asset-manager
@@ -1,3 +1,3 @@
 image_tag: v235
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true
 promote_deployment: false

--- a/charts/app-config/image-tags/staging/asset-manager
+++ b/charts/app-config/image-tags/staging/asset-manager
@@ -1,3 +1,3 @@
 image_tag: v260
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true
 promote_deployment: true


### PR DESCRIPTION
This was disabled in f6bee0a5bd24a4996c3265b1c6c560f702c6189d due to an incident, and should have been re-enabled post incident resolution.