### PR TITLE
Search API v2/Search Admin: Remove old env vars

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2880,11 +2880,6 @@ govukApplications:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_CREDENTIALS
-        - name: DISCOVERY_ENGINE_DATASTORE
-          valueFrom:
-            secretKeyRef:
-              name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
@@ -3122,26 +3117,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_PROJECT_ID
-        - name: DISCOVERY_ENGINE_DATASTORE
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE_BRANCH
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
-        - name: DISCOVERY_ENGINE_SERVING_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2776,11 +2776,6 @@ govukApplications:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_CREDENTIALS
-        - name: DISCOVERY_ENGINE_DATASTORE
-          valueFrom:
-            secretKeyRef:
-              name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
@@ -3015,26 +3010,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_PROJECT_ID
-        - name: DISCOVERY_ENGINE_DATASTORE
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE_BRANCH
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
-        - name: DISCOVERY_ENGINE_SERVING_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2754,11 +2754,6 @@ govukApplications:
             secretKeyRef:
               name: search-admin-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_CREDENTIALS
-        - name: DISCOVERY_ENGINE_DATASTORE
-          valueFrom:
-            secretKeyRef:
-              name: search-admin-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
@@ -2977,26 +2972,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_PROJECT_ID
-        - name: DISCOVERY_ENGINE_DATASTORE
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE
-        - name: DISCOVERY_ENGINE_DATASTORE_BRANCH
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_DATASTORE_BRANCH
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
-        - name: DISCOVERY_ENGINE_SERVING_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: search-api-v2-google-cloud-discovery-engine-configuration
-              key: DISCOVERY_ENGINE_SERVING_CONFIG
 
   - name: search-index-env-sync
     # See ../charts/search-index-env-sync/values.yaml for job configuration.


### PR DESCRIPTION
These apps now depend on `DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME` exclusively for their Discovery Engine configuration, and we no longer need the several other ones.