### PR TITLE
Bump search-api's redis maxmemory to 2.5GB in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2972,6 +2972,8 @@ govukApplications:
           requests:
             cpu: 500m
             memory: 3000Mi
+        config:
+          maxmemory: 2500mb
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"


### PR DESCRIPTION
Sidekiq workers aren't starting properly because redis is out of memory