### PR TITLE
Increase virus scanning scan size limit

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -26,7 +26,7 @@ data:
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).
     MaxFileSize 500M
-    MaxScanSize 2500M
+    MaxScanSize 5000M
     MaxScanTime 0
     MaxThreads 20
     SelfCheck 900


### PR DESCRIPTION
A file is being falsely reported as infected and is unavailable on a Published page. Increasing the virus scanner limit to get it through virus scanning.

https://trello.com/c/FdqreZY6/3480-asset-not-found
