### PR TITLE
Enforce govuk-exporter to be compliant when PSS is set to restricted

### DIFF
--- a/charts/govuk-exporter/templates/deployment.yaml
+++ b/charts/govuk-exporter/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: app
           image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/govuk-exporter:latest 
@@ -31,6 +33,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: metrics
               containerPort: 9090

--- a/charts/govuk-exporter/values.yaml
+++ b/charts/govuk-exporter/values.yaml
@@ -7,7 +7,6 @@ name: govuk-exporter
 replicaCount: 1
 
 securityContext:
-  fsGroup: 1001
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001


### PR DESCRIPTION
Description:
- Enforce `govuk-exporter` to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883