### PR TITLE
Add config for ephemeral grafana to set the timezone and date formats

### DIFF
--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -42,6 +42,7 @@
       "type": "tempo"
       "uid": "tempo"
       "url": "http://tempo-query-frontend.monitoring.svc.cluster.local:3100"
+  "defaultDashboardsTimezone": "Europe/London"
   "env":
     "AWS_ROLE_ARN": "arn:aws:iam::{{ .Values.awsAccountId }}:role/kube-prometheus-stack-grafana-govuk"
   "envValueFrom":
@@ -64,6 +65,9 @@
       "role_attribute_path": "'Admin'"
       "token_url": "https://dex.{{ $domainSuffix }}/token"
       "scopes": "openid profile email groups"
+    "date_formats":
+      "interval_day": "YYYY-MM-DD"
+      "interval_hour": "YYYY-MM-DD HH:mm"
     "server":
       "domain": "grafana.{{ $domainSuffix }}"
       "root_url": "https://%(domain)s"


### PR DESCRIPTION
This should bring the ephemeral grafana more in line with the production grafana

We've decided not to create the grafana admin user as it's not really used by anyone as changes to grafana are managed in charts.

https://github.com/alphagov/govuk-infrastructure/issues/1744