### PR TITLE
Switch Transition app to use new standalone Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3155,9 +3155,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &transition-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *transition-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       cronTasks:
         - name: import-all-organisations
           task: "import:all:organisations"


### PR DESCRIPTION
Switch Transition app to use new standalone Redis in integration<br><br>[Trello card](https://trello.com/c/zEfMAA3E)