### PR TITLE
Switch Collections Publisher app to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -321,9 +321,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &collections-publisher-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *collections-publisher-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained.

[Trello card](https://trello.com/c/1tV4HQSg)