### PR TITLE
Enable Renovate on Publishing API

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -5,5 +5,9 @@ metadata:
 data:
   config.json: |-
     {
-      "repositories": ["alphagov/govuk-helm-charts", "alphagov/govuk-infrastructure"]
+      "repositories": [
+        "alphagov/govuk-helm-charts",
+        "alphagov/govuk-infrastructure",
+        "alphagov/publishing-api"
+      ]
     }


### PR DESCRIPTION
[Trello](https://trello.com/c/KYb1Gz92/1653-use-renovate-for-ruby-version-maintenance)

We'd like to try out Renovate on Publishing API. A PR has been opened on that app to provide a configuration file: https://github.com/alphagov/publishing-api/pull/3260