### PR TITLE
Remove Chat Opensearch snapshot job in Staging

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -67,22 +67,6 @@ cronjobs:
             secretKeyRef:
               name: govuk-chat-opensearch
               key: password
-    chat-engine-snapshot:
-      schedule: "12 3 * * *"
-      args: [create_and_clean_up]
-      extraEnv:
-        - name: SUBDOMAIN
-          value: chat-opensearch
-        - name: SEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-opensearch
-              key: username
-        - name: SEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-opensearch
-              key: password
 
   integration:
     blue-es6-cp-stag:  # This would be too long as blue-elasticsearch6-domain-cp-stag


### PR DESCRIPTION
## What

Remove the Chat Opensearch snapshot creation cronjob for the Staging environment

## Why

Originally a snapshot restore cronjob was set up for the Integration environment to import a snapshot of the Staging environment, but this was then modified to import from Production instead, leaving this cronjob redundant