### PR TITLE
Bump Asset Manager virus scan limits

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -21,7 +21,7 @@ data:
     Foreground yes
     LogTime yes
     LogVerbose yes
-    MaxFiles 25000
+    MaxFiles 35000
     # Whitehall and Specialist Publisher allow up to 500 MB uploads. Keep in
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).


### PR DESCRIPTION
[Trello](https://trello.com/c/MqNqwltr/1567-investigate-a-support-ticket-file-not-uploading-correctly)

In https://github.com/alphagov/govuk-helm-charts/commit/229e16e1ef5ad9d27a73aac42d3d9ec01f2c1d97 and https://github.com/alphagov/govuk-helm-charts/commit/5c3383247b3c15127c97b3ed95625f4604536b68 we increased the max files setting which allows us to scan bigger files. We've had a new issue where the limits have been exceeded again, so we once more need to bump this a little higher. I've tested this locally and found that 35000 max files should be sufficient

I'll document how to run the scan locally in the developer docs. The final command looks something like this:

```
clamscan --alert-exceeds-max=yes --max-scansize=1200M --max-filesize=500M file.pdf
```