### PR TITLE
Reduce memory limit for Redis in search-api in int

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2373,13 +2373,6 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
-        resources:
-          limits:
-            cpu: 1
-            memory: 8Gi
-          requests:
-            cpu: 500m
-            memory: 6Gi
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"


### PR DESCRIPTION
This was bumped in this PR https://github.com/alphagov/govuk-helm-charts/pull/2570 to handle the overnight cron jobs running on Search API.

Now we've addressed the issue by removing giant payloads being passed in as params to workers we can revert the changes and test that the fix works as expected.