### PR TITLE
Remove scaling up of staging GOV.UK Chat infrastructure

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1342,14 +1342,6 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      replicaCount: 16
-      appResources:
-        limits:
-          cpu: 6
-          memory: 3Gi
-        requests:
-          cpu: 4
-          memory: 2Gi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -1452,8 +1444,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-smart-survey
               key: api_key_secret
-        - name: WEB_CONCURRENCY
-          value: '4'
         - name: REDIS_URL
           value: redis://chat-redis.eks.staging.govuk-internal.digital
         - name: BIGQUERY_PROJECT


### PR DESCRIPTION
This looks to be scaling that was left behind when load testing GOV.UK Chat in staging and is not necessary for the limited traffic this environment receives.