### PR TITLE
Fix comment spacing to appease the linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   render-charts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -12,7 +12,7 @@ jobs:
       - name: Run govuk-app-render
         run: ./govuk-app-render.sh
       - name: Archive rendered charts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: rendered-charts
           path: output/
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
-      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4
         with:
           name: rendered-charts
           path: .
 
-      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4
 
       - name: helm lint
         run: |
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
-      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4
         with:
           name: rendered-charts
           path: .
@@ -72,7 +72,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           show-progress: false
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
@@ -82,7 +82,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           show-progress: false
       - run: yamllint --version && yamllint -f github .
@@ -90,7 +90,7 @@ jobs:
   promtool:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           show-progress: false
       - name: Run promtool checks

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -164,7 +164,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "28 1 * * *" # must begin only after Whitehall sync has completed
+      schedule: "28 1 * * *"  # must begin only after Whitehall sync has completed
       db: link_checker_api_production
       operations:
         - op: backup
@@ -244,7 +244,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 0 * * *" # must complete before Link Checker API sync begins
+      schedule: "28 0 * * *"  # must complete before Link Checker API sync begins
       db: whitehall_production
       operations:
         - op: backup
@@ -367,7 +367,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "28 2 * * 1-5" # must begin only after Whitehall sync has completed
+      schedule: "28 2 * * 1-5"  # must begin only after Whitehall sync has completed
       db: link_checker_api_production
       operations:
         - op: restore
@@ -489,7 +489,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 1 * * 1-5" # must complete before Link Checker API sync begins
+      schedule: "28 1 * * 1-5"  # must complete before Link Checker API sync begins
       db: whitehall_production
       operations:
         - op: restore
@@ -619,7 +619,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "28 4 * * 1" # must begin only after Whitehall sync has completed
+      schedule: "28 4 * * 1"  # must begin only after Whitehall sync has completed
       db: link_checker_api_production
       operations:
         - op: restore
@@ -746,7 +746,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 3 * * 1" # must complete before Link Checker API sync begins
+      schedule: "28 3 * * 1"  # must complete before Link Checker API sync begins
       db: whitehall_production
       operations:
         - op: restore


### PR DESCRIPTION
This fixes the `too few spaces before comment` warnings from yamllint, as seen on every PR eg https://github.com/alphagov/govuk-helm-charts/actions/runs/13965500907 
