### PR TITLE
Resume RabbitMQ message processing now that the govuk publishing queue is cleared

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2816,12 +2816,12 @@ govukApplications:
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker
-          #- command: ['rake', 'message_queue:listen_to_publishing_queue']
-          #  name: publishing-queue-listener
-          #- command: ['rake', 'message_queue:insert_data_into_govuk']
-          #  name: govuk-index-queue-listener
-          #- command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
-          #  name: bulk-reindex-queue-listener
+          - command: ['rake', 'message_queue:listen_to_publishing_queue']
+            name: publishing-queue-listener
+          - command: ['rake', 'message_queue:insert_data_into_govuk']
+            name: govuk-index-queue-listener
+          - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']
+            name: bulk-reindex-queue-listener
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
The government indexing queue processor is much slower because it writes to stdout for each message, so we need our 8 replicas to get good throughput.