### PR TITLE
Redirect chat.eks domain to www.gov.uk in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1481,6 +1481,9 @@ govukApplications:
             if ($http_host = 'chat.publishing.service.gov.uk' ) {
               return 301 https://www.gov.uk$request_uri;
             }
+            if ($http_host = 'chat.eks.production.govuk.digital' ) {
+              return 301 https://www.gov.uk$request_uri;
+            }
             proxy_pass http://govuk-chat;
           }
 


### PR DESCRIPTION
We don't want people to be able to access the chat client directly through the load balancer.