### PR TITLE
Finder Frontend: Remove autocomplete URL env config

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1147,8 +1147,6 @@ govukApplications:
               key: bearer_token
         - name: DISABLE_LTR_ON_PATHS
           value: /find-licences
-        - name: SEARCH_AUTOCOMPLETE_API_URL
-          value: https://www.gov.uk/api/search.json?suggest=autocomplete
 
   - name: draft-finder-frontend
     repoName: finder-frontend

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1134,8 +1134,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: SEARCH_AUTOCOMPLETE_API_URL
-          value: https://www.gov.uk/api/search.json?suggest=autocomplete
 
   - name: frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1137,8 +1137,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: SEARCH_AUTOCOMPLETE_API_URL
-          value: https://www.gov.uk/api/search.json?suggest=autocomplete
 
   - name: draft-finder-frontend
     repoName: finder-frontend


### PR DESCRIPTION
This will now be a route directly on Finder Frontend itself rather than an external API, so it no longer needs configuring.