### PR TITLE
Switch Asset Manager app to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -131,9 +131,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &asset-manager-redis >-
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *asset-manager-redis
+          worker: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

[Trello card](https://trello.com/c/USP5EwYf)