### PR TITLE
Switch Content Data API workers to use new redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -525,8 +525,6 @@ govukApplications:
     helmValues:
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
[Trello](https://trello.com/c/n8NZZkcH/1365-create-new-redis-instance-for-content-data-api-and-move-content-data-api-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F)