### PR TITLE
Remove `REDIS_URL` for Release in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2091,8 +2091,6 @@ govukApplications:
             secretKeyRef:
               name: release-github
               key: token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This application does not have any workers in staging and does not need access to Redis.

[Trello card](https://trello.com/c/iH1oll4u)