### PR TITLE
Add extra fields to externalsecrets in monitoring-config

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanager-secret.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanager-secret.yaml
@@ -14,11 +14,15 @@ spec:
     - secretKey: pagerduty_routing_key
       remoteRef:
         key: govuk/alertmanager/pagerduty-routing-key
-        decodingStrategy: None
         version: AWSCURRENT
+        decodingStrategy: None
+        conversionStrategy: Default
+        metadataPolicy: None
     - secretKey: slack_api_url
       remoteRef:
         key: govuk/slack-webhook-url
         property: url
-        decodingStrategy: None
         version: AWSCURRENT
+        decodingStrategy: None
+        conversionStrategy: Default
+        metadataPolicy: None

--- a/charts/monitoring-config/templates/kube-prometheus-stack/grafana-admin-user-secret.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/grafana-admin-user-secret.yaml
@@ -13,3 +13,6 @@ spec:
   dataFrom:
     - extract:
         key: govuk/kube-prometheus-stack/grafana-admin-user
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
These fields are being added by external-secrets in the cluster, which is now causing argo to perpetually attempt to overwrite the resources. This is because server-side applies are now enabled for monitoring-config, so argo has no way of knowing the last state it applied, so always thinks its out-of-sync.