### PR TITLE
Add Support API bearer token for Specialist Publisher (other envs)

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3040,6 +3040,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-specialist-publisher-publishing-api
               key: bearer_token
+        - name: SUPPORT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-specialist-publisher-support-api
+              key: bearer_token
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2984,6 +2984,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-specialist-publisher-publishing-api
               key: bearer_token
+        - name: SUPPORT_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-specialist-publisher-support-api
+              key: bearer_token
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Attempt number two for #2737. We've now figured out what went wrong (need to run `signon-sync-token-secrets-to-k8s` cronjob as opposed to `signon-sync-app-secrets-to-k8s`. Already tested and works on Integration (#2742).

Trello: https://trello.com/c/YdGWsy0I/3035-integrate-the-specialist-finder-edit-forms-with-support-api