### PR TITLE
Use nfs `PersistentVolume` for assets to ensure PSS restricted compliance

### DIFF
--- a/charts/asset-manager/templates/assets-pv.yaml
+++ b/charts/asset-manager/templates/assets-pv.yaml
@@ -1,0 +1,19 @@
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $fullName }}-efs
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}-efs
+    app.kubernetes.io/component: {{ $fullName }}-efs
+spec:
+  capacity:
+    storage: {{ .Values.nfs.assetStorage }}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: "{{ .Values.assetManagerNFS }}"
+    path: /asset-manager

--- a/charts/asset-manager/templates/assets-pvc.yaml
+++ b/charts/asset-manager/templates/assets-pvc.yaml
@@ -1,0 +1,21 @@
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-efs
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}-efs
+    app.kubernetes.io/component: {{ $fullName }}-efs
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.nfs.assetStorage }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $fullName }}-efs
+      app.kubernetes.io/component: {{ $fullName }}-efs

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -46,9 +46,8 @@ spec:
         - name: nginx-tmp
           emptyDir: {}
         - name: asset-manager-efs
-          nfs:
-            server: {{ .Values.assetManagerNFS }}
-            path: /asset-manager
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-efs
         {{- with .Values.extraVolumes }}
           {{ . | toYaml | trim | nindent 8 }}
         {{- end }}

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -41,9 +41,8 @@ spec:
         - name: clamd-tmp
           emptyDir: {}
         - name: asset-manager-efs
-          nfs:
-            server: "{{ .Values.assetManagerNFS }}"
-            path: /asset-manager
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-efs
         - name: clam-virus-db
           persistentVolumeClaim:
             claimName: {{ $fullName }}-clamav-db

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -143,3 +143,4 @@ redis:
     workers: ""
 nfs:
   clamAvStorage: 15Gi
+  assetStorage: 15Gi


### PR DESCRIPTION
Description:
- PSS restricted doesn't allow volume types of `nfs` (see [here](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)) but does allow us to use a `PersistentVolume` of type NFS
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883