### PR TITLE
Switch Asset Manager app to use new Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -138,9 +138,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &asset-manager-redis >-
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *asset-manager-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

[Trello card](https://trello.com/c/USP5EwYf)