### PR TITLE
Handle verification files in production

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -181,10 +181,11 @@ http {
       return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
     }
 
+    {{- if ne .Stack "draft" }}
+
     # Google Search Console (gov.uk) verification files
     # See https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/3585441793/Google+Search+Console for ownership of these verification tokens
 
-{{- if (ne .Values.govukEnvironment "production") }}
     location = /googlea6393a390aadfbaa.html {
       add_header Content-Type text/html;
       return 200 'google-site-verification: googlea6393a390aadfbaa.html';
@@ -201,7 +202,8 @@ http {
       add_header Content-Type application/xml;
       return 200 '<?xml version="1.0"?><users><user>66F6ADB7C4481C94247D1E08FA04C6A4</user></users>';
     }
-{{- end }}
+
+    {{- end }}
 
     # DWP YouTube Channel Verification
     location = /dla-ending/google6db9c061ce178960.html {


### PR DESCRIPTION
Remove the not production block and replace it with a not-draft-stack block, so that verification files in production will be handled by nginx rather than static.

https://trello.com/c/o55zYQeB/317-tidy-verification-paths-in-static