### PR TITLE
Increase memory limit for `load-page-traffic` cronjob

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2260,6 +2260,13 @@ govukApplications:
           env:
             - name: AWS_SEARCH_ANALYTICS_BUCKET
               value: govuk-search-analytics-integration
+          resources:
+            limits:
+              cpu: 1
+              memory: 2500Mi
+            requests:
+              cpu: 0.1
+              memory: 800Mi
         - name: update-detailed-index-popularity
           task: "search:update_popularity"
           schedule: "42 4 * * *"

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -86,7 +86,7 @@ spec:
                 {{- with .env }}
                   {{- . | toYaml | trim | nindent 16 }}
                 {{- end }}
-              {{- with $.Values.appResources }}
+              {{- with .resources | default $.Values.appResources }}
               resources:
                 {{- . | toYaml | trim | nindent 16 }}
               {{- end }}


### PR DESCRIPTION
These pods are being OOM killed.

This PR also changes the template to allow us to tweak resources for individual cronjobs, without affecting resource allocation for the app itself.