### PR TITLE
Add to integration support for Frontend to render the static error pages

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1179,6 +1179,7 @@ govukApplications:
   - name: frontend
     helmValues:
       arch: arm64
+      uploadFrontendErrorPagesEnabled: true
       ingress:
         enabled: true
         annotations:

--- a/charts/generic-govuk-app/templates/frontend-error-page-upload-job.yaml
+++ b/charts/generic-govuk-app/templates/frontend-error-page-upload-job.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.uploadFrontendErrorPagesEnabled }}
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-upload-error-pages
+  labels:
+    {{- include "generic-govuk-app.labels" . | nindent 4 }}
+    app: {{ $fullName }}-upload-error-pages
+    app.kubernetes.io/name: {{ $fullName }}-upload-error-pages
+    app.kubernetes.io/component: upload-error-pages
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    kubernetes.io/description: >
+      Fetch "static" error pages from the Frontend app and upload them to S3.
+      ArgoCD runs this job after each deployment of the Frontend app.
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 1
+  template:
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default "true" }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: upload-frontend-error-pages
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/toolbox:latest
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default "false" }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default "true" }}
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: GOVUK_ENVIRONMENT
+              value: {{ .Values.govukEnvironment }}
+            - name: SERVICE
+              value: {{ $fullName }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              {{- .Files.Get "upload-frontend-error-pages.sh" | nindent 14 }}
+          {{- with .Values.jobResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      restartPolicy: Never
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+{{- end }}

--- a/charts/generic-govuk-app/upload-frontend-error-pages.sh
+++ b/charts/generic-govuk-app/upload-frontend-error-pages.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eux
+
+ERROR_PAGES='400 401 403 404 405 406 410 422 429 500 502 503 504'
+ERROR_PAGES_COMMA_SEPARATED=${ERROR_PAGES// /,}
+OUTPUT_PATH=/tmp/output
+
+# While testing, first check if deployed frontend branch supports this,
+# and exit with a 0 if not, so that we only try to get the static
+# files if the file exists
+
+if ! curl --head -f "${SERVICE}/static-error-pages/400.html"; then
+  echo "$SERVICE does not support static error pages, skipping."
+  exit 0
+fi
+
+mkdir -p "${OUTPUT_PATH}"
+cd "${OUTPUT_PATH}"
+curl --fail-early -fo '#1.html' "${SERVICE}/static-error-pages/{${ERROR_PAGES_COMMA_SEPARATED}}.html"
+eval ls "{$ERROR_PAGES_COMMA_SEPARATED}.html" || (echo Failed to download one or more files.; exit 1)
+aws s3 sync . "s3://govuk-app-assets-${GOVUK_ENVIRONMENT}/error_pages/"


### PR DESCRIPTION
We want to test that frontend can render static error pages in the same way that Static does (so that we can remove that from Static on the path to retiring it entirely) - this adds a similar job to the equivalent one for static. Both will run in integration, but static deployments are fairly rare so that shouldn't cause any problems with testing.

- Add in some temporary guard clauses so that this won't cause versions of frontend without the error pages code to fail.

(works with https://github.com/alphagov/frontend/pull/4382, but guard clause should mean it doesn't fail with other branches of Frontend)