### PR TITLE
Refactor db-backup cronjobs securityContext

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -45,16 +45,14 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
-  capabilities:
-    drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1001
-  seccompProfile:
-    type: RuntimeDefault
+  capabilities:
+    drop: ["ALL"]
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Description:
- Some of the fields can be moved into `podSecurityContext` so that they apply to all containers instead of setting it multiple times in the `container` field `securityContext`
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883