### PR TITLE
Add Search API worker replicas

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2812,6 +2812,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
+        replicaCount: 8
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker


### PR DESCRIPTION
For a large republishing job (e.g. > 200,000 documents), Search API is not able to process jobs quickly enough to clear the queue in a reasonable amount of time. For example republishing all publications can take more than 24 hours to clear.

This is exacerbated by the fact that republishing from Whitehall will include HTML attachments for many of the documents, and that whilst we are migrating to the govuk index any indexable but not migrated document types will need to be processed twice (once for the govuk index and once for the government index).