### PR TITLE
Switch Mainstream Publisher workers to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1892,8 +1892,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       cronTasks:
         - name: reports-generate
           task: "reports:generate"


### PR DESCRIPTION
[Trello](https://trello.com/c/Wtfqkkcm/1330-create-new-redis-instance-for-mainstream-publisher-and-move-mainstream-publisher-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)