### PR TITLE
Increase Prod Replica Counts for 3 services

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1155,7 +1155,7 @@ govukApplications:
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
-      replicaCount: 4
+      replicaCount: 6
       appResources:
         limits:
           cpu: 4
@@ -1679,6 +1679,7 @@ govukApplications:
 
   - name: local-links-manager
     helmValues:
+      replicaCount: 6
       redis:
         enabled: true
       ingress:
@@ -1795,11 +1796,13 @@ govukApplications:
 
   - name: locations-api
     helmValues:
+      replicaCount: 6
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
       workers:
         enabled: true
+        replicaCount: 6
       redis:
         enabled: true
       extraEnv:


### PR DESCRIPTION
## What?
This increases the replica counts in Production for the following apps/services:

* Frontend (4 to 6)
* Local Links Manager (3 to 6)
* Locations API - App & Workers (3 to 6)

These increases are expected to be temporary. Requested by @johnpauldickie 