### PR TITLE
Increase tracing sampling rate in integration and staging

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -44,8 +44,10 @@ data:
 
   ENABLE_OPEN_TELEMETRY: "true"
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo-distributor.monitoring.svc.cluster.local:4318"
+  {{- if eq .Values.govukEnvironment "production" }}
   OTEL_TRACES_SAMPLER: "traceidratio"
   OTEL_TRACES_SAMPLER_ARG: '0.001'
+  {{- end }}
   OTEL_RUBY_INSTRUMENTATION_RACK_CONFIG_OPTS: "untraced_endpoints=/healthcheck/live"
 
   PLEK_SERVICE_ASSETS_URI: https://{{ .Values.assetsDomain }}


### PR DESCRIPTION
This limits the sample rate to production, and reverts the "parentbased_always_on" default for integration and staging. Which means respects its parent span’s sampling decision, but otherwise always samples.