### PR TITLE
Disable creation of separate secrets for sentry

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2330,6 +2330,9 @@ govukApplications:
         createKeyBaseSecret: false
         # use the same secret as the mongo publisher
         secretKeyBaseName: publisher-rails-secret-key-base
+      sentry:
+        createSecret: false  # Sentry DSNs are per repo.
+        dsnSecretName: publisher
       uploadAssets:
         enabled: true
         path: /app/public/assets/publisher-on-pg/*


### PR DESCRIPTION
This is more likely temporary to allow us to be able to move forward in creation of kubernetes pods correctly, Once we are able to create pod and talk to db, we would be able to complete the spike and then we can create a separate secret if needed at the time of actual implementation. Also, we may also never need to create a separate secret as eventually it will all merge to main publisher.