### PR TITLE
Set Pub on PG Integration Image Tag

### DIFF
--- a/charts/app-config/image-tags/integration/publisher-on-postgres-branch
+++ b/charts/app-config/image-tags/integration/publisher-on-postgres-branch
@@ -1,3 +1,3 @@
-image_tag: 1
-automatic_deploys_enabled: false
+image_tag: v530
+automatic_deploys_enabled: true
 promote_deployment: false


### PR DESCRIPTION
## What?
This manually sets the latest Publisher Image tag for the Postgres "flavour" on Integration.