### PR TITLE
Load balancer fixes for ephemeral environments

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -21,6 +21,12 @@
       "domain": "grafana.{{ $domainSuffix }}"
   "ingress":
     "enabled": true
+    "annotations":
+      "alb.ingress.kubernetes.io/scheme": internet-facing
+      "alb.ingress.kubernetes.io/target-type": ip
+      "alb.ingress.kubernetes.io/listen-ports": '[{"HTTP":80},{"HTTPS":443}]'
+      "alb.ingress.kubernetes.io/ssl-redirect": "443"
+      "alb.ingress.kubernetes.io/ssl-policy": ELBSecurityPolicy-TLS-1-2-Ext-2018-06
     "hosts":
       - "grafana.{{ $domainSuffix }}"
   "replicas": 1

--- a/charts/monitoring-config/templates/kube-prometheus-stack/config/oauth2-proxy.tpl
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/config/oauth2-proxy.tpl
@@ -6,7 +6,6 @@ ingress:
   pathType: Prefix
   hosts: [ "{{ .app }}.{{ .Values.k8sExternalDomainSuffix }}" ]
   annotations:
-    alb.ingress.kubernetes.io/load-balancer-name: {{ .app }}
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'


### PR DESCRIPTION
* Annotate the grafana ingress properly so it gets a TLS listener
* Remove the static assigned name for monitoring ELBs, so it won't conflict if multiple clusters are started in the same AWS account

https://github.com/alphagov/govuk-infrastructure/issues/1744