### PR TITLE
Switch Content Data workers to use new Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -428,8 +428,6 @@ govukApplications:
     helmValues:
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         redirect: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -429,9 +429,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-data-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *content-data-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         redirect: true


### PR DESCRIPTION
Trello - https://trello.com/c/8uTXubXg/1298-create-new-redis-instance-for-content-data-admin-and-move-content-data-admin-to-it-in-integration-and-staging