### PR TITLE
Switch Signon workers to use new standalone Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2632,8 +2632,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Switch Signon workers to use new standalone Redis in staging<br><br>[Trello card](https://trello.com/c/rHooG45d)