### PR TITLE
Revert "Add Support API bearer token for Specialist Publisher"

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3042,11 +3042,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-specialist-publisher-publishing-api
               key: bearer_token
-        - name: SUPPORT_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-specialist-publisher-support-api
-              key: bearer_token
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#2737

Seeing `Warning  Failed     3s (x6 over 34s)  kubelet            Error: secret "signon-token-specialist-publisher-support-api" not found` errors.