### PR TITLE
Allow frontend to serve static files in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1224,6 +1224,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-publishing-api
               key: bearer_token
+        - name: RAILS_SERVE_STATIC_FILES
+          value: "true"
 
   - name: draft-frontend
     repoName: frontend


### PR DESCRIPTION
- necessary to test moving serving of a handful of static files (favicon, verification paths, etc) from static to frontend in preparation for retiring static.

https://trello.com/c/o55zYQeB/317-tidy-verification-paths-in-static