### PR TITLE
Add GOV.UK Chat chrontask to promote from waiting list.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1349,6 +1349,9 @@ govukApplications:
         - name: bigquery-export
           task: "bigquery:export"
           schedule: "0 7 * * *"
+        - name: promote-waiting-list
+          task: "users:promote_waiting_list"
+          schedule: "0 * * * *"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
Runs the `users:promote_waiting_list` task every hour.

Trello: https://trello.com/c/TELFc4LR/1853-write-a-rake-task-to-promote-waitinglistusers-to-earlyaccessusers-if-we-have-spaces