### PR TITLE
Load routes from Content Store in integration/staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2304,7 +2304,7 @@ govukApplications:
         - name: BACKEND_URL_manuals-frontend
           value: 'http://manuals-frontend'
         - name: CSMUX_SAMPLE_RATE
-          value: '0.0'
+          value: '1.0'
         - name: CONTENT_STORE_DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -2366,7 +2366,7 @@ govukApplications:
         - name: BACKEND_URL_manuals-frontend
           value: 'http://manuals-frontend'
         - name: CSMUX_SAMPLE_RATE
-          value: '0.0'
+          value: '1.0'
         - name: CONTENT_STORE_DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2350,7 +2350,7 @@ govukApplications:
         - name: BACKEND_URL_manuals-frontend
           value: 'http://manuals-frontend'
         - name: CSMUX_SAMPLE_RATE
-          value: '0.0'
+          value: '1.0'
         - name: CONTENT_STORE_DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -2412,7 +2412,7 @@ govukApplications:
         - name: BACKEND_URL_manuals-frontend
           value: 'http://manuals-frontend'
         - name: CSMUX_SAMPLE_RATE
-          value: '0.0'
+          value: '1.0'
         - name: CONTENT_STORE_DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This configures Router to load routes from Content Store instead of MongoDB.