### PR TITLE
Disable automatic production deploys for GOV.UK Chat

### DIFF
--- a/charts/app-config/image-tags/production/govuk-chat
+++ b/charts/app-config/image-tags/production/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v670
 promote_deployment: false
-automatic_deploys_enabled: true
+automatic_deploys_enabled: false


### PR DESCRIPTION
This is a cautionary measure that we want to take on Monday when there is going to be a filmed demo of chat for TV and live demo's for journalists.

This shouldn't be merged before Monday morning (4th November)