### PR TITLE
Add cluster-autoscaler application to ephemeral bootstrap chart

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.5
+version: 0.0.6

--- a/charts/argo-bootstrap-ephemeral/helm-versions.yaml
+++ b/charts/argo-bootstrap-ephemeral/helm-versions.yaml
@@ -1,0 +1,1 @@
+https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"

--- a/charts/argo-bootstrap-ephemeral/templates/_helpers.tpl
+++ b/charts/argo-bootstrap-ephemeral/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Get helm release
+*/}}
+{{- define "helm-release" -}}
+{{- $versions := $.Files.Get "helm-versions.yaml" | fromYaml -}}
+{{- $version := get $versions (printf "%s %s" .repoURL .chart) -}}
+repoURL: {{ .repoURL }}
+chart: {{ .chart }}
+targetRevision: "{{ $version }}"
+{{- end -}}

--- a/charts/argo-bootstrap-ephemeral/templates/cluster-autoscaler-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/cluster-autoscaler-application.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-autoscaler
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+spec:
+  project: default
+  source:
+    {{- include "helm-release"
+        ( dict "repoURL" "https://kubernetes.github.io/autoscaler" "chart" "cluster-autoscaler" )
+        | nindent 4 }}
+    helm:
+      values: |
+        awsRegion: eu-west-1
+        rbac:
+          create: true
+          serviceAccount:
+            name: cluster-autoscaler
+            annotations:
+              eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.awsAccountId }}:role/cluster-autoscaler-{{ .Values.clusterId }}
+        autoDiscovery:
+          clusterName: {{ .Values.clusterId }}
+          enabled: true
+        extraArgs:
+          balance-similar-node-groups: true
+          scale-down-utilization-threshold: "0.55"
+          skip-nodes-with-local-storage: false
+          v: "0"
+        replicaCount: 1
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
This is a duplicate of the one in app-config. I have also moved over the Helm version template and modified it to remove the environments part of it since we don't need that here.

https://github.com/alphagov/govuk-infrastructure/issues/1742