### PR TITLE
Remove arch: arm64 tag from draft-feedback in staging and production.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1058,7 +1058,6 @@ govukApplications:
   - name: draft-feedback
     repoName: feedback
     helmValues:
-      arch: arm64
       rails:
         createKeyBaseSecret: false
       sentry:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1062,7 +1062,6 @@ govukApplications:
   - name: draft-feedback
     repoName: feedback
     helmValues:
-      arch: arm64
       rails:
         createKeyBaseSecret: false
       sentry:


### PR DESCRIPTION
arm46 arch doesn't exist in staging / production, so remove arch: tag to revert to default.