### PR TITLE
Set `GIT_CONFIG_GLOBAL` to `/tmp` folder to prevent writing to root filesystem

### DIFF
--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -33,6 +33,8 @@ spec:
               secretKeyRef:
                 name: govuk-ci-github-creds
                 key: token
+          - name: GIT_CONFIG_GLOBAL
+            value: "/tmp/.gitconfig"
           - name: IMAGE_TAG
             value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: ENVIRONMENT


### PR DESCRIPTION
Description:
- Currently the `update-image-tag` workflow writes to `/root/.gitconfig` when `git config --global user.email` and `git config --global user.name` is called
- Setting `GIT_GLOBAL_CONFIG: tmp` will set the `.gitconfig` file in `/tmp` which is an `emptyDir` volume that is mounted into our container
- This will allow `readOnlyRootFileSystem: true` to be set on Argo Workflows to further harden our containers
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883