### PR TITLE
Switch prod Contacts Admin to use new Redis instance

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -397,9 +397,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &contacts-admin-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *contacts-admin-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
[Trello card](https://trello.com/c/CUTfHwI0/1343-create-new-redis-instance-for-contacts-admin-and-move-contacts-admin-to-it-in-production)

The workers will be switched over once the queue has been drained.