### PR TITLE
Add email alert frontend to draft stack

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -959,6 +959,37 @@ govukApplications:
               name: email-alert-auth
               key: token
 
+  - name: draft-email-alert-frontend
+    repoName: email-alert-frontend
+    helmValues:
+      arch: arm64
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+        - name: ACCOUNT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-email-alert-frontend-account-api
+              key: bearer_token
+        - name: EMAIL_ALERT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-email-alert-frontend-email-alert-api
+              key: bearer_token
+        - name: EMAIL_ALERT_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: email-alert-auth
+              key: token
+
   - name: email-alert-service
     helmValues:
       arch: arm64

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -941,8 +941,6 @@ govukApplications:
     helmValues:
       arch: arm64
       extraEnv:
-        - name: SUBSCRIPTION_MANAGEMENT_ENABLED
-          value: "yes"
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: ACCOUNT_API_BEARER_TOKEN

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -941,6 +941,36 @@ govukApplications:
               name: email-alert-auth
               key: token
 
+  - name: draft-email-alert-frontend
+    repoName: email-alert-frontend
+    helmValues:
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+        - name: ACCOUNT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-email-alert-frontend-account-api
+              key: bearer_token
+        - name: EMAIL_ALERT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-email-alert-frontend-email-alert-api
+              key: bearer_token
+        - name: EMAIL_ALERT_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: email-alert-auth
+              key: token
+
   - name: email-alert-service
     helmValues:
       appEnabled: false

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -923,8 +923,6 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       extraEnv:
-        - name: SUBSCRIPTION_MANAGEMENT_ENABLED
-          value: "yes"
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: ACCOUNT_API_BEARER_TOKEN

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -945,6 +945,36 @@ govukApplications:
               name: email-alert-auth
               key: token
 
+  - name: draft-email-alert-frontend
+    repoName: email-alert-frontend
+    helmValues:
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: PLEK_HOSTNAME_PREFIX
+          value: draft-
+        - name: REDIS_URL
+          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+        - name: ACCOUNT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-email-alert-frontend-account-api
+              key: bearer_token
+        - name: EMAIL_ALERT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-email-alert-frontend-email-alert-api
+              key: bearer_token
+        - name: EMAIL_ALERT_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: email-alert-auth
+              key: token
+
   - name: email-alert-service
     helmValues:
       appEnabled: false

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -927,8 +927,6 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       extraEnv:
-        - name: SUBSCRIPTION_MANAGEMENT_ENABLED
-          value: "yes"
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: ACCOUNT_API_BEARER_TOKEN


### PR DESCRIPTION
Defines draft- apps for email-alert-frontend in all environments (draft-router-api was previously pointing to these non-existent apps, so no need to update it).

- Also removes an environment variable from the non-draft apps that is no longer used.

https://trello.com/c/KjFnLQwu/283-add-email-alert-frontend-to-draft-stack