### PR TITLE
Ephemeral monitoring config

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: argo-bootstrap
+description: Bootstraps ArgoCD for ephemeral environments
+version: 0.0.1

--- a/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring-config
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  annotations:
+    repoName: monitoring-config
+spec:
+  project: monitoring
+  source:
+    repoURL: git@github.com/alphagov/govuk-helm-charts
+    path: charts/monitoring-config
+    helm:
+      values: |
+        govukEnvironment: ephemeral
+        clusterId: {{ .Values.clusterId }}
+        awsAccountId: {{ .Values.awsAccountId }}
+        k8sExternalDomainSuffix: {{ .Values.clusterId }}.ephemeral.govuk.digital
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.monitoringNamespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ApplyOutOfSyncOnly=true
+    - ServerSideApply=true

--- a/charts/argo-bootstrap-ephemeral/templates/monitoring-project.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/monitoring-project.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: monitoring
+  finalizers:
+    # Ensure that project is not deleted until it is not referenced by any application
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: ArgoCD project containing monitoring applications.
+
+  sourceRepos:
+  - '*'
+
+  # Deny all cluster-scoped resources from being created, except for Namespace
+  clusterResourceWhitelist:
+  - group: ''
+    kind: Namespace
+
+  destinations:
+  - namespace: "*"
+    server: https://kubernetes.default.svc
+
+  orphanedResources:
+    warn: false

--- a/charts/argo-bootstrap-ephemeral/values.yaml
+++ b/charts/argo-bootstrap-ephemeral/values.yaml
@@ -1,0 +1,14 @@
+awsAccountId:
+govukEnvironment:
+argocdUrl:
+argoWorkflowsUrl:
+argoEventsHost:
+clusterId:
+rbacTeams:
+  read_only:
+  read_write:
+iamRoleServiceAccounts:
+  tagImageWorkflow:
+    name:
+    iamRoleArn:
+

--- a/charts/argo-bootstrap-ephemeral/values.yaml
+++ b/charts/argo-bootstrap-ephemeral/values.yaml
@@ -11,4 +11,3 @@ iamRoleServiceAccounts:
   tagImageWorkflow:
     name:
     iamRoleArn:
-

--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -1,0 +1,67 @@
+{{- define "monitoring-config.ephemeral-kube-prometheus-stack-config" -}}
+{{- $clusterId := .Values.clusterId }}
+{{- $domainSuffix := .Values.k8sExternalDomainSuffix }}
+"alertmanager":
+  "alertmanagerSpec":
+    "externalUrl": "https://alertmanager.{{ $domainSuffix }}"
+    "podAntiAffinity": ""
+    "podDisruptionBudget":
+      "enabled": false
+    "replicas": 1
+"grafana":
+  "env":
+    "AWS_ROLE_ARN": "arn:aws:iam::{{ .Values.awsAccountId }}:role/kube-prometheus-stack-grafana-govuk"
+  "grafana.ini":
+    "auth.generic_oauth":
+      "api_url": "https://dex.{{ $domainSuffix }}/userinfo"
+      "auth_url": "https://dex.{{ $domainSuffix }}/auth"
+      "role_attribute_path": "'Admin'"
+      "token_url": "https://dex.{{ $domainSuffix }}/token"
+    "server":
+      "domain": "grafana.{{ $domainSuffix }}"
+  "ingress":
+    "hosts":
+      - "grafana.{{ $domainSuffix }}"
+  "replicas": 1
+  "serviceAccount":
+    "annotations":
+      "eks.amazonaws.com/role-arn":
+        "arn:aws:iam::{{ .Values.awsAccountId }}:role/kube-prometheus-stack-grafana-{{ $clusterId }}"
+"prometheus":
+  "prometheusSpec":
+    "externalUrl": "https://prometheus.{{ $domainSuffix }}"
+    "externalLabels":
+      "environment": "{{ $clusterId }}"
+    "podAntiAffinity": ""
+    "podDisruptionBudget":
+      "enabled": false
+    "replicas": 1
+    "storageSpec":
+      "volumeClaimTemplate":
+        "spec":
+          "resources":
+            "requests":
+              "storage": "50Gi"
+{{- end }}
+
+{{- define "monitoring-config.ephemeral-tempo-config" }}
+{{- $clusterId := .Values.clusterId }}
+storage:
+  trace:
+    backend: s3
+    s3:
+      bucket: govuk-{{ $clusterId }}-tempo
+      region: eu-west-1
+      endpoint: s3.dualstack.eu-west-1.amazonaws.com
+serviceAccount:
+  name: tempo
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.awsAccountId }}:role/tempo-govuk"
+metricsGenerator:
+  enabled: true
+  config:
+    storage:
+      remote_write:
+        - url: >-
+            http://prometheus-kube-prometheus-stack-prometheus-0.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write
+{{- end }}

--- a/charts/monitoring-config/templates/_helpers.tpl
+++ b/charts/monitoring-config/templates/_helpers.tpl
@@ -2,7 +2,11 @@
 Get helm release
 */}}
 {{- define "monitoring-config.helm-release" -}}
-{{- $versions := $.Files.Get (printf "helm-versions/%s" $.Values.govukEnvironment) | fromYaml -}}
+{{- $envName := "production" -}}
+{{- if ne .Values.govukEnvironment "ephemeral" -}}
+{{- $envName = $.Values.govukEnvironment -}}
+{{- end -}}
+{{- $versions := $.Files.Get (printf "helm-versions/%s" $envName) | fromYaml -}}
 {{- $version := get $versions (printf "%s %s" .repoURL .chart) -}}
 repoURL: {{ .repoURL }}
 chart: {{ .chart }}

--- a/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
+++ b/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.govukEnvironment "ephemeral" }}
 {{ $envValues := toYaml (fromYaml (.Files.Get (printf "fastly-prometheus-exporter-values-%s.yaml" .Values.govukEnvironment))) }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -34,3 +35,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+{{- end }}

--- a/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-external-secret.yaml
+++ b/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-external-secret.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.govukEnvironment "ephemeral" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -16,3 +17,4 @@ spec:
         decodingStrategy: None
         conversionStrategy: Default
         metadataPolicy: None
+{{- end }}

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanager-secret.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanager-secret.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.govukEnvironment "ephemeral" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -26,3 +27,4 @@ spec:
         decodingStrategy: None
         conversionStrategy: Default
         metadataPolicy: None
+{{- end }}

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.govukEnvironment "ephemeral" }}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
@@ -204,3 +205,4 @@ spec:
   - name: inhours
     timeIntervals:
     - weekdays: ['monday:friday']
+{{- end }}

--- a/charts/monitoring-config/templates/kube-prometheus-stack/grafana-admin-user-secret.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/grafana-admin-user-secret.yaml
@@ -1,3 +1,6 @@
+# TODO: this is probably not needed anymore
+# so we should investigate if it can be removed
+{{- if ne .Values.govukEnvironment "ephemeral" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -16,3 +19,4 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+{{- end }}

--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -1,6 +1,11 @@
+{{- $mergedValues := "" }}
+{{- if eq "ephemeral" .Values.govukEnvironment }}
+{{ $mergedValues = include "monitoring-config.ephemeral-kube-prometheus-stack-config" . }}
+{{- else }}
 {{ $baseValues := fromYaml (.Files.Get "kube-prometheus-stack-values.yaml") }}
 {{ $envValues := fromYaml (.Files.Get (printf "kube-prometheus-stack-values-%s.yaml" .Values.govukEnvironment)) }}
-{{ $mergedValues := toYaml (merge $envValues $baseValues) }}
+{{ $mergedValues = toYaml (merge $envValues $baseValues) }}
+{{- end }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/monitoring-config/templates/tempo/tempo-application.yaml
+++ b/charts/monitoring-config/templates/tempo/tempo-application.yaml
@@ -1,6 +1,11 @@
+{{- $mergedValues := "" }}
+{{- if eq "ephemeral" .Values.govukEnvironment }}
+{{ $mergedValues = include "monitoring-config.ephemeral-tempo-config" . }}
+{{- else }}
 {{ $baseValues := fromYaml (.Files.Get "tempo-values.yaml") }}
 {{ $envValues := fromYaml (.Files.Get (printf "tempo-values-%s.yaml" .Values.govukEnvironment)) }}
-{{ $mergedValues := toYaml (merge $envValues $baseValues) }}
+{{ $mergedValues = toYaml (merge $envValues $baseValues) }}
+{{- end }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/monitoring-config/values.yaml
+++ b/charts/monitoring-config/values.yaml
@@ -4,3 +4,7 @@ monitoring:
     githubOrganisation: alphagov
     readOnlyGithubTeam: gov-uk
     readWriteGithubTeam: gov-uk-production-deploy
+
+# ephemeral environment variables
+awsAccountId: "12345678"
+clusterId: "eph-xxxxxx"


### PR DESCRIPTION
This PR includes a lot of changes to monitoring-config. It is all so the chart will work on ephemeral clusters.

It does the following:

* Disables AlertManger config since we don't care about alerting on an ephemeral cluster
* Creates a new templated values file for kube-prometheus-stack
* Creates a new templated values file for tempo
* Adds a conditional that makes ephemeral envs use production helm chart versions
* Disables the Fastly exporter for Prometheus since we aren't using Fastly services here

https://github.com/alphagov/govuk-infrastructure/issues/1744