### PR TITLE
Configure Publishing API read replica environment variables

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2682,7 +2682,14 @@ govukApplications:
           valueFrom:
             secretKeyRef:
               name: publishing-api-postgres
+              key: DATABASE_URL
+        - name: REPLICA_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-postgres
               key: REPLICA_DATABASE_URL
+        - name: RAILS_ENV
+          value: production_replica
 
   - name: release
     helmValues:


### PR DESCRIPTION
The replica of this application needs access to both the primary and replica databases, so providing both through environment varaibles.

Additionally, it needs to have the `RAILS_ENV` overwritten, to tell the application to operate in replica mode.

This will allow https://github.com/alphagov/publishing-api/pull/3219 to be completed and merged.

[Trello card](https://trello.com/c/8QZKAla1)