### PR TITLE
Add argo-bootstrap-ephemeral chart to list of directories to check out in chart release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           show-progress: false
           sparse-checkout: |
             charts/argo-bootstrap
+            charts/argo-bootstrap-ephemeral
             charts/cluster-secret-store
             charts/cluster-secrets
 


### PR DESCRIPTION
This chart wasn't being released because the chart releaser wasn't checking out the files

https://github.com/alphagov/govuk-infrastructure/issues/1744