### PR TITLE
Licensify-Admin: Bump Proxy Read Timeout to debug Integration

### DIFF
--- a/charts/licensify/values.yaml
+++ b/charts/licensify/values.yaml
@@ -37,7 +37,7 @@ clamav:
 nginx:
   port: 8080
   proxyConnectTimeout: 30s
-  proxyReadTimeout: 15s
+  proxyReadTimeout: 60s
   clientMaxBodySize: 200M
   resources:
     limits:


### PR DESCRIPTION
## What?
The GDS Test Authority is currently timing-out when trying to fetch Applications on Integration. We want to increase the Proxy Read Timeout to see if we can get past the HTTP504 or if we can get it to produce an error.