### PR TITLE
Switch Content Tagger workers to use new Redis in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -788,8 +788,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello card](https://trello.com/c/eX3ypoTU/1322-create-new-redis-instance-for-content-tagger-and-move-content-tagger-to-it)