### PR TITLE
Switch Account API to use new Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -67,9 +67,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &account-api-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *account-api-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained

[Trello](https://trello.com/c/nOUqm9pp/1366-create-new-redis-instance-for-account-api-and-move-account-api-to-it-lemon-and-herb%F0%9F%8D%8B%F0%9F%8C%BF)