### PR TITLE
Remove -sa suffix from default service account name

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -35,7 +35,7 @@ spec:
         spec:
           {{- if $.Values.serviceAccount.enabled }}
           automountServiceAccountToken: true
-          serviceAccountName: {{ $.Values.serviceAccount.name | default (print $fullName "-sa") }}
+          serviceAccountName: {{ $.Values.serviceAccount.name | default $fullName }}
           {{- else }}
           automountServiceAccountToken: false
           {{- end }}

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       {{- if .Values.serviceAccount.enabled }}
       automountServiceAccountToken: true
-      serviceAccountName: {{ .Values.serviceAccount.name | default (print $fullName "-sa") }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default $fullName }}
       {{- else }}
       automountServiceAccountToken: false
       {{- end }}

--- a/charts/generic-govuk-app/templates/serviceaccount.yaml
+++ b/charts/generic-govuk-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .name | default (print $fullName "-sa") }}
+  name: {{ .name | default $fullName }}
   annotations:
     {{- toYaml .annotations | nindent 4 }}
 {{- end -}}

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       {{- if .Values.serviceAccount.enabled }}
       automountServiceAccountToken: true
-      serviceAccountName: {{ .Values.serviceAccount.name | default (print $fullName "-sa") }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default $fullName }}
       {{- else }}
       automountServiceAccountToken: false
       {{- end }}


### PR DESCRIPTION
The suffix isn't necessary, just using the app name is cleaner