### PR TITLE
Set PrunePropagationPolicy=orphan on external-secrets, external-dns and dex

### DIFF
--- a/charts/app-config/templates/dex.yaml
+++ b/charts/app-config/templates/dex.yaml
@@ -21,3 +21,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - PrunePropagationPolicy=orphan

--- a/charts/app-config/templates/external-dns.yaml
+++ b/charts/app-config/templates/external-dns.yaml
@@ -37,3 +37,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - PrunePropagationPolicy=orphan

--- a/charts/app-config/templates/external-secrets.yaml
+++ b/charts/app-config/templates/external-secrets.yaml
@@ -30,3 +30,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - PrunePropagationPolicy=orphan


### PR DESCRIPTION
These are dependencies of ArgoCD, so they need managing by Terraform instead of ArgoCD itself.
This option should make Argo not delete the underlying resources once the Application is removed.

https://github.com/alphagov/govuk-infrastructure/issues/1742