### PR TITLE
Add `fsGroup` and remove `rootOnlyFileSystem` from renovate

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -10,6 +10,13 @@ spec:
       suspend: false
       template:
         spec:
+          securityContext:
+            runAsUser: 12021
+            runAsGroup: 12021
+            fsGroup: 12021
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: renovate
               image: renovate/renovate:39.20.1
@@ -30,11 +37,7 @@ spec:
                 - name: RENOVATE_PR_BODY_TEMPLATE
                   value: '{{ "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}" }}'
               securityContext:
-                readOnlyRootFilesystem: true
                 allowPrivilegeEscalation: false
-                runAsUser: 1001
-                runAsGroup: 1001
-                runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
                 capabilities:


### PR DESCRIPTION
Description:
- renovate cronjob gives the following error:
```
[09:00:02.022] INFO (7): Initializing tools all...
chown: changing ownership of '/tmp/containerbase/cache/.mix': Operation not permitted
[09:00:02.056] FATAL (7): Command failed with exit code 1: /usr/local/containerbase/bin/init-tool.sh elixir
[09:00:02.066] FATAL (7): Initialize tools all failed in 43ms.
```
- The `USER` command for the renovate Dockerfile is set to `12021` [here](https://github.com/renovatebot/renovate/blob/1f719819c101d55b63ea94401127472943b6fec7/tools/docker/Dockerfile#L114) and since the process is running as `12021` and `fsGroup: 12021` this will allow `chown` to succeed
- Another error that came up was the container trying to write to `/opt` and failing because `readOnlyRootFileSystem: true`. Removing this makes the initialization of tools successful
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883