### PR TITLE
Switch integration content-data-admin to use new Redis instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -466,8 +466,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-data-redis redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *content-data-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       extraEnv:
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
This switches the web application in integration away from the shared Redis instance to a new dedicated instance for this app.

A later PR will switch the workers, once all the existing jobs have been processed.