### PR TITLE
Use curl image from quay.io instead of Docker Hub

### DIFF
--- a/charts/argo-services/templates/workflows/notify-release/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-release/workflow.yaml
@@ -17,7 +17,7 @@ spec:
         - name: commitSha
         - name: environment
       script:
-        image: curlimages/curl
+        image: quay.io/curl/curl
         command:
           - sh
         source: >

--- a/charts/argo-services/templates/workflows/notify-slack/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-slack/workflow.yaml
@@ -19,7 +19,7 @@ spec:
         - name: text
         - name: blocks
       container:
-        image: curlimages/curl
+        image: quay.io/curl/curl
         command:
           - "curl"
           - "--json"

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -90,7 +90,7 @@ spec:
         - name: imageTag
         - name: promoteDeployment
       script:
-        image: curlimages/curl
+        image: quay.io/curl/curl
         command:
           - sh
         source: >


### PR DESCRIPTION
We're getting rate limited by Docker Hub, causing workflow failures. The image on quay.io is identical to the Docker Hub one