### PR TITLE
Use the generated Signon API key in Whitehall

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3407,6 +3407,11 @@ govukApplications:
           value: *publishing-design-system-gtm-auth
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-design-system-gtm-preview
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-whitehall-signon-api
+              key: bearer_token
       extraVolumes:
         - name: asset-uploads-efs
           nfs:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3290,6 +3290,11 @@ govukApplications:
             secretKeyRef:
               name: whitehall-admin-mysql
               key: DATABASE_URL
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-whitehall-signon-api
+              key: bearer_token
       extraVolumes:
         - name: asset-uploads-efs
           nfs:


### PR DESCRIPTION
I’ve given the “Whitehall” user access to the newly-minted API endpoint in Signon, and run the `signon-sync-token-secrets-to-k8s` job, so this secret should be ready for use in each app.
