### PR TITLE
Add cronjob to cleanup old publishing intents in content store

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -735,6 +735,9 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
+        - name: cleanup-intents
+          task: "housekeeping:cleanup_publish_intents"
+          schedule: "38 2 * * *"
       uploadAssets:
         enabled: false
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -725,6 +725,9 @@ govukApplications:
         - name: report-delays
           task: "publishing_delay_report:report_delays"
           schedule: "15 2 * * *"
+        - name: cleanup-intents
+          task: "housekeeping:cleanup_publish_intents"
+          schedule: "38 2 * * *"
       uploadAssets:
         enabled: false
       extraEnv:


### PR DESCRIPTION
See: https://github.com/alphagov/content-store/pull/1360