### PR TITLE
Add service account to Chat in Staging & Production for Bedrock access

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1695,6 +1695,13 @@ govukApplications:
           value: "100"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "100"
+      # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
+      serviceAccount:
+        enabled: true
+        create: true
+        name: govuk-chat
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::172025368201:role/govuk-chat-bedrock-access-role
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1692,6 +1692,13 @@ govukApplications:
           value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "0"
+      # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
+      serviceAccount:
+        enabled: true
+        create: true
+        name: govuk-chat
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::696911096973:role/govuk-chat-bedrock-access-role
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests


### PR DESCRIPTION
## What 

Add a service account to the Chat pods in Staging & Production 

## Why

This will provide them with permission to access the Bedrock service in AWS