### PR TITLE
Allow email-alert-frontend access to the whitehall redis cluster in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -975,6 +975,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-auth
               key: token
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
 
   - name: draft-email-alert-frontend
     repoName: email-alert-frontend
@@ -1006,6 +1008,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-auth
               key: token
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
 
   - name: email-alert-service
     helmValues:


### PR DESCRIPTION
- This is necessary for the slimmer-free version of email-alert-frontend to read the emergency banner key.

Integration only while we test the approach.

https://trello.com/c/1REVdLAr/247-add-emergency-banner-handling-to-govukwebbanners