### PR TITLE
Set REDIS_URL for cron jobs in generic-govuk-app

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -80,6 +80,10 @@ spec:
                 - name: SENTRY_RELEASE
                   value: "{{ $.Values.appImage.tag }}"
                 {{- end }}
+                {{- if .Values.redis.enabled }}
+                - name: REDIS_URL
+                  value: {{ .Values.redis.redisUrlOverride.app | default (printf "redis://%s-redis" $fullName) }}
+                {{- end }}
                 {{- with $.Values.extraEnv }}
                   {{- . | toYaml | trim | nindent 16 }}
                 {{- end }}

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -57,6 +57,10 @@ spec:
             - name: SECRET_KEY_BASE
               value: unused_for_dbmigrate_but_still_required
             {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_URL
+              value: {{ .Values.redis.redisUrlOverride.app | default (printf "redis://%s-redis" $fullName) }}
+            {{- end }}
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
REDIS_URL isn't being set on cron jobs if the redis server is enabled for an app. This is causing some jobs to fail if they need to connect to redis.

#2098 