### PR TITLE
Switch Support workers to use new standalone Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2998,8 +2998,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       extraEnv:
         - name: AWS_S3_BUCKET_NAME
           value: govuk-integration-support-api-csvs


### PR DESCRIPTION
Switch Support workers to use new standalone Redis in integration

[Trello card](https://trello.com/c/8XxHPBgW)