### PR TITLE
Search API v2: Add `DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3150,6 +3150,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE_BRANCH
+        - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
         - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3048,6 +3048,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE_BRANCH
+        - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
         - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3010,6 +3010,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DATASTORE_BRANCH
+        - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
         - name: DISCOVERY_ENGINE_SERVING_CONFIG
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This adds the environment variable set up in
https://github.com/alphagov/govuk-infrastructure/pull/1686

Eventually this will replace several of the other env variables, but we need to add it first to allow Search API v2 to use it, before we can remove the other ones.