### PR TITLE
Give chat 800 places a day

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1385,7 +1385,7 @@ govukApplications:
           timeZone: "Europe/London"
         - name: increment-instant-access-places
           task: "settings:increment_pilot_places[instant_access]"
-          schedule: "0 9,11,13,15 * * *"
+          schedule: "0 9-16 * * *"
           timeZone: "Europe/London"
         - name: increment-delayed-access-places
           task: "settings:increment_pilot_places[delayed_access]"
@@ -1475,7 +1475,7 @@ govukApplications:
               name: govuk-chat-bigquery
               key: credentials
         - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "150"
+          value: "100"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "100"
       nginxConfigMap:


### PR DESCRIPTION
This increases the frequency of place allocation to once an hour and lowers the amount to 100. This task will run 8 times a day allocating 800 places.