### PR TITLE
Set PrunePropagationPolicy=orphan on aws-ebs-csi-driver

### DIFF
--- a/charts/app-config/templates/aws-ebs-csi-driver.yaml
+++ b/charts/app-config/templates/aws-ebs-csi-driver.yaml
@@ -40,3 +40,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - PrunePropagationPolicy=orphan


### PR DESCRIPTION
This is going to be moved to Terraform. It is required by DGU, but it is currently managed in the app-config chart which isn't being used by ephemeral clusters at the moment.

https://github.com/alphagov/govuk-infrastructure/issues/1742