### PR TITLE
Schedule pre-midnight syncs one day earlier

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -332,7 +332,7 @@ cronjobs:
     content-store-postgres:
       <<: *s5cmd-ram-workaround
       db: content_store_production
-      schedule: "06 22 * * 1-5"
+      schedule: "06 22 * * 0-4"
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
@@ -342,7 +342,7 @@ cronjobs:
     draft-content-store-postgres:
       <<: *s5cmd-ram-workaround
       db: draft_content_store_production
-      schedule: "16 22 * * 1-5"
+      schedule: "16 22 * * 0-4"
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups
@@ -603,7 +603,7 @@ cronjobs:
     content-store-postgres:
       <<: *s5cmd-ram-workaround
       db: content_store_production
-      schedule: "06 23 * * 1"
+      schedule: "06 23 * * 0"
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
@@ -613,7 +613,7 @@ cronjobs:
     draft-content-store-postgres:
       <<: *s5cmd-ram-workaround
       db: draft_content_store_production
-      schedule: "16 23 * * 1"
+      schedule: "16 23 * * 0"
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups


### PR DESCRIPTION
In production syncs happen every day. In staging, they happen Monday - Friday, and in integration they only happen on Monday.

Previously, the jobs that are scheduled to run before midnight in integration and staging would run 24 hours later than one would expect.

Before we reduced the frequency of integration refreshes this was hardly noticeable - you would not get a refresh of content store on Monday morning, so it would still have content from the weekend, and you would get an extra refresh on Friday night.

With the new, lower frequency of integration refreshes it's more problematic. People expect content to refresh on Monday morning, so refreshing content store at 11pm on Monday is surprising.

This moves the content store refreshes one day earlier, so they'll happen late on Sunday night, just before the other datbases are sync'd, instead of late on Monday night.