### PR TITLE
Search API v2: Schedule user events import (integration)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2582,6 +2582,12 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: user-events-import-yesterdays-events
+          task: "user_events:import_yesterdays_events"
+          schedule: "30 12 * * *"
+        - name: user-events-import-intraday-events
+          task: "user_events:import_intraday_events"
+          schedule: "45 05,11,17,23 * * *"
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *"  # 09:09am daily


### PR DESCRIPTION
This adds two scheduled tasks to run the two user events import Rake tasks, in integration only for now to verify it all works properly.

These will eventually replace the following GCP Cloud Scheduler runs: https://github.com/alphagov/search-v2-infrastructure/blob/main/terraform/environment/events_ingestion.tf#L366-L484

See https://github.com/alphagov/search-api-v2/pull/351