### PR TITLE
Increase instant access places to 150

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1475,7 +1475,7 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "100"
+          value: "150"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "100"
       nginxConfigMap:


### PR DESCRIPTION
We're getting a large amount of users so we want to bump the instant access places.