### PR TITLE
Add GOVUK_CHAT_PROMO_ENABLED env var for finder-frontend

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1159,6 +1159,8 @@ govukApplications:
               key: bearer_token
         - name: DISABLE_LTR_ON_PATHS
           value: /find-licences
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
 
   - name: draft-finder-frontend
     repoName: finder-frontend

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1142,6 +1142,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
 
   - name: frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1145,6 +1145,8 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: GOVUK_CHAT_PROMO_ENABLED
+          value: "true"
 
   - name: draft-finder-frontend
     repoName: finder-frontend


### PR DESCRIPTION
There is a increased promotional push for GOV.UK Chat which involves adding the promotional banner to finder-frontend in addition to the 3 other apps.

It is expected that these banners will be switched off on 20th December (by these env vars) before the code for the banners is removed and these env vars are removed altogether.