### PR TITLE
Add BigQuery env vars for GOV.UK Chat staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1395,6 +1395,15 @@ govukApplications:
               key: oauth_secret
         - name: REDIS_URL
           value: redis://chat-redis.eks.production.govuk-internal.digital
+        - name: BIGQUERY_PROJECT
+          value: "gov-uk-chat-production"
+        - name: BIGQUERY_DATASET
+          value: "chat_export"
+        - name: BIGQUERY_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-bigquery
+              key: credentials
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1400,6 +1400,15 @@ govukApplications:
               key: oauth_secret
         - name: REDIS_URL
           value: redis://chat-redis.eks.staging.govuk-internal.digital
+        - name: BIGQUERY_PROJECT
+          value: "gov-uk-chat-integration"
+        - name: BIGQUERY_DATASET
+          value: "chat_export"
+        - name: BIGQUERY_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-bigquery
+              key: credentials
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests


### PR DESCRIPTION
Adds env vars for connecting to the GCP BigQuery projects to be used for export by GOV.UK Chat staging and production environments. 

Note that staging uses the same GCP project as integration, hence the "gov-uk-chat-integration" project value in `charts/app-config/values-staging.yaml`. 

Credentials have already been added to Secrets Manager.