### PR TITLE
Revert "Temporary verbose logging for Publishing API"

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2465,8 +2465,6 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-bigquery
               key: client-secret
-        - name: RAILS_LOG_LEVEL
-          value: debug
 
   - name: release
     helmValues:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#3033

Remove temporary logging - this didn't yield the SQL logging