### PR TITLE
Set App Resource Requests/Limits in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -68,6 +68,13 @@ govukApplications:
       arch: arm64
       uploadAssets:
         enabled: false
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -142,6 +149,13 @@ govukApplications:
     chartPath: charts/asset-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 800Mi
       workers:
         enabled: true
       redis:
@@ -215,6 +229,13 @@ govukApplications:
   - name: authenticating-proxy
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 250m
+          memory: 500Mi
+        requests:
+          cpu: 50m
+          memory: 200Mi
       ingress:
         enabled: true
         annotations:
@@ -255,6 +276,13 @@ govukApplications:
   - name: bouncer
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 250m
+          memory: 250Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi
       rails:
         enabled: false
       uploadAssets:
@@ -297,6 +325,13 @@ govukApplications:
   - name: collections
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 750m
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
@@ -317,6 +352,13 @@ govukApplications:
     repoName: collections
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 200m
+          memory: 600Mi
+        requests:
+          cpu: 50m
+          memory: 400Mi
       rails:
         createKeyBaseSecret: false
       sentry:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -377,6 +377,13 @@ govukApplications:
   - name: collections-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 500Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -442,6 +449,13 @@ govukApplications:
   - name: contacts-admin
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 400Mi
       ingress:
         enabled: true
         annotations:
@@ -490,6 +504,13 @@ govukApplications:
   - name: content-data-admin
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 1.2Gi
+        requests:
+          cpu: 100m
+          memory: 600Mi
       ingress:
         enabled: true
         redirect: true
@@ -592,6 +613,13 @@ govukApplications:
   - name: content-data-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 750m
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       redis:
         enabled: true
       ingress:
@@ -693,6 +721,13 @@ govukApplications:
   - name: content-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 750Mi
+        requests:
+          cpu: 100m
+          memory: 320Mi
       dbMigrationEnabled: true
       nginxClientMaxBodySize: &max-upload-size 500M
       workers:
@@ -769,6 +804,13 @@ govukApplications:
   - name: content-store
     helmValues: &content-store
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1.5
+          memory: 1.5Gi
+        requests:
+          cpu: 750m
+          memory: 900Mi
       dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
       cronTasks:
@@ -806,6 +848,13 @@ govukApplications:
     postSyncWorkflowEnabled: "false"
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 4
+          memory: 2Gi
+        requests:
+          cpu: 2
+          memory: 1Gi
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
       serviceAccount:
         annotations:
@@ -849,6 +898,13 @@ govukApplications:
   - name: content-tagger
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 800Mi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -902,6 +958,13 @@ govukApplications:
   - name: email-alert-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 100m
+          memory: 1.5Gi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
@@ -990,6 +1053,13 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 800Mi
+        requests:
+          cpu: 100m
+          memory: 450Mi
       redis:
         enabled: true
       extraEnv:
@@ -1015,6 +1085,13 @@ govukApplications:
     repoName: email-alert-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       rails:
         createKeyBaseSecret: false
       redis:
@@ -1047,6 +1124,13 @@ govukApplications:
   - name: email-alert-service
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       appEnabled: false
       podDisruptionBudget: {}
       rails:
@@ -1082,6 +1166,13 @@ govukApplications:
   - name: feedback
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       extraEnv:
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: fee22233-2f28-4b0b-8b6c-4410979f2275
@@ -1124,6 +1215,13 @@ govukApplications:
     repoName: feedback
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 300Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -1173,6 +1271,13 @@ govukApplications:
   - name: finder-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1.5
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 1.2Gi
       cronTasks:
         - name: registries-refresh
           task: "registries:cache_refresh"
@@ -1192,6 +1297,13 @@ govukApplications:
     repoName: finder-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 320Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -1214,6 +1326,13 @@ govukApplications:
   - name: frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1.5
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 1Gi
       uploadFrontendErrorPagesEnabled: true
       ingress:
         enabled: true
@@ -1265,6 +1384,13 @@ govukApplications:
     repoName: frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 350Mi
       ingress:
         enabled: true
         annotations:
@@ -1321,6 +1447,13 @@ govukApplications:
   - name: government-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 3
+          memory: 3Gi
+        requests:
+          cpu: 1.5
+          memory: 1Gi
       extraEnv:
         - name: GOVUK_CHAT_PROMO_ENABLED
           value: "true"
@@ -1336,6 +1469,13 @@ govukApplications:
     repoName: government-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 750m
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -1354,6 +1494,13 @@ govukApplications:
   - name: govspeak-preview
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 750m
+          memory: 768Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       monitoring:
         enabled: false
       ingress:
@@ -1371,6 +1518,13 @@ govukApplications:
   - name: govuk-chat
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -1504,6 +1658,13 @@ govukApplications:
     chartPath: charts/govuk-e2e-tests
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 1Gi
       cronJobs:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5"
@@ -1512,6 +1673,13 @@ govukApplications:
   - name: hmrc-manuals-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 320Mi
       nginxClientMaxBodySize: 2M
       ingress:
         enabled: true
@@ -1611,11 +1779,25 @@ govukApplications:
   - name: link-checker-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 300Mi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 500Mi
+        requests:
+          cpu: 500m
+          memory: 175Mi
       redis:
         enabled: true
       extraEnv:
@@ -1652,6 +1834,13 @@ govukApplications:
   - name: local-links-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 700Mi
       redis:
         enabled: true
       ingress:
@@ -1769,11 +1958,25 @@ govukApplications:
   - name: locations-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       redis:
         enabled: true
       extraEnv:
@@ -1798,9 +2001,23 @@ govukApplications:
   - name: manuals-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       nginxClientMaxBodySize: *max-upload-size
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       redis:
         enabled: true
       ingress:
@@ -1865,6 +2082,13 @@ govukApplications:
   - name: maslow
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 500Mi
       ingress:
         enabled: true
         annotations:
@@ -1909,6 +2133,13 @@ govukApplications:
   - name: places-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       ingress:
         enabled: true
         annotations:
@@ -1925,6 +2156,13 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
       redis:
         enabled: true
       extraEnv:
@@ -1947,9 +2185,23 @@ govukApplications:
   - name: publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 650Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       redis:
         enabled: true
       cronTasks:
@@ -2061,9 +2313,23 @@ govukApplications:
   - name: publisher-on-postgres-branch
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 650Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       redis:
         enabled: true
       cronTasks:
@@ -2175,12 +2441,26 @@ govukApplications:
   - name: publishing-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 512Mi
       nginxClientMaxBodySize: 2M
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 4
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
       redis:
         enabled: true
       cronTasks:
@@ -2248,6 +2528,13 @@ govukApplications:
   - name: release
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2303,11 +2590,11 @@ govukApplications:
         enabled: false
       appResources:
         limits:
-          cpu: 2
+          cpu: 5
           memory: 3Gi
         requests:
           cpu: 1
-          memory: 1Gi
+          memory: 1.5Gi
       ingress:
         enabled: true
         annotations:
@@ -2424,11 +2711,11 @@ govukApplications:
         enabled: false
       appResources:
         limits:
-          cpu: 2
+          cpu: 5
           memory: 3Gi
         requests:
           cpu: 1
-          memory: 1Gi
+          memory: 1.5Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false
@@ -2481,6 +2768,13 @@ govukApplications:
   - name: search-admin
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 320Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2546,6 +2840,13 @@ govukApplications:
   - name: search-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.2Gi
+        requests:
+          cpu: 200m
+          memory: 600Mi
       rails:
         enabled: false
       nginxClientMaxBodySize: 20M
@@ -2607,6 +2908,13 @@ govukApplications:
             name: govuk-index-queue-listener
           - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
             name: bulk-reindex-queue-listener
+      workerResources:
+        limits:
+          cpu: 4
+          memory: 2Gi
+        requests:
+          cpu: 2
+          memory: 1Gi
       extraEnv:
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-integration-search-relevancy
@@ -2685,6 +2993,13 @@ govukApplications:
   - name: search-api-v2
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 1Gi
       dbMigrationEnabled: false
       ingress:
         enabled: true
@@ -2706,6 +3021,13 @@ govukApplications:
         types:
           - command: ['bin/rake', 'document_sync_worker:run']
             name: document-sync-worker
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       redis:
         enabled: true
       cronTasks:
@@ -2770,6 +3092,13 @@ govukApplications:
   - name: service-manual-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2835,9 +3164,23 @@ govukApplications:
   - name: signon
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 200m
+          memory: 550Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -2928,6 +3271,13 @@ govukApplications:
     repoName: smart-answers
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 5
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
       uploadAssets:
         # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
         path: /app/public/assets/smartanswers
@@ -2949,6 +3299,13 @@ govukApplications:
   - name: static
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 320Mi
       ingress:
         enabled: true
         annotations:
@@ -3003,6 +3360,13 @@ govukApplications:
     repoName: static
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 320Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -3035,6 +3399,13 @@ govukApplications:
   - name: short-url-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       ingress:
         enabled: true
         annotations:
@@ -3092,10 +3463,24 @@ govukApplications:
   - name: specialist-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 500Mi
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -3164,6 +3549,13 @@ govukApplications:
   - name: support
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 350Mi
       ingress:
         enabled: true
         annotations:
@@ -3179,6 +3571,13 @@ govukApplications:
         path: /app/public/assets/support
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
       redis:
         enabled: true
       extraEnv:
@@ -3224,11 +3623,25 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 350Mi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 250Mi
       redis:
         enabled: true
       cronTasks:
@@ -3288,6 +3701,13 @@ govukApplications:
   - name: transition
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       ingress:
         enabled: true
         annotations:
@@ -3302,6 +3722,13 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
       redis:
         enabled: true
       cronTasks:
@@ -3359,6 +3786,13 @@ govukApplications:
   - name: travel-advice-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       cronTasks:
         - name: publish-scheduled-editions
           task: "publish_scheduled_editions"
@@ -3366,6 +3800,13 @@ govukApplications:
       nginxClientMaxBodySize: *max-upload-size
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -3457,6 +3898,13 @@ govukApplications:
     repoName: whitehall
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 5
+          memory: 8Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
       assetManagerNFS: *assets-nfs
       nfsStorage: 15Gi
       securityContext:
@@ -3481,6 +3929,13 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
       redis:
         enabled: true
       nginxClientMaxBodySize: *max-upload-size

--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -48,8 +48,10 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             initialDelaySeconds: 10
+          {{- with $app.resources}}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: app-tmp
               mountPath: /tmp

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -86,9 +86,9 @@ spec:
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 2
-          {{- with $.Values.resources -}}
+          {{- with .resources }}
           resources:
-            {{- . | toYaml | trim | nindent 12 }}
+            {{- (tpl (toYaml .) $) | trim | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: licensify-config

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -86,8 +86,10 @@ spec:
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 2
+          {{- with $.Values.resources -}}
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: licensify-config
               mountPath: "/etc/licensing"

--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -23,6 +23,13 @@ clamav:
     repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/clamav
     tag: latest
     pullPolicy: Always
+  resources:
+    limits:
+      cpu: 1
+      memory: 3Gi
+    requests:
+      cpu: 100m
+      memory: 1.5Gi
   service:
     type: ClusterIP
     port: 3310
@@ -55,6 +62,13 @@ apps:
     ingress:
       enabled: true
       annotations: {}
+    resources:
+      limits:
+        cpu: 1
+        memory: 1.5Gi
+      requests:
+        cpu: 100m
+        memory: 700Mi
     service:
       port: 80
     extraEnv:
@@ -71,6 +85,13 @@ apps:
     healthcheckPath: "/licence-management/feed/process-applications"
     ingress:
       enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1.5Gi
+      requests:
+        cpu: 50m
+        memory: 512Mi
     service:
       port: 80
 
@@ -84,6 +105,13 @@ apps:
     ingress:
       enabled: true
       annotations: {}
+    resources:
+      limits:
+        cpu: 1
+        memory: 1.2Gi
+      requests:
+        cpu: 100m
+        memory: 650Mi
     service:
       port: 80
     extraEnv:


### PR DESCRIPTION
## What?
This tests adding app (and worker) Resource Requests and Limits to each of the GOV.UK apps, initially only in Integration for testing purposes. The idea here is by setting explicit Resource Requests for each set of pods, EKS will be able to do a much better job of anticipating workload requirements and scheduling workloads more efficiently (and hopefully result in less unnecessary over-provisioning and wasted CPU/Memory).

## How?
I've set each app's request and limits based on what each app has been doing for the last 30-90 days in Production - in most cases, a lot of our smaller apps are consuming very little CPU and instead have more demands on memory consumption. Where an app has regular CPU spikes, I have factored this into the CPU "requests" and given it a more generous CPU limit to permit bursting.

We may well decide that we want Staging to replicate Production and that in the future, we may wish to reduce the resources on Integration as the demands there are typically lower than Production. But that's something we can address for the future.