### PR TITLE
Attempt to Fix kubeconform failure

### DIFF
--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -27,6 +27,8 @@ workers:
   enabled: true
   replicaCount: 1
 
+repoName: "asset-manager"  # Dummy value, overridden in ArgoCD config.
+
 arch: amd64
 appImage:
   repository: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/asset-manager"


### PR DESCRIPTION
## What?
It looks like the "kubeconform" chart testing has started failing on this missing value, specifically on the asset-manager templates. Hopefully adding this default value will resolve the error.