### PR TITLE
Reduce publishing-api workers to 4 in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2571,7 +2571,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
-        replicaCount: 12
+        replicaCount: 4
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
12 is just getting bottlenecked by the database, 4 should be just as quick at clearing the queue and not put as much load on the DB