### PR TITLE
Switch specialist publisher workers to use new redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2884,8 +2884,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Trello - https://trello.com/c/49aaWWsp/1336-create-new-redis-instance-for-specialist-publisher-and-move-specialist-publisher-to-it