### PR TITLE
Update instant access places env var

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1475,7 +1475,7 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "50"
+          value: "100"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "100"
       nginxConfigMap:


### PR DESCRIPTION
## Description

We've added the chat promotional banners to more pages on GOV.UK. This bumps the instant access places to handle the increase in users.