### PR TITLE
Switch manuals publisher workers to use new redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1704,8 +1704,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Trello: https://trello.com/c/Cuhos1pn/1327-create-new-redis-instance-for-manuals-publisher-and-move-manuals-publisher-to-it