### PR TITLE
Switch Support workers to use new standalone Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2933,8 +2933,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       extraEnv:
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-support-api-csvs


### PR DESCRIPTION
Switch Support workers to use new standalone Redis in staging<br><br>[Trello card](https://trello.com/c/8XxHPBgW)