### PR TITLE
Mount a volume at `/tmp` for `update-image-tag` workflow

### DIFF
--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -22,6 +22,9 @@ spec:
       script:
         image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/toolbox:latest
         command: [/bin/bash]
+        volumeMounts:
+          - name: tmp
+            mountPath: /tmp
         env:
           - name: GIT_NAME
             valueFrom:
@@ -45,6 +48,9 @@ spec:
             value: "{{"{{inputs.parameters.promoteDeployment}}"}}"
         source: |
           {{- .Files.Get "scripts/update-image-tag.sh" | nindent 14 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
   podSpecPatch: |
     containers:
       - resources:


### PR DESCRIPTION
Description:
- Mount a volume at `/tmp` so that when `update-image-tag.sh` creates the `.gitconfig` file into `/tmp` it will do it in a volume
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883