### PR TITLE
Switch production Publishing API workers to use new Redis

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1990,8 +1990,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       workerReplicaCount: 12
       workerResources:
         limits:


### PR DESCRIPTION
[Trello](https://trello.com/c/piwScUqs/1334-create-new-redis-instance-for-publishing-api-and-move-publishing-api-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq