### PR TITLE
Add env vars for chat memcache servers

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1382,6 +1382,8 @@ govukApplications:
           value: 346cdea0-9d4e-4de1-a528-cded6713bc61
         - name: GOVUK_NOTIFY_REPLY_TO_ID
           value: f8669f4d-4923-4006-8b44-cbda1f3bc166
+        - name: MEMCACHE_SERVERS
+          value: chat-memcached.integration.govuk-internal.digital
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1399,6 +1399,8 @@ govukApplications:
           value: 7eb37ba5-f331-43e2-95fa-28d7405eb90b
         - name: GOVUK_NOTIFY_REPLY_TO_ID
           value: c30aaa89-4fac-4889-b1a0-6d4c74fbcd93
+        - name: MEMCACHE_SERVERS
+          value: chat-memcached.production.govuk-internal.digital
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1382,6 +1382,8 @@ govukApplications:
           value: 70883fba-853d-487a-9580-3ea1931ecb49
         - name: GOVUK_NOTIFY_REPLY_TO_ID
           value: d980e316-2338-4a8f-a318-12c827db6f5c
+        - name: MEMCACHE_SERVERS
+          value: chat-memcached.staging.govuk-internal.digital
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This adds the servers that were added in [1] to make use of config added to chat in [2].

[1]: https://github.com/alphagov/govuk-infrastructure/pull/1479
[2]: https://github.com/alphagov/govuk-chat/pull/834