### PR TITLE
Switch Transition app to use new standalone Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3094,9 +3094,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &transition-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *transition-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       cronTasks:
         - name: import-all-organisations
           task: "import:all:organisations"


### PR DESCRIPTION
Switch Transition app to use new standalone Redis in staging<br><br>[Trello card](https://trello.com/c/zEfMAA3E)