### PR TITLE
Set LOG_LEVEL env var to "info" on search-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3078,7 +3078,7 @@ govukApplications:
           value:
             https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
-          value: warn
+          value: info
         - name: SEARCH_INDEX
           value: all
         - name: GDS_SSO_OAUTH_ID

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2872,7 +2872,7 @@ govukApplications:
           value:
             https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
-          value: warn
+          value: info
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2894,7 +2894,7 @@ govukApplications:
           value:
             https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
-          value: warn
+          value: info
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Search API currently has this env var set to "warn" which means any
calls to `logger.info` in the codebase aren't being output anywhere, and
there's quite a few places where we do logging.

Note that calls to `logger.info` in Sidekiq workers _does_ work in
Search API. That's because Sidekiq uses its own logger that doesn't set
the level based on this env var [1].

It's only the calls to `logger.info` outside of background workers which
are affected, e.g. the actual API code, RabbitMQ consumers, etc. Basically
any code that's using the `logging` gem included in the app.

---

I found this out because I couldn't see any logs from the RabbitMQ consumers
but could see the ones from Sidekiq just fine. There's a few different ways to
solve this problem but I figured we probably do want the level to be `info` on
all environments. Logging is useful for debugging and we're not outputting a lot
of the logs currently.

[1]: https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/config.rb#L275-L284
