### PR TITLE
Switch specialist publisher workers to use new redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2948,8 +2948,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Trello - https://trello.com/c/49aaWWsp/1336-create-new-redis-instance-for-specialist-publisher-and-move-specialist-publisher-to-it