### PR TITLE
Increase search-api Redis memory limit

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2438,7 +2438,7 @@ govukApplications:
         resources:
           limits:
             cpu: 1
-            memory: 4Gi
+            memory: 10Gi
           requests:
             cpu: 500m
             memory: 2Gi


### PR DESCRIPTION
Temporarily until we understand why so much memory is being used and can set limits of Redis.