### PR TITLE
Fix redis-deployment.yaml in asset-manager chart not rendering

### DIFF
--- a/charts/asset-manager/templates/redis-deployment.yaml
+++ b/charts/asset-manager/templates/redis-deployment.yaml
@@ -31,10 +31,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-        fsGroup: {{ .Values.securityContext.runAsGroup }}
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: 1001
+        runAsUser: 1001
+        runAsGroup: 1001
+        runAsNonRoot: true
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}


### PR DESCRIPTION
Security context values do not exist for asset-manager, so just set them to some reasonable defaults

#2098 