### PR TITLE
Enforce renovate to be compliant when PSS is restricted

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -31,9 +31,14 @@ spec:
                   value: '{{ "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}" }}'
               securityContext:
                 readOnlyRootFilesystem: true
-                runAsUser: 1000
-                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                runAsUser: 1001
+                runAsGroup: 1001
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop: ["ALL"]
               volumeMounts:
                 - name: config
                   mountPath: /opt/renovate/


### PR DESCRIPTION
Description:
- Run as UID > 1000 to avoid conflicts with host's user table. See [here](https://kubesec.io/basics/containers-securitycontext-runasuser/)
- Enforce `renote` to be compliant when PSS is said to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883