### PR TITLE
Switch specialist publsher to use new redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2885,9 +2885,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &specialist-publisher-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *specialist-publisher-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

Trello - https://trello.com/c/49aaWWsp/1336-create-new-redis-instance-for-specialist-publisher-and-move-specialist-publisher-to-it