### PR TITLE
Enforce router to be compliant when PSS is set to restricted

### DIFF
--- a/charts/router-mongo/values.yaml
+++ b/charts/router-mongo/values.yaml
@@ -16,14 +16,14 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: *uid
   runAsGroup: *uid
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
-  capabilities:
-    drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: *uid
+  capabilities:
+    drop: ["ALL"]
 
 minReadySeconds: 60
 replicas: 3


### PR DESCRIPTION
Description:
- UID > 1000 see [here](https://kubesec.io/basics/containers-securitycontext-runasuser/)
- Enforces this container to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Tested on integration and `StatefulSet` deployed successfully
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883