### PR TITLE
Remove workflow name for event binding

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
@@ -6,8 +6,6 @@ spec:
   event:
     selector: payload.environment != "" && payload.repoName != "" && payload.imageTag != "" && discriminator == "update-image-tag"
   submit:
-    metadata:
-      name: "payload.repoName + \"-\" + payload.environment + \"-deploy-image-\" + string(now().Unix())"
     workflowTemplateRef:
       name: deploy-image
     arguments:

--- a/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
@@ -6,8 +6,6 @@ spec:
   event:
     selector: payload.application != "" && payload.repoName != "" && payload.imageTag != "" && discriminator == "post-sync"
   submit:
-    metadata:
-      name: "payload.repoName + \"-post-sync-\" + string(now().Unix())"
     workflowTemplateRef:
       name: post-sync
     arguments:


### PR DESCRIPTION
This property no longer seems to be supported and is causing a sync loop in ArgoCD.