### PR TITLE
Fix cluster-autoscaler helm template error in ephemeral bootstrap chart

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.6
+version: 0.0.7

--- a/charts/argo-bootstrap-ephemeral/templates/cluster-autoscaler-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/cluster-autoscaler-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     {{- include "helm-release"
-        ( dict "repoURL" "https://kubernetes.github.io/autoscaler" "chart" "cluster-autoscaler" )
+        ( merge (deepCopy .) (dict "repoURL" "https://kubernetes.github.io/autoscaler" "chart" "cluster-autoscaler") )
         | nindent 4 }}
     helm:
       values: |


### PR DESCRIPTION
The `helm-release` template needs `deepCopy` because it uses `.Files.Get` from the global state, and it won't be available unless its copied into the arguments passed to the template.

This issue is causing the bootstrap chart to fail to install at the moment.