### PR TITLE
Switch Release workers to use new standalone Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2042,8 +2042,6 @@ govukApplications:
       workerEnabled: false
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
Switch Release workers to use new standalone Redis in integration<br><br>[Trello card](https://trello.com/c/iH1oll4u)