### PR TITLE
Add govuk-helm-charts repository definition to ephemeral bootstrap chart

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.1
+version: 0.0.2

--- a/charts/argo-bootstrap-ephemeral/templates/repository-govuk-helm-charts.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/repository-govuk-helm-charts.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: govuk-helm-charts
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  url: git@github.com:alphagov/govuk-helm-charts


### PR DESCRIPTION
If the repo isn't defined in a secret like this, ArgoCD will refuse to pull charts from it

https://github.com/alphagov/govuk-infrastructure/issues/1744