### PR TITLE
Increase redis memory usage for search-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2356,6 +2356,13 @@ govukApplications:
       workerReplicaCount: 3
       redis:
         enabled: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 8Gi
+          requests:
+            cpu: 500m
+            memory: 6Gi
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"


### PR DESCRIPTION
The "search:update_popularity" task currently queues jobs with the full search information, which cause the task queue to use upto 6Gb of memory. We have worked planned to fix this memory issue.