### PR TITLE
Fix Redis URL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -141,7 +141,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &asset-manager-redis >
+          app: &asset-manager-redis >-
             redis://shared-redis-govuk.eks.integration.govuk-internal.digital
           workers: *asset-manager-redis
       ingress:


### PR DESCRIPTION
We are currently adding a newline character at the end of the string, which isn't needed.

This was based on the information at https://yaml-multiline.info/.

[Trello card](https://trello.com/c/USP5EwYf)