### PR TITLE
Point signon token slack alerts to #govuk-publishing-platform

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -80,7 +80,7 @@ spec:
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
   - name: 'slack-signon-token-expiry'
     slackConfigs:
-    - channel: '#govuk-2ndline-tech'
+    - channel: '#govuk-publishing-platform'
       sendResolved: true
       iconURL: https://avatars3.githubusercontent.com/u/3380462
       title: |-


### PR DESCRIPTION
These alerts are currently going to 2nd Line, but aren't necessarily actionable there. Reassign to owning team so they can decide whether the alerts are still necessary / useful.

https://trello.com/c/iVHdhusp/248-figure-out-next-steps-for-signon-permissions-token-alerts