### PR TITLE
Switch Mainstream Publisher workers to use new Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1864,8 +1864,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       cronTasks:
         - name: mail-fetcher
           command: "script/mail_fetcher"


### PR DESCRIPTION
[Trello](https://trello.com/c/Wtfqkkcm/1330-create-new-redis-instance-for-mainstream-publisher-and-move-mainstream-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)