### PR TITLE
BAU - Remove unused Helm chart versions

### DIFF
--- a/charts/app-config/helm-versions/integration
+++ b/charts/app-config/helm-versions/integration
@@ -1,6 +1,3 @@
 # $repo_url $chart_name: "$chart_version"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
-https://charts.dexidp.io dex: "0.22.1"
-https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"
-https://charts.external-secrets.io external-secrets: "0.14.4"
 https://stakater.github.io/stakater-charts reloader: "2.0.0"

--- a/charts/app-config/helm-versions/production
+++ b/charts/app-config/helm-versions/production
@@ -1,6 +1,3 @@
 # $repo_url $chart_name: "$chart_version"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
-https://charts.dexidp.io dex: "0.22.1"
-https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"
-https://charts.external-secrets.io external-secrets: "0.14.4"
 https://stakater.github.io/stakater-charts reloader: "1.3.0"

--- a/charts/app-config/helm-versions/staging
+++ b/charts/app-config/helm-versions/staging
@@ -1,6 +1,3 @@
 # $repo_url $chart_name: "$chart_version"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
-https://charts.dexidp.io dex: "0.22.1"
-https://kubernetes-sigs.github.io/external-dns external-dns: "1.15.2"
-https://charts.external-secrets.io external-secrets: "0.14.4"
 https://stakater.github.io/stakater-charts reloader: "1.3.0"


### PR DESCRIPTION
Description:
- These have all been moved to govuk-infrastructure
- See https://github.com/alphagov/govuk-infrastructure/pull/1800 and https://github.com/alphagov/govuk-infrastructure/pull/1801