### PR TITLE
Revert #3058

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -164,7 +164,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "28 1 * * *"  # must begin only after Whitehall sync has completed
+      schedule: "43 23 * * *"
       db: link_checker_api_production
       operations:
         - op: backup
@@ -244,7 +244,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 0 * * *"  # must complete before Link Checker API sync begins
+      schedule: "28 0 * * *"
       db: whitehall_production
       operations:
         - op: backup
@@ -367,7 +367,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "28 2 * * 1-5"  # must begin only after Whitehall sync has completed
+      schedule: "43 1 * * 1-5"
       db: link_checker_api_production
       operations:
         - op: restore
@@ -489,7 +489,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 1 * * 1-5"  # must complete before Link Checker API sync begins
+      schedule: "28 1 * * 1-5"
       db: whitehall_production
       operations:
         - op: restore
@@ -619,7 +619,7 @@ cronjobs:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "28 4 * * 1"  # must begin only after Whitehall sync has completed
+      schedule: "43 3 * * 1"
       db: link_checker_api_production
       operations:
         - op: restore
@@ -746,7 +746,7 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 3 * * 1"  # must complete before Link Checker API sync begins
+      schedule: "28 3 * * 1"
       db: whitehall_production
       operations:
         - op: restore


### PR DESCRIPTION
This complexity no longer needs to be managed in this brittle way because we've since switched to a unix epoch-based ID for link check reports: https://github.com/alphagov/link-checker-api/pull/983

Ordering therefore doesn't matter, as by the time anything calls Link Checker API post-env-sync, any newly generated IDs will already be 'newer' than whatever the upstream app will have on record.

Trello: https://trello.com/c/tmnht4P1