### PR TITLE
Add support for creating and assigning service accounts to generic-govuk-app chart

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3271,35 +3271,32 @@ govukApplications:
           external-dns.alpha.kubernetes.io/hostname: signon.{{ .Values.k8sExternalDomainSuffix }}
         hosts:
           - name: signon.{{ .Values.publishingDomainSuffix }}
+      serviceAccount:
+        enabled: true
+        create: false
+        name: signon
       cronTasks:
         - name: delete-expired-oauth-grants
           task: "oauth_access_grants:delete_expired"
           schedule: "29 12 * * 0"
-          serviceAccount: signon
         - name: delete-logs-older-than-two-years
           task: "event_log:delete_logs_older_than_two_years"
           schedule: "16 1 * * *"
-          serviceAccount: signon
         - name: fetch-whitehall-organisations
           task: "organisations:fetch"
           schedule: "11 11 * * *"
-          serviceAccount: signon
         - name: send-suspension-reminders
           task: "users:send_suspension_reminders"
           schedule: "57 11 * * *"
-          serviceAccount: signon
         - name: suspend-inactive-users
           task: "users:suspend_inactive"
           schedule: "27 11 * * *"
-          serviceAccount: signon
         - name: sync-app-secrets-to-k8s
           task: "kubernetes:sync_app_secrets"
           schedule: "6 1 * * *"
-          serviceAccount: signon
         - name: sync-token-secrets-to-k8s
           task: "kubernetes:sync_token_secrets"
           schedule: "7 1 * * *"
-          serviceAccount: signon
       extraEnv:
         - name: GOVUK_CSP_REPORT_ONLY
           value: "true"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3165,35 +3165,32 @@ govukApplications:
           external-dns.alpha.kubernetes.io/hostname: signon.{{ .Values.k8sExternalDomainSuffix }}
         hosts:
           - name: signon.{{ .Values.publishingDomainSuffix }}
+      serviceAccount:
+        enabled: true
+        create: false
+        name: signon
       cronTasks:
         - name: delete-expired-oauth-grants
           task: "oauth_access_grants:delete_expired"
           schedule: "22 12 * * 0"
-          serviceAccount: signon
         - name: delete-logs-older-than-two-years
           task: "event_log:delete_logs_older_than_two_years"
           schedule: "17 1 * * *"
-          serviceAccount: signon
         - name: fetch-whitehall-organisations
           task: "organisations:fetch"
           schedule: "11 3 * * *"
-          serviceAccount: signon
         - name: send-suspension-reminders
           task: "users:send_suspension_reminders"
           schedule: "57 6 * * *"
-          serviceAccount: signon
         - name: suspend-inactive-users
           task: "users:suspend_inactive"
           schedule: "27 4 * * *"
-          serviceAccount: signon
         - name: sync-app-secrets-to-k8s
           task: "kubernetes:sync_app_secrets"
           schedule: "8 1 * * *"
-          serviceAccount: signon
         - name: sync-token-secrets-to-k8s
           task: "kubernetes:sync_token_secrets"
           schedule: "9 1 * * *"
-          serviceAccount: signon
       extraEnv:
         - name: GOVUK_CSP_REPORT_ONLY
           value: "true"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3125,23 +3125,23 @@ govukApplications:
           external-dns.alpha.kubernetes.io/hostname: signon.{{ .Values.k8sExternalDomainSuffix }}
         hosts:
           - name: signon.{{ .Values.publishingDomainSuffix }}
+      serviceAccount:
+        enabled: true
+        create: false
+        name: signon
       cronTasks:
         - name: delete-expired-oauth-grants
           task: "oauth_access_grants:delete_expired"
           schedule: "53 12 * * 0"
-          serviceAccount: signon
         - name: delete-logs-older-than-two-years
           task: "event_log:delete_logs_older_than_two_years"
           schedule: "18 1 * * *"
-          serviceAccount: signon
         - name: sync-app-secrets-to-k8s
           task: "kubernetes:sync_app_secrets"
           schedule: "11 1 * * *"
-          serviceAccount: signon
         - name: sync-token-secrets-to-k8s
           task: "kubernetes:sync_token_secrets"
           schedule: "12 1 * * *"
-          serviceAccount: signon
       extraEnv:
         - name: GOVUK_CSP_REPORT_ONLY
           value: "true"

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -33,7 +33,12 @@ spec:
             app.kubernetes.io/name: "{{ $fullName }}-{{ .name }}"
             app.kubernetes.io/component: "{{ .name }}"
         spec:
-          automountServiceAccountToken: {{- if .serviceAccount }} true {{- else }} false {{- end }}
+          {{- if $.Values.serviceAccount.enabled }}
+          automountServiceAccountToken: true
+          serviceAccountName: {{ $.Values.serviceAccount.name | default (print $fullName "-sa") }}
+          {{- else }}
+          automountServiceAccountToken: false
+          {{- end }}
           enableServiceLinks: false
           securityContext:
             seccompProfile:
@@ -43,7 +48,6 @@ spec:
             runAsUser: {{ $.Values.securityContext.runAsUser }}
             runAsGroup: {{ $.Values.securityContext.runAsGroup }}
           restartPolicy: Never
-          {{ if .serviceAccount }}serviceAccountName: {{ .serviceAccount }}{{- end }}
           volumes:
             - name: app-tmp
               emptyDir: {}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -25,7 +25,12 @@ spec:
         app.kubernetes.io/name: {{ $fullName }}
         app.kubernetes.io/component: app
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      automountServiceAccountToken: true
+      serviceAccountName: {{ .Values.serviceAccount.name | default (print $fullName "-sa") }}
+      {{- else }}
       automountServiceAccountToken: false
+      {{- end }}
       enableServiceLinks: false
       securityContext:
         seccompProfile:

--- a/charts/generic-govuk-app/templates/serviceaccount.yaml
+++ b/charts/generic-govuk-app/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- $fullName := include "generic-govuk-app.fullname" . }}
+{{- with .Values.serviceAccount -}}
+{{- if and .enabled .create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name | default (print $fullName "-sa") }}
+  annotations:
+    {{- toYaml .annotations | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -25,7 +25,12 @@ spec:
         app.kubernetes.io/name: {{ $fullName }}-worker
         app.kubernetes.io/component: worker
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      automountServiceAccountToken: true
+      serviceAccountName: {{ .Values.serviceAccount.name | default (print $fullName "-sa") }}
+      {{- else }}
       automountServiceAccountToken: false
+      {{- end }}
       enableServiceLinks: false
       securityContext:
         seccompProfile:

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -173,3 +173,9 @@ rails:
 externalSecrets:
   refreshInterval: 1h  # Be kind to etcd and don't set this too short.
   deletionPolicy: Delete
+
+serviceAccount:
+  enabled: false
+  create: false
+  name: null
+  annotations: {}


### PR DESCRIPTION
The AI team wants this so they can authenticate with an AWS service without using long-lived credentials