### PR TITLE
Add publishing-api bearer token to frontend in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1435,6 +1435,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-frontend-publishing-api
+              key: bearer_token
 
   - name: draft-frontend
     repoName: frontend
@@ -1498,6 +1503,11 @@ govukApplications:
           valueFrom:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
+              key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-frontend-publishing-api
               key: bearer_token
 
   - name: government-frontend


### PR DESCRIPTION
- Needed for GraphQL trial

Related to: https://github.com/alphagov/frontend/pull/4696

Trello: https://trello.com/c/rKkLJkhX/528-add-graphql-support-to-frontend