### PR TITLE
Add EMERGENCY_BANNER_REDIS_URL values to email-alert-frontend in staging, production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1120,6 +1120,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-auth
               key: token
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
 
   - name: draft-email-alert-frontend
     repoName: email-alert-frontend
@@ -1158,6 +1160,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-auth
               key: token
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
 
   - name: email-alert-service
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1132,6 +1132,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-auth
               key: token
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
 
   - name: draft-email-alert-frontend
     repoName: email-alert-frontend
@@ -1170,6 +1172,8 @@ govukApplications:
             secretKeyRef:
               name: email-alert-auth
               key: token
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
 
   - name: email-alert-service
     helmValues:


### PR DESCRIPTION
Now that email-alert-frontend is running without static, it needs access to the redis cluster that stores emergency banner info:

https://trello.com/c/O6JhukLu/487-remove-slimmer-email-alert-frontend