### PR TITLE
Revert "Set configuration options for GitHub CLI into volume mounted at `/tmp`"

### DIFF
--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -37,9 +37,7 @@ spec:
                 name: govuk-ci-github-creds
                 key: token
           - name: GIT_CONFIG_GLOBAL
-            value: "/tmp/git/.gitconfig"
-          - name: GH_CONFIG_DIR
-            value: "/tmp/gh"
+            value: "/tmp/.gitconfig"
           - name: IMAGE_TAG
             value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: ENVIRONMENT


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#2794