### PR TITLE
Remove GraphQL feature flag environment variable

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -354,8 +354,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
-        - name: GRAPHQL_FEATURE_FLAG
-          value: "true"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
 


### PR DESCRIPTION
The feature flag was removed from Collections in https://github.com/alphagov/collections/pull/4039, so removing the environment variable that switches the flag on and off.

[Trello card](https://trello.com/c/stxnESVI)