### PR TITLE
Switch Draft Email Alert Frontend to use new Redis in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -978,9 +978,7 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: &email-alert-draft-frontend-redis >
-            redis://shared-redis-govuk.eks.integration.govuk-internal.digital
-          workers: *email-alert-draft-frontend-redis
+          workers: redis://shared-redis-govuk.eks.integration.govuk-internal.digital
       sentry:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:


### PR DESCRIPTION
The workers will be switched in a later PR, after the queue has been drained

[Trello](https://trello.com/c/lIGs2vnW/1417-create-new-redis-instance-for-draft-email-alert-frontend-and-move-draft-email-alert-frontend-to-it-lemon-and-herb-%F0%9F%8D%8B%F0%9F%8C%BF)