### PR TITLE
Add GOOGLE_ACCOUNT_TYPE to staging and production search-api

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2465,6 +2465,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-google-analytics
               key: govuk-view-id
+        - name: GOOGLE_ACCOUNT_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: search-api-google-analytics
+              key: account-type
         - name: GOOGLE_CLIENT_EMAIL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2433,6 +2433,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-google-analytics
               key: govuk-view-id
+        - name: GOOGLE_ACCOUNT_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: search-api-google-analytics
+              key: account-type
         - name: GOOGLE_CLIENT_EMAIL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Adding GOOGLE_ACCOUNT_TYPE to staging and production to allows us to fully migrate to GA4.