### PR TITLE
Double instant access places for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1472,7 +1472,7 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "25"
+          value: "50"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "100"
       nginxConfigMap:


### PR DESCRIPTION
Please confirm this change with Josh before merging

This will double the allocation of places made in the bi-hourly intervals through the day on GOV.UK Chat.

This has been done to reduce risk of a user being put on a waiting list as the current levels of traffic are very manageable and we believe we're unnecessarily delaying users.