### PR TITLE
Add NFS storage values for whitehall-admin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3301,6 +3301,8 @@ govukApplications:
     repoName: whitehall
     helmValues:
       arch: arm64
+      assetManagerNFS: *assets-nfs
+      nfsStorage: 15Gi
       securityContext:
         # Use the same uid/gid for NFS permissions as the old stack, so that
         # files uploaded by whitehall-admin on k8s can be processed by

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3257,6 +3257,8 @@ govukApplications:
   - name: whitehall-admin
     repoName: whitehall
     helmValues:
+      assetManagerNFS: *assets-nfs
+      nfsStorage: 15Gi
       appResources:
         limits:
           memory: 8Gi

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3255,6 +3255,8 @@ govukApplications:
     repoName: whitehall
     helmValues:
       arch: arm64
+      assetManagerNFS: *assets-nfs
+      nfsStorage: 15Gi
       appResources:
         limits:
           memory: 4Gi


### PR DESCRIPTION
Description:
- These values will be needed to setup the `PersistentVolume` and `PersistentVolumeClaim`
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883