### PR TITLE
Switch specialist publsher to use new redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2914,9 +2914,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &specialist-publisher-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *specialist-publisher-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Trello - https://trello.com/c/49aaWWsp/1336-create-new-redis-instance-for-specialist-publisher-and-move-specialist-publisher-to-it

The workers will be switched in a later PR, after the queue has been drained.