### PR TITLE
Fix Redis configuration for Asset Manager in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -141,9 +141,8 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &asset-manager-redis >-
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *asset-manager-redis
+          app: &asset-man-redis redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+          workers: *asset-man-redis
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Putting the URL over two lines appears to have stopped the redis deployment from occuring. Moving this to one line.

Note: `asset-manager` has been abbreviated `asset-man` as this repo lints line lengths to 100 characters.

[Trello card](https://trello.com/c/USP5EwYf)