### PR TITLE
Clone repository into volume mounted on `/tmp`

### DIFF
--- a/charts/argo-services/scripts/update-image-tag.sh
+++ b/charts/argo-services/scripts/update-image-tag.sh
@@ -8,6 +8,7 @@ git config --global user.email "${GIT_NAME}@digital.cabinet-office.gov.uk"
 git config --global user.name "${GIT_NAME}"
 
 gh auth setup-git
+cd /tmp
 gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main
 
 cd "govuk-helm-charts" || exit 1


### PR DESCRIPTION
Description:
- Ensures that `gh repo clone alphagov/govuk-helm-charts -- --depth 1 --branch main` writes into the `/tmp` directory
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883