### PR TITLE
Upgrade Argo Bootstrap chart to 0.3.3

### DIFF
--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps ArgoCD with initial configuration
-version: 0.3.2
+version: 0.3.3


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/2892 changed argo-bootstrap so changes need to be released in a new chart
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883