### PR TITLE
Finder Frontend: Remove new UI feature flag

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1145,8 +1145,6 @@ govukApplications:
               key: bearer_token
         - name: DISABLE_LTR_ON_PATHS
           value: /find-licences
-        - name: ENABLE_NEW_ALL_CONTENT_FINDER_UI
-          value: "true"
 
   - name: draft-finder-frontend
     repoName: finder-frontend

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1132,8 +1132,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: ENABLE_NEW_ALL_CONTENT_FINDER_UI
-          value: "true"
 
   - name: frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1135,8 +1135,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: ENABLE_NEW_ALL_CONTENT_FINDER_UI
-          value: "true"
 
   - name: draft-finder-frontend
     repoName: finder-frontend


### PR DESCRIPTION
This removes the `ENABLE_NEW_ALL_CONTENT_FINDER_UI` feature flag for Finder Frontend, now that this feature has proven itself and will remain permanently.