### PR TITLE
Set govuk-chat Production pod configuration ready for go-live

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1324,8 +1324,24 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
+      replicaCount: 8
+      appResources:
+        limits:
+          cpu: 4
+          memory: 2500Mi
+        requests:
+          cpu: 2
+          memory: 2Gi
       dbMigrationEnabled: true
       workerEnabled: true
+      workerReplicaCount: 4
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 2500Mi
+        requests:
+          cpu: 1
+          memory: 1500Mi
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
@@ -1397,6 +1413,8 @@ govukApplications:
             secretKeyRef:
               name: signon-app-chat
               key: oauth_secret
+        - name: WEB_CONCURRENCY
+          value: '4'
         - name: REDIS_URL
           value: redis://chat-redis.eks.production.govuk-internal.digital
         - name: BIGQUERY_PROJECT


### PR DESCRIPTION
## What

Set the configuration for the govuk-chat pods in Production

## Why

This is to cope with the expected traffic levels when the Chat Service goes live