### PR TITLE
Switch Support app to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3003,9 +3003,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &support-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *support-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: AWS_S3_BUCKET_NAME
           value: govuk-production-support-api-csvs


### PR DESCRIPTION
Switch Support app to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/8XxHPBgW)