### PR TITLE
De-integrate GOV.UK Chat from www.gov.uk in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1617,9 +1617,6 @@ govukApplications:
           schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
-        # remove the need for signon to access frontend of chat
-        - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION
-          value: "true"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -1698,17 +1695,6 @@ govukApplications:
           value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "0"
-      nginxConfigMap:
-        extraServerConf: |
-          location /chat {
-            if ($http_host = 'chat.integration.publishing.service.gov.uk' ) {
-              return 301 https://www.integration.publishing.service.gov.uk$request_uri;
-            }
-            if ($http_host = 'chat.eks.integration.govuk.digital' ) {
-              return 301 https://www.integration.publishing.service.gov.uk$request_uri;
-            }
-            proxy_pass http://govuk-chat;
-          }
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
@@ -2677,22 +2663,13 @@ govukApplications:
             access_logs.s3.enabled=true,
             access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
             access_logs.s3.prefix=elb/www-origin
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &router-conditions >
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
                 "www.{{ .Values.externalDomainSuffix }}",
                 "www-origin.{{ .Values.publishingDomainSuffix }}"
             ]}}]
-          alb.ingress.kubernetes.io/conditions.govuk-chat: *router-conditions
         hosts:
           - name: www-origin.{{ .Values.k8sExternalDomainSuffix }}
-            extraPaths:
-              - path: /chat
-                pathType: Prefix
-                backend:
-                  service:
-                    name: govuk-chat
-                    port:
-                      name: app
       nginxConfigMap:
         create: false
         name: live-router-nginx-conf


### PR DESCRIPTION
Trello: https://github.com/alphagov/govuk-helm-charts/pull/2977

Now that we have configured a gone route for www.gov.uk/chat [1] this removes the additional configuration to serve the /chat route with the www loadbalancer.

This removes the additional ALB conditions for router with extra paths for /chat. It removes the nginx redirects to keep people on www rather than the chat.publishing hostname, and turns on signon authentication for chat again, so that it can't be accessed without a signon account.

I've applied this only to integration so far so that I can verify it all works correctly.

I've left the ingress configuration [2] as it seemed every other app with public access has it, however I was a little confused as we didn't seem to add it until we configured the app to be served on www.

[1]: https://github.com/alphagov/publishing-api/pull/3122
[2]: https://github.com/alphagov/govuk-helm-charts/commit/06f61038f801fbee1ad2c4790ee9fb81ac92e8e2