### PR TITLE
Bump search-api's redis memory limit to 3GB in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2965,6 +2965,13 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 3000Mi
+          requests:
+            cpu: 500m
+            memory: 3000Mi
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"


### PR DESCRIPTION
It's running out of memory due to the republishing job that's running