### PR TITLE
Set trigger to correct evaluation for cronjob alerts

### DIFF
--- a/charts/monitoring-config/rules/search_api_cronjobs.yaml
+++ b/charts/monitoring-config/rules/search_api_cronjobs.yaml
@@ -4,6 +4,7 @@ groups:
       - alert: CronjobFailed => CronjobSuccessThreshold
         # Set alert to trigger when last successful time is over 50 hours
         expr: >-
+          time() -
           kube_cronjob_status_last_successful_time{cronjob="search-api-load-page-traffic"}
           > 180000
         for: 5m

--- a/charts/monitoring-config/rules/search_api_cronjobs_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_cronjobs_tests.yaml
@@ -11,7 +11,7 @@ tests:
           kube_cronjob_status_last_successful_time{
           cronjob="search-api-load-page-traffic"
           }
-        values: '179300+60x15'
+        values: '-179300+60x15'
     alert_rule_test:
       - alertname: CronjobFailed => CronjobSuccessThreshold
         eval_time: 15m
@@ -24,7 +24,7 @@ tests:
           kube_cronjob_status_last_successful_time{
           cronjob="search-api-load-page-traffic"
           }
-        values: '180300+60x15'
+        values: '-180300+60x15'
     alert_rule_test:
       - alertname: CronjobFailed => CronjobSuccessThreshold
         eval_time: 10m
@@ -38,6 +38,6 @@ tests:
               summary: search-api-load-page-traffic cronjob failing
               description: >-
                 The cronjob "search-api-load-page-traffic" has not run successfully
-                since 1970-01-03 02:15:00 +0000 UTC
+                since 1970-01-03 02:05:00 +0000 UTC
               cronjob_uri: >-
                 applications/search-api?orphaned=false&resource=&node=batch%2FCronJob%2Fapps%2Fsearch-api-load-page-traffic%2F0&tab=logs


### PR DESCRIPTION
## What

Set the evaluation to the correct expression for the cronjobs alert

## Why

The previous setting was a test to ensure the alert triggers. Now we are happy with the alert, this sets it to the correct value.