### PR TITLE
Use AWS hostnames for chat memcache servers

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1383,7 +1383,7 @@ govukApplications:
         - name: GOVUK_NOTIFY_REPLY_TO_ID
           value: f8669f4d-4923-4006-8b44-cbda1f3bc166
         - name: MEMCACHE_SERVERS
-          value: chat-memcached.integration.govuk-internal.digital
+          value: "chat-memcached-h4kg8u.serverless.euw1.cache.amazonaws.com:11211"
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1400,7 +1400,7 @@ govukApplications:
         - name: GOVUK_NOTIFY_REPLY_TO_ID
           value: c30aaa89-4fac-4889-b1a0-6d4c74fbcd93
         - name: MEMCACHE_SERVERS
-          value: chat-memcached.production.govuk-internal.digital
+          value: "chat-memcached-ufglhk.serverless.euw1.cache.amazonaws.com:11211"
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1384,7 +1384,7 @@ govukApplications:
         - name: GOVUK_NOTIFY_REPLY_TO_ID
           value: d980e316-2338-4a8f-a318-12c827db6f5c
         - name: MEMCACHE_SERVERS
-          value: chat-memcached.staging.govuk-internal.digital
+          value: "chat-memcached-tx6sx5.serverless.euw1.cache.amazonaws.com:11211"
         - name: OPENAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Trello: https://trello.com/c/sZ9PIjmv/2060-set-up-dedicated-memcache-instances-for-chat

These AWS memcache servers are accessed via TLS, if we use the govuk-internal.digital hostnames then we can't verify the hostname as part of TLS verification. Switching to these AWS ones allows it.

While these all use the default port and it isn't necessary to include it, I thought I would anyway to verbatim copy the endpoint URL that AWS provide in their console.