### PR TITLE
elasticache spike: swap publishing-api and whitehall-admin workers to shared redis

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2582,6 +2582,7 @@ govukApplications:
         enabled: true
         redisUrlOverride:
           app: "redis://govuk-shared.h4kg8u.ng.0001.euw1.cache.amazonaws.com:6379/0"
+          workers: "redis://govuk-shared.h4kg8u.ng.0001.euw1.cache.amazonaws.com:6379/0"
       cronTasks:
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"
@@ -4036,6 +4037,7 @@ govukApplications:
         enabled: true
         redisUrlOverride:
           app: "redis://govuk-shared.h4kg8u.ng.0001.euw1.cache.amazonaws.com:6379/1"
+          workers: "redis://govuk-shared.h4kg8u.ng.0001.euw1.cache.amazonaws.com:6379/1"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
Seems to be working for the apps, so lets try swapping the workers over too

https://github.com/alphagov/govuk-infrastructure/issues/1704