### PR TITLE
Make the publisher use its own sso auth and secret

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2433,12 +2433,12 @@ govukApplications:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
-              name: signon-app-publisher
+              name: signon-app-publisher-on-pg
               key: oauth_id
         - name: GDS_SSO_OAUTH_SECRET
           valueFrom:
             secretKeyRef:
-              name: signon-app-publisher
+              name: signon-app-publisher-on-pg
               key: oauth_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
**What**
Make helm use the publisher-on-pg secret and auth so the pods contain the environment variable that are created for publisher-on-pg for signon.
