### PR TITLE
Pin Prometheus image to `v2.55.1`

### DIFF
--- a/.github/actions/promtool/action.yml
+++ b/.github/actions/promtool/action.yml
@@ -7,7 +7,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://prom/prometheus
+  image: docker://prom/prometheus:v2.55.1
   entrypoint: /bin/sh
   args:
     - -c


### PR DESCRIPTION
- Currently `actions/promtool/action.yml` is failing [here](https://github.com/alphagov/govuk-helm-charts/actions/runs/11891225376/job/33131536576?pr=2777) for about a week on [redis_tests.yaml](https://github.com/alphagov/govuk-helm-charts/blob/e60c9178f0793208d1edeb26675e10db2b56ca6c/charts/monitoring-config/rules/redis_tests.yaml)
- This is because the [promtool action](https://github.com/alphagov/govuk-helm-charts/blob/e60c9178f0793208d1edeb26675e10db2b56ca6c/.github/actions/promtool/action.yml#L10) is pulling in the latest version of Prometheus which is on [3.0.0](https://github.com/prometheus/prometheus/releases/tag/v3.0.0-rc.1)
- Temporary fix by pinning to the last known working version until we upgrade the syntax to 3.0.0