### PR TITLE
Disable chat cron tasks

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1602,18 +1602,19 @@ govukApplications:
         s3Directory: chat
         path: /app/public/assets/chat
       cronTasks:
-        - name: promote-waiting-list
-          task: "users:promote_waiting_list"
-          schedule: "30 7-19 * * *"
-          timeZone: "Europe/London"
-        - name: increment-instant-access-places
-          task: "settings:increment_pilot_places[instant_access]"
-          schedule: "0 9,11,13,15 * * 1-5"
-          timeZone: "Europe/London"
-        - name: increment-delayed-access-places
-          task: "settings:increment_pilot_places[delayed_access]"
-          schedule: "15 9,11,13,15 * * 1-5"
-          timeZone: "Europe/London"
+        # cron tasks disabled while application is not available to public
+        # - name: promote-waiting-list
+        #   task: "users:promote_waiting_list"
+        #   schedule: "30 7-19 * * *"
+        #   timeZone: "Europe/London"
+        # - name: increment-instant-access-places
+        #   task: "settings:increment_pilot_places[instant_access]"
+        #   schedule: "0 9,11,13,15 * * 1-5"
+        #   timeZone: "Europe/London"
+        # - name: increment-delayed-access-places
+        #   task: "settings:increment_pilot_places[delayed_access]"
+        #   schedule: "15 9,11,13,15 * * 1-5"
+        #   timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1596,22 +1596,23 @@ govukApplications:
         s3Directory: chat
         path: /app/public/assets/chat
       cronTasks:
-        - name: bigquery-export
-          task: "bigquery:export"
-          schedule: "5 * * * *"
-          timeZone: "Europe/London"
-        - name: promote-waiting-list
-          task: "users:promote_waiting_list"
-          schedule: "30 7-22 * * *"
-          timeZone: "Europe/London"
-        - name: increment-instant-access-places
-          task: "settings:increment_pilot_places[instant_access]"
-          schedule: "0 * * * *"
-          timeZone: "Europe/London"
-        - name: increment-delayed-access-places
-          task: "settings:increment_pilot_places[delayed_access]"
-          schedule: "15 12 * * *"
-          timeZone: "Europe/London"
+        # cron tasks disabled while application is not available to public
+        # - name: bigquery-export
+        #   task: "bigquery:export"
+        #   schedule: "5 * * * *"
+        #   timeZone: "Europe/London"
+        # - name: promote-waiting-list
+        #   task: "users:promote_waiting_list"
+        #   schedule: "30 7-22 * * *"
+        #   timeZone: "Europe/London"
+        # - name: increment-instant-access-places
+        #   task: "settings:increment_pilot_places[instant_access]"
+        #   schedule: "0 * * * *"
+        #   timeZone: "Europe/London"
+        # - name: increment-delayed-access-places
+        #   task: "settings:increment_pilot_places[delayed_access]"
+        #   schedule: "15 12 * * *"
+        #   timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1600,18 +1600,19 @@ govukApplications:
         s3Directory: chat
         path: /app/public/assets/chat
       cronTasks:
-        - name: promote-waiting-list
-          task: "users:promote_waiting_list"
-          schedule: "30 7-19 * * *"
-          timeZone: "Europe/London"
-        - name: increment-instant-access-places
-          task: "settings:increment_pilot_places[instant_access]"
-          schedule: "0 9,11,13,15 * * 1-5"
-          timeZone: "Europe/London"
-        - name: increment-delayed-access-places
-          task: "settings:increment_pilot_places[delayed_access]"
-          schedule: "15 9,11,13,15 * * 1-5"
-          timeZone: "Europe/London"
+        # cron tasks disabled while application is not available to public
+        # - name: promote-waiting-list
+        #   task: "users:promote_waiting_list"
+        #   schedule: "30 7-19 * * *"
+        #   timeZone: "Europe/London"
+        # - name: increment-instant-access-places
+        #   task: "settings:increment_pilot_places[instant_access]"
+        #   schedule: "0 9,11,13,15 * * 1-5"
+        #   timeZone: "Europe/London"
+        # - name: increment-delayed-access-places
+        #   task: "settings:increment_pilot_places[delayed_access]"
+        #   schedule: "15 9,11,13,15 * * 1-5"
+        #   timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
Trello: https://trello.com/c/evNZhxxc/2285-set-up-410-page-for-govuk-chat-to-be-served-by-govuk

These mostly are just performing no-ops because chat isn't doing anything with users at the moment.

There is one however, the bigquery:export task, which risks the authenticity of the exported pilot data. Hence disabling it before anyone uses production for any questions and affects it.