### PR TITLE
Switch integration Email Alert API app to use new Redis instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -856,9 +856,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &email-alert-api-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *email-alert-api-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello](https://trello.com/c/hTtgKKyE/1362-create-new-redis-instance-for-email-alert-api-and-move-email-alert-api-to-it-lemon-and-herb%F0%9F%8D%8B%F0%9F%8C%BF)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq