### PR TITLE
Add Publishing API token for Collections app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -307,6 +307,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-collections-publishing-api
+              key: bearer_token
 
   - name: draft-collections
     repoName: collections

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -303,6 +303,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-collections-publishing-api
+              key: bearer_token
 
   - name: draft-collections
     repoName: collections

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -309,6 +309,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-collections-publishing-api
+              key: bearer_token
 
   - name: draft-collections
     repoName: collections


### PR DESCRIPTION
Collections can now serve some responses using GraphQL queries. These are made directly to Publishing API (instead of Content Store).

Therefore we need to give Collections the ability to make queries to Publishing API.

The tokens have already been set up in Signon and the task run to synchronise them with the secret manager.

[Trello card](https://trello.com/c/HWsouIXh)