### PR TITLE
Revert "Upload 503.html page to mirror bucket as part of static error page creation"

### DIFF
--- a/charts/generic-govuk-app/upload-frontend-error-pages.sh
+++ b/charts/generic-govuk-app/upload-frontend-error-pages.sh
@@ -9,6 +9,4 @@ mkdir -p "${OUTPUT_PATH}"
 cd "${OUTPUT_PATH}"
 curl --fail-early -fo '#1.html' "${SERVICE}/static-error-pages/{${ERROR_PAGES_COMMA_SEPARATED}}.html"
 eval ls "{$ERROR_PAGES_COMMA_SEPARATED}.html" || (echo Failed to download one or more files.; exit 1)
-
 aws s3 sync . "s3://govuk-app-assets-${GOVUK_ENVIRONMENT}/error_pages/"
-aws s3 sync 503.html "s3://govuk-${GOVUK_ENVIRONMENT}-mirror/error/503.html"


### PR DESCRIPTION
Fixes 2 problems in deploying frontend