### PR TITLE
Switch Release app to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2076,9 +2076,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &release-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *release-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       replicaCount: 2
       workerReplicaCount: 1
       podDisruptionBudget:


### PR DESCRIPTION
Switch Release app to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/iH1oll4u)