### PR TITLE
Remove Licensify namespace configuration

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -58,11 +58,5 @@ spec:
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
-    managedNamespaceMetadata:
-      labels:
-        argocd.argoproj.io/managed-by: {{ $.Values.argoNamespace | default $.Release.Namespace }}
-        pod-security.kubernetes.io/audit: "restricted"
-        pod-security.kubernetes.io/enforce: "baseline"
-        pod-security.kubernetes.io/warn: "restricted"
 ---
 {{ end }}


### PR DESCRIPTION
- Licensify namespace is now managed by Terraform in https://github.com/alphagov/govuk-infrastructure/pull/1571
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883