### PR TITLE
Add env var for GOV.UK Chat Slack integration

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1383,6 +1383,11 @@ govukApplications:
           schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
+        - name: AI_SLACK_CHANNEL_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-slack
+              key: AI_SLACK_CHANNEL_WEBHOOK_URL
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/external-secrets/templates/govuk-chat/slack.yaml
+++ b/charts/external-secrets/templates/govuk-chat/slack.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: govuk-chat-slack
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for integrating with Slack
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: govuk-chat-slack
+  dataFrom:
+    - extract:
+        key: govuk/govuk-chat/slack


### PR DESCRIPTION
Extracts a secret from Secrets Manager and sets it as an env var in the
GOV.UK Chat app.

We only need this in production as we don't want to trigger Slack
notifications from other environments.