### PR TITLE
Add labels to post-sync argo workflow

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -3,6 +3,11 @@ kind: WorkflowTemplate
 metadata:
   name: post-sync
 spec:
+  workflowMetadata:
+    labels:
+      repoName: "{{ `{{workflow.parameters.repoName}}` }}"
+      application: "{{ `{{workflow.parameters.application}}` }}"
+      imageTag: "{{ `{{workflow.parameters.imageTag}}` }}"
   entrypoint: handle-sync-event
   onExit: exit-handler
   retryStrategy:


### PR DESCRIPTION
This will make it easier to find which workflows refer to a particular application, repository or image tag.

https://argo-workflows.readthedocs.io/en/latest/workflow-templates/#adding-labelsannotations-to-workflows-with-workflowmetadata

I've used a slightly different disgusting double escaping syntax for these than the rest of the file, because it took me so long to work out what all the double quotes and curly braces were doing.

For posterity, starting from the left, this is how to read the ones I've used:

                ╭─── Go template expression (Helm) ──╮
                │                                    │
                │  ╭── Argo workflow expression ──╮  │
                │  │                              │  │
                ▼  ▼                              ▼  ▼
    repoName: "{{ `{{workflow.parameters.repoName}}` }}"
              ▲   ▲                                ▲   ▲
              │   │                                │   │
              │   ╰────── Go literal string ───────╯   │
              │                                        │
           YAML double quote                       YAML double quote


After this has been processed by the Go templating engine (via Helm) this will produce:

    repoName: "{{workflow.parameters.repoName}}"

The outer quotes are required to ensure YAML treats the curly brackets as part of a string instead of the start of an object.

I think the backtick style string is a fair bit clearer than using double quoutes inside the Go template expression, because it makes it more obvious what pairs with what.