### PR TITLE
Remove original redis URL for integration as I forgot in earlier PR

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1745,8 +1745,6 @@ govukApplications:
             secretKeyRef:
               name: manuals-publisher-docdb
               key: MONGODB_URI
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-design-system-gtm-id
         - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only


### PR DESCRIPTION
Trello: https://trello.com/c/Cuhos1pn/1327-create-new-redis-instance-for-manuals-publisher-and-move-manuals-publisher-to-it