### PR TITLE
Env vars to restrict email sending for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1348,6 +1348,8 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-postgres
               key: DATABASE_URL
+        - name: EMAIL_ADDRESS_OVERRIDE
+          value: govuk-chat-notifications-integration@digital.cabinet-office.gov.uk
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1354,6 +1354,8 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-postgres
               key: DATABASE_URL
+        - name: EMAIL_ADDRESS_OVERRIDE
+          value: govuk-chat-notifications-staging@digital.cabinet-office.gov.uk
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This sets up the EMAIL_ADDRESS_OVERRIDE env var for chat, which will override the email address for emails sent via Notify.

This has been done in the GOV.UK Chat integration and staging environment with a Google Group. This prevents any emails going out to any actual users whose data ends up in integration or staging (from data sync) and prevents Notify errors as the staging and integration accounts do not allow emails to users outside of group members.