### PR TITLE
Switch local links manager to use new redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1565,9 +1565,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &local-links-manager-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *local-links-manager-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

Trello - https://trello.com/c/7JSwL8T5/1331-create-new-redis-instance-for-local-links-manager-and-move-local-links-manager-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF