### PR TITLE
Add cron jobs for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1346,6 +1346,12 @@ govukApplications:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
           schedule: "0 7-19 * * *"
+        - name: increment-instant-access-places
+          task: "settings:increment_pilot_places[instant_access]"
+          schedule: "0 9,11,13,15 * * 1-5"
+        - name: increment-delayed-access-places
+          task: "settings:increment_pilot_places[delayed_access]"
+          schedule: "1 9,11,13,15 * * 1-5"
       extraEnv:
         # remove the need for signon to access frontend of chat
         - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1368,6 +1368,12 @@ govukApplications:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
           schedule: "0 * * * *"
+        - name: increment-instant-access-places
+          task: "settings:increment_pilot_places[instant_access]"
+          schedule: "0 9,11,13,15 * * 1-5"
+        - name: increment-delayed-access-places
+          task: "settings:increment_pilot_places[delayed_access]"
+          schedule: "1 9,11,13,15 * * 1-5"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1352,6 +1352,12 @@ govukApplications:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
           schedule: "0 7-19 * * *"
+        - name: increment-instant-access-places
+          task: "settings:increment_pilot_places[instant_access]"
+          schedule: "0 9,11,13,15 * * 1-5"
+        - name: increment-delayed-access-places
+          task: "settings:increment_pilot_places[delayed_access]"
+          schedule: "1 9,11,13,15 * * 1-5"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
## Description 

These jobs increment the amount of users that we give access too. Since the rake task uses pessimistic locking, i've ensured the second job runs a minute after the first job.

Realistically the second job should just wait for the transaction to finish, but running it a minute later seems slight safer.

These jobs run at

instant access places - 9am, 11am, 1pm & 3pm on weekdays 
delayed access places - 9.01am, 11.01am, 1.01pm & 3.01pm on weekdays

## Ui for playing with cron job schedules

Just in case you want to check them 

https://crontab.guru/#0_9,11,13,15_*_*_1-5

## Trello card 

https://trello.com/c/ToYKGVel/1892-cron-based-basic-places-schedule