### PR TITLE
Use standalone Redis for emergency banner and Whitehall taxonomy cache in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3305,6 +3305,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: TAXONOMY_CACHE_REDIS_URL
+          value: redis://whitehall-admin-redis/2
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -55,6 +55,8 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
     access_logs.s3.prefix=elb/backend
 
+emergency-banner-redis:
+  - &emergency-banner-redis redis://whitehall-admin-redis/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -2799,6 +2801,8 @@ govukApplications:
               key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
       nginxConfigMap:
@@ -2842,6 +2846,8 @@ govukApplications:
               key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
 
@@ -3297,6 +3303,8 @@ govukApplications:
           value: whitehall-emails-staging@digital.cabinet-office.gov.uk
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Whitehall uses Redis for three purposes:
- Taxonomy Cache
- Emergency Banner
- Sidekiq

We've created a new dedicated Redis instance for this to move it off the shared instance, and using different numerically-named databases which are accessed via the trailing `/1` or `/2` on that instance, rather than namespacing.

[Trello card](https://trello.com/c/6R3NueMz)