### PR TITLE
Redirect chat.eks domain to publishing.service domain in staging and …

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1452,6 +1452,9 @@ govukApplications:
             if ($http_host = 'chat.integration.publishing.service.gov.uk' ) {
               return 301 https://www.integration.publishing.service.gov.uk$request_uri;
             }
+            if ($http_host = 'chat.eks.integration.govuk.digital' ) {
+              return 301 https://www.integration.publishing.service.gov.uk$request_uri;
+            }
             proxy_pass http://govuk-chat;
           }
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1464,6 +1464,9 @@ govukApplications:
             if ($http_host = 'chat.staging.publishing.service.gov.uk' ) {
               return 301 https://www.staging.publishing.service.gov.uk$request_uri;
             }
+            if ($http_host = 'chat.eks.staging.govuk.digital' ) {
+              return 301 https://www.staging.publishing.service.gov.uk$request_uri;
+            }
             proxy_pass http://govuk-chat;
           }
 


### PR DESCRIPTION
…integration

We don't want people to be able to access the chat client directly through the load balancer.