### PR TITLE
Configure Prometheus to monitor DGU in ephemeral

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -54,9 +54,36 @@
     "externalUrl": "https://prometheus.{{ $domainSuffix }}"
     "externalLabels":
       "environment": "{{ $clusterId }}"
+    "evaluationInterval": "1m"
     "podAntiAffinity": ""
     "podDisruptionBudget":
       "enabled": false
+    "podMonitorNamespaceSelector":
+      "matchExpressions":
+        - "key": "no_monitor"
+          "operator": "DoesNotExist"
+          "values": []
+    "podMonitorSelectorNilUsesHelmValues": false
+    "probeNamespaceSelector":
+      "matchExpressions":
+        - "key": "no_monitor"
+          "operator": "DoesNotExist"
+          "values": []
+    "probeSelectorNilUsesHelmValues": false
+    "ruleNamespaceSelector":
+      "matchExpressions":
+        - "key": "no_monitor"
+          "operator": "DoesNotExist"
+          "values": []
+    "ruleSelectorNilUsesHelmValues": false
+    "scrapeInterval": "1m"
+    "scrapeTimeout": "15s"
+    "serviceMonitorNamespaceSelector":
+      "matchExpressions":
+        - "key": "no_monitor"
+          "operator": "DoesNotExist"
+          "values": []
+    "serviceMonitorSelectorNilUsesHelmValues": false
     "replicas": 1
     "storageSpec":
       "volumeClaimTemplate":


### PR DESCRIPTION
Description:
- Currently Prometheus doesn't scrape DGU because podMonitor and serviceMonitor isn't configured properly
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744