### PR TITLE
[DO NOT MERGE] Remove GOV.UK Chat resource increases

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1339,35 +1339,14 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
-      replicaCount: 8
-      appResources:
-        limits:
-          cpu: 6
-          memory: 3Gi
-        requests:
-          cpu: 4
-          memory: 2Gi
       dbMigrationEnabled: true
       workers:
         enabled: true
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker
-            env:
-              - name: SIDEKIQ_CONCURRENCY
-                value: "25"
-              - name: DATABASE_POOL
-                value: "25"
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
-        replicaCount: 4
-      workerResources:
-        limits:
-          cpu: 4
-          memory: 2500Mi
-        requests:
-          cpu: 2
-          memory: 2Gi
       ingress:
         enabled: true
         annotations:
@@ -1469,8 +1448,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-smart-survey
               key: api_key_secret
-        - name: WEB_CONCURRENCY
-          value: '4'
         - name: REDIS_URL
           value: redis://chat-redis.eks.production.govuk-internal.digital
         - name: BIGQUERY_PROJECT


### PR DESCRIPTION
Trello: https://trello.com/c/lMX2BET0/2201-shut-down-govuk-chat

This commit is intended to be applied after the pilot of GOV.UK Chat closes on the 23rd December.

This removes the customisations made to the govuk-chat helm chart to increase the resources available to GOV.UK Chat in the event of a spike. When the GOV.UK Chat pilot closes the application will still be running but users viewing the frontend part will receive a 409 response. We do however need to keep resources available as the app is still maintaining a search index and still has an admin area that can be used for analysis. Hence this just reduces the parts of our Kubernetes infrastructure where we've pushed for additional resources beyond the GOV.UK default.