### PR TITLE
Define secret for Publishing API to access BigQuery

### DIFF
--- a/charts/external-secrets/templates/publishing-api/bigquery.yaml
+++ b/charts/external-secrets/templates/publishing-api/bigquery.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: publishing-api-bigquery
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for a GCP service account to communicate with BigQuery. Field names are "project-id" for the project ID to use, "client-email" for the service account's email, and "client-secret" for the private key used to access the endpoint
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: publishing-api-bigquery
+  dataFrom:
+    - extract:
+        key: govuk/publishing-api/bigquery


### PR DESCRIPTION
This defines a secret to be used in Publishing API to allow the team to access BigQuery for Analytics data (See https://github.com/alphagov/publishing-api/pull/2957)

The secrets are set up in all three AWS environments