### PR TITLE
Switch email-alert-service app to use new redis instance in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1001,9 +1001,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &email-alert-service-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *email-alert-service-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       extraEnv:
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
Trello: https://trello.com/c/A7w1KOnN/1397-create-new-redis-instance-for-email-alert-service-and-move-email-alert-service-to-it-lemon-and-herb-%F0%9F%8D%8B%F0%9F%8C%BF