### PR TITLE
Turn off Signon authentication for frontend of chat

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1388,6 +1388,9 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-slack
               key: AI_SLACK_CHANNEL_WEBHOOK_URL
+        # remove the need for signon to access frontend of chat
+        - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION
+          value: "true"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
**Do not merge until release**

## Description 

When we go live we want to stop Signon auth being required for the frontend of the chat application.