### PR TITLE
Bump integration memory to test new rake task change

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2239,6 +2239,13 @@ govukApplications:
 
   - name: search-api
     helmValues:
+      appResources:
+        limits:
+          cpu: 1
+          memory: 2500Mi
+        requests:
+          cpu: 1
+          memory: 1Gi
       arch: arm64
       rails:
         enabled: false


### PR DESCRIPTION
Due to the migration of GA into `search-api` we have encountered an issue when running the rake task the pod runs out of memory. Under local testing we see that memory spikes to 1.1GB and then sits at around 660MB. So the idea is we bump the memory in integration to 2.5GB to test the rake task and see if this provides enough resource to finish the job and maintain a stable application.

NOTE: This will be temporary and will be removed once established if the memory limit is suitable.

GA Migration PR: https://github.com/alphagov/search-api/pull/2964