### PR TITLE
Use Publishing API read replica for GraphQL queries in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -361,6 +361,8 @@ govukApplications:
               key: bearer_token
         - name: GRAPHQL_FEATURE_FLAG
           value: "true"
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-collections
     repoName: collections
@@ -1440,6 +1442,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-publishing-api
               key: bearer_token
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-frontend
     repoName: frontend
@@ -1528,6 +1532,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-government-frontend-publishing-api
               key: bearer_token
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-government-frontend
     repoName: government-frontend

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -354,11 +354,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-collections-publishing-api
-              key: bearer_token
         - name: GRAPHQL_FEATURE_FLAG
           value: "true"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
@@ -1436,11 +1431,6 @@ govukApplications:
           valueFrom:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
-              key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-frontend-publishing-api
               key: bearer_token
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -348,11 +348,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-collections-publishing-api
-              key: bearer_token
 
   - name: draft-collections
     repoName: collections

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -355,11 +355,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-collections-publishing-api
-              key: bearer_token
 
   - name: draft-collections
     repoName: collections


### PR DESCRIPTION
This switches the three applications that are making GraphQL queries (Collections, Frontend and Government Frontend) to use the Publishing API read replica in integration.

[Trello card](https://trello.com/c/QmLFtTHQ)