### PR TITLE
[DO NOT MERGE] Disable GOV.UK Chat promotional banners

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -300,8 +300,6 @@ govukApplications:
     helmValues:
       arch: arm64
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -1159,8 +1157,6 @@ govukApplications:
               key: bearer_token
         - name: DISABLE_LTR_ON_PATHS
           value: /find-licences
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
 
   - name: draft-finder-frontend
     repoName: finder-frontend
@@ -1209,8 +1205,6 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -296,8 +296,6 @@ govukApplications:
           cpu: 1
           memory: 1Gi
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -1142,8 +1140,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
 
   - name: frontend
     helmValues:
@@ -1176,8 +1172,6 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1295,8 +1289,6 @@ govukApplications:
           cpu: 1
           memory: 1500Mi
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
         - name: PUBLISHING_API_BEARER_TOKEN

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -302,8 +302,6 @@ govukApplications:
           cpu: 1
           memory: 1Gi
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: EMAIL_ALERT_API_BEARER_TOKEN
@@ -1145,8 +1143,6 @@ govukApplications:
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
 
   - name: draft-finder-frontend
     repoName: finder-frontend
@@ -1201,8 +1197,6 @@ govukApplications:
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1298,8 +1292,6 @@ govukApplications:
           cpu: 1
           memory: 1500Mi
       extraEnv:
-        - name: GOVUK_CHAT_PROMO_ENABLED
-          value: "true"
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
         - name: PUBLISHING_API_BEARER_TOKEN


### PR DESCRIPTION
Trello: https://trello.com/c/VAZZP53L/2200-shut-down-govuk-chat-promotion

This is intended to be merged at the end of the working day on December 20th.

The GOV.UK Chat trial is due to end on December 23rd and we're planning to stop showing these banners from the end of the 20th.