### PR TITLE
Allow specifying extra env vars to individual worker processes

### DIFF
--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -79,7 +79,7 @@ spec:
               value: {{ $.Values.redis.redisUrlOverride.workers | default (printf "redis://%s-redis" $fullName) }}
             {{- end }}
             {{- with $.Values.extraEnv }}
-              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+              {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
             {{- with .env }}
               {{- . | toYaml | trim | nindent 12 }}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -81,6 +81,9 @@ spec:
             {{- with $.Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}
+            {{- with .env }}
+              {{- . | toYaml | trim | nindent 12 }}
+            {{- end }}
           {{- with $.Values.workerResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}


### PR DESCRIPTION
This is to allow an individual worker process to have environment
variables just for that process. This can be defined with an env
argument as part of a worker - in an approach consistent to that of a
cron task [1].

The specific use case for this feature is for configuring the database
pool for sidekiq on GOV.UK Chat. We want to run Sidekiq with a
concurrency of 25 and thus want a connection pool of the same size.
However we don't want to set this connection pool size as a global
setting as the web servers, which will use 10 threads, won't need a pool
of that size and we'd be wasting scalability room by using those.

[1]: https://github.com/alphagov/govuk-helm-charts/blob/47b08df3988ce4c795936644340a538f9ace7317/charts/app-config/values-production.yaml#L2407-L2412