### PR TITLE
Fix the url of the runbook in Chat alerts

### DIFF
--- a/charts/monitoring-config/rules/chat_ai.yaml
+++ b/charts/monitoring-config/rules/chat_ai.yaml
@@ -14,15 +14,14 @@ groups:
           > 10
         for: 5m
         labels:
-          severity: critical
-          destination: slack-chat-notifications
+          severity: page
         annotations:
           summary: Elevated rate of 5xx return codes for Chat AI
           description: >-
             The rate of http 5xx return codes is above 10% of total requests
             for more than 5 minutes.
           runbook_url: >-
-            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+            https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
       - alert: LongRequestDuration
         expr: >-
@@ -38,14 +37,13 @@ groups:
           > 1
         for: 5m
         labels:
-          severity: critical
-          destination: slack-chat-notifications
+          severity: page
         annotations:
           summary: Elevated HTTP request duration for Chat AI
           description: >-
             75th percentile HTTP request duration over 1 second for more than 5 minutes.
           runbook_url: >-
-            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+            https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
       - alert: HighPodCPUFE
         expr: >-
@@ -63,7 +61,7 @@ groups:
           description: >-
             The FE Pod CPU usage is above 80% for a container for more than 5 minutes.
           runbook_url: >-
-            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+            https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
       - alert: HighPodCPUWorker
         expr: >-
@@ -81,7 +79,7 @@ groups:
           description: >-
             The Worker Pod CPU usage is above 80% for a container for more than 5 minutes.
           runbook_url: >-
-            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+            https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
       - alert: HighPodMemoryFE
         expr: >-
@@ -101,7 +99,7 @@ groups:
           description: >-
             The FE Pod Memory usage is above 80% for a container for more than 5 minutes.
           runbook_url: >-
-            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+            https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
       - alert: HighPodMemoryWorker
         expr: >-
@@ -121,4 +119,4 @@ groups:
           description: >-
             The Worker Pod Memory usage is above 80% for a container for more than 5 minutes.
           runbook_url: >-
-            https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+            https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html

--- a/charts/monitoring-config/rules/chat_ai_tests.yaml
+++ b/charts/monitoring-config/rules/chat_ai_tests.yaml
@@ -45,15 +45,14 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: High5xxRate
-              severity: critical
-              destination: slack-chat-notifications
+              severity: page
             exp_annotations:
               summary: Elevated rate of 5xx return codes for Chat AI
               description: >-
                 The rate of http 5xx return codes is above 10% of total requests
                 for more than 5 minutes.
               runbook_url: >-
-                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+                https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
   - interval: 1m
     input_series:
@@ -92,14 +91,13 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: LongRequestDuration
-              severity: critical
-              destination: slack-chat-notifications
+              severity: page
             exp_annotations:
               summary: Elevated HTTP request duration for Chat AI
               description: >-
                 75th percentile HTTP request duration over 1 second for more than 5 minutes.
               runbook_url: >-
-                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+                https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
   - interval: 1m
     input_series:
@@ -138,7 +136,7 @@ tests:
               description: >-
                 The FE Pod CPU usage is above 80% for a container for more than 5 minutes.
               runbook_url: >-
-                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+                https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
   - interval: 1m
     input_series:
@@ -177,7 +175,7 @@ tests:
               description: >-
                 The Worker Pod CPU usage is above 80% for a container for more than 5 minutes.
               runbook_url: >-
-                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+                https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
   - interval: 1m
     input_series:
@@ -221,7 +219,7 @@ tests:
               description: >-
                 The FE Pod Memory usage is above 80% for a container for more than 5 minutes.
               runbook_url: >-
-                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+                https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html
 
   - interval: 1m
     input_series:
@@ -265,4 +263,4 @@ tests:
               description: >-
                 The Worker Pod Memory usage is above 80% for a container for more than 5 minutes.
               runbook_url: >-
-                https://docs.publishing.service.gov.uk/alerts/chat-ai-alerts.html
+                https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html


### PR DESCRIPTION
## What

Update the runbook URL in the Chat AI Alerts
Update alerts `High5xxRate` and `LongRequestDuration` to go to pager

## Why

The current url is incorrect, so this should direct people to the right location for the runbook
The `High5xxRate` and `LongRequestDuration` alerts are high priority