### PR TITLE
Increase web pod to 16 in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1325,7 +1325,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      replicaCount: 6
+      replicaCount: 16
       dbMigrationEnabled: true
       workers:
         enabled: true


### PR DESCRIPTION
We temporarily match the number of web pods in staging to those in production for the purpose of load testing.