### PR TITLE
Add secret for mongo db uri to allow working with both mongo and postgres

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2485,6 +2485,11 @@ govukApplications:
             secretKeyRef:
               name: publisher-on-pg
               key: DATABASE_URL
+        - name: MONGODB_URI
+          valueFrom:
+            secretKeyRef:
+              name: publisher-docdb
+              key: MONGODB_URI
         - name: EMAIL_GROUP_BUSINESS
           value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
         - name: EMAIL_GROUP_CITIZEN


### PR DESCRIPTION
**Why**
We want to be able to use both mongo and postgres db in parallel for development while in transition.
This is likely to live till the end of migration, while we migrate to postgres, 