### PR TITLE
Refactor security context

### DIFF
--- a/charts/generic-govuk-app/templates/assets-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/assets-upload-job.yaml
@@ -28,11 +28,12 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        fsGroup: 1001
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: copy-assets-for-upload
           image: "{{ .Values.appImage.repository }}:{{ required "Valid .Values.appImage.tag required!" .Values.appImage.tag }}"
@@ -46,10 +47,7 @@ spec:
               mountPath: /assets-to-upload
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
-            seccompProfile:
-              type: RuntimeDefault
             capabilities:
               drop: ["ALL"]
       containers:
@@ -67,8 +65,8 @@ spec:
           {{- end }}
           volumeMounts: *volumeMounts
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
             capabilities:
               drop: ["ALL"]
       restartPolicy: Never

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -65,10 +65,7 @@ spec:
               mountPath: /assets
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
-            seccompProfile:
-              type: RuntimeDefault
             capabilities:
               drop: ["ALL"]
 

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -158,8 +158,6 @@ securityContext:
   runAsUser: 1001
   runAsGroup: 1001
   readOnlyRootFilesystem: true
-  capabilities:
-    drop: ["ALL"]
 
 sentry:
   enabled: true


### PR DESCRIPTION
Description:
- Pod containers need to have the following fields to ensure compliance when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Refactored some fields into the podSecurityContext
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883