### PR TITLE
Use the Signon API Key in Publisher

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1980,6 +1980,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-publisher-publishing-api
               key: bearer_token
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-signon-api
+              key: bearer_token
         - name: FACT_CHECK_USERNAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This builds on the previous PR (https://github.com/alphagov/govuk-helm-charts/pull/2946) and adds the generated Signon API key for Publisher in production.