### PR TITLE
Switch Mainstream Publisher app to use new Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1849,9 +1849,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &mainstream-publisher-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *mainstream-publisher-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       cronTasks:
         - name: mail-fetcher
           command: "script/mail_fetcher"


### PR DESCRIPTION
[Trello](https://trello.com/c/Wtfqkkcm/1330-create-new-redis-instance-for-mainstream-publisher-and-move-mainstream-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)

The workers will be switched in a later PR, after the queue has been drained.