### PR TITLE
Add read replica for Publishing API in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2650,6 +2650,38 @@ govukApplications:
               name: publishing-api-bigquery
               key: client-secret
 
+  - name: publishing-api-read-replica
+    repoName: publishing-api
+    helmValues:
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
+      nginxClientMaxBodySize: 2M
+      dbMigrationEnabled: false
+      extraEnv:
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publishing-api
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publishing-api
+              key: oauth_secret
+        - name: GOVUK_CONTENT_SCHEMAS_PATH
+          value: /app/content_schemas
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-postgres
+              key: REPLICA_DATABASE_URL
+
   - name: release
     helmValues:
       arch: arm64

--- a/charts/external-secrets/externalsecrets-templates/psql-conn-string-replica.tpl
+++ b/charts/external-secrets/externalsecrets-templates/psql-conn-string-replica.tpl
@@ -1,0 +1,1 @@
+postgresql://{{ .username | toString }}:{{ .password | toString }}@{{ .hostReplica | toString }}

--- a/charts/external-secrets/templates/publishing-api/postgres.yaml
+++ b/charts/external-secrets/templates/publishing-api/postgres.yaml
@@ -18,6 +18,7 @@ spec:
     template:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/publishing_api_production'
+        REPLICA_DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string-replica.tpl" | trim }}/publishing_api_production'
   dataFrom:
     - extract:
         key: govuk/publishing-api/postgres


### PR DESCRIPTION
This will be a parallel deployment of the Publishing API application in intgegration, used solely for serving GraphQL queries from frontend applications.

As this will not be receiving any write requests, it does not need access to Redis or any workers.

The `hostReplica` secret has already been added through [the AWS Console](https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=govuk%2Fpublishing-api%2Fpostgres&region=eu-west-1). The other credentials remain the same as the main version of the database.

[Trello card](https://trello.com/c/8QZKAla1)