### PR TITLE
Set Yarn global folder for `govuk-e2e-tests`

### DIFF
--- a/charts/govuk-e2e-tests/templates/cronjob.yaml
+++ b/charts/govuk-e2e-tests/templates/cronjob.yaml
@@ -52,6 +52,7 @@ spec:
           - command:
             - yarn
             args:
+            - --global-folder=/tmp/global
             - playwright
             - test
             - --reporter=list

--- a/charts/govuk-e2e-tests/templates/workflow.yaml
+++ b/charts/govuk-e2e-tests/templates/workflow.yaml
@@ -32,6 +32,7 @@ spec:
         command:
           - yarn
         args:
+          - --global-folder=/tmp/global
           - playwright
           - test
           - --pass-with-no-tests


### PR DESCRIPTION
Description:
- `govuk-e2e-tests` cronjob and workflow are giving a non-blocking error:
```
warning Cannot find a suitable global folder. Tried these: "/usr/local, /app/.yarn".
```
- This is because `readOnlyRootFileSystem: true` is set and these directories aren't writable. See this [issue](https://github.com/yarnpkg/yarn/issues/8705). This is caused by not having set the global folder for global installations of packages from Yarn
- Though we don't install any Yarn packages as global (see https://github.com/alphagov/govuk-e2e-tests/blob/05fd974da059b40498f8d3f588d8b3af6e799651/Dockerfile#L24) if we explicitly set the global folder into a writable directory this will suppress the error.