### PR TITLE
Switch Whitehall app to use new standalone Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3303,9 +3303,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &whitehall-admin-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *whitehall-admin-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
Switch Whitehall app to use new standalone Redis in production<br><br>[Trello card](https://trello.com/c/2RF94Axr)