### PR TITLE
Refactor securityContext from container level to pod

### DIFF
--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -49,7 +49,7 @@ spec:
               - {{ $.Values.govukEnvironment }}.govuk-internal.digital
           serviceAccountName: {{ include "db-backup.serviceAccountName" $ }}
           securityContext:
-            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+            {{- toYaml $.Values.securityContext | nindent 12 }}
           volumes:
             - name: scripts
               configMap:
@@ -107,8 +107,6 @@ spec:
                 {{- end }}
               resources:
                 {{- merge ($job.resources | default dict) $.Values.resources | toYaml | nindent 16 }}
-              securityContext:
-                {{- toYaml $.Values.securityContext | nindent 16 }}
               volumeMounts:
                 - name: scripts
                   mountPath: /opt/bin

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -40,21 +40,17 @@ _mongoResources: &mongo-resources
     requests:
       memory: 768Mi
 
-podSecurityContext:
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   fsGroup: 1001
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001
-
-securityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop: [ALL]
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1001
   seccompProfile:
     type: RuntimeDefault
+  capabilities:
+    drop: ["ALL"]
 
 serviceAccount:
   create: true

--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -28,11 +28,15 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop: ["ALL"]
       initContainers:
         - name: copy-assets-for-upload
           image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
@@ -44,14 +48,6 @@ spec:
           volumeMounts: &volumeMounts
             - name: assets-to-upload
               mountPath: /assets-to-upload
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
-            seccompProfile:
-              type: RuntimeDefault
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: upload-assets
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/toolbox:latest
@@ -66,11 +62,6 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           volumeMounts: *volumeMounts
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       restartPolicy: Never
       volumes:
         - name: assets-to-upload

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -36,12 +36,16 @@ spec:
           automountServiceAccountToken: {{- if .serviceAccount }} true {{- else }} false {{- end }}
           enableServiceLinks: false
           securityContext:
-            seccompProfile:
-              type: RuntimeDefault
+            allowPrivilegeEscalation: false
             fsGroup: {{ $.Values.securityContext.runAsGroup }}
             runAsNonRoot: {{ $.Values.securityContext.runAsNonRoot }}
             runAsUser: {{ $.Values.securityContext.runAsUser }}
             runAsGroup: {{ $.Values.securityContext.runAsGroup }}
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           restartPolicy: Never
           {{ if .serviceAccount }}serviceAccountName: {{ .serviceAccount }}{{- end }}
           volumes:
@@ -96,10 +100,7 @@ spec:
                 {{- . | toYaml | trim | nindent 16 }}
               {{- end }}
               securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                capabilities:
-                  drop: ["ALL"]
+
               volumeMounts:
                 - name: app-tmp
                   mountPath: /tmp

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -26,12 +26,16 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
         fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop: ["ALL"]
       restartPolicy: Never
       volumes:
         - name: app-tmp
@@ -68,11 +72,6 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -28,12 +28,16 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
         fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFileSystem }}
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop: ["ALL"]
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
@@ -63,14 +67,6 @@ spec:
           volumeMounts:
             - name: assets
               mountPath: /assets
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
-            seccompProfile:
-              type: RuntimeDefault
-            capabilities:
-              drop: ["ALL"]
 
       {{- end }}
       containers:
@@ -134,11 +130,6 @@ spec:
             periodSeconds: 2
             timeoutSeconds: 2
           {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFileSystem }}
-            capabilities:
-              drop: ["ALL"]
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp
@@ -171,11 +162,6 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
           volumeMounts:
             - name: {{ .Values.nginxConfigMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -28,12 +28,16 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
         fsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop: ["ALL"]
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- . | toYaml | trim | nindent 8 }}
@@ -88,11 +92,6 @@ spec:
           resources:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp

--- a/charts/govuk-e2e-tests/templates/cronjob.yaml
+++ b/charts/govuk-e2e-tests/templates/cronjob.yaml
@@ -38,11 +38,15 @@ spec:
           enableServiceLinks: false
           restartPolicy: Never
           securityContext:
-            seccompProfile:
-              type: RuntimeDefault
-            runAsGroup: 1001
             runAsNonRoot: true
             runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
           - emptyDir: {}
             name: tmp
@@ -63,11 +67,6 @@ spec:
             resources:
               {{- . | toYaml | trim | nindent 14 }}
             {{- end }}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities:
-                drop: ["ALL"]
             volumeMounts:
             - mountPath: /tmp
               name: tmp

--- a/charts/govuk-jobs/templates/dependabot-metrics-cronjob.yaml
+++ b/charts/govuk-jobs/templates/dependabot-metrics-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
         spec:
           enableServiceLinks: false
           securityContext:
-            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+            {{- toYaml $.Values.securityContext | nindent 12 }}
           restartPolicy: Never
           containers:
             - name: main
@@ -45,6 +45,4 @@ spec:
               resources:
                 {{- . | toYaml | trim | nindent 16 }}
               {{- end }}
-              securityContext:
-                {{- toYaml $.Values.securityContext | nindent 16 }}
 {{- end }}

--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -27,9 +27,15 @@ spec:
           serviceAccountName: govuk-mirror-sync
           securityContext:
             fsGroup: {{ .Values.securityContext.runAsGroup }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
             runAsUser: {{ .Values.securityContext.runAsUser }}
             runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           restartPolicy: Never
           volumes:
             - name: app-mirror-sync
@@ -49,14 +55,6 @@ spec:
                 requests:
                   cpu: 2
                   memory: 15000Mi
-              securityContext:
-                allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
-                runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
-                readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
-                seccompProfile:
-                  type: RuntimeDefault
-                capabilities:
-                  drop: {{ .Values.securityContext.capabilities.drop }}
               volumeMounts:
                 - name: app-mirror-sync
                   mountPath: /data
@@ -89,9 +87,6 @@ spec:
                 requests:
                   cpu: 2
                   memory: 5000Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
               volumeMounts:
                 - name: app-mirror-sync
                   mountPath: /data

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -1,20 +1,18 @@
 # ⚠️ DEPRECATED; please do not add new jobs to this chart. See README.md for
 # better alternatives.
 
-podSecurityContext:
+securityContext:
   fsGroup: 1001
   fsGroupChangePolicy: OnRootMismatch
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001
-
-securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1001
+  seccompProfile:
+    type: RuntimeDefault
 
 resources:
   limits:


### PR DESCRIPTION
Description:
- Moves all securityContext to pod level where it applies to all containers
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883