### PR TITLE
Set GOV.UK Chat places env vars to 0

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1394,9 +1394,9 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "26"
+          value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "26"
+          value: "0"
       nginxConfigMap:
         extraServerConf: |
           location /chat {

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1413,9 +1413,9 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "26"
+          value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "26"
+          value: "0"
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1397,9 +1397,9 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "26"
+          value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "26"
+          value: "0"
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests


### PR DESCRIPTION
If we merged this PR https://github.com/alphagov/govuk-helm-charts/pull/2450 we would immediately start incrmenting the number of sign up places available in the app.

By setting the env vars for places to 0, we can ensure that sign ups aren't incremented until we're ready.

At which point we will revert these values.