### PR TITLE
Update kube-prometheus-stack apps to use new dex secret names

### DIFF
--- a/charts/monitoring-config/kube-prometheus-stack-values.yaml
+++ b/charts/monitoring-config/kube-prometheus-stack-values.yaml
@@ -61,11 +61,11 @@
     "GF_AUTH_GENERIC_OAUTH_CLIENT_ID":
       "secretKeyRef":
         "key": "clientID"
-        "name": "govuk-dex-grafana"
+        "name": "dex-client-grafana"
     "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET":
       "secretKeyRef":
         "key": "clientSecret"
-        "name": "govuk-dex-grafana"
+        "name": "dex-client-grafana"
     "GF_DATABASE_HOST":
       "secretKeyRef":
         "key": "host"

--- a/charts/monitoring-config/templates/kube-prometheus-stack/config/oauth2-proxy.tpl
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/config/oauth2-proxy.tpl
@@ -28,16 +28,16 @@ extraEnv:
   - name: OAUTH2_PROXY_CLIENT_ID
     valueFrom:
       secretKeyRef:
-        name: govuk-dex-{{ .app }}
+        name: dex-client-{{ .app }}
         key: clientID
   - name: OAUTH2_PROXY_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: govuk-dex-{{ .app }}
+        name: dex-client-{{ .app }}
         key: clientSecret
   - name: OAUTH2_PROXY_COOKIE_SECRET
     valueFrom:
       secretKeyRef:
-        name: govuk-dex-{{ .app }}
+        name: dex-client-{{ .app }}
         key: cookieSecret
 {{- end -}}

--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -25,4 +25,3 @@ spec:
     syncOptions:
       - ApplyOutOfSyncOnly=true
       - ServerSideApply=true
-      - PrunePropagationPolicy=orphan

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
@@ -21,4 +21,3 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
-      - PrunePropagationPolicy=orphan

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
@@ -21,4 +21,3 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
-      - PrunePropagationPolicy=orphan


### PR DESCRIPTION
Related: https://github.com/alphagov/govuk-infrastructure/pull/1803

https://github.com/alphagov/govuk-infrastructure/issues/1742