### PR TITLE
Switch search-api-v2 workers to use new redis instance in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2516,8 +2516,6 @@ govukApplications:
             name: document-sync-worker
       redis:
         enabled: true
-        redisUrlOverride:
-          workers: redis://shared-redis-govuk.eks.staging.govuk-internal.digital
       cronTasks:
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"


### PR DESCRIPTION
Trello: https://trello.com/c/H4PW2hNC/1399-create-new-redis-instance-for-search-api-v2-and-move-search-api-v2-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F
