### PR TITLE
Set GOV.UK Chat sidekiq concurrency as env vars

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1326,6 +1326,11 @@ govukApplications:
       workers:
         - command: ["sidekiq", "-C", "config/sidekiq.yml"]
           name: worker
+          env:
+            - name: SIDEKIQ_CONCURRENCY
+              value: "25"
+            - name: DATABASE_POOL
+              value: "25"
         - command: ['rake', 'message_queue:published_documents_consumer']
           name: published-documents-consumer
       ingress:


### PR DESCRIPTION
This change depends on https://github.com/alphagov/govuk-helm-charts/pull/2573 and is branched from it

We previously didn't specify this as env vars and just had a concurrency set in the Sidekiq config file, however we had made a mistake that there wasn't a large enough DB connection pool to satisfy that level of concurrency.

As we don't want to change the size of DB connection pool everywhere, we only set it as an env var for this process. Since we want it to match the concurrency level of sidekiq it seems logical to have it defined together.

This pairs with an application change in: https://github.com/alphagov/govuk-chat/pull/709