### PR TITLE
Search API v2: Schedule user events import (production)

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2662,6 +2662,12 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: user-events-import-yesterdays-events
+          task: "user_events:import_yesterdays_events"
+          schedule: "30 12 * * *"
+        - name: user-events-import-intraday-events
+          task: "user_events:import_intraday_events"
+          schedule: "45 05,11,17,23 * * *"
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm


### PR DESCRIPTION
This adds two scheduled tasks to run the two user events import Rake tasks. It has already been deployed and tested in integration.

These replace the following GCP Cloud Scheduler runs: https://github.com/alphagov/search-v2-infrastructure/blob/main/terraform/environment/events_ingestion.tf#L366-L484

See alphagov/search-api-v2#351