### PR TITLE
Switch Signon workers to use new standalone Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2656,8 +2656,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Switch Signon workers to use new standalone Redis in integration<br><br>[Trello card](https://trello.com/c/rHooG45d)