### PR TITLE
Remove shared redis var in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -530,8 +530,6 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *publishing-notify-template
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: FIND_CONTENT_QUERY_PAGE_SIZE
           value: "1000"
 


### PR DESCRIPTION
Remove shared redis var in integration, a new redis instance was provisioned here https://github.com/alphagov/govuk-helm-charts/pull/2279

This is part of wider work to break up our big shared instance