### PR TITLE
✨ Allow user to rewrite worker secret key base name

### DIFF
--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.repoName }}-rails-secret-key-base
+                  name: {{ .Values.rails.secretKeyBaseName | default (printf "%s-rails-secret-key-base" .Values.repoName) }}
                   key: secret-key-base
             {{- end }}
             {{- if $.Values.sentry.enabled }}


### PR DESCRIPTION

## 👀 Purpose

- After some troubleshooting with a user, it became clear that we allow a user to overwrite this key name in deployment.yaml but not deployment-worker.yaml. That doesn't make sense to me, so this commit allows the value to be specified but auto-populated if left blank.
- Here is the key name in [deployment.yaml.](https://github.com/alphagov/govuk-helm-charts/blob/157e2027ffbe8a62d4d458bcb25764a9e37098b7/charts/generic-govuk-app/templates/deployment.yaml#L92)

## ♻️ What's changed

- A change in how the key name in deployment-worker.yaml is interpolated.

