### PR TITLE
Add BigQuery env vars for GOV.UK Chat integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1338,6 +1338,15 @@ govukApplications:
               key: oauth_secret
         - name: REDIS_URL
           value: redis://chat-redis.eks.integration.govuk-internal.digital
+        - name: BIGQUERY_PROJECT
+          value: "gov-uk-chat-integration"
+        - name: BIGQUERY_DATASET
+          value: "chat_export"
+        - name: BIGQUERY_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-bigquery
+              key: credentials
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests

--- a/charts/external-secrets/templates/govuk-chat/bigquery.yaml
+++ b/charts/external-secrets/templates/govuk-chat/bigquery.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-bigquery
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for connecting to the GOV.UK Chat GCP BigQuery project.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/bigquery
+


### PR DESCRIPTION
Adds env vars for connecting to the GCP BigQuery integration project to be used for BigQuery export.

Credentials have already been added to Secrets Manager.