### PR TITLE
Use the Signon API Key in Whitehall (production)

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3360,6 +3360,11 @@ govukApplications:
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
           value: redis://whitehall-admin-redis/2
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-whitehall-signon-api
+              key: bearer_token
       extraVolumes:
         - name: asset-uploads-efs
           nfs:


### PR DESCRIPTION
This builds on the previous PR (https://github.com/alphagov/govuk-helm-charts/pull/2864) and adds the generated Signon API key for Whitehall in production.