### PR TITLE
Change disabling of search autocomplete

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -16,9 +16,6 @@ data:
   GOVUK_APP_DOMAIN_EXTERNAL: {{ .Values.publishingDomainSuffix }}
   GOVUK_ASSET_ROOT: https://{{ .Values.assetsDomain }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
-  {{- if .Values.disableSearchAutocomplete }}
-  GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: "1"
-  {{- end }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
   GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -60,8 +60,6 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
-disableSearchAutocomplete: false
-
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:
@@ -2563,6 +2561,8 @@ govukApplications:
           schedule: "09 9 * * *"  # 09:09am daily
           suspend: true  # Too noisy for integration to run on schedule, but can be run manually.
       extraEnv:
+        - name: ENABLE_AUTOCOMPLETE
+          value: "true"
         # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -51,8 +51,6 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
-disableSearchAutocomplete: false
-
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:
@@ -2583,6 +2581,8 @@ govukApplications:
           task: "quality_monitoring:assert_invariants"
           schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm
       extraEnv:
+        - name: ENABLE_AUTOCOMPLETE
+          value: "true"
         # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -58,8 +58,6 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis/1
 
-disableSearchAutocomplete: false
-
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:
@@ -2589,6 +2587,8 @@ govukApplications:
           schedule: "09 9 * * *"  # 09:09am daily
           suspend: true  # Too noisy for staging to run on schedule, but can be run manually.
       extraEnv:
+        - name: ENABLE_AUTOCOMPLETE
+          value: "true"
         # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
         - name: GOVUK_PROMETHEUS_EXPORTER
           value: force


### PR DESCRIPTION
> [!CAUTION]
> This requires the following PRs to be merged first, or autocomplete will temporarily stop working: 
> * https://github.com/alphagov/govuk_publishing_components/pull/4533
> * https://github.com/alphagov/finder-frontend/pull/3624
> * https://github.com/alphagov/frontend/pull/4569

This was previously managed by rendering a different component in _every_ single rendering application (due to the autocomplete functionality being present in the global header).

This changes it to be a single feature flag on `search-api-v2` instead that controls whether any results are returned, and changes it to be a positive flag instead.