### PR TITLE
Stop using branch for monitoring application

### DIFF
--- a/charts/app-config/templates/monitoring-application.yaml
+++ b/charts/app-config/templates/monitoring-application.yaml
@@ -10,9 +10,6 @@ spec:
   project: monitoring
   source:
     repoURL: git@github.com/alphagov/govuk-helm-charts
-    {{- if ne .Values.govukEnvironment "production" }}
-    targetRevision: samsimpson1/move-to-tf
-    {{- end }}
     path: charts/monitoring-config
     helm:
       values: |


### PR DESCRIPTION
The changes in the branch are about to be applied to production, so the branch isn't required anymore

https://github.com/alphagov/govuk-infrastructure/issues/1742