### PR TITLE
Remove dangling EBS CSI driver references

### DIFF
--- a/charts/app-config/helm-versions/integration
+++ b/charts/app-config/helm-versions/integration
@@ -1,5 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
-https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.39.3"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
 https://charts.dexidp.io dex: "0.22.1"
 https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"

--- a/charts/app-config/helm-versions/production
+++ b/charts/app-config/helm-versions/production
@@ -1,5 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
-https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.39.3"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
 https://charts.dexidp.io dex: "0.22.1"
 https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"

--- a/charts/app-config/helm-versions/staging
+++ b/charts/app-config/helm-versions/staging
@@ -1,5 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
-https://kubernetes-sigs.github.io/aws-ebs-csi-driver aws-ebs-csi-driver: "2.39.3"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
 https://charts.dexidp.io dex: "0.22.1"
 https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"


### PR DESCRIPTION
Description:
- EBS CSI driver helm chart is now installed by Terraform in https://github.com/alphagov/govuk-infrastructure/pull/1821
- Remove some dangling references
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1743