### PR TITLE
Turn off disableSearchAutocomplete flag for production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -51,7 +51,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
-disableSearchAutocomplete: true
+disableSearchAutocomplete: false
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 


### PR DESCRIPTION
This completes enabling the site search autocomplete by turning it on in production.