### PR TITLE
Add env vars for loading routes from CS

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2297,6 +2297,19 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL_info-frontend
+          value: 'http://info-frontend'
+        - name: BACKEND_URL_whitehall-frontend
+          value: 'http://whitehall-frontend'
+        - name: BACKEND_URL_manuals-frontend
+          value: 'http://manuals-frontend'
+        - name: CSMUX_SAMPLE_RATE
+          value: '0.0'
+        - name: CONTENT_STORE_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              key: DATABASE_URL
+              name: content-store-postgres
   - name: draft-router
     repoName: router
     helmValues:
@@ -2346,6 +2359,19 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL_info-frontend
+          value: 'http://info-frontend'
+        - name: BACKEND_URL_whitehall-frontend
+          value: 'http://whitehall-frontend'
+        - name: BACKEND_URL_manuals-frontend
+          value: 'http://manuals-frontend'
+        - name: CSMUX_SAMPLE_RATE
+          value: '0.0'
+        - name: CONTENT_STORE_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: draft-content-store-postgres
+              key: DATABASE_URL
 
   - name: router-mongo
     chartPath: charts/router-mongo

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2376,6 +2376,19 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL_info-frontend
+          value: 'http://info-frontend'
+        - name: BACKEND_URL_whitehall-frontend
+          value: 'http://whitehall-frontend'
+        - name: BACKEND_URL_manuals-frontend
+          value: 'http://manuals-frontend'
+        - name: CSMUX_SAMPLE_RATE
+          value: '0.0'
+        - name: CONTENT_STORE_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              key: DATABASE_URL
+              name: content-store-postgres
 
   - name: draft-router
     repoName: router
@@ -2425,6 +2438,19 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL_info-frontend
+          value: 'http://info-frontend'
+        - name: BACKEND_URL_whitehall-frontend
+          value: 'http://whitehall-frontend'
+        - name: BACKEND_URL_manuals-frontend
+          value: 'http://manuals-frontend'
+        - name: CSMUX_SAMPLE_RATE
+          value: '0.0'
+        - name: CONTENT_STORE_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: draft-content-store-postgres
+              key: DATABASE_URL
 
   - name: router-mongo
     chartPath: charts/router-mongo

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2342,6 +2342,19 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL_info-frontend
+          value: 'http://info-frontend'
+        - name: BACKEND_URL_whitehall-frontend
+          value: 'http://whitehall-frontend'
+        - name: BACKEND_URL_manuals-frontend
+          value: 'http://manuals-frontend'
+        - name: CSMUX_SAMPLE_RATE
+          value: '0.0'
+        - name: CONTENT_STORE_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              key: DATABASE_URL
+              name: content-store-postgres
 
   - name: draft-router
     repoName: router
@@ -2391,6 +2404,19 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL_info-frontend
+          value: 'http://info-frontend'
+        - name: BACKEND_URL_whitehall-frontend
+          value: 'http://whitehall-frontend'
+        - name: BACKEND_URL_manuals-frontend
+          value: 'http://manuals-frontend'
+        - name: CSMUX_SAMPLE_RATE
+          value: '0.0'
+        - name: CONTENT_STORE_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: draft-content-store-postgres
+              key: DATABASE_URL
 
   - name: router-mongo
     chartPath: charts/router-mongo


### PR DESCRIPTION
This adds env vars to provide the content store db creds, other backends present in the CS and the sample rate for using CS for routing. This will have no effect until Router is updated and the CS_MUX_SAMPLE_RATE is set to non-zero.