### PR TITLE
Use branch for monitoring-config in all envs but production

### DIFF
--- a/charts/app-config/templates/monitoring-application.yaml
+++ b/charts/app-config/templates/monitoring-application.yaml
@@ -10,7 +10,7 @@ spec:
   project: monitoring
   source:
     repoURL: git@github.com/alphagov/govuk-helm-charts
-    {{- if eq .Values.govukEnvironment "integration" }}
+    {{- if ne .Values.govukEnvironment "production" }}
     targetRevision: samsimpson1/move-to-tf
     {{- end }}
     path: charts/monitoring-config


### PR DESCRIPTION
This is to roll out changes to Dex client secrets to staging. This change is to swap from manually managed client secrets to automatically generated ones. It has already been done in integration.

https://github.com/alphagov/govuk-infrastructure/issues/1742