### PR TITLE
Fix Renovate cronjob configuration

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                 - name: config
                   mountPath: /opt/renovate/
                 - name: tmp
-                  mountPath: /tmp
+                  mountPath: /tmp/renovate
           restartPolicy: Never
           volumes:
             - name: config


### PR DESCRIPTION
Description:
- In the Renovate [source code](https://github.com/renovatebot/renovate/blob/97ace64c0a249abfa7f78be9bed1bca21b5833bb/tools/docker/bin/renovate-entrypoint.sh#L8) the container base tools are installed if `tmp/containerbase` directory doesn't exist:
```
if [[ ! -d "/tmp/containerbase" ]]; then
  # initialize all prepared tools
  containerbase-cli init tool all
fi
```
- But since we are mounting a `volumeMount` at `tmp` this 'hides' the `/tmp/containerbase` directory leading the shell script to reinstall the tools
- These tools are already installed because the Dockerfile pulls in the containerBase [Dockerfile](https://github.com/containerbase/sidecar/blob/ba52e89906f590cf594bb948eb99f28a87b13f6f/Dockerfile#L11) which already has these tools installed
- Instead if we mount at `/tmp/renovate` this will allow the script to correctly detect `tmp/containerbase` exists and skip the installation of the tools