### PR TITLE
Switch integration Travel Advice Publisher app to use new Redis instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3181,9 +3181,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &travel-advice-publisher-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *travel-advice-publisher-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello](https://trello.com/c/On2XrBAQ/1337-create-new-redis-instance-for-travel-advice-publisher-and-move-travel-advice-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq