### PR TITLE
Set Yarn global folder for `govuk-e2e-tests`

### DIFF
--- a/charts/govuk-e2e-tests/templates/cronjob.yaml
+++ b/charts/govuk-e2e-tests/templates/cronjob.yaml
@@ -52,7 +52,6 @@ spec:
           - command:
             - yarn
             args:
-            - --global-folder=/tmp/global
             - playwright
             - test
             - --reporter=list
@@ -77,6 +76,10 @@ spec:
               name: app-tmp
             env:
             - name: YARN_CACHE_FOLDER
+              value: /tmp/.cache/yarn
+            - name: YARN_GLOBAL_FOLDER
+              value: /tmp/.cache/yarn
+            - name: PREFIX
               value: /tmp/.cache/yarn
             - name: PUBLIC_DOMAIN
               value: www.{{ $.Values.externalDomainSuffix }}

--- a/charts/govuk-e2e-tests/templates/workflow.yaml
+++ b/charts/govuk-e2e-tests/templates/workflow.yaml
@@ -49,6 +49,10 @@ spec:
         env:
           - name: YARN_CACHE_FOLDER
             value: /tmp/.cache/yarn
+          - name: YARN_GLOBAL_FOLDER
+            value: /tmp/.cache/yarn
+          - name: PREFIX
+            value: /tmp/.cache/yarn
           - name: PUBLIC_DOMAIN
             value: www.{{ $.Values.externalDomainSuffix }}
           - name: PUBLISHING_DOMAIN


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/2786 didn't work
- See https://yarnpkg.com/configuration/yarnrc#globalFolder on adding `YARN_GLOBAL_FOLDER` which houses global node_modules
- The issue is caused by `yarn global bin` which is the location where Yarn installs symlinks to installed executables. The behaviour is controlled by the `PREFIX` variable here (see [this issue](https://github.com/yarnpkg/yarn/issues/1040)
- For the documentation on `yarn global` see [here](https://classic.yarnpkg.com/lang/en/docs/cli/global/)