### PR TITLE
Disable RabbitMQ for Publishing API read replica

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2690,6 +2690,8 @@ govukApplications:
               key: REPLICA_DATABASE_URL
         - name: RAILS_ENV
           value: production_replica
+        - name: DISABLE_QUEUE_PUBLISHER
+          value: "true"
 
   - name: release
     helmValues:


### PR DESCRIPTION
We need to [explicitly switch off RabbitMQ](https://github.com/alphagov/publishing-api/blob/526c8b6a9290bb748dbea4298525aa03890e955c/config/initializers/services.rb#L38-L44) in Publishing API's read replica, since it is not reading or writing to it.

[Trello card](https://trello.com/c/8QZKAla1)