### PR TITLE
Switch off Collections's GRAPHQL_FEATURE_FLAG

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -307,8 +307,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
-        - name: GRAPHQL_FEATURE_FLAG
-          value: "true"
 
   - name: draft-collections
     repoName: collections


### PR DESCRIPTION
This feature flag tells Collections whether to request (a very limited subset of its) data from Publishing API's GraphQL endpoint rather than from Content Store.

There is an issue on integration right now that's causing errors on the frontend when Collections makes the request to Publishing API for the World Index page. Since this error in turn prevents the Collections app from being deployed and since I haven't managed to debug the problem very quickly, I'm proposing just disabling the feature until we can diagnose it.