### PR TITLE
Bump router resource limits

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2201,6 +2201,13 @@ govukApplications:
         enabled: false
       uploadAssets:
         enabled: false
+      appResources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 2Gi
       ingress:
         enabled: true
         annotations:
@@ -2320,6 +2327,13 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
+      appResources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 2Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2400,6 +2400,13 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
+      appResources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 2Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2366,6 +2366,13 @@ govukApplications:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
+      appResources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 2Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false


### PR DESCRIPTION
Due to router loading the mux from content store and mongodb, resource usage will be higher. This increases the limits in integration. Also the draft router for staging and production.