### PR TITLE
Turn off default alerting rules for API server on ephemeral Grafana

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -64,6 +64,17 @@
     "annotations":
       "eks.amazonaws.com/role-arn":
         "arn:aws:iam::{{ .Values.awsAccountId }}:role/kube-prometheus-stack-grafana-{{ $clusterId }}"
+"kubeApiServer":
+  "enabled": false
+"kubeControllerManager":
+  "enabled": false
+"kubeEtcd":
+  "enabled": false
+"kubeScheduler":
+  "enabled": false
+"kube_state_metrics":
+  "selfMonitor":
+    "enabled": true
 "prometheus":
   "prometheusSpec":
     "externalUrl": "https://prometheus.{{ $domainSuffix }}"


### PR DESCRIPTION
Description:
- Copy the configuration over from production configuration file
- `kube-prometheus-stack` configures some default alerting rules for the API server. We've disabled them in AlertManager so turn them off in Grafana as well
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744