### PR TITLE
Switch Transition workers to use new standalone Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3154,8 +3154,6 @@ govukApplications:
         enabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       cronTasks:
         - name: import-all-organisations
           task: "import:all:organisations"


### PR DESCRIPTION
Switch Transition workers to use new standalone Redis in integration<br><br>[Trello card](https://trello.com/c/zEfMAA3E)