### PR TITLE
Clean up Licensify config

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1510,7 +1510,6 @@ govukApplications:
 
   - name: licensify
     chartPath: charts/licensify
-    namespace: licensify
     imageValues:
       - "licensify-admin"
       - "licensify-backend"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1544,7 +1544,6 @@ govukApplications:
 
   - name: licensify
     chartPath: charts/licensify
-    namespace: licensify
     imageValues:
       - "licensify-admin"
       - "licensify-backend"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1564,7 +1564,6 @@ govukApplications:
 
   - name: licensify
     chartPath: charts/licensify
-    namespace: licensify
     imageValues:
       - "licensify-admin"
       - "licensify-backend"

--- a/charts/licensify/templates/clamav/pv.yaml
+++ b/charts/licensify/templates/clamav/pv.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "licensify.name" . }}-{{ .Values.appName }}-db
   labels:
     {{- include "licensify.labels" . | nindent 4 }}
+    app: {{ .Values.appName }}
+    app.kubernetes.io/name: {{ .Values.appName }}
+    app.kubernetes.io/component: {{ .Values.appName }}
 spec:
   capacity:
     storage: {{ .Values.nfs.storage }}

--- a/charts/licensify/templates/clamav/pvc.yaml
+++ b/charts/licensify/templates/clamav/pvc.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "licensify.labels" . | nindent 4 }}
     app: {{ .Values.appName }}
     app.kubernetes.io/name: {{ .Values.appName }}
+    app.kubernetes.io/component: {{ .Values.appName }}
 spec:
   storageClassName: ""
   accessModes:
@@ -18,3 +19,4 @@ spec:
   selector:
     matchLabels:
       {{- include "licensify.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ .Values.appName }}


### PR DESCRIPTION
Description:
- Licensify is now managed in Terraform https://github.com/alphagov/govuk-infrastructure/pull/1571
- Add a few labels to volumes
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883