### PR TITLE
Add monitoring Namespace default

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.3
+version: 0.0.4

--- a/charts/argo-bootstrap-ephemeral/values.yaml
+++ b/charts/argo-bootstrap-ephemeral/values.yaml
@@ -4,6 +4,7 @@ argocdUrl:
 argoWorkflowsUrl:
 argoEventsHost:
 clusterId:
+monitoringNamespace: monitoring
 rbacTeams:
   read_only:
   read_write:


### PR DESCRIPTION
## What?
This adds a default "monitoring namespace" value for the argo-bootstrap-ephemeral chart to see if it resolves the missing monitoring apps.