### PR TITLE
Unsuspend CKAN DB backup on Staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -268,7 +268,6 @@ cronjobs:
         - op: backup
 
     ckan-postgres:
-      suspend: true
       schedule: "43 1 * * 0"
       db: ckan_production
       operations:


### PR DESCRIPTION
Seems like the DB backup was suspended for CKAN so reactivate it. 
