### PR TITLE
Switch search-api-v2 to new redis instance in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2517,6 +2517,8 @@ govukApplications:
         types:
           - command: ['bin/rake', 'document_sync_worker:run']
             name: document-sync-worker
+      redis:
+        enabled: true
       cronTasks:
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
@@ -2532,8 +2534,6 @@ govukApplications:
           value: "30"
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_MAX_UNACKED
           value: "30"
-        - name: REDIS_URL
-          value: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Provision new redis instance for search-api-v2 in integration and switch application and workers to use it.

Draining approach not necessary at Sidekiq/redis are not used for the workers.

Trello: https://trello.com/c/H4PW2hNC/1399-create-new-redis-instance-for-search-api-v2-and-move-search-api-v2-to-it-peri-peri-%F0%9F%8C%B6%EF%B8%8F