### PR TITLE
Add additional securityContext details to Licensify

### DIFF
--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- include "licensify.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: {{ .Values.securityContext.runAsGroup }}
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-        runAsUser: 1000
-        runAsGroup: 1000
+        {{- toYaml $.Values.podSecurityContext | nindent 12 }}
       containers:
         - name: main
           command:

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -20,24 +20,21 @@ spec:
         {{- include "licensify.labels" $ | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: {{ $.Values.securityContext.runAsGroup }}
-        runAsNonRoot: {{ $.Values.securityContext.runAsNonRoot }}
-        runAsUser: {{ $.Values.securityContext.runAsUser }}
-        runAsGroup: {{ $.Values.securityContext.runAsGroup }}
+        {{- toYaml $.Values.podSecurityContext | nindent 12 }}
       volumes:
         - name: licensify-config
           secret:
             secretName: licensify-config
+        - name: app-tmp
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
         - name: logging-config
           configMap:
             name: licensify-logging-config
-        - name: app-tmp
-          emptyDir: {}
         - name: nginx-conf
           configMap:
             name: {{ .name }}-nginx-conf
-        - name: nginx-tmp
-          emptyDir: {}
       containers:
         - name: main
           securityContext:
@@ -123,8 +120,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            {{- toYaml $.Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: nginx-conf
               mountPath: /etc/nginx/nginx.conf

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -2,11 +2,19 @@
 
 arch: amd64
 
-securityContext:
-  runAsNonRoot: true
-  allowPrivilegeEscalation: false
+podSecurityContext:
+  fsGroup: 1001
   runAsUser: 1001
   runAsGroup: 1001
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
 
 clamav:
   name: clamav


### PR DESCRIPTION
Description:
- Adds additional securityContext details so that `licensify` can be compliant when PSSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Tested on integration by going through `[https://www.integration.publishing.service.gov.uk/apply-for-a-licence`](https://www.integration.publishing.service.gov.uk/apply-for-a-licence%60) and using `kubectl -n licensify port-forward svc/licensify-feed 9400:80` and accessing the submitted report at `http://localhost:9400/licence-management/feed/submittedApplicationsReport` to verify that it was uploaded
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883