### PR TITLE
Reduce Router memory request/limits

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2210,11 +2210,11 @@ govukApplications:
         enabled: false
       appResources:
         limits:
-          cpu: 4
-          memory: 6Gi
+          cpu: 1
+          memory: 3Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 1Gi
       ingress:
         enabled: true
         annotations:
@@ -2339,10 +2339,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 3Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 1Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2280,10 +2280,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 3Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 1Gi
       ingress:
         enabled: true
         annotations:
@@ -2408,10 +2408,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 3Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 1Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2246,10 +2246,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 3Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 1Gi
       ingress:
         enabled: true
         annotations:
@@ -2374,10 +2374,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 3Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 1Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false


### PR DESCRIPTION
Router no longer stores 2 triemuxes since migrating to loading routes from the Content Store.