### PR TITLE
Remove REDIS_URL from integration TAP

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3232,8 +3232,6 @@ govukApplications:
             secretKeyRef:
               name: travel-advice-publisher-docdb
               key: MONGODB_URI
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-design-system-gtm-id
         - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only


### PR DESCRIPTION
[Trello](https://trello.com/c/On2XrBAQ/1337-create-new-redis-instance-for-travel-advice-publisher-and-move-travel-advice-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)

This was missed when provisioning the Redis for Travel Advice Publisher