### PR TITLE
Revert increased resources for publishing-api and search-api in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2964,15 +2964,6 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
-        resources:
-          limits:
-            cpu: 1
-            memory: 6000Mi
-          requests:
-            cpu: 500m
-            memory: 6000Mi
-        config:
-          maxmemory: 5500mb
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2571,7 +2571,6 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
-        replicaCount: 4
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
The integration queues have cleared now, so we can drop these back down to their defaults