### PR TITLE
Use BigQuery secrets in Publishing API

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2073,6 +2073,21 @@ govukApplications:
               key: DATABASE_URL
         - name: ENQUEUE_PUBLISH_INTENTS
           value: "true"
+        - name: BIGQUERY_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: project-id
+        - name: BIGQUERY_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: client-email
+        - name: BIGQUERY_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: client-secret
 
   - name: release
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2107,6 +2107,21 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-postgres
               key: DATABASE_URL
+        - name: BIGQUERY_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: project-id
+        - name: BIGQUERY_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: client-email
+        - name: BIGQUERY_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: client-secret
 
   - name: release
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2088,6 +2088,21 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-postgres
               key: DATABASE_URL
+        - name: BIGQUERY_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: project-id
+        - name: BIGQUERY_CLIENT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: client-email
+        - name: BIGQUERY_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-bigquery
+              key: client-secret
 
   - name: release
     helmValues:


### PR DESCRIPTION
Now we have the secrets defined (see https://github.com/alphagov/govuk-helm-charts/pull/2734), we can use them and set the relevant environment variables in Publishing API.