### PR TITLE
Move Pagerduty drill to Monday morning now that all on-call shifts begin on Monday.

### DIFF
--- a/charts/monitoring-config/rules/pagerdutydrill.yaml
+++ b/charts/monitoring-config/rules/pagerdutydrill.yaml
@@ -4,7 +4,7 @@ groups:
     rules:
       - alert: PagerDutyDrill
         expr: |
-          (day_of_week() == 3) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
+          (day_of_week() == 1) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
         labels:
           severity: page
         annotations:


### PR DESCRIPTION
Previously drills ran at 10/11 on Wednesday mornings, the start of SMT shifts. This meant that 2nd line in-hours teams did a drill half-way through their shift. Now that we've aligned the shifts, we should move the drill to a Monday morning (sadly prometheus still doesn't have good timezone support, it seems, so it'll still be 11 BST / 10 GMT)