### PR TITLE
Use nfs PersistentVolume for Licensify Helm chart for compliance with PSS restricted

### DIFF
--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -63,10 +63,8 @@ spec:
         - name: app-clamav-log
           emptyDir: {}
         - name: app-clamav-db
-          nfs:
-            server: "{{ .Values.assetManagerNFS }}"
-            path: /clamav-db
-            readOnly: true
+          persistentVolumeClaim:
+            claimName: {{ include "licensify.name" . }}-{{ .Values.appName }}-db
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch

--- a/charts/licensify/templates/clamav/pv.yaml
+++ b/charts/licensify/templates/clamav/pv.yaml
@@ -1,0 +1,18 @@
+{{ $app := .Values.clamav }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "licensify.name" . }}-{{ .Values.appName }}-db
+  labels:
+    {{- include "licensify.labels" . | nindent 4 }}
+spec:
+  capacity:
+    storage: {{ .Values.nfs.storage }}
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: "{{ .Values.assetManagerNFS }}"
+    path: /clamav-db
+    readOnly: true

--- a/charts/licensify/templates/clamav/pvc.yaml
+++ b/charts/licensify/templates/clamav/pvc.yaml
@@ -1,0 +1,20 @@
+{{ $app := .Values.clamav }}
+{{ $_ := set .Values "appName" $app.name }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "licensify.name" . }}-{{ .Values.appName }}-db
+  labels:
+    {{- include "licensify.labels" . | nindent 4 }}
+    app: {{ .Values.appName }}
+    app.kubernetes.io/name: {{ .Values.appName }}
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.nfs.storage }}
+  selector:
+    matchLabels:
+      {{- include "licensify.selectorLabels" . | nindent 6 }}

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -39,6 +39,9 @@ nginx:
     requests:
       cpu: 50m
       memory: 512Mi
+nfs:
+  # Value is arbitrary and used to check PersistentVolume and PersistentVolumeClaim compatibility
+  storage: 15Gi
 
 apps:
   licensifyAdmin:


### PR DESCRIPTION
Description:
- PSS restricted doesn't allow volume types of `nfs`(see [here](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)) but does allow `PersistentVolume`
- Refactor the NFS volume to use a `PersistentVolume` of type NFS
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883