### PR TITLE
Add reloader chart to helm versions

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.8
+version: 0.0.9

--- a/charts/argo-bootstrap-ephemeral/helm-versions.yaml
+++ b/charts/argo-bootstrap-ephemeral/helm-versions.yaml
@@ -1,1 +1,2 @@
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.46.3"
+https://stakater.github.io/stakater-charts reloader: "2.0.0"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3114 forgot to include the Helm reloader version in helm-versions.yaml
- Bump chart to 0.0.9
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744