### PR TITLE
Update cronjob alerts to fire at any time

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -76,8 +76,6 @@ spec:
       repeatInterval: 1d
       groupWait: 5m
       groupInterval: 30m
-      activeTimeIntervals:
-        - inhours
     - matchers:
       - name: destination
         value: slack-cronjob-notifications
@@ -86,8 +84,6 @@ spec:
       repeatInterval: 1d
       groupWait: 5m
       groupInterval: 30m
-      activeTimeIntervals:
-        - inhours
   receivers:
   - name: 'null'
   - name: 'pagerduty'


### PR DESCRIPTION
## What

Remove alert inhours restriction

## Why

We would like the alert to go to the Slack channel at any time