### PR TITLE
Finder Frontend: Add initial autocomplete API URL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1147,6 +1147,8 @@ govukApplications:
               key: bearer_token
         - name: DISABLE_LTR_ON_PATHS
           value: /find-licences
+        - name: SEARCH_AUTOCOMPLETE_API_URL
+          value: https://www.gov.uk/api/search.json?suggest=autocomplete
 
   - name: draft-finder-frontend
     repoName: finder-frontend

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1134,6 +1134,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: SEARCH_AUTOCOMPLETE_API_URL
+          value: https://www.gov.uk/api/search.json?suggest=autocomplete
 
   - name: frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1137,6 +1137,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: SEARCH_AUTOCOMPLETE_API_URL
+          value: https://www.gov.uk/api/search.json?suggest=autocomplete
 
   - name: draft-finder-frontend
     repoName: finder-frontend


### PR DESCRIPTION
This will allow us to test the new autocomplete component. It's not the final URL yet, as the real API isn't available yet, so we're using the legacy v1 API's autocomplete functionality (the final URL will be added before the AB test goes live).