### PR TITLE
Rename Chat AI dashboard to GOV.UK Chat Technical

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -3065,8 +3065,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Chat AI Dashboard",
-  "uid": "chat-ai-dashboard",
+  "title": "GOV.UK Chat Technical",
+  "uid": "govuk-chat-techical",
   "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description

We're adding additional dashboards for Chat. This renames the existing dashboard to make it clear that it's for technical monitoring of the application as the next dashboard will largely be for product monitoring.

## Trello card

https://trello.com/c/NCemum5m/1934-rename-grafana-chat-ai-dashboard