### PR TITLE
Disable migration to test if the app spins up correctly

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2325,7 +2325,7 @@ govukApplications:
         requests:
           cpu: 100m
           memory: 650Mi
-      dbMigrationEnabled: true
+      dbMigrationEnabled: false
       uploadAssets:
         enabled: true
         path: /app/public/assets/publisher-on-pg/*


### PR DESCRIPTION
This is a temporary change and will be reverted once test is complete