### PR TITLE
Adds GOV.UK Chat crontask to export to BigQuery

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1345,6 +1345,10 @@ govukApplications:
       uploadAssets:
         s3Directory: chat
         path: /app/public/assets/chat
+      cronTasks:
+        - name: bigquery-export
+          task: "bigquery:export"
+          schedule: "0 7 * * *"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
Automatically runs the `rake bigquery:export` task daily at 7 AM in the production server only.