### PR TITLE
Switch Support API workers to point to standalone redis in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3074,8 +3074,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       workerReplicaCount: 2
       cronTasks:
         - name: feedback-deduplication-nightly


### PR DESCRIPTION
[Trello card](https://trello.com/c/QoMuqkjn/1335-create-new-redis-instance-for-support-api-and-move-support-api-to-it)