### PR TITLE
Enable db migration to allow db setup

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2325,7 +2325,7 @@ govukApplications:
         requests:
           cpu: 100m
           memory: 650Mi
-      dbMigrationEnabled: false
+      dbMigrationEnabled: true
       rails:
         createKeyBaseSecret: false
         # use the same secret as the mongo publisher


### PR DESCRIPTION
Now that we have table in the database, we can enable the migration that was disabled here : https://github.com/alphagov/govuk-helm-charts/pull/2954/files