### PR TITLE
Add read replica for Publishing API in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2463,6 +2463,48 @@ govukApplications:
               name: publishing-api-bigquery
               key: client-secret
 
+  - name: publishing-api-read-replica
+    helmValues:
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 20m
+          memory: 768Mi
+      nginxClientMaxBodySize: 2M
+      dbMigrationEnabled: false
+      uploadAssets:
+        enabled: false
+      extraEnv:
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publishing-api
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publishing-api
+              key: oauth_secret
+        - name: GOVUK_CONTENT_SCHEMAS_PATH
+          value: /app/content_schemas
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-postgres
+              key: DATABASE_URL
+        - name: REPLICA_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publishing-api-postgres
+              key: REPLICA_DATABASE_URL
+        - name: RAILS_ENV
+          value: production_replica
+        - name: DISABLE_QUEUE_PUBLISHER
+          value: "true"
+
   - name: release
     helmValues:
       arch: arm64


### PR DESCRIPTION
[Trello](https://trello.com/c/yvkqI642/1630-set-up-the-read-replica-in-staging)

This will be a parallel deployment of the Publishing API application in staging, used solely for serving GraphQL queries from frontend applications