### PR TITLE
Remove Publishing API events export cronjob

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1962,9 +1962,6 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
-        - name: events-export
-          task: "events:export_to_s3"
-          schedule: "38 5 * * 0"
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"
           schedule: "22 * * * *"  # every hour, at 22 minutes past the hour

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2003,9 +2003,6 @@ govukApplications:
           cpu: 500m
           memory: 512Mi
       cronTasks:
-        - name: events-export
-          task: "events:export_to_s3"
-          schedule: "38 5 * * 0"
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"
           schedule: "22 * * * *"  # every hour, at 22 minutes past the hour

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1973,9 +1973,6 @@ govukApplications:
           cpu: 100m
           memory: 512Mi
       cronTasks:
-        - name: events-export
-          task: "events:export_to_s3"
-          schedule: "38 5 * * 0"
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"
           schedule: "22 * * * *"  # every hour, at 22 minutes past the hour


### PR DESCRIPTION
This job exports the data from the `events` table in Publishing API to S3.

It has been broken for months without anyone outside the team noticing, so we believe the export isn't being used for anything.

Therefore removing the cronjob that runs this task.

[Trello card](https://trello.com/c/VFxaKKIw)