### PR TITLE
Use the generated Signon API key in Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2250,6 +2250,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-publisher-publishing-api
               key: bearer_token
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-signon-api
+              key: bearer_token
         - name: FACT_CHECK_USERNAME
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2006,6 +2006,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-publisher-publishing-api
               key: bearer_token
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-signon-api
+              key: bearer_token
         - name: FACT_CHECK_USERNAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
I’ve given the “Publisher” user access to the newly-minted API endpoint in Signon, and run the `signon-sync-token-secrets-to-k8s` job, so this secret should be ready for use in each app.

Trying this in non-prod environments first. Will roll out to prod if/when this is proved to be working.

This is similar to https://github.com/alphagov/govuk-helm-charts/pull/2864, but for the Publisher app