### PR TITLE
Use the same secret as the mongo publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2326,6 +2326,10 @@ govukApplications:
           cpu: 100m
           memory: 650Mi
       dbMigrationEnabled: false
+      rails:
+        createKeyBaseSecret: false
+        # use the same secret as the mongo publisher
+        secretKeyBaseName: publisher-rails-secret-key-base
       uploadAssets:
         enabled: true
         path: /app/public/assets/publisher-on-pg/*


### PR DESCRIPTION
As there is no new secret that is added for postgres, we can potentially share the secret with mongo publisher.