### PR TITLE
Licensing - Enable debug logging surrounding payments

### DIFF
--- a/charts/licensify/templates/logging-configmap.yaml
+++ b/charts/licensify/templates/logging-configmap.yaml
@@ -14,6 +14,8 @@ data:
         <logger name="application" level="WARN"/>
         <logger name="akka" level="WARN"/>
         <logger name="play" level="WARN"/>
+        <logger name="uk.gov.gds.payments" level="DEBUG"/>
+        <logger name="uk.gov.gds.licensing.frontend.controllers" level="DEBUG"/>
         <logger name="uk.gov" level="WARN"/>
         <root level="WARN">
             <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Currently we're unable to diagnose issues using logging breadcrumbs, as logging is being suppressed to warn/error to reduce noise (as was done in https://github.com/alphagov/govuk-helm-charts/commit/5860cb305f6e1263cfb0b64a55f06cd4fcf18d64). 

Enabled debug/info level logging around the packages of interest, so these should be output to aid diagnosing