### PR TITLE
Set publishing-api app to use serverless valkey

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2580,6 +2580,8 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "rediss://publishing-api-h4kg8u.serverless.euw1.cache.amazonaws.com:6379"
       cronTasks:
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"


### PR DESCRIPTION
Workers will be swapped to the serverless instance after they have been given chance to drain jobs

https://github.com/alphagov/govuk-infrastructure/issues/1704