### PR TITLE
Use Europe/London Timezone on chat cron tasks

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1343,12 +1343,15 @@ govukApplications:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
           schedule: "0 7-19 * * *"
+          timeZone: "Europe/London"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
           schedule: "0 9,11,13,15 * * 1-5"
+          timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
           schedule: "1 9,11,13,15 * * 1-5"
+          timeZone: "Europe/London"
       extraEnv:
         # remove the need for signon to access frontend of chat
         - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1342,7 +1342,7 @@ govukApplications:
       cronTasks:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
-          schedule: "0 7-19 * * *"
+          schedule: "30 7-19 * * *"
           timeZone: "Europe/London"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
@@ -1350,7 +1350,7 @@ govukApplications:
           timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
-          schedule: "1 9,11,13,15 * * 1-5"
+          schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
         # remove the need for signon to access frontend of chat

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1364,14 +1364,15 @@ govukApplications:
           timeZone: "Europe/London"
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
-          schedule: "0 * * * *"
+          schedule: "30 7-22 * * *"
+          timeZone: "Europe/London"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
           schedule: "0 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
-          schedule: "1 9,11,13,15 * * 1-5"
+          schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1361,15 +1361,18 @@ govukApplications:
         - name: bigquery-export
           task: "bigquery:export"
           schedule: "0 7 * * *"
+          timeZone: "Europe/London"
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
           schedule: "0 * * * *"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
           schedule: "0 9,11,13,15 * * 1-5"
+          timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
           schedule: "1 9,11,13,15 * * 1-5"
+          timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1343,12 +1343,15 @@ govukApplications:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
           schedule: "0 7-19 * * *"
+          timeZone: "Europe/London"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
           schedule: "0 9,11,13,15 * * 1-5"
+          timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
           schedule: "1 9,11,13,15 * * 1-5"
+          timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1342,7 +1342,7 @@ govukApplications:
       cronTasks:
         - name: promote-waiting-list
           task: "users:promote_waiting_list"
-          schedule: "0 7-19 * * *"
+          schedule: "30 7-19 * * *"
           timeZone: "Europe/London"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
@@ -1350,7 +1350,7 @@ govukApplications:
           timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
-          schedule: "1 9,11,13,15 * * 1-5"
+          schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/component: "{{ .name }}"
 spec:
   schedule: "{{ .schedule }}"
+  {{ if .timeZone }}timeZone: "{{ .timeZone }}"{{- end }}
   suspend: {{ .suspend | default false }}
   jobTemplate:
     metadata:


### PR DESCRIPTION
This allows setting the a time zone for cron jobs so they can run in a London timezone. 

I've also tweaked the config of chat cron job tasks following chats with team leads to avoid situations where we accumulate stuff overnight or have jobs clashing.