### PR TITLE
Switch Signon app to use new standalone Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2657,9 +2657,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &signon-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *signon-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Switch Signon app to use new standalone Redis in integration<br><br>[Trello card](https://trello.com/c/rHooG45d)