### PR TITLE
Search Admin: Add Redis configuration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2859,6 +2859,8 @@ govukApplications:
             ]}}]
         hosts:
           - name: search-admin.{{ .Values.k8sExternalDomainSuffix }}
+      redis:
+        enabled: true
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2764,6 +2764,8 @@ govukApplications:
             ]}}]
         hosts:
           - name: search-admin.{{ .Values.k8sExternalDomainSuffix }}
+      redis:
+        enabled: true
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2744,6 +2744,8 @@ govukApplications:
             ]}}]
         hosts:
           - name: search-admin.{{ .Values.k8sExternalDomainSuffix }}
+      redis:
+        enabled: true
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
Search Admin will need Sidekiq configured again. This adds Redis first so it can stand up, and workers will be set up in a subsequent change.