### PR TITLE
Set Licensify PSS to enforce baseline

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -61,5 +61,8 @@ spec:
     managedNamespaceMetadata:
       labels:
         argocd.argoproj.io/managed-by: {{ $.Values.argoNamespace | default $.Release.Namespace }}
+        pod-security.kubernetes.io/audit: "restricted"
+        pod-security.kubernetes.io/enforce: "baseline"
+        pod-security.kubernetes.io/warn: "restricted"
 ---
 {{ end }}


### PR DESCRIPTION
Description:
- Currently PSS is enforced through [annotations on namespaces](https://kubernetes.io/docs/tutorials/security/ns-level-pss/). At present only the `apps` namespace has PSS applied from [argo.tf](https://github.com/alphagov/govuk-infrastructure/blob/763974632b01930cfbf06d01bc22ae691f5fa944/terraform/deployments/cluster-services/argo.tf) in `govuk-infrastructure`
- `licensify` lives in the `licensify` not the `apps` namespace so the PSS labels aren't applied to it from `argo.tf`
- Both applications in the `app` and `licensify` namespace use the [govuk-application](https://github.com/alphagov/govuk-helm-charts/blob/fd843878789ddf6150053c1e3540b8205fa42b42/charts/app-config/templates/govuk-application.yaml) Helm template to generate ArgoCD applications
- Now the `apps` namespace is created through Terraform (see `argo.tf`) but the `licensify` namespace is created through the `CreateNamespace=true` option in `govuk-application`. Adding the metadata here will mean that the `licensify` namespace will have PSS set to baseline and warn and audit on restricted ensuring parity with the `app` namespace.
- See [Argo docs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#namespace-metadata) for more information
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883