### PR TITLE
Provision Redis instance for production Travel Advice Publisher

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3159,6 +3159,12 @@ govukApplications:
           schedule: "29 5 * * *"
       nginxClientMaxBodySize: *max-upload-size
       workerEnabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &travel-advice-publisher-redis >
+            redis://shared-redis-govuk.eks.production.govuk-internal.digital
+          workers: *travel-advice-publisher-redis
       ingress:
         enabled: true
         annotations:
@@ -3211,8 +3217,6 @@ govukApplications:
             secretKeyRef:
               name: travel-advice-publisher-docdb
               key: MONGODB_URI
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-design-system-gtm-id
 


### PR DESCRIPTION
[Trello](https://trello.com/c/On2XrBAQ/1337-create-new-redis-instance-for-travel-advice-publisher-and-move-travel-advice-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq