### PR TITLE
Switch Content Tagger app to use new Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -793,9 +793,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-tagger-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *content-tagger-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello card](https://trello.com/c/eX3ypoTU/1322-create-new-redis-instance-for-content-tagger-and-move-content-tagger-to-it)

The workers will be switched over in a later PR, after the queue has been drained.