### PR TITLE
Reduce Publishing API replica count further

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2409,7 +2409,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
-        replicaCount: 6
+        replicaCount: 3
       redis:
         enabled: true
       workerResources:


### PR DESCRIPTION
Related to: https://github.com/alphagov/govuk-helm-charts/pull/3028 this reduces the replica count of Publishing API workers from 6 to 3 to reduce the amount of concurrent workers to 36.

With 72 workers doing dependency resolution we're still seeing full utilisation of the PostgreSQL CPU.