### PR TITLE
Setup default rules on ephemeral Alert Manager

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -8,6 +8,21 @@
     "podDisruptionBudget":
       "enabled": false
     "replicas": 1
+"defaultRules":
+  "disabled":
+    "KubePodNotReady": true
+    "NodeClockNotSynchronising": true
+    "NodeClockSkewDetected": true
+    "NodeNetworkReceiveErrs": true
+    "NodeNetworkTransmitErrs": true
+    "NodeRAIDDegraded": true
+    "NodeRAIDDiskFailure": true
+  "rules":
+    "kubeApiserverAvailbility": false
+    "kubeApiserverBurnrate": false
+    "kubeApiserverHistogram": false
+    "kubeApiserverSlos": false
+    "network": false
 "grafana":
   "env":
     "AWS_ROLE_ARN": "arn:aws:iam::{{ .Values.awsAccountId }}:role/kube-prometheus-stack-grafana-govuk"


### PR DESCRIPTION
Description:
- Copy the configuration from the other environments into the ephemeral environment
- These metrics on which the alerts are based on aren't ingested by Prometheus so disable them
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744