### PR TITLE
Set Redis maxmemory config

### DIFF
--- a/charts/generic-govuk-app/templates/redis-configmap.yaml
+++ b/charts/generic-govuk-app/templates/redis-configmap.yaml
@@ -18,6 +18,9 @@ data:
 
     daemonize no
 
+    maxmemory-policy noeviction
+    maxmemory {{ .Values.redis.config.maxmemory }}
+
     # Use AOF for persistence
     dir /data
     appendonly yes

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -34,10 +34,13 @@ redis:
   resources:
     limits:
       cpu: 1
-      memory: 1000Mi
+      memory: 1500Mi
     requests:
       cpu: 500m
       memory: 500Mi
+  config:
+    # Needs to be smaller that the memory limit with some buffer
+    maxmemory: 1000mb
   redisUrlOverride:
     app: ""
     workers: ""


### PR DESCRIPTION
The maxmemory and maxmemory-policy settings prevent Redis from caching any further values if it reaches the limit. It will return an error to the client. This prevents Redis from exceeding the container memory limit and being OOM-killed. Because we have data persistence enabled, when a new container is created, it immediately fills the memory from the data on disk, causing a crash loop. This results in the unavailability of Redis and prevents Sidekiq jobs from being processed. Setting the memory limit will help keep Redis available for read operations by Sidekiq workers.