### PR TITLE
Use standalone Redis for emergency banner and Whitehall taxonomy cache in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -48,6 +48,8 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
     access_logs.s3.prefix=elb/backend
 
+emergency-banner-redis:
+  - &emergency-banner-redis redis://whitehall-admin-redis/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -2858,6 +2860,8 @@ govukApplications:
               key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
       nginxConfigMap:
@@ -2897,6 +2901,8 @@ govukApplications:
               key: bearer_token
         - name: REDIS_URL
           value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
 
@@ -3375,6 +3381,8 @@ govukApplications:
               key: DATABASE_URL
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-design-system-gtm-id
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
       extraVolumes:
         - name: asset-uploads-efs
           nfs:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3383,6 +3383,8 @@ govukApplications:
           value: *publishing-design-system-gtm-id
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: TAXONOMY_CACHE_REDIS_URL
+          value: redis://whitehall-admin-redis/2
       extraVolumes:
         - name: asset-uploads-efs
           nfs:


### PR DESCRIPTION
Whitehall uses Redis for three purposes:
- Taxonomy Cache
- Emergency Banner
- Sidekiq

We've created a new dedicated Redis instance for this to move it off the shared instance, and using different numerically-named databases which are accessed via the trailing `/1` or `/2` on that instance, rather than namespacing.

[Trello card](https://trello.com/c/2RF94Axr)