### PR TITLE
Re-tune Resource Amounts for Integration & Staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2060,9 +2060,9 @@ govukApplications:
       appResources:
         limits:
           cpu: 1
-          memory: 1.5Gi
+          memory: 1.2Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 512Mi
       nginxClientMaxBodySize: *max-upload-size
       workers:
@@ -2072,8 +2072,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -2141,10 +2141,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 1
-          memory: 1.5Gi
+          memory: 1.2Gi
         requests:
-          cpu: 100m
-          memory: 500Mi
+          cpu: 10m
+          memory: 400Mi
       ingress:
         enabled: true
         annotations:
@@ -2194,7 +2194,7 @@ govukApplications:
           cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 512Mi
       ingress:
         enabled: true
@@ -2217,7 +2217,7 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 200Mi
       redis:
         enabled: true
@@ -2246,8 +2246,8 @@ govukApplications:
           cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 100m
-          memory: 650Mi
+          cpu: 10m
+          memory: 512Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -2256,8 +2256,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       cronTasks:
@@ -2393,8 +2393,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       cronTasks:
@@ -2509,9 +2509,9 @@ govukApplications:
       appResources:
         limits:
           cpu: 2
-          memory: 1Gi
+          memory: 1.5Gi
         requests:
-          cpu: 200m
+          cpu: 10m
           memory: 512Mi
       nginxClientMaxBodySize: 2M
       dbMigrationEnabled: true
@@ -2522,9 +2522,9 @@ govukApplications:
       workerResources:
         limits:
           cpu: 4
-          memory: 1Gi
+          memory: 1.5Gi
         requests:
-          cpu: 500m
+          cpu: 10m
           memory: 512Mi
       redis:
         enabled: true
@@ -2598,8 +2598,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 200Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2655,11 +2655,11 @@ govukApplications:
         enabled: false
       appResources:
         limits:
-          cpu: 5
+          cpu: 4
           memory: 3Gi
         requests:
-          cpu: 1
-          memory: 1.5Gi
+          cpu: 10m
+          memory: 1Gi
       ingress:
         enabled: true
         annotations:
@@ -2776,11 +2776,11 @@ govukApplications:
         enabled: false
       appResources:
         limits:
-          cpu: 5
+          cpu: 4
           memory: 3Gi
         requests:
-          cpu: 1
-          memory: 1.5Gi
+          cpu: 10m
+          memory: 1Gi
       appProbes: *router-app-probes
       nginxConfigMap:
         create: false
@@ -2838,8 +2838,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 320Mi
+          cpu: 10m
+          memory: 256Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2910,8 +2910,8 @@ govukApplications:
           cpu: 2
           memory: 1.2Gi
         requests:
-          cpu: 200m
-          memory: 600Mi
+          cpu: 10m
+          memory: 512Mi
       rails:
         enabled: false
       nginxClientMaxBodySize: 20M
@@ -2976,10 +2976,10 @@ govukApplications:
       workerResources:
         limits:
           cpu: 4
-          memory: 2Gi
+          memory: 2.5Gi
         requests:
-          cpu: 2
-          memory: 1Gi
+          cpu: 10m
+          memory: 512Mi
       extraEnv:
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-integration-search-relevancy
@@ -3061,10 +3061,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 2
-          memory: 2Gi
+          memory: 2.5Gi
         requests:
-          cpu: 500m
-          memory: 1Gi
+          cpu: 10m
+          memory: 256Mi
       dbMigrationEnabled: false
       ingress:
         enabled: true
@@ -3089,10 +3089,10 @@ govukApplications:
       workerResources:
         limits:
           cpu: 2
-          memory: 1Gi
+          memory: 1.5Gi
         requests:
-          cpu: 100m
-          memory: 512Mi
+          cpu: 10m
+          memory: 384Mi
       redis:
         enabled: true
       cronTasks:
@@ -3162,7 +3162,7 @@ govukApplications:
           cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 512Mi
       dbMigrationEnabled: true
       ingress:
@@ -3234,8 +3234,8 @@ govukApplications:
           cpu: 2
           memory: 1.5Gi
         requests:
-          cpu: 200m
-          memory: 550Mi
+          cpu: 10m
+          memory: 600Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -3244,7 +3244,7 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 200Mi
       redis:
         enabled: true
@@ -3338,11 +3338,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 5
-          memory: 4Gi
+          cpu: 2
+          memory: 1Gi
         requests:
-          cpu: 500m
-          memory: 2Gi
+          cpu: 10m
+          memory: 384Mi
       uploadAssets:
         # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
         path: /app/public/assets/smartanswers
@@ -3369,8 +3369,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 320Mi
+          cpu: 10m
+          memory: 256Mi
       ingress:
         enabled: true
         annotations:
@@ -3469,8 +3469,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 176Mi
       ingress:
         enabled: true
         annotations:
@@ -3533,8 +3533,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 500Mi
+          cpu: 10m
+          memory: 384Mi
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:
@@ -3544,7 +3544,7 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 200Mi
       redis:
         enabled: true
@@ -3619,8 +3619,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 350Mi
+          cpu: 10m
+          memory: 320Mi
       ingress:
         enabled: true
         annotations:
@@ -3641,8 +3641,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 200Mi
+          cpu: 10m
+          memory: 168Mi
       redis:
         enabled: true
       extraEnv:
@@ -3693,8 +3693,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 350Mi
+          cpu: 10m
+          memory: 320Mi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
@@ -3705,8 +3705,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 250Mi
+          cpu: 10m
+          memory: 192Mi
       redis:
         enabled: true
       cronTasks:
@@ -3771,7 +3771,7 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 400Mi
       ingress:
         enabled: true
@@ -3792,8 +3792,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 200Mi
+          cpu: 10m
+          memory: 192Mi
       redis:
         enabled: true
       cronTasks:
@@ -3856,8 +3856,8 @@ govukApplications:
           cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 100m
-          memory: 512Mi
+          cpu: 10m
+          memory: 384Mi
       cronTasks:
         - name: publish-scheduled-editions
           task: "publish_scheduled_editions"
@@ -3870,8 +3870,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 200Mi
+          cpu: 10m
+          memory: 175Mi
       redis:
         enabled: true
       ingress:
@@ -3965,11 +3965,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 5
-          memory: 8Gi
+          cpu: 4
+          memory: 5Gi
         requests:
-          cpu: 1
-          memory: 2Gi
+          cpu: 10m
+          memory: 1.5Gi
       assetManagerNFS: *assets-nfs
       nfsStorage: 15Gi
       securityContext:
@@ -3999,7 +3999,7 @@ govukApplications:
           cpu: 2
           memory: 1.5Gi
         requests:
-          cpu: 500m
+          cpu: 10m
           memory: 512Mi
       redis:
         enabled: true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -73,11 +73,18 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -154,10 +161,17 @@ govukApplications:
           cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 100m
-          memory: 800Mi
+          cpu: 10m
+          memory: 320Mi
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 4Gi
+        requests:
+          cpu: 10m
+          memory: 2Gi
       redis:
         enabled: true
       ingress:
@@ -231,11 +245,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 250m
-          memory: 500Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 50m
-          memory: 200Mi
+          cpu: 10m
+          memory: 256Mi
       ingress:
         enabled: true
         annotations:
@@ -278,11 +292,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 250m
-          memory: 250Mi
+          cpu: 1
+          memory: 500Mi
         requests:
-          cpu: 50m
-          memory: 128Mi
+          cpu: 10m
+          memory: 100Mi
       rails:
         enabled: false
       uploadAssets:
@@ -327,10 +341,10 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 750m
-          memory: 1Gi
+          cpu: 2
+          memory: 1.5Gi
         requests:
-          cpu: 500m
+          cpu: 10m
           memory: 512Mi
       extraEnv:
         - name: MEMCACHE_SERVERS
@@ -354,11 +368,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 200m
-          memory: 600Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 50m
-          memory: 400Mi
+          cpu: 10m
+          memory: 320Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -379,14 +393,21 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
+          cpu: 1
           memory: 1Gi
         requests:
-          cpu: 200m
-          memory: 500Mi
+          cpu: 10m
+          memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -451,10 +472,10 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
+          cpu: 1
           memory: 1Gi
         requests:
-          cpu: 200m
+          cpu: 10m
           memory: 400Mi
       ingress:
         enabled: true
@@ -506,11 +527,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
+          cpu: 1
           memory: 1.2Gi
         requests:
-          cpu: 100m
-          memory: 600Mi
+          cpu: 10m
+          memory: 550Mi
       ingress:
         enabled: true
         redirect: true
@@ -542,6 +563,13 @@ govukApplications:
       nginxProxyReadTimeout: 60s
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       redis:
         enabled: true
       extraEnv:
@@ -615,10 +643,10 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 750m
+          cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 400Mi
       redis:
         enabled: true
@@ -637,6 +665,13 @@ govukApplications:
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 650Mi
       workers:
         enabled: true
         types:
@@ -723,15 +758,22 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 750Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 320Mi
       dbMigrationEnabled: true
       nginxClientMaxBodySize: &max-upload-size 500M
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       redis:
         enabled: true
       ingress:
@@ -806,11 +848,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 1.5
+          cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 750m
-          memory: 900Mi
+          cpu: 10m
+          memory: 512Mi
       dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
       cronTasks:
@@ -851,9 +893,9 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 2Gi
+          memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 1.5
           memory: 1Gi
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
       serviceAccount:
@@ -900,14 +942,21 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 800Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -963,13 +1012,20 @@ govukApplications:
           cpu: 1
           memory: 2.5Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 1.5Gi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1.5
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 350Mi
       redis:
         enabled: true
       ingress:
@@ -1055,11 +1111,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 800Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 450Mi
+          cpu: 10m
+          memory: 320Mi
       redis:
         enabled: true
       extraEnv:
@@ -1087,11 +1143,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 300Mi
       rails:
         createKeyBaseSecret: false
       redis:
@@ -1124,13 +1180,6 @@ govukApplications:
   - name: email-alert-service
     helmValues:
       arch: arm64
-      appResources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 256Mi
       appEnabled: false
       podDisruptionBudget: {}
       rails:
@@ -1142,6 +1191,13 @@ govukApplications:
         types:
           - command: ['bin/email-alert-service']
             name: email-alert-service
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       extraEnv:
@@ -1168,11 +1224,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 400Mi
+          cpu: 10m
+          memory: 320Mi
       extraEnv:
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: fee22233-2f28-4b0b-8b6c-4410979f2275
@@ -1217,10 +1273,10 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 300Mi
       rails:
         createKeyBaseSecret: false
@@ -1276,8 +1332,8 @@ govukApplications:
           cpu: 1.5
           memory: 2Gi
         requests:
-          cpu: 500m
-          memory: 1.2Gi
+          cpu: 10m
+          memory: 400Mi
       cronTasks:
         - name: registries-refresh
           task: "registries:cache_refresh"
@@ -1299,10 +1355,10 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 320Mi
       rails:
         createKeyBaseSecret: false
@@ -1328,11 +1384,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 1.5
-          memory: 4Gi
-        requests:
-          cpu: 500m
+          cpu: 1
           memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       uploadFrontendErrorPagesEnabled: true
       ingress:
         enabled: true
@@ -1386,11 +1442,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 500m
-          memory: 1.5Gi
+          cpu: 1
+          memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 350Mi
+          cpu: 10m
+          memory: 320Mi
       ingress:
         enabled: true
         annotations:
@@ -1449,11 +1505,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 3
-          memory: 3Gi
-        requests:
-          cpu: 1.5
+          cpu: 1
           memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 384Mi
       extraEnv:
         - name: GOVUK_CHAT_PROMO_ENABLED
           value: "true"
@@ -1471,10 +1527,10 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 750m
+          cpu: 1
           memory: 1.5Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 512Mi
       rails:
         createKeyBaseSecret: false
@@ -1496,11 +1552,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 750m
+          cpu: 1
           memory: 768Mi
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 10m
+          memory: 200Mi
       monitoring:
         enabled: false
       ingress:
@@ -1523,8 +1579,8 @@ govukApplications:
           cpu: 2
           memory: 1.5Gi
         requests:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 10m
+          memory: 768Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -1678,7 +1734,7 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 320Mi
       nginxClientMaxBodySize: 2M
       ingress:
@@ -1784,8 +1840,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 300Mi
+          cpu: 10m
+          memory: 320Mi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
@@ -1794,9 +1850,9 @@ govukApplications:
       workerResources:
         limits:
           cpu: 1
-          memory: 500Mi
+          memory: 1Gi
         requests:
-          cpu: 500m
+          cpu: 10m
           memory: 175Mi
       redis:
         enabled: true
@@ -1837,10 +1893,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 1
-          memory: 1.5Gi
+          memory: 1.2Gi
         requests:
-          cpu: 100m
-          memory: 700Mi
+          cpu: 10m
+          memory: 512Mi
       redis:
         enabled: true
       ingress:
@@ -1963,8 +2019,8 @@ govukApplications:
           cpu: 1
           memory: 1Gi
         requests:
-          cpu: 100m
-          memory: 400Mi
+          cpu: 10m
+          memory: 320Mi
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
@@ -1972,11 +2028,11 @@ govukApplications:
         enabled: true
       workerResources:
         limits:
-          cpu: 1
-          memory: 1Gi
+          cpu: 1.5
+          memory: 1.1Gi
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 650Mi
       redis:
         enabled: true
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -66,9 +66,23 @@ govukApplications:
       arch: arm64
       uploadAssets:
         enabled: false
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -140,8 +154,22 @@ govukApplications:
     chartPath: charts/asset-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 100m
+          memory: 800Mi
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 4Gi
+        requests:
+          cpu: 10m
+          memory: 2Gi
       redis:
         enabled: true
       ingress:
@@ -216,6 +244,13 @@ govukApplications:
   - name: authenticating-proxy
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       ingress:
         enabled: true
         annotations:
@@ -256,6 +291,13 @@ govukApplications:
   - name: bouncer
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 500Mi
+        requests:
+          cpu: 50m
+          memory: 200Mi
       rails:
         enabled: false
       uploadAssets:
@@ -301,10 +343,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 2
-          memory: 1500Mi
+          memory: 1.5Gi
         requests:
           cpu: 1
-          memory: 1Gi
+          memory: 512Mi
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
@@ -323,6 +365,13 @@ govukApplications:
     repoName: collections
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -341,9 +390,23 @@ govukApplications:
   - name: collections-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -406,6 +469,13 @@ govukApplications:
   - name: contacts-admin
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       ingress:
         enabled: true
         annotations:
@@ -448,6 +518,13 @@ govukApplications:
   - name: content-data-admin
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.2Gi
+        requests:
+          cpu: 10m
+          memory: 550Mi
       redis:
         enabled: true
       ingress:
@@ -481,6 +558,13 @@ govukApplications:
       nginxProxyReadTimeout: 60s
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       extraEnv:
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:
@@ -552,6 +636,13 @@ govukApplications:
   - name: content-data-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       redis:
         enabled: true
       ingress:
@@ -569,6 +660,13 @@ govukApplications:
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 650Mi
       workers:
         enabled: true
         types:
@@ -653,10 +751,24 @@ govukApplications:
   - name: content-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       dbMigrationEnabled: true
       nginxClientMaxBodySize: &max-upload-size 500M
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       redis:
         enabled: true
       ingress:
@@ -729,6 +841,13 @@ govukApplications:
   - name: content-store
     helmValues: &content-store
       arch: arm64
+      appResources:
+        limits:
+          cpu: 5
+          memory: 1.5Gi
+        requests:
+          cpu: 500m
+          memory: 768Mi
       dbMigrationEnabled: true
       nginxClientMaxBodySize: 20M
       replicaCount: 6
@@ -769,6 +888,13 @@ govukApplications:
     postSyncWorkflowEnabled: "false"
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 1.5
+          memory: 1Gi
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
       serviceAccount:
         annotations:
@@ -811,9 +937,23 @@ govukApplications:
   - name: content-tagger
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -864,11 +1004,25 @@ govukApplications:
   - name: email-alert-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 2.5Gi
+        requests:
+          cpu: 20m
+          memory: 1.5Gi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1.5
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 350Mi
       redis:
         enabled: true
       ingress:
@@ -953,6 +1107,13 @@ govukApplications:
   - name: email-alert-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 450Mi
       redis:
         enabled: true
       extraEnv:
@@ -976,6 +1137,13 @@ govukApplications:
     repoName: email-alert-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 300Mi
       rails:
         createKeyBaseSecret: false
       redis:
@@ -1017,6 +1185,13 @@ govukApplications:
         types:
           - command: ['bin/email-alert-service']
             name: email-alert-service
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       redis:
         enabled: true
       extraEnv:
@@ -1041,6 +1216,13 @@ govukApplications:
   - name: feedback
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 30m
+          memory: 400Mi
       extraEnv:
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: 91ee838c-ef9c-4d10-b3d6-5f73441e08b7
@@ -1083,6 +1265,13 @@ govukApplications:
     repoName: feedback
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 300Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -1135,10 +1324,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 2500Mi
+          memory: 2Gi
         requests:
-          cpu: 2
-          memory: 2000Mi
+          cpu: 600m
+          memory: 1Gi
       cronTasks:
         - name: registries-refresh
           task: "registries:cache_refresh"
@@ -1158,6 +1347,13 @@ govukApplications:
     repoName: finder-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -1202,9 +1398,9 @@ govukApplications:
       appResources:
         limits:
           cpu: 4
-          memory: 1500Mi
+          memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 500m
           memory: 1Gi
       extraEnv:
         - name: MEMCACHE_SERVERS
@@ -1241,6 +1437,13 @@ govukApplications:
     repoName: frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 350Mi
       ingress:
         enabled: true
         annotations:
@@ -1300,11 +1503,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 2Gi
         requests:
           cpu: 1
-          memory: 1500Mi
+          memory: 768Mi
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
@@ -1318,6 +1521,13 @@ govukApplications:
     repoName: government-frontend
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -1336,6 +1546,13 @@ govukApplications:
   - name: govspeak-preview
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 768Mi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       monitoring:
         enabled: false
       ingress:
@@ -1353,6 +1570,13 @@ govukApplications:
   - name: govuk-chat
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 768Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -1486,6 +1710,13 @@ govukApplications:
     chartPath: charts/govuk-e2e-tests
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 1Gi
       cronJobs:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5"
@@ -1524,6 +1755,13 @@ govukApplications:
   - name: hmrc-manuals-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1.5
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       nginxClientMaxBodySize: 2M
       ingress:
         enabled: true
@@ -1628,11 +1866,25 @@ govukApplications:
   - name: link-checker-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       redis:
         enabled: true
       extraEnv:
@@ -1670,6 +1922,13 @@ govukApplications:
   - name: local-links-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.3Gi
+        requests:
+          cpu: 20m
+          memory: 650Mi
       redis:
         enabled: true
       ingress:
@@ -1787,11 +2046,25 @@ govukApplications:
   - name: locations-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.2Gi
+        requests:
+          cpu: 20m
+          memory: 650Mi
       uploadAssets:
         enabled: false
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1.5
+          memory: 1.1Gi
+        requests:
+          cpu: 200m
+          memory: 650Mi
       redis:
         enabled: true
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2091,9 +2091,23 @@ govukApplications:
   - name: manuals-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.2Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
       nginxClientMaxBodySize: *max-upload-size
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       redis:
         enabled: true
       ingress:
@@ -2152,6 +2166,13 @@ govukApplications:
   - name: maslow
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.2Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       ingress:
         enabled: true
         annotations:
@@ -2190,6 +2211,13 @@ govukApplications:
   - name: places-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
       ingress:
         enabled: true
         annotations:
@@ -2206,6 +2234,13 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       extraEnv:
@@ -2228,9 +2263,23 @@ govukApplications:
   - name: publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       cronTasks:
@@ -2341,6 +2390,13 @@ govukApplications:
   - name: publishing-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 20m
+          memory: 768Mi
       nginxClientMaxBodySize: 2M
       dbMigrationEnabled: true
       uploadAssets:
@@ -2351,10 +2407,10 @@ govukApplications:
         enabled: true
       workerResources:
         limits:
-          cpu: 4000m
-          memory: 1Gi
+          cpu: 4
+          memory: 1.5Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 512Mi
       cronTasks:
         - name: metrics-report-to-prometheus
@@ -2419,6 +2475,13 @@ govukApplications:
   - name: release
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2433,22 +2496,15 @@ govukApplications:
           - name: release.{{ .Values.k8sExternalDomainSuffix }}
       workers:
         enabled: false
-      podDisruptionBudget:
-        minAvailable: 1
-      appResources:
-        limits:
-          cpu: 1
-          memory: 1Gi
-        requests:
-          cpu: 100m
-          memory: 400Mi
       workerResources:
         limits:
           cpu: 250m
           memory: 1Gi
         requests:
-          cpu: 100m
+          cpu: 10m
           memory: 400Mi
+      podDisruptionBudget:
+        minAvailable: 1
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
@@ -2493,7 +2549,7 @@ govukApplications:
           cpu: 4
           memory: 3Gi
         requests:
-          cpu: 2
+          cpu: 50m
           memory: 1Gi
       ingress:
         enabled: true
@@ -2615,7 +2671,7 @@ govukApplications:
           cpu: 4
           memory: 3Gi
         requests:
-          cpu: 2
+          cpu: 10m
           memory: 1Gi
       appProbes: *router-app-probes
       nginxConfigMap:
@@ -2669,6 +2725,13 @@ govukApplications:
   - name: search-admin
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2728,6 +2791,13 @@ govukApplications:
   - name: search-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.2Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       rails:
         enabled: false
       nginxClientMaxBodySize: 20M
@@ -2778,6 +2848,13 @@ govukApplications:
             name: govuk-index-queue-listener
           - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
             name: bulk-reindex-queue-listener
+      workerResources:
+        limits:
+          cpu: 4
+          memory: 3Gi
+        requests:
+          cpu: 10m
+          memory: 768Mi
       extraEnv:
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-staging-search-relevancy
@@ -2854,6 +2931,13 @@ govukApplications:
   - name: search-api-v2
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 2.5Gi
+        requests:
+          cpu: 20m
+          memory: 768Mi
       dbMigrationEnabled: false
       ingress:
         enabled: true
@@ -2875,6 +2959,13 @@ govukApplications:
         types:
           - command: ['bin/rake', 'document_sync_worker:run']
             name: document-sync-worker
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 384Mi
       redis:
         enabled: true
       cronTasks:
@@ -2933,6 +3024,13 @@ govukApplications:
   - name: service-manual-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
       dbMigrationEnabled: true
       ingress:
         enabled: true
@@ -2992,9 +3090,23 @@ govukApplications:
   - name: signon
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 600Mi
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -3071,6 +3183,14 @@ govukApplications:
     repoName: smart-answers
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          # Being strict here - smart-answers is showing signs of a memory leak
+          memory: 1Gi
+        requests:
+          cpu: 50m
+          memory: 512Mi
       uploadAssets:
         # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
         path: /app/public/assets/smartanswers
@@ -3090,6 +3210,13 @@ govukApplications:
   - name: static
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       ingress:
         enabled: true
         annotations:
@@ -3145,6 +3272,13 @@ govukApplications:
     repoName: static
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       rails:
         createKeyBaseSecret: false
       sentry:
@@ -3177,6 +3311,13 @@ govukApplications:
   - name: short-url-manager
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 256Mi
       ingress:
         enabled: true
         annotations:
@@ -3228,10 +3369,24 @@ govukApplications:
   - name: specialist-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 450Mi
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
       redis:
         enabled: true
       ingress:
@@ -3294,6 +3449,13 @@ govukApplications:
   - name: support
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       ingress:
         enabled: true
         annotations:
@@ -3309,6 +3471,13 @@ govukApplications:
         path: /app/public/assets/support
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 168Mi
       redis:
         enabled: true
       extraEnv:
@@ -3348,11 +3517,25 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 320Mi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 192Mi
       redis:
         enabled: true
       cronTasks:
@@ -3412,6 +3595,13 @@ govukApplications:
   - name: transition
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 400Mi
       ingress:
         enabled: true
         annotations:
@@ -3426,6 +3616,13 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 192Mi
       redis:
         enabled: true
       cronTasks:
@@ -3467,6 +3664,13 @@ govukApplications:
   - name: travel-advice-publisher
     helmValues:
       arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 384Mi
       cronTasks:
         - name: publish-scheduled-editions
           task: "publish_scheduled_editions"
@@ -3474,6 +3678,13 @@ govukApplications:
       nginxClientMaxBodySize: *max-upload-size
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 175Mi
       redis:
         enabled: true
       ingress:
@@ -3533,15 +3744,15 @@ govukApplications:
     repoName: whitehall
     helmValues:
       arch: arm64
-      assetManagerNFS: *assets-nfs
-      nfsStorage: 15Gi
       appResources:
         limits:
+          cpu: 2
           memory: 4Gi
-          cpu: "2"
         requests:
+          cpu: 50m
           memory: 2Gi
-          cpu: "1"
+      assetManagerNFS: *assets-nfs
+      nfsStorage: 15Gi
       securityContext:
         # Use the same uid/gid for NFS permissions as the old stack, so that
         # files uploaded by whitehall-admin on k8s can be processed by
@@ -3564,6 +3775,13 @@ govukApplications:
       dbMigrationEnabled: true
       workers:
         enabled: true
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
       redis:
         enabled: true
       nginxClientMaxBodySize: *max-upload-size


### PR DESCRIPTION
## What?
To make better use of our EKS node resources, I have adjusted down the CPU requests for each of the pods to a minimum of 10m (which may still be too generous) because the baseline CPU usage of many of our apps is practically nil. Our resource bottleneck is usually on memory consumption (I may change our Launch Templates to swap us to R-type instances soon).