### PR TITLE
Emphasise app and environment in deploy failure alerts

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -62,7 +62,7 @@ spec:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "Deploy image workflow for {{"{{workflow.parameters.repoName}}"}} to {{"{{workflow.parameters.environment}}"}} has {{"{{= sprig.lower(workflow.status) }}"}}."
+                          "text": "Deploy image workflow for *{{"{{workflow.parameters.repoName}}"}}* to *{{"{{workflow.parameters.environment}}"}}* has {{"{{= sprig.lower(workflow.status) }}"}}."
                       },
                       "accessory": {
                         "type": "button",

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -161,7 +161,7 @@ spec:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "Post-deploy workflow for {{"{{workflow.parameters.application}}"}} in {{ .Values.govukEnvironment }} has {{"{{= sprig.lower(workflow.status) }}"}}. \n\n {{"{{ steps.parse-failures.outputs.parameters.message }}"}}"
+                          "text": "Post-deploy workflow for *{{"{{workflow.parameters.application}}"}}* in *{{ .Values.govukEnvironment }}* has {{"{{= sprig.lower(workflow.status) }}"}}. \n\n {{"{{ steps.parse-failures.outputs.parameters.message }}"}}"
                       },
                       "accessory": {
                         "type": "button",


### PR DESCRIPTION
It's useful for developers to monitor the deploy alerts channel in Slack to be aware of any failures to promote deployments for their apps. This channel can sometimes get a little crowded, and it can be a challenge to see which app and environment a failed workflow run relates to at a glance

This bolds these two variables to make the alerts easier to parse both in:
- the post-sync/post-deploy workflow, which is for promoting deployment to the next environment - failures usually come from end-to-end tests
- the deploy-image workflow, which has a similar template, so it would seem useful to keep them consistent

Longer term, it might be better to route these alerts to the relevant team channel, but this is a quicker win in the short term