### PR TITLE
Ensure Whitehall is synchronised before Link Checker API

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -164,7 +164,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "43 23 * * *"
+      schedule: "28 1 * * *" # must begin only after Whitehall sync has completed
       db: link_checker_api_production
       operations:
         - op: backup
@@ -244,7 +244,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 0 * * *"
+      schedule: "28 0 * * *" # must complete before Link Checker API sync begins
       db: whitehall_production
       operations:
         - op: backup
@@ -367,7 +367,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "43 1 * * 1-5"
+      schedule: "28 2 * * 1-5" # must begin only after Whitehall sync has completed
       db: link_checker_api_production
       operations:
         - op: restore
@@ -489,7 +489,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 1 * * 1-5"
+      schedule: "28 1 * * 1-5" # must complete before Link Checker API sync begins
       db: whitehall_production
       operations:
         - op: restore
@@ -619,7 +619,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "43 3 * * 1"
+      schedule: "28 4 * * 1" # must begin only after Whitehall sync has completed
       db: link_checker_api_production
       operations:
         - op: restore
@@ -746,7 +746,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 3 * * 1"
+      schedule: "28 3 * * 1" # must complete before Link Checker API sync begins
       db: whitehall_production
       operations:
         - op: restore


### PR DESCRIPTION
Trello: https://trello.com/c/tmnht4P1

When syncing databases between environments (e.g. production to staging), the order in which Whitehall and Link Checker API are synced can cause batch ID mismatches. If Link Checker API is synced first, it leads to a uniqueness constraint error when Whitehall tries to store a new batch ID that already exists.

## Example of the Problem
Before Syncing (Production Data):

    Whitehall’s highest batch ID = 1,000
    LinkChecker API’s highest batch ID = 950

After Syncing to Staging (LinkChecker API First):

    LinkChecker API is synced first
        The highest batch ID in Staging’s LinkChecker API = 950

    Whitehall is synced afterward
        The highest batch ID in Staging’s Whitehall = 1,000 (copied from production)

    When Checking for Broken Links on Staging:
        A user requests a link check in Whitehall.
        Whitehall sends a request to the LinkChecker API.
        LinkChecker API assigns batch ID 951 (since its last known max was 950).
        Whitehall stores the batch ID 951, but there’s already a different link check report with that ID.

## Current "Solution": Overwriting

Currently, the workaround (introduced in https://github.com/alphagov/whitehall/pull/3675) is that when a new link check report is created in Whitehall, if the batch ID already exists in the database, Whitehall overwrites the existing report. The problem with this approach is that the overwrite does not update the correct edition's link check report. Instead, it replaces an unrelated edition’s link check report with the results from the new request.
Whilst this doesn't break Whitehall in the same way as the uniqueness constraint would, it's definitely not intended behaviour, and means the report for an old, unrelated edition is lost, while the edition that actually requested the check never gets updated properly.

## Proposed Solution: Change Sync Order

To avoid this, sync Whitehall before LinkChecker API:

    Sync Whitehall first → Ensures Whitehall retains the latest batch ID (1,000) before calling the API.
    Sync LinkChecker API afterward → Ensures LinkChecker API starts from the correct batch ID (1,000) and generates the next one properly (1,001 instead of 951).

Why This Fix Works:

✅ Prevents batch ID conflicts by ensuring Whitehall’s batch IDs are always up to date. ✅ Stops Whitehall from accidentally overwriting link check reports for unrelated editions. ✅ Ensures the edition that actually requested the link check gets the correct report.

## Timings

The Whitehall sync in Staging takes about 30 mins for restore, 16 mins for backup, and there's no timestamp logging for the SQL transformation step. See Logit:

- [restore step](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/app/discover#/doc/filebeat-*/filebeat-2025.03.12?id=LcX3h5UB-xiI7sZbhIEi) starts at 01:28
- [transform step](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/app/discover#/doc/filebeat-*/filebeat-2025.03.12?id=y8gTiJUB-xiI7sZbk_sV) starts at 01:58
- [backup step](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/app/discover#/doc/filebeat-*/filebeat-2025.03.12?id=VY8UiJUB-l-lDbAPMSAa) starts at 01:59
- it [finishes](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/app/discover#/doc/filebeat-*/filebeat-2025.03.12?id=uJIjiJUB-l-lDbAPaqmS) ("echo done") at  02:16

A total duration of 48 minutes. So it seems reasonable to allow a full hour as a buffer.