### PR TITLE
[WIP] Add a global variable to enable search autocomplete

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -16,6 +16,7 @@ data:
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.publishingDomainSuffix }}
   GOVUK_ASSET_ROOT: https://{{ .Values.assetsDomain }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
+  GOVUK_ENABLE_SEARCH_AUTOCOMPLETE: {{ .Values.enableSearchAutocomplete }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -60,6 +60,8 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
+enableSearchAutocomplete: "true"
+
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -51,6 +51,8 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
+enableSearchAutocomplete: "true"
+
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -58,6 +58,8 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
+enableSearchAutocomplete: "true"
+
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:


### PR DESCRIPTION
The new search autocomplete is due to be rolled out across GOV.UK

Autocomplete uses a denylist to stop certain terms from serving suggestions. The process to update the denylist is very manual and developer heavy.

If might be difficult to update the denylist over the holiday period. In that situation the decision might be taken to temporarily turn off autocomplete entirely.

A global environment variable has been added rather than individual environment variables for each affect app as the search bar exists in the header on all pages on GOV.UK. This means that it needs to be accessed by the [layout_super_navigation_header](https://github.com/alphagov/govuk_publishing_components/pull/4451/files) which is pulled in by static for use in 6 other rendering apps.