### PR TITLE
Update test cronjob alerts for search api

### DIFF
--- a/charts/monitoring-config/rules/search_api_cronjobs.yaml
+++ b/charts/monitoring-config/rules/search_api_cronjobs.yaml
@@ -1,15 +1,19 @@
 groups:
   - name: SearchApiCronjobs
     rules:
-      - alert: CronjobFailed
+      - alert: CronjobFailed => CronjobSuccessThreshold
         # Set alert to trigger when last successful time is over 50 hours
         expr: >-
-          kube_cronjob_status_last_successful_time{cronjob="search-api-load-page-traffic"} > 180000
+          kube_cronjob_status_last_successful_time{cronjob="search-api-load-page-traffic"}
+          > 180000
         for: 5m
         labels:
           severity: critical
-          destination: slack-chat-notifications
+          destination: slack-cronjob-notifications
         annotations:
-          summary: Search api load page cronjob failed
+          summary: search-api-load-page-traffic cronjob failing
           description: >-
-            The cronjob "search-api-load-page-traffic" has been failing for over two days.
+            The cronjob "search-api-load-page-traffic" has not run successfully
+            since {{ $value | humanizeTimestamp }}
+          cronjob_uri: >-
+            applications/search-api?orphaned=false&resource=&node=batch%2FCronJob%2Fapps%2Fsearch-api-load-page-traffic%2F0&tab=logs

--- a/charts/monitoring-config/rules/search_api_cronjobs_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_cronjobs_tests.yaml
@@ -13,7 +13,7 @@ tests:
           }
         values: '179300+60x15'
     alert_rule_test:
-      - alertname: CronjobFailed
+      - alertname: CronjobFailed => CronjobSuccessThreshold
         eval_time: 15m
         exp_alerts: []
 
@@ -24,17 +24,20 @@ tests:
           kube_cronjob_status_last_successful_time{
           cronjob="search-api-load-page-traffic"
           }
-        values: '180000+60x15'
+        values: '180300+60x15'
     alert_rule_test:
-      - alertname: CronjobFailed
+      - alertname: CronjobFailed => CronjobSuccessThreshold
         eval_time: 10m
         exp_alerts:
           - exp_labels:
               alertname: CronjobFailed
-              destination: slack-chat-notifications
+              destination: slack-cronjob-notifications
               cronjob: search-api-load-page-traffic
               severity: critical
             exp_annotations:
-              summary: Search api load page cronjob failed
+              summary: search-api-load-page-traffic cronjob failing
               description: >-
-                The cronjob "search-api-load-page-traffic" has been failing for over two days.
+                The cronjob "search-api-load-page-traffic" has not run successfully
+                since 1970-01-03 02:15:00 +0000 UTC
+              cronjob_uri: >-
+                applications/search-api?orphaned=false&resource=&node=batch%2FCronJob%2Fapps%2Fsearch-api-load-page-traffic%2F0&tab=logs

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -78,6 +78,16 @@ spec:
       groupInterval: 30m
       activeTimeIntervals:
         - inhours
+    - matchers:
+      - name: destination
+        value: slack-cronjob-notifications
+        matchType: =
+      receiver: 'slack-cronjob-notifications'
+      repeatInterval: 1d
+      groupWait: 5m
+      groupInterval: 30m
+      activeTimeIntervals:
+        - inhours
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -123,6 +133,22 @@ spec:
         *Environment:* {{ .Values.govukEnvironment }}
 
         *Runbook:* {{ "{{ .CommonAnnotations.runbook_url }}" }}
+      apiURL: *slack_api_url
+  - name: 'slack-cronjob-notifications'
+    slackConfigs:
+    - channel: '#dev-notifications-ai-govuk'
+      sendResolved: true
+      iconURL: https://avatars3.githubusercontent.com/u/3380462
+      title: |-
+        {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}" }}
+      text: >-
+        *Summary:* {{ "{{ .CommonAnnotations.summary }}" }}
+
+        *Environment:* {{ .Values.govukEnvironment }}
+
+        *Description:* {{ "{{ .CommonAnnotations.description }}" }}
+
+        *ArgoCD Job:* https://argo.eks.{{ .Values.govukEnvironment }}.govuk.digital/{{ "{{ .CommonAnnotations.cronjob_uri }}" }}
       apiURL: *slack_api_url
   - name: 'slack-mirror-freshness'
     slackConfigs:


### PR DESCRIPTION
## What

Update cronjob alerts with additional information and add alert matcher & receiver

## Why

The additional information will help identify the cronjob with the issue by adding a link to the job in ArgoCD.
The new alert matcher & receiver are to make use of this new information.