### PR TITLE
Switch Content Data API to use new Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -532,9 +532,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &content-data-api-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *content-data-api-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained

[Trello](https://trello.com/c/n8NZZkcH/1365-create-new-redis-instance-for-content-data-api-and-move-content-data-api-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)