### PR TITLE
Update static-error-page-upload-job container to be PSS compliant

### DIFF
--- a/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/static-error-page-upload-job.yaml
@@ -32,8 +32,13 @@ spec:
         - name: upload-static-error-pages
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/toolbox:latest
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: GOVUK_ENVIRONMENT
               value: {{ .Values.govukEnvironment }}


### PR DESCRIPTION
Description:
- Enforces this container to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883