### PR TITLE
Add GOVUK_CHAT_PROMO_ENABLED env vars to addtional apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1143,6 +1143,8 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1198,6 +1200,8 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2793,6 +2797,8 @@ govukApplications:
       extraEnv:
         - name: EXPOSE_GOVSPEAK
           value: "1"
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1137,6 +1137,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "false"
 
   - name: frontend
     helmValues:
@@ -1168,6 +1170,8 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "false"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2832,6 +2836,8 @@ govukApplications:
           memory: 1Gi
           cpu: "2"
       extraEnv:
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "false"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1140,6 +1140,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "false"
 
   - name: draft-finder-frontend
     repoName: finder-frontend
@@ -1193,6 +1195,8 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "false"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2776,6 +2780,8 @@ govukApplications:
         path: /app/public/assets/smartanswers
         s3Directory: "smartanswers"
       extraEnv:
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "false"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We're adding the GOV.UK Chat promo banner to some pages in:

- frontend
- finder_frontend
- smart_answers

This adds the GOVUK_CHAT_PROMO_ENABLED env var to the config for these apps. They're currently all set to false with the exception of integration as we're almost ready to test those pages

## Trello card

https://trello.com/c/W5kqrrTr/2171-set-up-chat-promo-banner-for-frontend-application