### PR TITLE
Revert "Update Helm release aws-ebs-csi-driver to v2.40.1 (integration)"

### DIFF
--- a/charts/app-config/helm-versions/integration
+++ b/charts/app-config/helm-versions/integration
@@ -1,5 +1,5 @@
 # $repo_url $chart_name: "$chart_version"
-https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.40.1"
+https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.39.3"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.2"
 https://charts.dexidp.io dex: "0.22.0"
 https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#3002

```Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached): failed to execute helm template command: failed to get command args to log: `helm template . --name-template aws-ebs-csi-driver --namespace kube-system --kube-version 1.31 --values /tmp/9b5e1314-d4d5-46ec-8b0a-1925b5d5cfe1 <api versions removed> --include-crds` failed exit status 1: Error: values don't meet the specifications of the schema(s) in the following chart(s): aws-ebs-csi-driver: - (root): Additional property enableVolumeResizing is not allowed```

For some reason `enableVolumeResizing` isn't allowed