### PR TITLE
Update places env vars 

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1419,9 +1419,9 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "13"
+          value: "26"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "13"
+          value: "26"
       nginxConfigMap:
         extraServerConf: |
           location /chat {

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1438,9 +1438,9 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
+          value: "26"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
+          value: "26"
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1416,9 +1416,9 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
+          value: "26"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
+          value: "26"
       nginxConfigMap:
         extraServerConf: |
           location /chat {


### PR DESCRIPTION
We've updated Chat's config to include the correct release date. This bumps the places env vars to the correct values for the first week of release.

The rake task will return from the rake tasks before the configured release date in GOV.UK Chat.