### PR TITLE
Add internal ALB to production search-api-v2

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2524,6 +2524,18 @@ govukApplications:
   - name: search-api-v2
     helmValues:
       dbMigrationEnabled: false
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-defaults]
+          alb.ingress.kubernetes.io/scheme: "internal"
+          alb.ingress.kubernetes.io/group.order: "172"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "search-api.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: search-api.{{ .Values.k8sExternalDomainSuffix }}
       replicaCount: 6
       uploadAssets:
         enabled: false


### PR DESCRIPTION
Adding to production now. Staging and integration were done in https://github.com/alphagov/govuk-helm-charts/pull/2705

This is a new load balancer, because it behaves differently from the backend apps (this one is internal to the VPC), and will require different WAF settings because it will have a different traffic profile.

It allows traffic to be routed to search-api-v2 from applications outside the EKS cluster such as an API gateway.

We're doing this to allow publicly routed search API requests, while maintaining more control over what happens than usual. We don't want to adopt the previous approach of allowing open access to the API via a www.gov.uk route (eg www.gov.uk/api/search-v2.json) because of the cost implications. Because of that, this load balancer allows internal traffic only.