### PR TITLE
Correct scaling up chat for launch

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1322,7 +1322,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      replicaCount: 8
+      replicaCount: 16
       appResources:
         limits:
           cpu: 6
@@ -1343,7 +1343,7 @@ govukApplications:
                 value: "25"
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
-        replicaCount: 24
+        replicaCount: 4
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
This resets the value of 24 worker processes back to 4, since scaling this up would have not the desired effect of making the system more resilient for sign-ups as the worker processes are not involved in them.

It does double the number of web pods so that there are more of these available as this will allow handling more web requests and thus increase ability to handle signups.