### PR TITLE
Update init containers to be PSS compliant in the apps namespace

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -53,6 +53,8 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001
+  seccompProfile:
+    type: RuntimeDefault
 
 serviceAccount:
   create: true

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -45,8 +45,11 @@ spec:
             - name: assets-to-upload
               mountPath: /assets-to-upload
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop: ["ALL"]
       containers:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -63,6 +63,15 @@ spec:
           volumeMounts:
             - name: assets
               mountPath: /assets
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
+
       {{- end }}
       containers:
         - name: app
@@ -127,7 +136,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFileSystem }}
             capabilities:
               drop: ["ALL"]
           volumeMounts:

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -157,6 +157,9 @@ securityContext:
   allowPrivilegeEscalation: false
   runAsUser: 1001
   runAsGroup: 1001
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
 
 sentry:
   enabled: true

--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -50,8 +50,13 @@ spec:
                   cpu: 2
                   memory: 15000Mi
               securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+                runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
+                readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop: {{ .Values.securityContext.capabilities.drop }}
               volumeMounts:
                 - name: app-mirror-sync
                   mountPath: /data

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -11,7 +11,7 @@ podSecurityContext:
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
-    drop: [ALL]
+    drop: ["ALL"]
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001


### PR DESCRIPTION
Description:
- Enforce initContainers in the `app` namespace to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Tested in integration and observed that `content-data-admin` initContainers were starting properly
- `govuk-mirror-sync-cronjob` can't be tested in integration as this has no mirrors so the PR will have to be merged and we will have to manually inspect staging ot see if it succeeds.
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883
- Paired with @MahmudH