### PR TITLE
Downgrade Argo Bootstrap Helm chart to 0.3.2

### DIFF
--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps ArgoCD with initial configuration
-version: 0.3.3
+version: 0.3.2


### PR DESCRIPTION
Description:
- The Helm chart release action isn't working so temporarily downgrade to fix then re-enable