### PR TITLE
Allow clamav to write log file on startup

### DIFF
--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -56,10 +56,14 @@ spec:
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp
+            - name: app-clamav-log
+              mountPath: /var/log/clamav
             - name: app-clamav-db
               mountPath: /var/lib/clamav
       volumes:
         - name: app-tmp
+          emptyDir: {}
+        - name: app-clamav-log
           emptyDir: {}
         - name: app-clamav-db
           nfs:


### PR DESCRIPTION
As of ClamAV 1.3.2, log files no longer can reference symlinks which mean that it cannot be explicitly configured to /dev/stdout. However the default behaviour is to write to stdout anyways, but without explicit config it tries to touch log files under /var/logs/clamav. This gives it write permission to do so.