### PR TITLE
Disable govuk-chat banners in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -296,8 +296,8 @@ govukApplications:
     helmValues:
       arch: arm64
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
+        # - name: GOVUK_CHAT_PROMO_ENABLED
+        #   value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -1285,8 +1285,8 @@ govukApplications:
     helmValues:
       arch: arm64
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
+        # - name: GOVUK_CHAT_PROMO_ENABLED
+        #   value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: PUBLISHING_API_BEARER_TOKEN


### PR DESCRIPTION
These were turned on for a test and demo. I'm leaving them as commented out as a means to show what they need to be to go live.