### PR TITLE
Enable GraphQL feature flag for Collections in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -307,6 +307,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_FEATURE_FLAG
+          value: true
 
   - name: draft-collections
     repoName: collections


### PR DESCRIPTION
This will be used to build a proof of concept for GraphQL on GOV.UK.

The feature flag is added in https://github.com/alphagov/collections/pull/3825.

[Trello card](https://trello.com/c/jDF1nSQ0)