### PR TITLE
Switch Mainstream Publisher app to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1893,9 +1893,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &mainstream-publisher-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *mainstream-publisher-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       cronTasks:
         - name: reports-generate
           task: "reports:generate"


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained

[Trello](https://trello.com/c/Wtfqkkcm/1330-create-new-redis-instance-for-mainstream-publisher-and-move-mainstream-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)