### PR TITLE
Enable GOV.UK Chat banners on integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -296,6 +296,8 @@ govukApplications:
     helmValues:
       arch: arm64
       extraEnv:
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -1283,6 +1285,8 @@ govukApplications:
     helmValues:
       arch: arm64
       extraEnv:
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: PUBLISHING_API_BEARER_TOKEN


### PR DESCRIPTION
This is to test the functionality as part of a launch demo exercise.