### PR TITLE
Switch link checker api workers to use new redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1573,8 +1573,6 @@ govukApplications:
             secretKeyRef:
               name: link-checker-api-postgres
               key: DATABASE_URL
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
   - name: local-links-manager
     helmValues:


### PR DESCRIPTION
Trello - https://trello.com/c/eqvVgy68/1261-create-new-redis-instance-for-link-checker-api-and-move-link-checker-api-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF