### PR TITLE
Switch Content Data to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -425,9 +425,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-data-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *content-data-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         redirect: true


### PR DESCRIPTION
Trello - https://trello.com/c/8uTXubXg/1298-create-new-redis-instance-for-content-data-admin-and-move-content-data-admin-to-it-in-integration-and-staging