### PR TITLE
Revert "Turn off disableSearchAutocomplete flag for production"

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -51,7 +51,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
-disableSearchAutocomplete: false
+disableSearchAutocomplete: true
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 


### PR DESCRIPTION
We're seeing some issues with this in integration environment (some pages without super nav styling others autocomplete not working) so going to disable this while we investigate.

Reverts alphagov/govuk-helm-charts#2842