### PR TITLE
Enforce search-index-env-sync

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -119,14 +119,14 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1001
   runAsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
-  capabilities:
-    drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1001
+  capabilities:
+    drop: ["ALL"]
 
 resources:
   limits:


### PR DESCRIPTION
Description:
- Enforce `search-index-env-sync` to be compliant when PSS is saod to be [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883