### PR TITLE
Set PrunePropagationPolicy=orphan on kube-prometheus-stack

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -25,3 +25,4 @@ spec:
     syncOptions:
       - ApplyOutOfSyncOnly=true
       - ServerSideApply=true
+      - PrunePropagationPolicy=orphan


### PR DESCRIPTION
This needs moving to Terraform, so set this first before we remove the Argo app

https://github.com/alphagov/govuk-infrastructure/issues/1742