### PR TITLE
Pass in all values from ephemeral bootstrap chart to monitoring application

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.4
+version: 0.0.5

--- a/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
@@ -12,9 +12,7 @@ spec:
     path: charts/monitoring-config
     helm:
       values: |
-        govukEnvironment: ephemeral
-        clusterId: {{ .Values.clusterId }}
-        awsAccountId: {{ .Values.awsAccountId }}
+        {{- toYaml .Values | nindent 8 }}
         k8sExternalDomainSuffix: {{ .Values.clusterId }}.ephemeral.govuk.digital
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
We need to pass in `argoNamespace`, but its easier to just give it everything instead of manually adding each value that is required

https://github.com/alphagov/govuk-infrastructure/issues/1744