### PR TITLE
Disable `uploadAssets` for Publishing API read replica

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2662,6 +2662,8 @@ govukApplications:
           cpu: 10m
           memory: 512Mi
       nginxClientMaxBodySize: 2M
+      uploadAssets:
+        enabled: false
       dbMigrationEnabled: false
       extraEnv:
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
This is a API application, so there are no assets to upload.

Adding this configuration to match the main Publishing API deployment, as this was missed in https://github.com/alphagov/govuk-helm-charts/pull/3074.

[Trello card](https://trello.com/c/8QZKAla1)