### PR TITLE
Switch Whitehall app to use new standalone Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3230,9 +3230,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &whitehall-admin-redis >
-            redis://shared-redis-govuk.eks.staging.govuk-internal.digital
-          workers: *whitehall-admin-redis
+          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
Switch Whitehall app to use new standalone Redis in staging<br><br>[Trello card](https://trello.com/c/6R3NueMz)