### PR TITLE
Add Security Context to argo workflow post-sync

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -18,6 +18,13 @@ spec:
       - name: repoName
       - name: imageTag
   podSpecPatch: |
+    initContainers:
+      - name: init-main
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
     containers:
       - name: main
         resources:
@@ -25,7 +32,7 @@ spec:
             memory: 2Gi
   templates:
     - name: handle-sync-event
-      podSpecPatch: '{"containers":[{"name":"main","resources":{"limits":{"cpu":2,"memory":"2Gi"},"requests":{"cpu":1,"memory":"1Gi"}}}]}'
+      podSpecPatch: '{"initContainers:["name":"init-main","securityContext":{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"capabilities":{"drop":["ALL"]}},"containers":[{"name":"main","resources":{"limits":{"cpu":2,"memory":"2Gi"},"requests":{"cpu":1,"memory":"1Gi"}}}]}'
       dag:
         tasks:
           - name: smoke-test


### PR DESCRIPTION
There are PodSecurity warnings present in the kibana logs. This PR fixes this.

As part of https://github.com/alphagov/govuk-helm-charts/issues/1883