### PR TITLE
Switch places manager to use new redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1850,9 +1850,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &places-manager-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *places-manager-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

Trello - https://trello.com/c/k5Lc3Pxz/1333-create-new-redis-instance-for-places-manager-and-move-places-manager-to-it-lemon-herb-%F0%9F%8D%8B%F0%9F%8C%BF