### PR TITLE
Add smart survey env vars for chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1415,6 +1415,16 @@ govukApplications:
             secretKeyRef:
               name: signon-app-chat
               key: oauth_secret
+        - name: SMART_SURVEY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-smart-survey
+              key: api_key
+        - name: SMART_SURVEY_API_KEY_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-smart-survey
+              key: api_key_secret
         - name: REDIS_URL
           value: redis://chat-redis.eks.integration.govuk-internal.digital
         - name: BIGQUERY_PROJECT

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1432,6 +1432,16 @@ govukApplications:
             secretKeyRef:
               name: signon-app-chat
               key: oauth_secret
+        - name: SMART_SURVEY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-smart-survey
+              key: api_key
+        - name: SMART_SURVEY_API_KEY_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-smart-survey
+              key: api_key_secret
         - name: WEB_CONCURRENCY
           value: '4'
         - name: REDIS_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1415,6 +1415,16 @@ govukApplications:
             secretKeyRef:
               name: signon-app-chat
               key: oauth_secret
+        - name: SMART_SURVEY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-smart-survey
+              key: api_key
+        - name: SMART_SURVEY_API_KEY_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-smart-survey
+              key: api_key_secret
         - name: REDIS_URL
           value: redis://chat-redis.eks.staging.govuk-internal.digital
         - name: BIGQUERY_PROJECT


### PR DESCRIPTION
## Description

We're integrating with the SmartSurvey API to retrieve information from our survey for Chat. This commit adds the necessary environment variables for auth and retrieval of the survey data.

## Trello card

https://trello.com/c/IuRaZivo/2005-use-the-smartsurvey-api-to-export-to-bigquery-the-number-of-responses-weve-got