### PR TITLE
Deintegrate GOV.UK Chat from www.gov.uk

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1618,9 +1618,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-slack
               key: AI_SLACK_CHANNEL_WEBHOOK_URL
-        # remove the need for signon to access frontend of chat
-        - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION
-          value: "true"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -1697,17 +1694,6 @@ govukApplications:
           value: "100"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "100"
-      nginxConfigMap:
-        extraServerConf: |
-          location /chat {
-            if ($http_host = 'chat.publishing.service.gov.uk' ) {
-              return 301 https://www.gov.uk$request_uri;
-            }
-            if ($http_host = 'chat.eks.production.govuk.digital' ) {
-              return 301 https://www.gov.uk$request_uri;
-            }
-            proxy_pass http://govuk-chat;
-          }
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
@@ -2581,22 +2567,13 @@ govukApplications:
             access_logs.s3.enabled=true,
             access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
             access_logs.s3.prefix=elb/www-origin
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &router-conditions >
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
                 "www.{{ .Values.externalDomainSuffix }}",
                 "www-origin.{{ .Values.publishingDomainSuffix }}"
             ]}}]
-          alb.ingress.kubernetes.io/conditions.govuk-chat: *router-conditions
         hosts:
           - name: www-origin.{{ .Values.k8sExternalDomainSuffix }}
-            extraPaths:
-              - path: /chat
-                pathType: Prefix
-                backend:
-                  service:
-                    name: govuk-chat
-                    port:
-                      name: app
       nginxConfigMap:
         create: false
         name: live-router-nginx-conf

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1613,9 +1613,6 @@ govukApplications:
           schedule: "15 9,11,13,15 * * 1-5"
           timeZone: "Europe/London"
       extraEnv:
-        # remove the need for signon to access frontend of chat
-        - name: AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION
-          value: "true"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -1694,17 +1691,6 @@ govukApplications:
           value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "0"
-      nginxConfigMap:
-        extraServerConf: |
-          location /chat {
-            if ($http_host = 'chat.staging.publishing.service.gov.uk' ) {
-              return 301 https://www.staging.publishing.service.gov.uk$request_uri;
-            }
-            if ($http_host = 'chat.eks.staging.govuk.digital' ) {
-              return 301 https://www.staging.publishing.service.gov.uk$request_uri;
-            }
-            proxy_pass http://govuk-chat;
-          }
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
@@ -2561,22 +2547,13 @@ govukApplications:
             access_logs.s3.enabled=true,
             access_logs.s3.bucket=govuk-{{ .Values.govukEnvironment }}-aws-logging,
             access_logs.s3.prefix=elb/www-origin
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: &router-conditions >
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [
                 "www.{{ .Values.externalDomainSuffix }}",
                 "www-origin.{{ .Values.publishingDomainSuffix }}"
             ]}}]
-          alb.ingress.kubernetes.io/conditions.govuk-chat: *router-conditions
         hosts:
           - name: www-origin.{{ .Values.k8sExternalDomainSuffix }}
-            extraPaths:
-              - path: /chat
-                pathType: Prefix
-                backend:
-                  service:
-                    name: govuk-chat
-                    port:
-                      name: app
       nginxConfigMap:
         create: false
         name: live-router-nginx-conf


### PR DESCRIPTION
Trello: https://trello.com/c/evNZhxxc/2285-set-up-410-page-for-govuk-chat-to-be-served-by-govuk

This applies the changes made in https://github.com/alphagov/govuk-helm-charts/pull/2977 to staging and production. These changes stop www.gov.uk/chat being handled by chat.publishing.service.gov.uk and fall back to regular router. They also remove redirects from chat.publishing.service.gov.uk that would redirect a user to www and require signon authentication to use chat.