### PR TITLE
Add redis resources to asset-manager chart

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
+            {{- if $.Values.redis.enabled }}
+            - name: REDIS_URL
+              value: {{ $.Values.redis.redisUrlOverride.app | default (printf "redis://%s-redis" $fullName) }}
+            {{- end }}
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}

--- a/charts/asset-manager/templates/redis-configmap.yaml
+++ b/charts/asset-manager/templates/redis-configmap.yaml
@@ -1,0 +1,25 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-redis-conf
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: redis
+data:
+  redis.conf: |-
+    bind *
+    port 6379
+
+    protected-mode no
+
+    daemonize no
+
+    # Use AOF for persistence
+    dir /data
+    appendonly yes
+    save ""
+{{ end }}

--- a/charts/asset-manager/templates/redis-deployment.yaml
+++ b/charts/asset-manager/templates/redis-deployment.yaml
@@ -1,0 +1,90 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-redis
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}-redis
+    app.kubernetes.io/name: {{ $fullName }}-redis
+    app.kubernetes.io/component: redis
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-redis
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "asset-manager.labels" . | nindent 8 }}
+        app: {{ $fullName }}-redis
+        app.kubernetes.io/name: {{ $fullName }}-redis
+        app.kubernetes.io/component: redis
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        fsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-redis-conf
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-redis
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          command: ["redis-server", "/etc/redis/redis.conf"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          livenessProbe: &redisProbe
+            tcpSocket:
+              port: 6379
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            <<: *redisProbe
+          startupProbe:
+            <<: *redisProbe
+            failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis.conf
+            - name: storage
+              mountPath: /data
+          resources:
+            {{- .Values.redis.resources | toYaml | trim | nindent 12 }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+{{ end }}

--- a/charts/asset-manager/templates/redis-pvc.yaml
+++ b/charts/asset-manager/templates/redis-pvc.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-redis
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: redis
+spec:
+  storageClassName: {{ .Values.redis.storageClassName }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.redis.storage }}
+{{ end }}

--- a/charts/asset-manager/templates/redis-service.yaml
+++ b/charts/asset-manager/templates/redis-service.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.redis.enabled }}
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-redis
+  labels:
+    app: {{ $fullName }}-redis
+    app.kubernetes.io/name: {{ $fullName }}-redis
+    app.kubernetes.io/component: redis
+spec:
+  type: NodePort
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+  selector:
+    app: {{ $fullName }}-redis
+    app.kubernetes.io/component: redis
+{{ end }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -93,6 +93,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.repoName }}-rails-secret-key-base
                   key: secret-key-base
+            {{- if $.Values.redis.enabled }}
+            - name: REDIS_URL
+              value: {{ $.Values.redis.redisUrlOverride.workers | default (printf "redis://%s-redis" $fullName) }}
+            {{- end }}
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -116,3 +116,24 @@ rails:
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.
   deletionPolicy: Delete
+
+# redis.enabled controls whether a Redis database is set up for the app
+# REDIS_URL is automatically set unless redis.redisUrlOverride values are provided
+redis:
+  enabled: false
+  image:
+    repository: redis
+    tag: "7.4"
+    pullPolicy: Always
+  storageClassName: ebs-gp3
+  storage: 10Gi
+  resources:
+    limits:
+      cpu: 1
+      memory: 1000Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
+  redisUrlOverride:
+    app: ""
+    workers: ""


### PR DESCRIPTION
These resources needed duplicating into the asset-manager chart (from generic-govuk-app) so redis instances can be created for asset-manager

#2098 