### PR TITLE
Enable server-side apply for monitoring-config app

### DIFF
--- a/charts/app-config/templates/monitoring-application.yaml
+++ b/charts/app-config/templates/monitoring-application.yaml
@@ -23,4 +23,5 @@ spec:
       selfHeal: true
     syncOptions:
     - ApplyOutOfSyncOnly=true
+    - ServerSideApply=true
 {{- end }}


### PR DESCRIPTION
Argo CD is currently failing to apply changes to the grafana dashboards, because the data in the configmap is too large to fit in the `kubectl.kubernetes.io/last-applied-configuration` annotation, which is required for client-side applies. 