### PR TITLE
Switch Transition workers to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3155,8 +3155,6 @@ govukApplications:
         enabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       cronTasks:
         - name: import-all-organisations
           task: "import:all:organisations"


### PR DESCRIPTION
Switch Transition workers to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/zEfMAA3E)