### PR TITLE
Switch on feature flag for Collections to use GraphQL in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -312,6 +312,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-publishing-api
               key: bearer_token
+        - name: GRAPHQL_FEATURE_FLAG
+          value: "true"
 
   - name: draft-collections
     repoName: collections


### PR DESCRIPTION
This was reverted in https://github.com/alphagov/govuk-helm-charts/pull/2766 as the bearer token for Publishing API had not been added as an environment variable.

Now that has been done in https://github.com/alphagov/govuk-helm-charts/pull/2776, we can switch the feature flag back on.

I've opened a Rails console in integration and checked that Collections can now access Publishing API, which includes a 200 response code:
```ruby
Services.publishing_api.get_content("f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a")
=> #<GdsApi::Response:0x0000ffff7b5d00b8 @http_response=<RestClient::Response 200 "{\"auth_bypa...">, @web_urls_relative_to=nil>
```

[Trello card](https://trello.com/c/HWsouIXh)