### PR TITLE
Switch Signon app to use new standalone Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2633,9 +2633,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &signon-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *signon-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Switch Signon app to use new standalone Redis in staging<br><br>[Trello card](https://trello.com/c/rHooG45d)