### PR TITLE
Configure CloudWatch and Tempo data sources for ephemeral Grafana

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -24,6 +24,24 @@
     "kubeApiserverSlos": false
     "network": false
 "grafana":
+  "additionalDataSources":
+    - "access": "proxy"
+      "editable": false
+      "jsonData":
+        "authType": "default"
+        "defaultRegion": "eu-west-1"
+      "name": "CloudWatch"
+      "type": "cloudwatch"
+      "uid": "cloudwatch"
+    - "access": "proxy"
+      "editable": false
+      "jsonData":
+        "serviceMap":
+          "datasourceUid": "prometheus"
+      "name": "Tempo"
+      "type": "tempo"
+      "uid": "tempo"
+      "url": "http://tempo-query-frontend.monitoring.svc.cluster.local:3100"
   "env":
     "AWS_ROLE_ARN": "arn:aws:iam::{{ .Values.awsAccountId }}:role/kube-prometheus-stack-grafana-govuk"
   "envValueFrom":


### PR DESCRIPTION
Description:
- Configure these additional sources for ephemeral Grafana
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744