### PR TITLE
Provision redis for specialist publisher in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2946,6 +2946,12 @@ govukApplications:
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &specialist-publisher-redis >
+            redis://shared-redis-govuk.eks.production.govuk-internal.digital
+          workers: *specialist-publisher-redis
       ingress:
         enabled: true
         annotations:
@@ -2997,8 +3003,6 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *publishing-notify-template
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-bootstrap-gtm-id
 


### PR DESCRIPTION
Trello - https://trello.com/c/49aaWWsp/1336-create-new-redis-instance-for-specialist-publisher-and-move-specialist-publisher-to-it