### PR TITLE
Refactor clamav for asset-manager to be compliant with PSS restricted

### DIFF
--- a/charts/asset-manager/templates/_freshclam_podspec.yaml
+++ b/charts/asset-manager/templates/_freshclam_podspec.yaml
@@ -11,10 +11,11 @@ spec:
   automountServiceAccountToken: false
   enableServiceLinks: false
   securityContext:
-    seccompProfile:
-      type: RuntimeDefault
+    runAsNonRoot: true
     runAsUser: 1001
     runAsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: freshclam
       image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
@@ -35,6 +36,8 @@ spec:
       securityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
   volumes:
     - name: clam-virus-db
       persistentVolumeClaim:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -108,6 +108,8 @@ spec:
             # Asset Manager shares an NFS volume with its EC2 counterpart.
             runAsUser: *old-ec2-deploy-uid
             runAsGroup: *old-ec2-deploy-uid
+            capabilities:
+              drop: [ "ALL" ]
         - name: clamd
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
@@ -129,6 +131,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
Description:
- Containers need additional fields to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883