### PR TITLE
Switch Content Publisher app to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -627,9 +627,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-publisher-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *content-publisher-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

[Trello card](https://trello.com/c/JDLHXKuN)