### PR TITLE
Increase resource limits for Production Chat AI

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1308,21 +1308,21 @@ govukApplications:
       replicaCount: 8
       appResources:
         limits:
-          cpu: 4
-          memory: 2500Mi
+          cpu: 6
+          memory: 3Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 2Gi
       dbMigrationEnabled: true
       workerEnabled: true
       workerReplicaCount: 4
       workerResources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 2500Mi
         requests:
-          cpu: 1
-          memory: 1500Mi
+          cpu: 2
+          memory: 2Gi
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker


### PR DESCRIPTION
## What

Increase the CPU & Memory limits & resources for Chat AI in Production

## Why

It has been  suggested we set resources to what we think our normal usage is and only use limits for extra headroom. This sets the number of CPUs in requests to match the number of processes we’ll have.