### PR TITLE
Turn off signon authentication for frontend of chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1347,6 +1347,9 @@ govukApplications:
           task: "users:promote_waiting_list"
           schedule: "0 7-19 * * *"
       extraEnv:
+        # remove the need for signon to access frontend of chat
+        - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION
+          value: true
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This is needed to test out the integration of chat into the www hostname.