### PR TITLE
Add env vars for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1392,6 +1392,10 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-bigquery
               key: credentials
+        - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
+          value: "26"
+        - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
+          value: "26"
       nginxConfigMap:
         extraServerConf: |
           location /chat {

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1411,6 +1411,10 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-bigquery
               key: credentials
+        - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
+          value: "26"
+        - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
+          value: "26"
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1395,6 +1395,10 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-bigquery
               key: credentials
+        - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
+          value: "26"
+        - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
+          value: "26"
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests


### PR DESCRIPTION
## Description

This adds two env vars that we will use to increment the amount of user signups in our application.

## Trello card

https://trello.com/c/ToYKGVel/1892-cron-based-basic-places-schedule