### PR TITLE
Switch email-alert-service workers to use new redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -996,8 +996,6 @@ govukApplications:
             name: email-alert-service
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
Trello: https://trello.com/c/A7w1KOnN/1397-create-new-redis-instance-for-email-alert-service-and-move-email-alert-service-to-it-lemon-and-herb-%F0%9F%8D%8B%F0%9F%8C%BF