### PR TITLE
Remove non-existent ingress-class sparse checkout from Helm chart release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
           show-progress: false
           sparse-checkout: |
             charts/argo-bootstrap
-            charts/ingress-class
             charts/cluster-secret-store
             charts/cluster-secrets
 


### PR DESCRIPTION
Description:
- Nothing matches `charts/ingress-class` in our `govuk-helm-charts` repository so this line should be removed