### PR TITLE
Revert to default memory for Redis in search-api

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2416,13 +2416,6 @@ govukApplications:
             name: bulk-reindex-queue-listener
       redis:
         enabled: true
-        resources:
-          limits:
-            cpu: 1
-            memory: 8Gi
-          requests:
-            cpu: 500m
-            memory: 6Gi
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2382,13 +2382,6 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
-        resources:
-          limits:
-            cpu: 1
-            memory: 8Gi
-          requests:
-            cpu: 500m
-            memory: 6Gi
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"


### PR DESCRIPTION
This was bumped in this PR https://github.com/alphagov/govuk-helm-charts/pull/2570 to handle the overnight cron jobs running on Search API.

Now we've addressed the issue by removing giant payloads being passed in as params to workers we can revert the changes.