### PR TITLE
Remove chat promo banner env var from Smart answers

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2806,8 +2806,6 @@ govukApplications:
       extraEnv:
         - name: EXPOSE_GOVSPEAK
           value: "1"
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2839,8 +2839,6 @@ govukApplications:
           memory: 1Gi
           cpu: "2"
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2783,8 +2783,6 @@ govukApplications:
         path: /app/public/assets/smartanswers
         s3Directory: "smartanswers"
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We're no longer rendering the chat promo banner on any pages in Smart answers, so we can remove the related environment variable.