### PR TITLE
Switch search api workers to use new redis instance in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2396,8 +2396,6 @@ govukApplications:
           requests:
             cpu: 500m
             memory: 6Gi
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"


### PR DESCRIPTION
Trello: https://trello.com/c/znEDt0yK/1364-create-new-redis-instance-for-search-api-and-move-search-api-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F