### PR TITLE
RAILS_LOG_LEVEL debug for Publishing API Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2641,6 +2641,8 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-bigquery
               key: client-secret
+        - name: RAILS_LOG_LEVEL
+          value: debug
 
   - name: release
     helmValues:


### PR DESCRIPTION
This is added as part of an ongoing incident (https://docs.google.com/document/d/1wlG9wL2b_pcBunyqrCVsQRcfIqiK1PXt6leOyNPvFDg/edit) to try identify the cause of the slow task as part of Publishing API publishing.