### PR TITLE
Switch staging Email Alert API workers to use new Redis

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -846,8 +846,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello](https://trello.com/c/hTtgKKyE/1362-create-new-redis-instance-for-email-alert-api-and-move-email-alert-api-to-it-lemon-and-herb%F0%9F%8D%8B%F0%9F%8C%BF)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq