### PR TITLE
Remove the `readOnlyRootFileSystem` requirement

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -70,7 +70,6 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           volumeMounts:


### PR DESCRIPTION
Description:
- `db:migrate` job is failing because `app` isn't mounted in