### PR TITLE
Define signon-api-token

### DIFF
--- a/charts/external-secrets/templates/whitehall/signon-api-token.yaml
+++ b/charts/external-secrets/templates/whitehall/signon-api-token.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: whitehall-signon-api-token
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      A token for accessing the Signon API for fetching user details
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: whitehall-signon-api-token
+  dataFrom:
+    - extract:
+        key: govuk/whitehall/signon-api-token


### PR DESCRIPTION
This defines a new secret for Whitehall to access the newly minted user details endpoint in Signon. 

The secrets are set up in all three AWS environments