### PR TITLE
Switch Whitehall workers to use new standalone Redis in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3229,8 +3229,6 @@ govukApplications:
         enabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
Switch Whitehall workers to use new standalone Redis in staging<br><br>[Trello card](https://trello.com/c/6R3NueMz)