### PR TITLE
Enable site search autocomplete for production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -51,7 +51,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
-disableSearchAutocomplete: true
+disableSearchAutocomplete: false
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 


### PR DESCRIPTION
We believe we have resolved the issues now that led to this feature being disabled (see: https://github.com/alphagov/static/pull/3532)

I've opened this as a draft as I plan for us to enable this at the start of the working day tomorrow (Thursday) just to give us an opportunity to react if more problems occur.