### PR TITLE
Revert "Set publishing-api app to use serverless valkey"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2580,8 +2580,6 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "rediss://publishing-api-h4kg8u.serverless.euw1.cache.amazonaws.com:6379"
       cronTasks:
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"


### PR DESCRIPTION
Turns out Sidekiq doesn't support Redis in cluster mode, so serverless ElastiCache can't work

Reverts alphagov/govuk-helm-charts#3006