### PR TITLE
Switch production Locations API app to use new Redis instance

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1730,9 +1730,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &locations-api-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *locations-api-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
[Trello](https://trello.com/c/THXeEzy4/1363-create-new-redis-instance-for-locations-api-and-move-locations-api-to-it-lemon-and-herb-%F0%9F%8D%8B%F0%9F%8C%BF)

This is part of the work to have each app using its own Redis instance, which will eventually allow us to upgrade Sidekiq