### PR TITLE
Add a general alertmanager config settings for ephemeral cluster

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -8,6 +8,8 @@
     "podDisruptionBudget":
       "enabled": false
     "replicas": 1
+  "alertmanagerConfiguration":
+    "name": alertmanagerconfig-general
 "defaultRules":
   "disabled":
     "KubePodNotReady": true


### PR DESCRIPTION
Adds some missing config to make the ephemeral cluster more in line with the production cluster 

https://github.com/alphagov/govuk-infrastructure/issues/1744