### PR TITLE
Increase integration pub api worker replicas to 12

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2571,6 +2571,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
+        replicaCount: 12
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
This matches the value in production. Unfortunately we'll probably find that the database remains a bottleneck, as it's already hovering around 70-80% CPU.

This is an interesting scaling scenario though. Since replatforming we've always been able to increase queue throughput by scaling the worker replicas, and this might be a case where that isn't enough (in which case we'll have to work out whether to scale the DB, or wait it out).