### PR TITLE
Use Publishing API read replica in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -355,6 +355,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-collections
     repoName: collections
@@ -1431,6 +1433,8 @@ govukApplications:
               key: bearer_token
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-frontend
     repoName: frontend
@@ -1515,6 +1519,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-government-frontend-publishing-api
               key: bearer_token
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-government-frontend
     repoName: government-frontend


### PR DESCRIPTION
[Trello](https://trello.com/c/yvkqI642/1630-set-up-the-read-replica-in-staging)

This switches the three apps that (conditionally) use GraphQL to use the read replica instead of the main deployment, per
60078085211390a49abd6c24ab6a6458308c9588 for integration

The diff isn't helpful here for identifying which apps are changed: collections, frontend, and government-frontend