### PR TITLE
Clean up asset-manager deployment to be compliant with PSS restricted

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -126,6 +126,8 @@ spec:
             # Asset Manager shares an NFS volume with its EC2 counterpart.
             runAsUser: *old-ec2-deploy-uid
             runAsGroup: *old-ec2-deploy-uid
+            capabilities:
+              drop: ["ALL"]
           lifecycle:
             preStop:
               exec:
@@ -163,6 +165,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           lifecycle:
             preStop:
               exec:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -108,7 +108,7 @@ spec:
             runAsUser: *old-ec2-deploy-uid
             runAsGroup: *old-ec2-deploy-uid
             capabilities:
-              drop: [ "ALL" ]
+              drop: ["ALL"]
         - name: clamd
           image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}


### PR DESCRIPTION
Description:
- Enforce `govuk-exporter` to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883