### PR TITLE
Refactor govuk-jobs to be compliant when PSS is set to restricted

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -26,10 +26,12 @@ spec:
           enableServiceLinks: false
           serviceAccountName: govuk-mirror-sync
           securityContext:
-            fsGroup: {{ .Values.securityContext.runAsGroup }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            fsGroup: {{ .Values.podSecurityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+            runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
+            seccompProfile:
+              type: RuntimeDefault
           restartPolicy: Never
           volumes:
             - name: app-mirror-sync
@@ -51,12 +53,9 @@ spec:
                   memory: 15000Mi
               securityContext:
                 allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
-                runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
                 readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
-                seccompProfile:
-                  type: RuntimeDefault
                 capabilities:
-                  drop: {{ .Values.securityContext.capabilities.drop }}
+                  drop: ["ALL"]
               volumeMounts:
                 - name: app-mirror-sync
                   mountPath: /data
@@ -90,8 +89,10 @@ spec:
                   cpu: 2
                   memory: 5000Mi
               securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+                readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+                capabilities:
+                  drop: ["ALL"]
               volumeMounts:
                 - name: app-mirror-sync
                   mountPath: /data

--- a/charts/govuk-jobs/values.yaml
+++ b/charts/govuk-jobs/values.yaml
@@ -2,7 +2,6 @@
 # better alternatives.
 
 podSecurityContext:
-  fsGroup: 1001
   fsGroupChangePolicy: OnRootMismatch
   runAsNonRoot: true
   runAsUser: 1001
@@ -10,11 +9,7 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
-  capabilities:
-    drop: ["ALL"]
   readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1001
 
 resources:
   limits:


### PR DESCRIPTION
Description:
- Containers need additional fields to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883