### PR TITLE
Bump search-api Redis memory limit

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2435,6 +2435,15 @@ govukApplications:
             name: bulk-reindex-queue-listener
       redis:
         enabled: true
+        config:
+          maxmemory: 8000mb
+        resources:
+          limits:
+            cpu: 1
+            memory: 10Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"


### PR DESCRIPTION
This is incase we need to increase the memory limit temporarily - to be used by on-call if needed.