### PR TITLE
Reduce replica count of Publishing API

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2409,7 +2409,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
-        replicaCount: 12
+        replicaCount: 6
       redis:
         enabled: true
       workerResources:


### PR DESCRIPTION
Publishing API database is currently struggling at near 100% CPU while it is trying to process 144 concurrent dependency resolutions. This is causing a cascade of problems as any apps that read from the Publishing API at runtime are experiencing timeouts.

We are reducing this in half to see if it can reduce the database CPU load.

This is related to an incident: https://docs.google.com/document/d/1a8NDUb4ilVOASUnBa3su2ylBJ7Y5H1TDtrhyqg84qwA/edit?tab=t.0#heading=h.p99426yo0rbv