### PR TITLE
Increase webpod to 16 and reduce worker to 4 for chat.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1322,7 +1322,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      replicaCount: 8
+      replicaCount: 16
       appResources:
         limits:
           cpu: 6
@@ -1343,7 +1343,7 @@ govukApplications:
                 value: "25"
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
-        replicaCount: 24
+        replicaCount: 4
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
We want to increase the number of webpod to absorb the onslaught of new users signing up to the service.
Worker are not involved in the signup process and were increased previously by mistake.