### PR TITLE
Switch Account API to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -60,9 +60,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &account-api-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *account-api-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained

[Trello](https://trello.com/c/nOUqm9pp/1366-create-new-redis-instance-for-account-api-and-move-account-api-to-it-lemon-and-herb-%F0%9F%8D%8B%F0%9F%8C%BF)