### PR TITLE
Increase router memory request and limits

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2276,10 +2276,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 2Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 2Gi
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2242,10 +2242,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 2Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 2Gi
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Apart of the work to switch Router to use the Content Store for routes, requires it to build two trie data structure with routes whilst migration takes place. This doubles the memory usage. Add a bit more room, and will right size once migration is complete.