### PR TITLE
Switch manuals publisher workers to new redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1747,8 +1747,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Trello: https://trello.com/c/Cuhos1pn/1327-create-new-redis-instance-for-manuals-publisher-and-move-manuals-publisher-to-it