### PR TITLE
Switch local links manager to use new redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1601,9 +1601,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &local-links-manager-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *local-links-manager-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1598,6 +1598,12 @@ govukApplications:
 
   - name: local-links-manager
     helmValues:
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &local-links-manager-redis >
+            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+          workers: *local-links-manager-redis
       ingress:
         enabled: true
         annotations:
@@ -1684,8 +1690,6 @@ govukApplications:
               key: LINK_CHECKER_API_SECRET_TOKEN
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: RUN_LINK_GA_EXPORT
           value: "false"
         - name: AWS_S3_ASSET_BUCKET_NAME


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

Trello - https://trello.com/c/7JSwL8T5/1331-create-new-redis-instance-for-local-links-manager-and-move-local-links-manager-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF