### PR TITLE
Add GOOGLE_ACCOUNT_TYPE ENV var to integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2314,6 +2314,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-google-analytics
               key: govuk-view-id
+        - name: GOOGLE_ACCOUNT_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: search-api-google-analytics
+              key: account-type
         - name: GOOGLE_CLIENT_EMAIL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Adding `GOOGLE_ACCOUNT_TYPE` to integration to help test the new GA migration changes. This will need to be added to the other envs once working in integration