### PR TITLE
Remove bumped search-api-redis memory limit

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2435,13 +2435,6 @@ govukApplications:
             name: bulk-reindex-queue-listener
       redis:
         enabled: true
-        resources:
-          limits:
-            cpu: 1
-            memory: 10Gi
-          requests:
-            cpu: 500m
-            memory: 2Gi
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"


### PR DESCRIPTION
Redis now has maxmemory defined and shouldn't OOM killed anymore.