### PR TITLE
Switch Support workers to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3002,8 +3002,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: AWS_S3_BUCKET_NAME
           value: govuk-production-support-api-csvs


### PR DESCRIPTION
Switch Support workers to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/8XxHPBgW)