### PR TITLE
Exclude 503 from alert and switch LongRequestDuration from Pagerduty to Slack

### DIFF
--- a/charts/monitoring-config/rules/chat_ai.yaml
+++ b/charts/monitoring-config/rules/chat_ai.yaml
@@ -5,7 +5,8 @@ groups:
         expr: >-
           sum(rate(http_requests_total{
             job="govuk-chat",
-            status=~"5.."
+            status=~"5..",
+            status!~"503"
           }[60m]))
           /
           (sum(rate(http_requests_total{
@@ -37,7 +38,8 @@ groups:
           > 1
         for: 5m
         labels:
-          severity: page
+          severity: critical
+          destination: slack-chat-notifications
         annotations:
           summary: Elevated HTTP request duration for Chat AI
           description: >-

--- a/charts/monitoring-config/rules/chat_ai_tests.yaml
+++ b/charts/monitoring-config/rules/chat_ai_tests.yaml
@@ -26,6 +26,26 @@ tests:
 
   - interval: 1m
     input_series:
+      # No alert with 503 errors > 10%
+      - series: >-
+          http_requests_total{
+          job="govuk-chat",
+          status="200"
+          }
+        values: '1000x15'
+      - series: >-
+          http_requests_total{
+          job="govuk-chat",
+          status="503"
+          }
+        values: '0+100x15'
+    alert_rule_test:
+      - alertname: High5xxRate
+        eval_time: 15m
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
       # Alert with 5xx errors > 10%
       - series: >-
           http_requests_total{
@@ -91,7 +111,8 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: LongRequestDuration
-              severity: page
+              severity: critical
+              destination: slack-chat-notifications
             exp_annotations:
               summary: Elevated HTTP request duration for Chat AI
               description: >-


### PR DESCRIPTION
## What

Exclude 503 from the `High5xxRate` alert and switch `LongRequestDuration` alert to go to Slack instead of Pagerduty

## Why

The 503 error code will be used when the Chat service is disabled, so we do not want alerts to go to Pagerduty in that situation.

We have decided that alerts for `LongRequestDuration` should not go to Pagerduty, as there will likely be nothing an on-call engineer will be able to do to resolve the issue.