### PR TITLE
Renovate: pin GitHub Action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "platformAutomerge": true,
   "argocd": {


### PR DESCRIPTION
This will cause Renovate to pin the digests of external GHA workflows/steps to hopefully avoid the effects of a compromised GHA step

https://github.com/alphagov/govuk-platform-internal/issues/23