### PR TITLE
Provision new redis instance for search-api-v2 in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2538,6 +2538,12 @@ govukApplications:
           - command: ['bin/rake', 'document_sync_worker:run']
             name: document-sync-worker
         replicaCount: 3
+      redis:
+        enabled: true
+        redisUrlOverride:
+          app: &search-api-v2-redis >
+            redis://shared-redis-govuk.eks.production.govuk-internal.digital
+          workers: *search-api-v2-redis
       cronTasks:
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
@@ -2552,8 +2558,6 @@ govukApplications:
           value: "30"
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_MAX_UNACKED
           value: "30"
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.production.govuk-internal.digital
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Trello: https://trello.com/c/H4PW2hNC/1399-create-new-redis-instance-for-search-api-v2-and-move-search-api-v2-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F