### PR TITLE
Revert "Increase Prod Replica Counts for 3 services"

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1151,7 +1151,7 @@ govukApplications:
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
-      replicaCount: 6
+      replicaCount: 4
       appResources:
         limits:
           cpu: 4
@@ -1648,7 +1648,6 @@ govukApplications:
 
   - name: local-links-manager
     helmValues:
-      replicaCount: 6
       redis:
         enabled: true
       ingress:
@@ -1765,13 +1764,11 @@ govukApplications:
 
   - name: locations-api
     helmValues:
-      replicaCount: 6
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
       workers:
         enabled: true
-        replicaCount: 6
       redis:
         enabled: true
       extraEnv:


### PR DESCRIPTION
## What?
This PR reverts alphagov/govuk-helm-charts#2860 which was merged in anticipation of additional traffic/load. We no longer need this surplus capacity so should revert the values to the previous defaults.