### PR TITLE
Increase storage request for prometheus

### DIFF
--- a/charts/monitoring-config/kube-prometheus-stack-values-integration.yaml
+++ b/charts/monitoring-config/kube-prometheus-stack-values-integration.yaml
@@ -39,4 +39,4 @@
         "spec":
           "resources":
             "requests":
-              "storage": "200Gi"
+              "storage": "250Gi"

--- a/charts/monitoring-config/kube-prometheus-stack-values-production.yaml
+++ b/charts/monitoring-config/kube-prometheus-stack-values-production.yaml
@@ -39,4 +39,4 @@
         "spec":
           "resources":
             "requests":
-              "storage": "200Gi"
+              "storage": "250Gi"

--- a/charts/monitoring-config/kube-prometheus-stack-values-staging.yaml
+++ b/charts/monitoring-config/kube-prometheus-stack-values-staging.yaml
@@ -39,4 +39,4 @@
         "spec":
           "resources":
             "requests":
-              "storage": "200Gi"
+              "storage": "250Gi"


### PR DESCRIPTION
We're running out of disk space in all environments, staging has 5GB free and prod has 12GB free. This is probably due to the Redis work increasing the amount of pods sending metrics to prometheus.