### PR TITLE
Increase firing duration for high Fastly bandwidth alert

### DIFF
--- a/charts/monitoring-config/rules/fastly.yaml
+++ b/charts/monitoring-config/rules/fastly.yaml
@@ -12,7 +12,7 @@ groups:
 
       - alert: HighBandwidthUsage
         expr: global:fastly_global_bandwidth_bytes:rate1d > 5.5 * (10 ^ 12)
-        for: 1m
+        for: 2d
         labels:
           severity: warning
           destination: slack-platform-engineering


### PR DESCRIPTION
This is to prevent flappy alerts, we only care if this is sustained for more than 2 days.