### PR TITLE
Frontend has no publishing_api tasks, so no longer needs access to publishing-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1213,11 +1213,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
-              key: bearer_token
 
   - name: draft-frontend
     repoName: frontend
@@ -1274,11 +1269,6 @@ govukApplications:
           valueFrom:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
-              key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
               key: bearer_token
 
   - name: government-frontend

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1184,11 +1184,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
-              key: bearer_token
         - name: WEB_CONCURRENCY
           value: '4'
 
@@ -1268,11 +1263,6 @@ govukApplications:
           valueFrom:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
-              key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
               key: bearer_token
 
   - name: government-frontend

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1209,11 +1209,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
-              key: bearer_token
         - name: WEB_CONCURRENCY
           value: '4'
 
@@ -1272,11 +1267,6 @@ govukApplications:
           valueFrom:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
-              key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
               key: bearer_token
 
   - name: government-frontend


### PR DESCRIPTION

(As of: https://github.com/alphagov/frontend/pull/4223)