### PR TITLE
Remove `REDIS_URL` for Static and Draft Static

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2830,8 +2830,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-static-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
@@ -2876,8 +2874,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-static-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2858,8 +2858,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-static-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
@@ -2899,8 +2897,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-static-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2799,8 +2799,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-static-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE
@@ -2844,8 +2842,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-static-publishing-api
               key: bearer_token
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: USE_TMPDIR_PAGE_CACHE


### PR DESCRIPTION
Static only uses Redis to display the emergency banner. This now has a dedicated environment variable, so we don't need to include `REDIS_URL` anymore.

[Trello card](https://trello.com/c/2RF94Axr)