### PR TITLE
Fix worker secret name template error

### DIFF
--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.rails.secretKeyBaseName | default (printf "%s-rails-secret-key-base" .Values.repoName) }}
+                  name: {{ $.Values.rails.secretKeyBaseName | default (printf "%s-rails-secret-key-base" $.Values.repoName) }}
                   key: secret-key-base
             {{- end }}
             {{- if $.Values.sentry.enabled }}


### PR DESCRIPTION
This is in a `range` block so the `$.` is necessary to access the value correctly