### PR TITLE
Keep asset path to publisher so it does not do duplicate

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2391,8 +2391,8 @@ govukApplications:
         dsnSecretName: publisher-sentry
       uploadAssets:
         enabled: true
-        path: /app/public/assets/publisher-on-pg/*
-        s3Directory: "publisher-on-pg"
+        path: /app/public/assets/publisher/*
+        s3Directory: "publisher"
       workers:
         enabled: true
       workerResources:


### PR DESCRIPTION
We do not really need to store asset to separate path, keeping it to publisher saves some config. less changes would make merge easier