### PR TITLE
Search API v2: Run user event import in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2950,6 +2950,12 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: user-events-import-yesterdays-events
+          task: "user_events:import_yesterdays_events"
+          schedule: "30 12 * * *"
+        - name: user-events-import-intraday-events
+          task: "user_events:import_intraday_events"
+          schedule: "45 05,11,17,23 * * *"
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *"  # 09:09am daily


### PR DESCRIPTION
We are already running this in integration and production, and we want it to be running in staging too to have the datastore in that environment in a comparable state.

see https://github.com/alphagov/govuk-helm-charts/pull/2825