### PR TITLE
Switch staging Publishing API app to use new Redis instance

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1966,9 +1966,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &publishing-api-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *publishing-api-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       workerResources:
         limits:
           cpu: 4000m


### PR DESCRIPTION
[Trello](https://trello.com/c/piwScUqs/1334-create-new-redis-instance-for-publishing-api-and-move-publishing-api-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq