### PR TITLE
Switch integration content-data-admin workers to use new Redis instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -465,8 +465,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       extraEnv:
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
This switches the workers in integration away from the shared Redis instance to a new dedicated instance for this app.