### PR TITLE
Provision Redis instance for staging Travel Advice Publisher

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3085,6 +3085,12 @@ govukApplications:
           schedule: "29 5 * * *"
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &travel-advice-publisher-redis >
+            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+          workers: *travel-advice-publisher-redis
       ingress:
         enabled: true
         annotations:
@@ -3137,8 +3143,6 @@ govukApplications:
             secretKeyRef:
               name: travel-advice-publisher-docdb
               key: MONGODB_URI
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
 
   - name: whitehall-admin
     repoName: whitehall


### PR DESCRIPTION
[Trello](https://trello.com/c/On2XrBAQ/1337-create-new-redis-instance-for-travel-advice-publisher-and-move-travel-advice-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq