### PR TITLE
Increase MaxScanSize limit for Asset Manager virus scanning

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -26,7 +26,7 @@ data:
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).
     MaxFileSize 500M
-    MaxScanSize 2000M
+    MaxScanSize 2500M
     MaxScanTime 0
     MaxThreads 20
     SelfCheck 900


### PR DESCRIPTION
[Trello card](https://trello.com/c/flCzjlAc/1314-investigate-a-support-ticket-user-unable-to-download-a-zipped-file)

We've had another issue where a user has tried to upload a `.zip` file and it's being marked as "infected" due to
`Heuristics.Limits.Exceeded.MaxScanSize`.

When ClamAV scans a file, it appears to scan more data than the size of the file as it scans recursively, which would explain why this is complaining despite the unzipped files being only around 65mb.

We've increased the limits before in 229e16e.

I've tested this limit locally against the offending file and it appears to pass virus scanning:

```
❯ clamscan --alert-exceeds-max=yes --max-scansize=2500M --max-filesize=500M
~/Downloads/vehicle-licensing-statistics-2023-data-tables1.zip

Loading:     6s, ETA:   0s [========================>]    8.70M/8.70M
sigs
Compiling:   1s, ETA:   0s [========================>]       41/41 tasks

/Downloads/vehicle-licensing-statistics-2023-data-tables1.zip:
OK

----------- SCAN SUMMARY -----------
Known viruses: 8698275
Engine version: 1.4.1
Scanned directories: 0
Scanned files: 1
Infected files: 0
Data scanned: 2368.38 MB
Data read: 60.41 MB (ratio 39.21:1)
Time: 110.936 sec (1 m 50 s)
Start Date: 2024:09:05 11:49:24
End Date:   2024:09:05 11:51:15
```

## Caveat

I don't know what the policy is here on the limits we set, and if we should enforce these to prevent people uploading increasingly large documents - see relevant discussion on https://github.com/alphagov/govuk-helm-charts/pull/1448.