### PR TITLE
Canary loading routes from CS in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2384,7 +2384,7 @@ govukApplications:
         - name: BACKEND_URL_manuals-frontend
           value: 'http://manuals-frontend'
         - name: CSMUX_SAMPLE_RATE
-          value: '0.0'
+          value: '0.01'
         - name: CONTENT_STORE_DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -2453,7 +2453,7 @@ govukApplications:
         - name: BACKEND_URL_manuals-frontend
           value: 'http://manuals-frontend'
         - name: CSMUX_SAMPLE_RATE
-          value: '0.0'
+          value: '0.01'
         - name: CONTENT_STORE_DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This enabled Router to load routes from the Content Store and serve 1% of requests using that triemux.