### PR TITLE
Switch Clamav back to using the latest image

### DIFF
--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -13,7 +13,7 @@ clamav:
   replicaCount: 1
   image:
     repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/clamav
-    tag: 074b24e44907ac7c01a68d8a877b3b6e995fbd3f
+    tag: latest
     pullPolicy: Always
   service:
     type: ClusterIP


### PR DESCRIPTION
The latest image contains a fix for the issues that prevent Clamav from starting up successfully. The new version upgrades Clamav to 1.3.2 which contains security patches. Further work still needs to be done to make Clamav deployed with explicit version references and sequentially through our environments