### PR TITLE
Switch Asset Manager app to use new Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -141,8 +141,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &asset-man-redis redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *asset-man-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

[Trello card](https://trello.com/c/USP5EwYf)