### PR TITLE
Add the repo name to the pub-on-pg app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2017,6 +2017,7 @@ govukApplications:
           value: *publishing-bootstrap-gtm-preview
 
   - name: publisher-on-postgres-branch
+    repoName: publisher
     helmValues:
       arch: arm64
       dbMigrationEnabled: true


### PR DESCRIPTION
## What?
Argo cannot find the app image for the `publisher-on-postgres` app. This adds the missing `repoName` property so Argo/k8s can find the correct repo.