### PR TITLE
Revert "Disable automatic production deploys for GOV.UK Chat"

### DIFF
--- a/charts/app-config/image-tags/production/govuk-chat
+++ b/charts/app-config/image-tags/production/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v683
 promote_deployment: true
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true


### PR DESCRIPTION
This reverts commit 4a420581287dfadbfaf6a89019a33ef5e2c73a92.

This setting did not achieve the goal I had of stopping production deploys as they have still occurred, not sure if this actually does something as looking at [1] I think the values on the production tags have no effect and it's the staging one I need to change.

[1]: https://github.com/alphagov/govuk-helm-charts/blob/924f302a10ea8f951ed47c897827edee0c21f5d9/charts/argo-services/scripts/check-for-promotion.sh#L8