### PR TITLE
Use `GOVUK_CI_GITHUB_API_TOKEN` instead of the GitHub App `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_SKIP_EXISTING: "true"
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/actions/runs/12769758779/attempts/1 failed because the `GITHUB_TOKEN` doesn't have permission to push to `gh-pages` as it is a protected branch. It isn't currently possible to allow the GitHub app created by GitHub Actions permission to push to the branch
- Use the `GOVUK_CI_GITHUB_API_TOKEN` instead which is long-lived but has permissions to push to the branch