### PR TITLE
Provision Redis instance for staging Publishing API

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1963,6 +1963,12 @@ govukApplications:
       uploadAssets:
         enabled: false
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &publishing-api-redis >
+            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+          workers: *publishing-api-redis
       workerResources:
         limits:
           cpu: 4000m
@@ -2013,8 +2019,6 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-rabbitmq
               key: RABBITMQ_URL
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: EVENT_LOG_AWS_BUCKETNAME
           value: govuk-publishing-api-event-log-staging
         - name: GOVUK_CONTENT_SCHEMAS_PATH


### PR DESCRIPTION
[Trello](https://trello.com/c/piwScUqs/1334-create-new-redis-instance-for-publishing-api-and-move-publishing-api-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq