### PR TITLE
Switch Transition app to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3156,9 +3156,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &transition-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *transition-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       cronTasks:
         - name: import-all-organisations
           task: "import:all:organisations"


### PR DESCRIPTION
Switch Transition app to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/zEfMAA3E)