### PR TITLE
Mount `emptyDir` volumes into `govuk-e2e-tests` workflow pod

### DIFF
--- a/charts/govuk-e2e-tests/templates/workflow.yaml
+++ b/charts/govuk-e2e-tests/templates/workflow.yaml
@@ -22,6 +22,11 @@ spec:
           duration: "15s"
           factor: 2
           maxDuration: "16m"
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: app-tmp
+          emptyDir: {}
       container:
         image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
         command:
@@ -35,6 +40,11 @@ spec:
           - --project=main
           - --grep-invert=@not-{{ .Values.govukEnvironment }}
           - "--grep={{ `{{ inputs.parameters.grep }}` }}"
+        volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          - name: app-tmp
+            mountPath: /app/tmp
         env:
           - name: YARN_CACHE_FOLDER
             value: /tmp/.cache/yarn


### PR DESCRIPTION
Description:
- Currently `govuk-e2e-tests` is writing to the root filesystem which precludes setting `rootOnlyFileSystem: true` in the `securityContext` for workflow pods
- Mounting these volumes into the container will allow us to set `rootOnlyFileSystem`
- See https://github.com/alphagov/govuk-helm-charts/blob/c8f57a5f1deba0ffb06a0182a21050d5486cf948/charts/govuk-e2e-tests/templates/cronjob.yaml
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883