### PR TITLE
Turn off signon authentication for frontend of chat on staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1353,6 +1353,9 @@ govukApplications:
           schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
+        # remove the need for signon to access frontend of chat
+        - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION
+          value: "true"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We've moved over serving chat frontend  to `www` on staging so sign on integration is not required.