### PR TITLE
Add alerts for high 5xx and long duration http requests in Chat Service

### DIFF
--- a/charts/monitoring-config/rules/chat_ai.yaml
+++ b/charts/monitoring-config/rules/chat_ai.yaml
@@ -1,0 +1,48 @@
+groups:
+  - name: ChatAI
+    rules:
+      - alert: High5xxRate
+        expr: >-
+          sum(rate(http_requests_total{
+            job="govuk-chat",
+            status=~"5.."
+          }[60m]))
+          /
+          (sum(rate(http_requests_total{
+            job="govuk-chat"
+          }[60m])) / 100)
+          > 10
+        for: 5m
+        labels:
+          severity: critical
+          destination: slack-chat-notifications
+        annotations:
+          summary: Elevated rate of 5xx return codes for Chat AI
+          description: >-
+            The rate of http 5xx return codes is above 10% of total requests
+            for more than 5 minutes.
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+
+      - alert: LongRequestDuration
+        expr: >-
+          quantile(0.75,
+            sum(rate(http_request_duration_seconds_sum{
+              job="govuk-chat"
+            }[60m]))
+            /
+            sum(rate(http_request_duration_seconds_count{
+              job="govuk-chat"
+            }[60m]))
+          )
+          > 1
+        for: 5m
+        labels:
+          severity: critical
+          destination: slack-chat-notifications
+        annotations:
+          summary: Elevated HTTP request duration for Chat AI
+          description: >-
+            75th percentile HTTP request duration over 1 second for more than 5 minutes.
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html

--- a/charts/monitoring-config/rules/chat_ai_tests.yaml
+++ b/charts/monitoring-config/rules/chat_ai_tests.yaml
@@ -1,0 +1,102 @@
+rule_files:
+  - chat_ai.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # No alert with 5xx errors < 10%
+      - series: >-
+          http_requests_total{
+          job="govuk-chat",
+          status="200"
+          }
+        values: '1000+100x15'
+      - series: >-
+          http_requests_total{
+          job="govuk-chat",
+          status="500"
+          }
+        values: '0+10x15'
+    alert_rule_test:
+      - alertname: High5xxRate
+        eval_time: 15m
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Alert with 5xx errors > 10%
+      - series: >-
+          http_requests_total{
+          job="govuk-chat",
+          status="200"
+          }
+        values: '1000x15'
+      - series: >-
+          http_requests_total{
+          job="govuk-chat",
+          status="500"
+          }
+        values: '0+100x15'
+    alert_rule_test:
+      - alertname: High5xxRate
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              alertname: High5xxRate
+              severity: critical
+              destination: slack-chat-notifications
+            exp_annotations:
+              summary: Elevated rate of 5xx return codes for Chat AI
+              description: >-
+                The rate of http 5xx return codes is above 10% of total requests
+                for more than 5 minutes.
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+
+  - interval: 1m
+    input_series:
+      # No alert for LongRequestDuration
+      - series: >-
+          http_request_duration_seconds_sum{
+          job="govuk-chat",
+          }
+        values: '50+1x15'
+      - series: >-
+          http_request_duration_seconds_count{
+          job="govuk-chat",
+          }
+        values: '20000+1000x15'
+    alert_rule_test:
+      - alertname: LongRequestDuration
+        eval_time: 15m
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Alert for LongRequestDuration
+      - series: >-
+          http_request_duration_seconds_sum{
+          job="govuk-chat"
+          }
+        values: '0+10x15'
+      - series: >-
+          http_request_duration_seconds_count{
+          job="govuk-chat"
+          }
+        values: '0+1x15'
+    alert_rule_test:
+      - alertname: LongRequestDuration
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              alertname: LongRequestDuration
+              severity: critical
+              destination: slack-chat-notifications
+            exp_annotations:
+              summary: Elevated HTTP request duration for Chat AI
+              description: >-
+                75th percentile HTTP request duration over 1 second for more than 5 minutes.
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -68,6 +68,16 @@ spec:
       groupInterval: 30m
       activeTimeIntervals:
         - inhours
+    - matchers:
+      - name: destination
+        value: slack-chat-notifications
+        matchType: =
+      receiver: 'slack-chat-notifications'
+      repeatInterval: 1d
+      groupWait: 12h
+      groupInterval: 12h
+      activeTimeIntervals:
+        - inhours
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -100,6 +110,20 @@ spec:
       apiURL: &slack_api_url
         name: alertmanager-receivers
         key: slack_api_url
+  - name: 'slack-chat-notifications'
+    slackConfigs:
+    - channel: '#dev-notifications-ai-govuk'
+      sendResolved: true
+      iconURL: https://avatars3.githubusercontent.com/u/3380462
+      title: |-
+        {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}" }}
+      text: >-
+        *Description:* {{ "{{ .CommonAnnotations.description }}" }}
+
+        *Environment:* {{ .Values.govukEnvironment }}
+
+        *Runbook:* {{ "{{ .CommonAnnotations.runbook_url }}" }}
+      apiURL: *slack_api_url
   - name: 'slack-mirror-freshness'
     slackConfigs:
     - channel: '#govuk-platform-engineering'


### PR DESCRIPTION
## What

Add notification destination #dev-notifications-ai-govuk for alerts from Chat AI service, along with 2 alerts:
- Elevated rate of 5xx return codes for Chat AI
- Elevated HTTP request duration for Chat AI

## Why

To provide warnings of unusual activity on the Chat Service