### PR TITLE
Reduce number of pods for govuk-chat to 8

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1328,7 +1328,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      replicaCount: 16
+      replicaCount: 8
       appResources:
         limits:
           cpu: 6


### PR DESCRIPTION
This reduces the number of pods from 16 to 8. The reason for this is that we're heavily over provisioned for the amount of resources we are using currently. However keeping 8 pods should still allow us to scale requests rapidly, should there be any kind of viral spike (from earlier estimates that may get us in the  1000 r/s region)