### PR TITLE
Add gov.uk/chat as a routing rule in www-origin LB on integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1331,12 +1331,20 @@ govukApplications:
       ingress:
         enabled: true
         annotations:
-          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-          alb.ingress.kubernetes.io/group.order: "95"
+          <<: [*alb-ingress-defaults, *alb-ingress-waf-ruleset-www]
+          alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
+          alb.ingress.kubernetes.io/load-balancer-name: www-origin
+          alb.ingress.kubernetes.io/group.order: "10"
+          alb.ingress.kubernetes.io/load-balancer-attributes: >
+            access_logs.s3.enabled=true,
+            access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
+            access_logs.s3.prefix=elb/govuk-chat
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "chat.{{ .Values.publishingDomainSuffix }}"
-            ]}}]
+                "www.{{ .Values.externalDomainSuffix }}",
+                "www-origin.{{ .Values.publishingDomainSuffix }}",
+                "www.{{ .Values.k8sExternalDomainSuffix }}"
+            ]}},{"field":"path-pattern","pathPatternConfig":{"values":["/chat","/chat/*"]}}]
         hosts:
           - name: chat.{{ .Values.k8sExternalDomainSuffix }}
       uploadAssets:
@@ -2129,6 +2137,7 @@ govukApplications:
           <<: [*alb-ingress-defaults, *alb-ingress-waf-ruleset-www]
           alb.ingress.kubernetes.io/security-groups: eks_ingress_www_origin
           alb.ingress.kubernetes.io/load-balancer-name: www-origin
+          alb.ingress.kubernetes.io/group.order: "20"
           alb.ingress.kubernetes.io/load-balancer-attributes: >
             access_logs.s3.enabled=true,
             access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,


### PR DESCRIPTION
We want to be able to access the govuk-chat app through the www.gov.uk/chat URL.
This modify the www-origin LB config to add a rule with higher priority that match on the www.gov.uk host and the /chat path.