### PR TITLE
Search API v2: Add `GOOGLE_CLOUD_PROJECT_ID` env var

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2606,6 +2606,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_CREDENTIALS
+        - name: GOOGLE_CLOUD_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_PROJECT_ID
         - name: DISCOVERY_ENGINE_DATASTORE
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2651,6 +2651,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_CREDENTIALS
+        - name: GOOGLE_CLOUD_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_PROJECT_ID
         - name: DISCOVERY_ENGINE_DATASTORE
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2614,6 +2614,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_CREDENTIALS
+        - name: GOOGLE_CLOUD_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_PROJECT_ID
         - name: DISCOVERY_ENGINE_DATASTORE
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This adds an additional environment variable from an existing Secrets Manager defining the GCP project Discovery Engine is running in for future use in Search API v2.

see https://github.com/alphagov/search-v2-infrastructure/pull/315