### PR TITLE
New search alert receivers and routes

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -48,26 +48,6 @@ spec:
       groupInterval: 12h
       activeTimeIntervals:
         - inhours
-    - matchers:
-      - name: destination
-        value: slack-search-team
-        matchType: =
-      receiver: 'slack-search-team'
-      repeatInterval: 3h
-      groupWait: 1m
-      groupInterval: 30m
-      activeTimeIntervals:
-        - inhours
-    - matchers:
-      - name: destination
-        value: slack-search-quality-monitoring
-        matchType: =
-      receiver: slack-search-quality-monitoring
-      repeatInterval: 24h
-      groupWait: 5m
-      groupInterval: 30m
-      activeTimeIntervals:
-        - inhours
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -124,35 +104,6 @@ spec:
       iconURL: https://avatars3.githubusercontent.com/u/3380462
       text: |-
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
-      apiURL: *slack_api_url
-  - name: 'slack-search-team'
-    slackConfigs:
-    - channel: '#govuk-search-improvement-alerts'
-      sendResolved: true
-      iconURL: https://avatars3.githubusercontent.com/u/3380462
-      text: |-
-        {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
-      apiURL: *slack_api_url
-  - name: slack-search-quality-monitoring
-    slackConfigs:
-    - channel: '#govuk-search-improvement'
-      sendResolved: true
-      iconEmoji: '{{ `{{ if eq .Status "firing" }}:warning:{{ else }}:white_check_mark:{{ end }}` }}'
-      color: '{{ `{{ if eq .Status "firing" }}#FFFF00{{ else }}#36a64f{{ end }}` }}'
-      title: '{{ `{{ if eq .Status "firing" }}Quality monitoring warning{{ else }}Quality monitoring issues resolved{{ end }}` }}'
-      text: |
-        {{ `{{ if eq .Status "firing" }}
-          {{ len .Alerts.Firing }} invariant dataset(s) have scores lower than 0.95:
-          {{ range .Alerts.Firing }}
-            • {{ .Labels.dataset_name }}: {{ printf "%.2f" .Value }}
-          {{ end }}
-        {{ else }}
-          All invariant datasets have returned to normal levels (0.95 or above).
-        {{ end }}` }}
-      actions:
-      - type: button
-        text: 'View logs in Kibana'
-        url: "https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-quality-monitoring-assert-invariants),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-quality-monitoring-assert-invariants)))),sort:!())"
       apiURL: *slack_api_url
   muteTimeIntervals:
   - name: inhours

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -48,6 +48,25 @@ spec:
       groupInterval: 12h
       activeTimeIntervals:
         - inhours
+    - receiver: search-slack-warning
+      groupBy:
+        - destination
+      groupWait: 1m
+      groupInterval: 10m
+      repeatInterval: 1h
+      matchers:
+        - name: destination
+          value: search-alerts
+      routes:
+        - matchers:
+            - name: severity
+              value: critical|page
+              matchType: =~
+          continue: true
+          groupWait: 1m
+          groupInterval: 15m
+          repeatInterval: 24h
+          receiver: search-slack-critical
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -105,6 +124,63 @@ spec:
       text: |-
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
       apiURL: *slack_api_url
+  - name: search-slack-warning
+    slackConfigs:
+    - &search-slack-config
+      channel: '#govuk-search-improvement-alerts'
+      username: Search health alerts
+      iconEmoji: '{{ "{{ if eq .Status \"firing\" }}:warning:{{ else }}:large_green_circle:{{ end }}" }}'
+      color: '{{ "{{ if eq .Status \"firing\" }}#ffdd00{{ else }}#00703c{{ end }}" }}'
+      title: >-
+        {{ "{{ if eq .Status \"firing\" }}" }}
+          {{ "{{ len .Alerts.Firing }} search health warning(s) ongoing" }}
+        {{ "{{ else }}" }}
+          All search health warnings resolved
+        {{ "{{ end }}" }}
+      text: >-
+        {{ "{{- if eq .Status \"firing\" -}}" }}
+          {{ "{{- range .Alerts.Firing -}}" }}
+            • *{{ "{{ .Annotations.summary }}" }}* ({{ "{{ .Annotations.description }}" }}){{ "{{- \"\\n\" -}}" }}
+          {{ "{{- end -}}" }}
+        {{ "{{- else -}}" }}
+          All search health warnings have now been resolved :raised_hands:
+        {{ "{{- end -}}" }}
+      actions:
+        - type: button
+          text: ':grafana: Service dashboard'
+          url: >-
+            https://grafana.eks.production.govuk.digital/d/e4f052f5-e292-42d2-9ca9-32c53bd7ee6d/christian-sutterat-search-api-v2?orgId=1&refresh=1m&from=now-24h&to=now
+        - type: button
+          text: ':elasticsearch: Invariant check logs'
+          url: >-
+            https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-quality-monitoring-assert-invariants),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-quality-monitoring-assert-invariants)))),sort:!())
+        - type: button
+          text: ':book: Documentation'
+          url: https://docs.publishing.service.gov.uk/repos/search-api-v2.html
+      sendResolved: true
+      apiURL:
+        key: slack_api_url
+        name: alertmanager-receivers
+  - name: search-slack-critical
+    slackConfigs:
+    - <<: *search-slack-config
+      channel: '#govuk-search-improvement'
+      iconEmoji: '{{ "{{ if eq .Status \"firing\" }}:sos:{{ else }}:large_green_circle:{{ end }}" }}'
+      color: '{{ "{{ if eq .Status \"firing\" }}#d4351c{{ else }}#00703c{{ end }}" }}'
+      title: >-
+        {{ "{{ if eq .Status \"firing\" }}" }}
+          {{ "{{ len .Alerts.Firing }} critical search health issue(s) ongoing" }}
+        {{ "{{ else }}" }}
+          Critical search health issues resolved
+        {{ "{{ end }}" }}
+      text: >-
+        {{ "{{- if eq .Status \"firing\" -}}" }}
+          {{ "{{- range .Alerts.Firing -}}" }}
+            • *{{ "{{ .Annotations.summary }}" }}* ({{ "{{ .Annotations.description }}" }}){{ "{{- \"\\n\" -}}" }}
+          {{ "{{- end -}}" }}
+        {{ "{{- else -}}" }}
+          All critical search health issues have now been resolved. :raised_hands:
+        {{ "{{- end -}}" }}
   muteTimeIntervals:
   - name: inhours
     timeIntervals:


### PR DESCRIPTION
This removes the old MVP search alerting receivers and routes, and adds two new Slack receivers with appropriate routing rules:

- A `search-slack-warning` receiver for minor or developing issues that goes to our team's alerts channel
- A `search-slack-critical` receiver for major issues that goes to our team's main channel

Both of these are configured to group all ongoing alerts into a single notification to avoid excessive messages, and are generic to any alert unlike before (taking alert data from the alert's summary and description annotations).