### PR TITLE
Promote GOV.UK Chat users in integration and staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1342,6 +1342,10 @@ govukApplications:
       uploadAssets:
         s3Directory: chat
         path: /app/public/assets/chat
+      cronTasks:
+        - name: promote-waiting-list
+          task: "users:promote_waiting_list"
+          schedule: "0 7-19 * * *"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1348,6 +1348,10 @@ govukApplications:
       uploadAssets:
         s3Directory: chat
         path: /app/public/assets/chat
+      cronTasks:
+        - name: promote-waiting-list
+          task: "users:promote_waiting_list"
+          schedule: "0 7-19 * * *"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
This adds the task we added for the production environment [1] to the staging and integration environments as well. I've set this to not run every hour here but just copying a precedent from a different one that is 7am to 7pm - which seemed a good shout to avoid any data sync issues.

[1]: https://github.com/alphagov/govuk-helm-charts/pull/2343