### PR TITLE
Fix more comment spacing to appease the linter

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   render-charts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -12,7 +12,7 @@ jobs:
       - name: Run govuk-app-render
         run: ./govuk-app-render.sh
       - name: Archive rendered charts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02   # v4
         with:
           name: rendered-charts
           path: output/
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
-      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e   # v4
         with:
           name: rendered-charts
           path: .
 
-      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112   # v4
 
       - name: helm lint
         run: |
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
-      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e   # v4
         with:
           name: rendered-charts
           path: .
@@ -72,7 +72,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
         with:
           show-progress: false
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
@@ -82,7 +82,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
         with:
           show-progress: false
       - run: yamllint --version && yamllint -f github .
@@ -90,7 +90,7 @@ jobs:
   promtool:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
         with:
           show-progress: false
       - name: Run promtool checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           ref: main
           fetch-depth: 0
@@ -28,10 +28,10 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         env:
           CR_SKIP_EXISTING: "true"
           CR_TOKEN: "${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}"

--- a/.github/workflows/sqlfluff.yml
+++ b/.github/workflows/sqlfluff.yml
@@ -9,10 +9,10 @@ jobs:
   sqlfluff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           show-progress: false
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5
         with:
           python-version: "3.13"
           cache: pip


### PR DESCRIPTION
This fixes more `too few spaces before comment` warnings from yamllint, as seen on PRs eg https://github.com/alphagov/govuk-helm-charts/actions/runs/14057912400 