### PR TITLE
Switch manuals publisher workers to use new redis in prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1771,8 +1771,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Trello: https://trello.com/c/Cuhos1pn/1327-create-new-redis-instance-for-manuals-publisher-and-move-manuals-publisher-to-it