### PR TITLE
Increase redis memory for staging/production search-api

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2389,6 +2389,13 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 8Gi
+          requests:
+            cpu: 500m
+            memory: 6Gi
         redisUrlOverride:
           app: &search-api-redis >
             redis://shared-redis-govuk.eks.production.govuk-internal.digital

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2370,6 +2370,13 @@ govukApplications:
       workerEnabled: true
       redis:
         enabled: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 8Gi
+          requests:
+            cpu: 500m
+            memory: 6Gi
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"


### PR DESCRIPTION
Missed staging and production from the previous PR - https://github.com/alphagov/govuk-helm-charts/pull/2570

The "search:update_popularity" task currently queues jobs with the full search information, which cause the task queue to use upto 6Gb of memory. We have worked planned to fix this memory issue.