### PR TITLE
Set configuration options for GitHub CLI into volume mounted at `/tmp`

### DIFF
--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -37,7 +37,9 @@ spec:
                 name: govuk-ci-github-creds
                 key: token
           - name: GIT_CONFIG_GLOBAL
-            value: "/tmp/.gitconfig"
+            value: "/tmp/git/.gitconfig"
+          - name: GH_CONFIG_DIR
+            value: "/tmp/gh"
           - name: IMAGE_TAG
             value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: ENVIRONMENT


### PR DESCRIPTION
Description:
- As a precaution set the configuration options for GitHub CLI into the `/tmp` directory so that it needn't write to the root filesystem
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883