### PR TITLE
Mount `emptyDir` volume into the `script` template of the `parse-failures` workflow

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -127,10 +127,16 @@ spec:
         command:
           - /bin/bash
         resources: {}
+        volumeMounts:
+          - name: out
+            mountPath: /tmp
         source: >
           #!/usr/bin/env bash
 
           echo {{"{{workflow.failures}}"}} | jq -r 'group_by(.templateName) | map({templateName: .[0].templateName, errorMessages: [.[].message | select(length > 0)] | unique}) | map("- \(.templateName): " + (["\(.errorMessages[])"] | join(",")) ) | .[]' > /tmp/message.txt
+      volumes:
+        - name: out
+          emptyDir: {}
     - name: exit-handler
       steps:
         - - name: parse-failures


### PR DESCRIPTION
Description:
- In order to `runAsNonRoot` we can't have containers writing to the base layer. So mount an `emptyDir` volume to write `message.txt` to - see guidance [here](https://argo-workflows.readthedocs.io/en/latest/empty-dir/)