### PR TITLE
Switch search-api workers to use new redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2362,8 +2362,6 @@ govukApplications:
       workerReplicaCount: 3
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"


### PR DESCRIPTION
Trello: https://trello.com/c/znEDt0yK/1364-create-new-redis-instance-for-search-api-and-move-search-api-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F