### PR TITLE
Switch Content Tagger to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -789,9 +789,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-tagger-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *content-tagger-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello card](https://trello.com/c/eX3ypoTU/1322-create-new-redis-instance-for-content-tagger-and-move-content-tagger-to-it)

The workers will be switched over in a later PR, after the queue has been drained.