### PR TITLE
Switch Email Alert Frontend to use new Redis in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -935,9 +935,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &email-alert-frontend-redis >
-            redis://shared-redis-govuk.eks.production.govuk-internal.digital
-          workers: *email-alert-frontend-redis
+          workers: redis://shared-redis-govuk.eks.production.govuk-internal.digital
       extraEnv:
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained

[Trello](https://trello.com/c/MVrEPmqP/1396-create-new-redis-instance-for-email-alert-frontend-and-move-email-alert-frontend-to-it-lemon-and-herb-%F0%9F%8D%8B%F0%9F%8C%BF)