### PR TITLE
Use NFS PersistentVolume for asset-manager clamav for compliance with PSS restricted

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -37,9 +37,8 @@ spec:
         readOnlyRootFilesystem: true
   volumes:
     - name: clam-virus-db
-      nfs:
-        server: "{{ .Values.assetManagerNFS }}"
-        path: /clamav-db
+      persistentVolumeClaim:
+        claimName: {{ $fullName }}-clamav-db
     - name: etc-clamav
       configMap:
         name: {{ $fullName }}-etc-clamav

--- a/charts/asset-manager/templates/clamav-pv.yaml
+++ b/charts/asset-manager/templates/clamav-pv.yaml
@@ -1,0 +1,20 @@
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $fullName }}-clamav-db
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}-clamav-db
+    app.kubernetes.io/component: {{ $fullName }}-clamav-db
+spec:
+  capacity:
+    storage: {{ .Values.nfs.clamAvStorage }}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: "{{ .Values.assetManagerNFS }}"
+    path: /clamav-db
+    readOnly: true

--- a/charts/asset-manager/templates/clamav-pvc.yaml
+++ b/charts/asset-manager/templates/clamav-pvc.yaml
@@ -1,0 +1,20 @@
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-clamav-db
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}-clamav-db
+    app.kubernetes.io/component: {{ $fullName }}-clamav-db
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.nfs.clamAvStorage }}
+  selector:
+    matchLabels:
+      {{- include "asset-manager.selectorLabels" . | nindent 6 }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -45,10 +45,8 @@ spec:
             server: "{{ .Values.assetManagerNFS }}"
             path: /asset-manager
         - name: clam-virus-db
-          nfs:
-            server: "{{ .Values.assetManagerNFS }}"
-            path: /clamav-db
-            readOnly: true
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-clamav-db
         - name: etc-clamav
           configMap:
             name: {{ $fullName }}-etc-clamav

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -141,3 +141,5 @@ redis:
   redisUrlOverride:
     app: ""
     workers: ""
+nfs:
+  clamAvStorage: 15Gi


### PR DESCRIPTION
Description:
- PSS restricted doesn't allow volume types of `nfs` (see [here](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)) but does allow us to use a `PersistentVolume` of type NFS
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883