### PR TITLE
Switch Signon app to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2668,9 +2668,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &signon-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *signon-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Switch Signon app to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/rHooG45d)