### PR TITLE
Switch contacts-admin staging to use new redis instance

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -400,6 +400,8 @@ govukApplications:
         - name: org-import
           task: "organisations:import"
           schedule: "0 3 * * *"
+      redis:
+        enabled: true
       extraEnv:
         - name: DATABASE_URL
           valueFrom:
@@ -421,8 +423,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-contacts-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
   - name: content-data-admin
     helmValues:


### PR DESCRIPTION
This does not require as much work as other applications, as it appears contacts-admin only uses Redis for locking in a rake task.

Trello: https://trello.com/c/T2w1jKaF/1297-create-new-redis-instance-for-contacts-admin-and-move-contacts-admin-to-it-in-integration-and-staging