### PR TITLE
Use Publishing API read replica in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -348,6 +348,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-collections-email-alert-api
               key: bearer_token
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-collections
     repoName: collections
@@ -1390,6 +1392,8 @@ govukApplications:
               key: bearer_token
         - name: WEB_CONCURRENCY
           value: '4'
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-finder-frontend
     repoName: finder-frontend
@@ -1504,6 +1508,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-government-frontend-publishing-api
               key: bearer_token
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
 
   - name: draft-government-frontend
     repoName: government-frontend


### PR DESCRIPTION
[Trello](https://trello.com/c/ZwWoo7Mg/1640-set-up-the-read-replica-in-production)

This switches the three apps that (conditionally) use GraphQL to use the read replica instead of the main deployment, per db38169a1ac91ae62941f8fd0e0ac6c7e92c7ab2 for staging and 60078085211390a49abd6c24ab6a6458308c9588 for integration

The diff isn't helpful here for identifying which apps are changed: collections, frontend, and government-frontend