### PR TITLE
Enforce govuk-sli-exporter to be compliant when PSS is set to restricted

### DIFF
--- a/charts/govuk-sli-collector/values.yaml
+++ b/charts/govuk-sli-collector/values.yaml
@@ -18,14 +18,14 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
-  capabilities:
-    drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1001
+  capabilities:
+    drop: ["ALL"]
 
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.


### PR DESCRIPTION
Description:
- Enforce `govuk-sli-exporter` to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883