### PR TITLE
Search Admin: Update Discovery Engine configuration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2903,16 +2903,11 @@ govukApplications:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_ENGINE
-        - name: DISCOVERY_ENGINE_SERVING_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_SERVING_CONFIG
+              key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
 
   - name: search-api
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2804,16 +2804,11 @@ govukApplications:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_ENGINE
-        - name: DISCOVERY_ENGINE_SERVING_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_SERVING_CONFIG
+              key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
 
   - name: search-api
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2782,16 +2782,11 @@ govukApplications:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_ENGINE
+        - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_ENGINE
-        - name: DISCOVERY_ENGINE_SERVING_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_SERVING_CONFIG
+              key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
 
   - name: search-api
     helmValues:


### PR DESCRIPTION
This removes two currently unused configuration env vars from Search Admin, and replaces them with a new `DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME` one.

See https://github.com/alphagov/govuk-infrastructure/pull/1686