### PR TITLE
Add govuk-graphql

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-graphql
+++ b/charts/app-config/image-tags/integration/govuk-graphql
@@ -1,0 +1,3 @@
+image_tag: latest
+automatic_deploys_enabled: true
+promote_deployment: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2542,7 +2542,8 @@ govukApplications:
             secretKeyRef:
               name: signon-app-govukgraphql
               key: oauth_secret
-        # Intentionally connecting to the same DB as publishing-api - we should probably have a replica instead if this goes to prod
+        # Intentionally connecting to the same DB as publishing-api - we should probably have a
+        # replica instead if this goes to prod
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2502,6 +2502,53 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
 
+  - name: govuk-graphql
+    helmValues:
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
+      nginxClientMaxBodySize: 2M
+      dbMigrationEnabled: false
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "250"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "govuk-graphql.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: govuk-graphql.{{ .Values.k8sExternalDomainSuffix }}
+      uploadAssets:
+        enabled: false
+      workers:
+        enabled: false
+      redis:
+        enabled: false
+      extraEnv:
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-govukgraphql
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-govukgraphql
+              key: oauth_secret
+        # Intentionally connecting to the same DB as publishing-api - we should probably have a replica instead if this goes to prod
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-postgres
+              key: DATABASE_URL
+
   - name: publishing-api
     helmValues:
       arch: arm64


### PR DESCRIPTION
This is an experiment, so only going to integration for now.

The app exposes an API and a user interface, both authenticated behind GDS SSO.

The API includes draft content, which is potentially sensitive, but any risk of information being exposed unnecessarily is adequately mitigated:

- The app uses gds-sso, like other apps. So only users with access to the app in Signon can see the UI, and API calls require bearer tokens (or session cookies)
- Sensitive data (like access limited drafts) is sanitized in integration in any case.

The other main weirdness here is that I'm reusing publishing-api's database credentials. I think this is okay for a test in integration, but for a higher environment we'd at the very least want a read-only user, and probably a whole database read replica so we don't have to worry so much about performance impacts on the primary.

I've already added the secrets to Signon in integration, and sync'd them to k8s.