### PR TITLE
Remove robot disallow for some Asset Manager URLs

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -228,10 +228,5 @@ data:
         location = /readyz {
           return 200 'ok\n';
         }
-
-        # Temporary robots.txt to stop indexing of files specified
-        location = /robots.txt {
-          return 200 'User-agent: *\nDisallow: /media/6582f7c4ed3c3400133bfc8f/pc1-interactive.pdf*\nDisallow: /government/uploads/system/uploads/attachment_data/file/881746/pc1-print.pdf*';
-        }
       }
     }


### PR DESCRIPTION
It has been confirmed by DWP that the removal from search engines of these URLs is no longer required.

This reverts 0f9999f32b487bd66c812a6ad42251bebbc6cf99 and f10c681be9dbaacefd5f7ed8781a45977ebf827f.

[Trello card](https://trello.com/c/mS1Ys5vR)