### PR TITLE
Update Slack channel for Signon alerts

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -90,7 +90,7 @@ spec:
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
   - name: 'slack-signon-token-expiry'
     slackConfigs:
-    - channel: '#govuk-publishing-platform'
+    - channel: '#govuk-publishing-platform-system-alerts'
       sendResolved: true
       iconURL: https://avatars3.githubusercontent.com/u/3380462
       title: |-


### PR DESCRIPTION
The GOV.UK Publishing Platform team have set up a dedicated Slack channel for alerting.

Therefore updating the Signon token expiration alert to use that channel.

[Trello card](https://trello.com/c/NKbo84JK)