### PR TITLE
Remove `REDIS_URL` for Release in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2066,8 +2066,6 @@ govukApplications:
             secretKeyRef:
               name: release-github
               key: token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This application does not have any workers in integration and does not need access to Redis.

[Trello card](https://trello.com/c/iH1oll4u)