### PR TITLE
Switch Content Tagger workers to use new Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -800,8 +800,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello card](https://trello.com/c/eX3ypoTU/1322-create-new-redis-instance-for-content-tagger-and-move-content-tagger-to-it)