### PR TITLE
Switch Release workers to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2075,8 +2075,6 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       replicaCount: 2
       workerReplicaCount: 1
       podDisruptionBudget:


### PR DESCRIPTION
Switch Release workers to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/iH1oll4u)