### PR TITLE
Add nginx redirect for /favicon.ico from static in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2841,6 +2841,10 @@ govukApplications:
           location = /googlec908b3bc32386239.html {
             return 200 'google-site-verification: googlec908b3bc32386239.html';
           }
+          # Favicon now that static isn't serving it
+          location = /favicon.ico {
+            return 301 https://www.integration.publishing.service.gov.uk/favicon.ico;
+          }
 
   - name: draft-static
     repoName: static


### PR DESCRIPTION
- Static now no longer serves the favicon on gov.uk (that's done by frontend), but it was also serving the favicon for assets.publishing.service.gov.uk (which appear in search results), so while static still exists we need to add a redirect to the frontend version of the file. When static is removed entirely, we'll have to find a new solution to this (possibly in the fastly configuration, or maybe in another place in the nginx configuration in this repo - the google site verification and the zendesk logo will also need this).