### PR TITLE
Add missing options for external secret

### DIFF
--- a/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-external-secret.yaml
+++ b/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-external-secret.yaml
@@ -13,3 +13,6 @@ spec:
   dataFrom:
     - extract:
         key: govuk/fastly/prometheus-exporter
+        decodingStrategy: None
+        conversionStrategy: Default
+        metadataPolicy: None


### PR DESCRIPTION
These options are being added externally and cause Argo to be in sync loop as it tries to remove them.