### PR TITLE
Add whitehall error rate alert and send to slack

### DIFF
--- a/charts/monitoring-config/rules/whitehall.yaml
+++ b/charts/monitoring-config/rules/whitehall.yaml
@@ -1,6 +1,36 @@
 groups:
   - name: WhitehallAlerts
     rules:
+      - record: global:whitehall_requests:rate5m
+        expr: |
+          sum by (status) (
+            rate(http_requests_total{namespace="apps", job="whitehall-admin", controller!="other"}[5m])
+          )
+
+      - record: global:whitehall_5xx_responses:ratio_rate5m
+        expr: |
+          sum (global:whitehall_requests:rate5m{status=~"5.."})
+          /
+          sum (global:whitehall_requests:rate5m)
+
+      - alert: WhitehallErrorRatioTooHigh
+        # Note: Whitehall usually receives more than 0.5 requests per second during working hours.
+        #       We only alert if it's receiving more than 0.2 requests per second to avoid noise.
+        expr: |
+          sum (global:whitehall_5xx_responses:ratio_rate5m) > 0.1
+          and
+          sum (global:whitehall_requests:rate5m) > 0.2
+        for: 10m
+        labels:
+          severity: critical
+          destination: slack-whitehall-notifications
+        annotations:
+          summary: Whitehall error ratio too high
+          description: >-
+            More than 10% of HTTP responses from Whitehall were 500-series errors for 10 minutes.
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/alerts/whitehall-error-ratio-too-high.html
+
       - alert: WhitehallScheduledPublicationsOverdue
         expr: |
           whitehall_scheduled_publishing_overdue > 0

--- a/charts/monitoring-config/rules/whitehall_tests.yaml
+++ b/charts/monitoring-config/rules/whitehall_tests.yaml
@@ -1,0 +1,91 @@
+rule_files:
+  - whitehall.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Alert fires when threshold exceeded for too long.
+  - interval: 1m
+    input_series:
+      - series: 'http_requests_total{
+          namespace="apps",
+          job="whitehall-admin",
+          controller="editions",
+          status="200"
+        }'
+        values: '0+90x15'
+      - series: 'http_requests_total{
+          namespace="apps",
+          job="whitehall-admin",
+          controller="editions",
+          status="500"
+        }'
+        values: '0+30x15'
+    promql_expr_test:
+      - expr: 'sum (global:whitehall_requests:rate5m{status=~"5.."})'
+        eval_time: 15m
+        exp_samples:
+          # 30 5xx responses per minute = 0.5 per second
+          - value: 0.5
+      - expr: 'sum (global:whitehall_5xx_responses:ratio_rate5m)'
+        eval_time: 15m
+        exp_samples:
+          # 30 5xx responses out of 120 total responses = 0.25
+          - value: 0.25
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: WhitehallErrorRatioTooHigh
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              destination: slack-whitehall-notifications
+            exp_annotations:
+              summary: Whitehall error ratio too high
+              description: >-
+                More than 10% of HTTP responses from Whitehall were 500-series errors for 10 minutes.
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/alerts/whitehall-error-ratio-too-high.html
+
+  # Alert does not fire when threshold not exceeded for long enough.
+  - interval: 1m
+    input_series:
+      - series: 'http_requests_total{
+          namespace="apps",
+          job="whitehall-admin",
+          controller="editions",
+          status="200",
+        }'
+        values: '0+60x15'
+      - series: 'http_requests_total{
+          namespace="apps",
+          job="whitehall-admin",
+          controller="editions",
+          status="500",
+        }'
+        values: '0+12x8 0x7'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: WhitehallErrorRatioTooHigh
+        exp_alerts: []
+
+  # Alert does not fire when min QPS threshold is not met.
+  - interval: 1m
+    input_series:
+      - series: 'http_requests_total{
+          namespace="apps",
+          job="whitehall-admin",
+          controller="editions",
+          status="200",
+        }'
+        values: '0+3x15'
+      - series: 'http_requests_total{
+          namespace="apps",
+          job="whitehall-admin",
+          controller="editions",
+          status="500",
+        }'
+        values: '0+2x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: WhitehallErrorRatioTooHigh
+        exp_alerts: []

--- a/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -85,6 +85,14 @@ spec:
       repeatInterval: 1d
       groupWait: 5m
       groupInterval: 30m
+    - matchers:
+        - name: destination
+          value: slack-whitehall-notifications
+          matchType: =
+      receiver: 'slack-whitehall-notifications'
+      repeatInterval: 1d
+      groupWait: 5m
+      groupInterval: 30m
   receivers:
   - name: 'null'
   - name: 'pagerduty'
@@ -201,6 +209,20 @@ spec:
         text: 'View logs in Kibana'
         url: "https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-quality-monitoring-assert-invariants),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-quality-monitoring-assert-invariants)))),sort:!())"
       apiURL: *slack_api_url
+  - name: 'slack-whitehall-notifications'
+    slackConfigs:
+      - channel: '#govuk-whitehall-experience-tech'
+        sendResolved: true
+        iconURL: https://avatars3.githubusercontent.com/u/3380462
+        title: |-
+          {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}" }}
+        text: >-
+          *Description:* {{ "{{ .CommonAnnotations.description }}" }}
+          
+          *Environment:* {{ .Values.govukEnvironment }}
+          
+          *Runbook:* {{ "{{ .CommonAnnotations.runbook_url }}" }}
+        apiURL: *slack_api_url
   muteTimeIntervals:
   - name: inhours
     timeIntervals:


### PR DESCRIPTION
This adds an alert if:

- whitehall is serving more than 0.2 requests per second
- more than 10% of the responses have 5xx statuses
- for more than 10 minutes

If this situation occurs, alertmanager will send a slack message to #govuk-whitehall-experience-tech

I've added a runbook for this alert in a separate PR in the developer docs: https://github.com/alphagov/govuk-developer-docs/pull/5042