### PR TITLE
Set GitHub CLI configuration options

### DIFF
--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -38,6 +38,8 @@ spec:
                 key: token
           - name: GIT_CONFIG_GLOBAL
             value: "/tmp/.gitconfig"
+          - name: GH_CONFIG_DIR
+            value: "/tmp"
           - name: IMAGE_TAG
             value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: ENVIRONMENT


### PR DESCRIPTION
Description:
- Set `GH_CONFIG_DIR` to write to the volume mounted to `/tmp` rather than the root file system
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883