### PR TITLE
Provision new Redis instance for Whitehall integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3323,6 +3323,12 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &whitehall-admin-redis >
+            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
+          workers: *whitehall-admin-redis
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
@@ -3393,8 +3399,6 @@ govukApplications:
           value: whitehall-emails-integration@digital.cabinet-office.gov.uk
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We're not switching any apps or workers to use this just yet - we'll need to do a bit of configuring on both Whitehall and Static to use this new instance for three different purposes - Whitehall and Static need to share an instance of Redis for the Emergency Banner.