### PR TITLE
Move Whitehall app over to new Redis [Integration]

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3328,9 +3328,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &whitehall-admin-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *whitehall-admin-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
[Trello card](https://trello.com/c/zkDNXi7x/1400-create-new-redis-instance-for-whitehall-admin-integration)

Now that we've moved the Emergency Banner and Taxonomy cache to their own databases on the new instance, we can move the app over to use the default `/0` database for Sidekiq jobs.

The workers will be switched over once the queue has been drained.