### PR TITLE
Add Recreate Strategy for Redis Deployments

### DIFF
--- a/charts/generic-govuk-app/templates/redis-deployment.yaml
+++ b/charts/generic-govuk-app/templates/redis-deployment.yaml
@@ -18,6 +18,8 @@ spec:
     matchLabels:
       app: {{ $fullName }}-redis
       app.kubernetes.io/component: redis
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Redis uses a PVC with ReadWriteOnce, which causes a deadlock during pod rollouts. With the rolling update strategy, a new pod is brought up before the old pod is deleted. However, the new pod cannot start because it waits for access to the PVC, which is still being used by the old pod. Meanwhile, the old pod is not deleted until the new pod is created, resulting in a deadlock.