### PR TITLE
Pin clamav image at last working version

### DIFF
--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -13,7 +13,7 @@ clamav:
   replicaCount: 1
   image:
     repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/clamav
-    tag: latest
+    tag: 074b24e44907ac7c01a68d8a877b3b6e995fbd3f
     pullPolicy: Always
   service:
     type: ClusterIP


### PR DESCRIPTION
Newer images of clamav are unable to start correctly. This pins the configuration to that last working version. This is to allow us time debug what has broken in new images.