### PR TITLE
Monitor redis memory and disk usage

### DIFF
--- a/charts/monitoring-config/rules/redis.yaml
+++ b/charts/monitoring-config/rules/redis.yaml
@@ -1,0 +1,45 @@
+groups:
+  - name: RedisAlerts
+    rules:
+      - alert: RedisDiskSpaceLow
+        expr: >
+          kubelet_volume_stats_available_bytes{persistentvolumeclaim=~".*-redis"}
+            <
+          (1024^3 * 2) # 2GB
+        labels:
+          severity: warning
+        annotations:
+          summary: Disk space for Redis instance is low
+          description: >-
+            Less than 2GB of disk space is remaining on the Redis data volume.
+            Increase by setting redis.storage value in app-config.
+      - alert: RedisDiskSpaceCritical
+        expr: >
+          kubelet_volume_stats_available_bytes{persistentvolumeclaim=~".*-redis"}
+            <
+          (1024^2 * 512) # 512MB
+        labels:
+          severity: page
+        annotations:
+          summary: Disk space for Redis instance is critical
+          description: >-
+            Less than 512MB of disk space is remaining on the Redis data volume.
+            Increase by setting redis.storage value in app-config.
+      - record: global:redis:memory_usage_percentage
+        expr: >
+          avg(container_memory_usage_bytes{namespace="apps", container=~".*redis.*"}) by (pod)
+            /
+          avg(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+            namespace="apps", container=~".*redis.*"
+          }) by (pod)
+            * 100
+      - alert: RedisMemoryUsageHigh
+        expr: >
+          global:redis:memory_usage_percentage > 90
+        labels:
+          severity: warning
+        annotations:
+          summary: Redis memory usage is high
+          description: >-
+            Redis memory usage exceeds 90%.
+            Ensure Sidekiq queues are being processed and increase memory limit if necessary.

--- a/charts/monitoring-config/rules/redis_tests.yaml
+++ b/charts/monitoring-config/rules/redis_tests.yaml
@@ -1,0 +1,73 @@
+rule_files:
+  - redis.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'kubelet_volume_stats_available_bytes{persistentvolumeclaim="test-redis"}'
+        values: '3221225472' # 3GB remaining
+      - series: 'global:redis:memory_usage_percentage{pod="test-app-redis-abc213"}'
+        values: '25' # 25% of memory limit used
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RedisDiskSpaceLow
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: RedisMemoryUsageHigh
+        exp_alerts: []
+
+  # Warn with >90% memory usage
+  - interval: 1m
+    input_series:
+      - series: 'global:redis:memory_usage_percentage{pod="test-app-redis-abc213"}'
+        values: '95' # 95% of memory limit used
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RedisMemoryUsageHigh
+        exp_alerts:
+          - exp_labels:
+              pod: test-app-redis-abc213
+              severity: warning
+            exp_annotations:
+              summary: Redis memory usage is high
+              description: >-
+                Redis memory usage exceeds 90%.
+                Ensure Sidekiq queues are being processed and increase memory limit if necessary.
+
+  # Warn with <2GB remaining
+  - interval: 1m
+    input_series:
+      - series: 'kubelet_volume_stats_available_bytes{persistentvolumeclaim="test-redis"}'
+        values: '1610612736' # 1.5GB remaining
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RedisDiskSpaceLow
+        exp_alerts:
+          - exp_labels:
+              persistentvolumeclaim: test-redis
+              severity: warning
+            exp_annotations:
+              summary: Disk space for Redis instance is low
+              description: >-
+                Less than 2GB of disk space is remaining on the Redis data volume.
+                Increase by setting redis.storage value in app-config.
+
+  # Page with <512MB remaining
+  - interval: 1m
+    input_series:
+      - series: 'kubelet_volume_stats_available_bytes{persistentvolumeclaim="test-redis"}'
+        values: '322122547' # 300MB remaining
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RedisDiskSpaceCritical
+        exp_alerts:
+          - exp_labels:
+              persistentvolumeclaim: test-redis
+              severity: page
+            exp_annotations:
+              summary: Disk space for Redis instance is critical
+              description: >-
+                Less than 512MB of disk space is remaining on the Redis data volume.
+                Increase by setting redis.storage value in app-config.


### PR DESCRIPTION
Sidekiq could start dropping jobs if its Redis instance runs out of memory. We need to monitor these basic metrics to ensure this doesn't happen in production.

#2098 