### PR TITLE
Update chat banner env vars

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1143,8 +1143,6 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: EMAIL_ALERT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1137,8 +1137,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "false"
 
   - name: frontend
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1169,7 +1169,7 @@ govukApplications:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "false"
+          value: "true"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2835,7 +2835,7 @@ govukApplications:
           cpu: "2"
       extraEnv:
         - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "false"
+          value: "true"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1140,8 +1140,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "false"
 
   - name: draft-finder-frontend
     repoName: finder-frontend

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1194,7 +1194,7 @@ govukApplications:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "false"
+          value: "true"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2779,7 +2779,7 @@ govukApplications:
         s3Directory: "smartanswers"
       extraEnv:
         - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "false"
+          value: "true"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Description

We're no longer adding the chat banner to any pages on Frontend finder and are ready to show the pages on prod for Frontend and Smart answers.

## Trello card

https://trello.com/c/W5kqrrTr/2171-set-up-chat-promo-banner-for-frontend-application