### PR TITLE
Set PrunePropagationPolicy=orphan on prometheus and alertmanager oauth proxy

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
@@ -21,3 +21,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - PrunePropagationPolicy=orphan

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
@@ -21,3 +21,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - PrunePropagationPolicy=orphan


### PR DESCRIPTION
This needs moving to Terraform, so set this first before we remove the Argo app

https://github.com/alphagov/govuk-infrastructure/issues/1742