### PR TITLE
Switch Content Data API workers to use new redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -531,8 +531,6 @@ govukApplications:
     helmValues:
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello](https://trello.com/c/n8NZZkcH/1365-create-new-redis-instance-for-content-data-api-and-move-content-data-api-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)