### PR TITLE
Fix dsn name for publisher sentry in publisher-on-pg

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2332,7 +2332,7 @@ govukApplications:
         secretKeyBaseName: publisher-rails-secret-key-base
       sentry:
         createSecret: false  # Sentry DSNs are per repo.
-        dsnSecretName: publisher-dsn
+        dsnSecretName: publisher-sentry
       uploadAssets:
         enabled: true
         path: /app/public/assets/publisher-on-pg/*


### PR DESCRIPTION
this is a miss from the commit: https://github.com/alphagov/govuk-helm-charts/pull/2956 and https://github.com/alphagov/govuk-helm-charts/pull/2957