### PR TITLE
Create config for publisher-on-postgres branch

### DIFF
--- a/charts/app-config/image-tags/integration/publisher-on-postgres-branch
+++ b/charts/app-config/image-tags/integration/publisher-on-postgres-branch
@@ -1,0 +1,3 @@
+image_tag: 1
+automatic_deploys_enabled: false
+promote_deployment: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2016,6 +2016,120 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
 
+  - name: publisher-on-postgres-branch
+    helmValues:
+      arch: arm64
+      dbMigrationEnabled: true
+      workers:
+        enabled: true
+      redis:
+        enabled: true
+      cronTasks:
+        - name: mail-fetcher
+          command: "script/mail_fetcher"
+          schedule: "*/5 * * * *"
+        - name: reports-generate
+          task: "reports:generate"
+          schedule: "0 * * * *"
+        - name: reschedule-pubs-after-db-restore  # non-prod only
+          task: "editions:requeue_scheduled_for_publishing"
+          schedule: "38 7 * * 1-5"
+        - name: publish-missed-scheduled-editions
+          task: "editions:publish_missed_scheduled_editions"
+          schedule: "27 5 * * *"
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "150"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "publisher.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: publisher-on-postgres.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 30s
+      extraEnv:
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publisher
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publisher
+              key: oauth_secret
+        - name: ASSET_MANAGER_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-asset-manager
+              key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-publishing-api
+              key: bearer_token
+        - name: FACT_CHECK_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_USERNAME
+        - name: FACT_CHECK_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_PASSWORD
+        - name: GOVUK_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publisher-notify
+              key: GOVUK_NOTIFY_API_KEY
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
+        - name: LINK_CHECKER_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-link-checker-api
+              key: bearer_token
+        - name: LINK_CHECKER_API_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: publisher-link-checker-api-callback-token
+              key: LINK_CHECKER_API_SECRET_TOKEN
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publisher-postgres
+              key: DATABASE_URL
+        - name: EMAIL_GROUP_BUSINESS
+          value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_CITIZEN
+          value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_DEV
+          value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
+          value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
+        - name: FACT_CHECK_SUBJECT_PREFIX
+          value: dev
+        - name: FACT_CHECK_REPLY_TO_ADDRESS
+          value: govuk-fact-check-integration@digital.cabinet-office.gov.uk
+        - name: FACT_CHECK_REPLY_TO_ID
+          value: 6b6ee566-54f2-48f6-98c4-21a373e6dea2
+        - name: GOVUK_NOTIFY_TEMPLATE_ID
+          value: *publishing-notify-template
+        - name: REPORTS_S3_BUCKET_NAME
+          value: govuk-integration-publisher-csvs
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
+        - name: GOOGLE_TAG_MANAGER_AUTH  # Non-prod only
+          value: *publishing-bootstrap-gtm-auth
+        - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
+          value: *publishing-bootstrap-gtm-preview
+
   - name: publishing-api
     helmValues:
       arch: arm64

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2044,7 +2044,7 @@ govukApplications:
           alb.ingress.kubernetes.io/group.order: "150"
           alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "publisher.{{ .Values.publishingDomainSuffix }}"
+                "publisher-on-postgres.{{ .Values.publishingDomainSuffix }}"
             ]}}]
         hosts:
           - name: publisher-on-postgres.{{ .Values.k8sExternalDomainSuffix }}

--- a/charts/external-secrets/templates/publisher-on-postgres-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/publisher-on-postgres-branch/postgresql.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: publisher-on-postgres-branch
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for publisher-on-postgres-branch's Postgres DB hosted in RDS.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: publisher-on-postgres
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/publisher_production'
+  dataFrom:
+    - extract:
+        key: govuk/publisher/postgres


### PR DESCRIPTION
[Trello](https://trello.com/c/7TgXoJSL/586-enable-eks-for-postgres-branch-of-publisher)

As an step towards moving Mainstream publisher from Mongo database to Postgres database, we want to be able to spin up a separate app integration from a branch that runs postgres database.
We have created the database [in this PR](https://github.com/alphagov/govuk-infrastructure/pull/1569).

A step pending is to create secrets in aws secrets manager for the database arn, which will be completed before merge.

These changes will only live till the time we need to run postgres in parallel to mongo. As a first, we want to run the app in integration for all our migrations and testing.