### PR TITLE
Reduce number of Search API worker replicas to 2

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2812,7 +2812,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
-        replicaCount: 8
+        replicaCount: 2
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker


### PR DESCRIPTION
Now that we have cleared our backlog of search indexing jobs, we can reduce the number of worker pod replicas to 2 again. This should be more than enough to handle our regular indexing load.