### PR TITLE
Remove expectation of Redis/Sidekiq from `search-admin`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2298,8 +2298,6 @@ govukApplications:
     helmValues:
       arch: arm64
       dbMigrationEnabled: true
-      workers:
-        enabled: true
       ingress:
         enabled: true
         annotations:
@@ -2327,8 +2325,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-search-admin-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2349,8 +2349,6 @@ govukApplications:
   - name: search-admin
     helmValues:
       dbMigrationEnabled: true
-      workers:
-        enabled: true
       ingress:
         enabled: true
         annotations:
@@ -2378,8 +2376,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-search-admin-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2329,8 +2329,6 @@ govukApplications:
   - name: search-admin
     helmValues:
       dbMigrationEnabled: true
-      workers:
-        enabled: true
       ingress:
         enabled: true
         annotations:
@@ -2358,8 +2356,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-search-admin-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The `search-admin` app doesn't have any workers or any other usage of Redis, so it doesn't need to be configured as such.

Therefore removing the `REDIS_URL` environment variable and switching off the expectation of workers.

This means the app does not need to be migrated to a Redis instance of it's own.