### PR TITLE
Enable grafana ingress in ephemeral clusters

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -20,6 +20,7 @@
     "server":
       "domain": "grafana.{{ $domainSuffix }}"
   "ingress":
+    "enabled": true
     "hosts":
       - "grafana.{{ $domainSuffix }}"
   "replicas": 1


### PR DESCRIPTION
This isn't enabled for some reason. It'll probably need enabling in the other envs too to ensure it doesn't get out of sync with what's in the chart.

https://github.com/alphagov/govuk-infrastructure/issues/1744