### PR TITLE
Configure reloader for ephemeral environment

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.7
+version: 0.0.8

--- a/charts/argo-bootstrap-ephemeral/templates/reloader.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/reloader.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+spec:
+  project: default
+  source:
+    {{- include "helm-release"
+        ( merge (deepCopy .) (dict "repoURL" "https://stakater.github.io/stakater-charts" "chart" "reloader") )
+        | nindent 4 }}
+    helm:
+      values: |
+        reloader:
+          reloadStrategy: annotations
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.argoNamespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
Description:
- Install reloader in the ephemeral environment
- Bump chart version to 0.0.8
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744