### PR TITLE
Allow lines up to 180 chars long

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,7 +9,7 @@ rules:
   key-duplicates:
     forbid-duplicated-merge-keys: true
   line-length:
-    max: 100
+    max: 180
     allow-non-breakable-words: true
   truthy:
     check-keys: false  # GitHub Actions uses `on` as a key :(


### PR DESCRIPTION
100 chars is annoyingly restrictive. My editor draws a line at 120 chars, so it's always catching me out.

It's really no big deal if a line is a bit long, but I guess there's got to be some limit. 180 seems high enough not to regularly make me rage, but low enough not to allow ridiculous lines.