### PR TITLE
Add notify reply to id for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1364,6 +1364,8 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: 346cdea0-9d4e-4de1-a528-cded6713bc61
+        - name: GOVUK_NOTIFY_REPLY_TO_ID
+          value: govuk-chat-notifications-integration@digital.cabinet-office.gov.uk
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1381,6 +1381,8 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: 7eb37ba5-f331-43e2-95fa-28d7405eb90b
+        - name: GOVUK_NOTIFY_REPLY_TO_ID
+          value: govuk-chat-beta@digital.cabinet-office.gov.uk
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1367,6 +1367,8 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: 70883fba-853d-487a-9580-3ea1931ecb49
+        - name: GOVUK_NOTIFY_REPLY_TO_ID
+          value: govuk-chat-notifications-staging@digital.cabinet-office.gov.uk
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Description

We want users to be able to reply to our emails. This adds a GOVUK_NOTIFY_REPLY_TO_ID env var which we use to set the reply to id in our application.