### PR TITLE
Provision new redis instance for manuals publisher in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1769,6 +1769,12 @@ govukApplications:
     helmValues:
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &manuals-publisher-redis >
+            redis://shared-redis-govuk.eks.production.govuk-internal.digital
+          workers: *manuals-publisher-redis
       ingress:
         enabled: true
         annotations:
@@ -1821,8 +1827,6 @@ govukApplications:
             secretKeyRef:
               name: manuals-publisher-docdb
               key: MONGODB_URI
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-design-system-gtm-id
 


### PR DESCRIPTION
Trello: https://trello.com/c/Cuhos1pn/1327-create-new-redis-instance-for-manuals-publisher-and-move-manuals-publisher-to-it