### PR TITLE
Search API v2: Simplify alerting tests

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -8,122 +8,110 @@ tests:
   - interval: 1m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0+100x5'
+        values: '0+60x5'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0+5x5'
+        values: '0+6x5'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="502"}'
         values: '0+3x5'
     promql_expr_test:
-      - expr: round(search_api_v2:search_requests:rate5m{status="200"}, 1E-3)
+      - expr: search_api_v2:search_requests:rate5m{status="200"}
         eval_time: 5m
         exp_samples:
-          - labels: '{status="200"}'
-            value: 1.667
-      - expr: round(search_api_v2:search_requests:rate5m{status="500"}, 1E-3)
+          - labels: 'search_api_v2:search_requests:rate5m{status="200"}'
+            value: 1
+      - expr: search_api_v2:search_requests:rate5m{status="500"}
         eval_time: 5m
         exp_samples:
-          - labels: '{status="500"}'
-            value: 0.083
-      - expr: round(search_api_v2:search_requests:rate5m{status="502"}, 1E-3)
+          - labels: 'search_api_v2:search_requests:rate5m{status="500"}'
+            value: 0.1
+      - expr: search_api_v2:search_requests:rate5m{status="502"}
         eval_time: 5m
         exp_samples:
-          - labels: '{status="502"}'
-            value: 0.050
+          - labels: 'search_api_v2:search_requests:rate5m{status="502"}'
+            value: 0.05
 
   # Tests for search_api_v2:autocomplete_requests:rate5m
   - interval: 1m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0+80x5'
+        values: '0+120x5'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0+10x5'
+        values: '0+12x5'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="502"}'
-        values: '0+5x5'
+        values: '0+6x5'
     promql_expr_test:
-      - expr: round(search_api_v2:autocomplete_requests:rate5m{status="200"}, 1E-3)
+      - expr: search_api_v2:autocomplete_requests:rate5m{status="200"}
         eval_time: 5m
         exp_samples:
-          - labels: '{status="200"}'
-            value: 1.333
-      - expr: round(search_api_v2:autocomplete_requests:rate5m{status="500"}, 1E-3)
+          - labels: 'search_api_v2:autocomplete_requests:rate5m{status="200"}'
+            value: 2
+      - expr: search_api_v2:autocomplete_requests:rate5m{status="500"}
         eval_time: 5m
         exp_samples:
-          - labels: '{status="500"}'
-            value: 0.167
-      - expr: round(search_api_v2:autocomplete_requests:rate5m{status="502"}, 1E-3)
+          - labels: 'search_api_v2:autocomplete_requests:rate5m{status="500"}'
+            value: 0.2
+      - expr: search_api_v2:autocomplete_requests:rate5m{status="502"}
         eval_time: 5m
         exp_samples:
-          - labels: '{status="502"}'
-            value: 0.083
+          - labels: 'search_api_v2:autocomplete_requests:rate5m{status="502"}'
+            value: 0.1
 
   # Tests for search_api_v2:search_successful_requests:ratio_rate5m
   - interval: 1m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0+100x5'
+        values: '0x5 0+92x5'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0+8x5'
-    promql_expr_test:
-      - expr: round(search_api_v2:search_successful_requests:ratio_rate5m, 1E-3)
-        eval_time: 5m
-        exp_samples:
-          - labels: '{}'
-            value: 0.926
-
-  # Test for search_api_v2:search_successful_requests:ratio_rate5m with no requests
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0x5'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0x5'
+        values: '0x5 0+8x5'
     promql_expr_test:
       - expr: search_api_v2:search_successful_requests:ratio_rate5m
         eval_time: 5m
         exp_samples:
-          - labels: 'search_api_v2:search_successful_requests:ratio_rate5m'
-            value: 1
+          - labels: 'search_api_v2:search_successful_requests:ratio_rate5m{}'
+            value: 1  # No requests means 100% success rate
+      - expr: search_api_v2:search_successful_requests:ratio_rate5m
+        eval_time: 10m
+        exp_samples:
+          - labels: 'search_api_v2:search_successful_requests:ratio_rate5m{}'
+            value: 0.92
 
   # Tests for search_api_v2:autocomplete_successful_requests:ratio_rate5m
   - interval: 1m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0+80x5'
+        values: '0x5 0+85x5'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0+15x5'
-    promql_expr_test:
-      - expr: round(search_api_v2:autocomplete_successful_requests:ratio_rate5m, 1E-3)
-        eval_time: 5m
-        exp_samples:
-          - labels: '{}'
-            value: 0.842
-
-  # Test for search_api_v2:autocomplete_successful_requests:ratio_rate5m with no requests
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0x5'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0x5'
+        values: '0x5 0+15x5'
     promql_expr_test:
       - expr: search_api_v2:autocomplete_successful_requests:ratio_rate5m
         eval_time: 5m
         exp_samples:
-          - labels: 'search_api_v2:autocomplete_successful_requests:ratio_rate5m'
-            value: 1
+          - labels: 'search_api_v2:autocomplete_successful_requests:ratio_rate5m{}'
+            value: 1  # No requests means 100% success rate
+      - expr: search_api_v2:autocomplete_successful_requests:ratio_rate5m
+        eval_time: 10m
+        exp_samples:
+          - labels: 'search_api_v2:autocomplete_successful_requests:ratio_rate5m{}'
+            value: 0.85
 
-  # Tests for SearchDegradedAcute - Positive Test (alert should fire)
+  # Tests for SearchDegradedAcute alert
   - interval: 1m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0+980x10'
+        values: '0x10 0+99x10 0+98x13'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0+20x10'
+        values: '0x10 0+1x10 0+2x13'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 11m
         alertname: SearchDegradedAcute
         exp_alerts: []
-      - eval_time: 11m
+      - eval_time: 20m
+        alertname: SearchDegradedAcute
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: SearchDegradedAcute
+        exp_alerts: []
+      - eval_time: 33m
         alertname: SearchDegradedAcute
         exp_alerts:
           - exp_labels:
@@ -134,30 +122,24 @@ tests:
               summary: "Search API v2: Degraded search performance (acute)"
               description: "5 minute rolling success rate for search requests has dropped below 99% for more than 10 minutes."
 
-  # Tests for SearchDegradedAcute - Negative Test (alert should not fire)
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0+995x14'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0+5x14'
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: SearchDegradedAcute
-        exp_alerts: []
-
-  # Tests for AutocompleteDegradedAcute - Positive Test (alert should fire)
+  # Tests for AutocompleteDegradedAcute alert
   - interval: 1m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0+850x10'
+        values: '0x10 0+90x10 0+89x13'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0+150x10'
+        values: '0x10 0+10x10 0+11x13'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 11m
         alertname: AutocompleteDegradedAcute
         exp_alerts: []
-      - eval_time: 11m
+      - eval_time: 20m
+        alertname: AutocompleteDegradedAcute
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: AutocompleteDegradedAcute
+        exp_alerts: []
+      - eval_time: 33m
         alertname: AutocompleteDegradedAcute
         exp_alerts:
           - exp_labels:
@@ -168,71 +150,50 @@ tests:
               summary: "Search API v2: Degraded autocomplete performance (acute)"
               description: "5 minute rolling success rate for autocomplete requests has dropped below 90% for more than 10 minutes."
 
-  # Tests for AutocompleteDegradedAcute - Negative Test (alert should not fire)
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0+920x14'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0+80x14'
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: AutocompleteDegradedAcute
-        exp_alerts: []
-
   # Tests for search_api_v2:search_requests:rate1h
   - interval: 5m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0+100x12'
+        values: '0+300x12'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0+5x12'
+        values: '0+30x12'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="502"}'
         values: '0+3x12'
     promql_expr_test:
-      - expr: round(search_api_v2:search_requests:rate1h{status="200"}, 1E-3)
+      - expr: search_api_v2:search_requests:rate1h{status="200"}
         eval_time: 1h
         exp_samples:
-          - labels: '{status="200"}'
-            value: 0.333
-      - expr: round(search_api_v2:search_requests:rate1h{status="500"}, 1E-3)
+          - labels: 'search_api_v2:search_requests:rate1h{status="200"}'
+            value: 1
+      - expr: search_api_v2:search_requests:rate1h{status="500"}
         eval_time: 1h
         exp_samples:
-          - labels: '{status="500"}'
-            value: 0.017
-      - expr: round(search_api_v2:search_requests:rate1h{status="502"}, 1E-3)
+          - labels: 'search_api_v2:search_requests:rate1h{status="500"}'
+            value: 0.1
+      - expr: search_api_v2:search_requests:rate1h{status="502"}
         eval_time: 1h
         exp_samples:
-          - labels: '{status="502"}'
-            value: 0.010
+          - labels: 'search_api_v2:search_requests:rate1h{status="502"}'
+            value: 0.01
 
 # Tests for search_api_v2:search_successful_requests:ratio_rate1h
   - interval: 5m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0+92x12'
+        values: '0x12 0+92x12'
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0+8x12'
-    promql_expr_test:
-      - expr: round(search_api_v2:search_successful_requests:ratio_rate1h, 1E-3)
-        eval_time: 1h
-        exp_samples:
-          - labels: '{}'
-            value: 0.92
-
-  # Test for search_api_v2:search_successful_requests:ratio_rate1h with no requests
-  - interval: 1h
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
-        values: '0x12'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
-        values: '0x12'
+        values: '0x12 0+8x12'
     promql_expr_test:
       - expr: search_api_v2:search_successful_requests:ratio_rate1h
         eval_time: 1h
         exp_samples:
-          - labels: 'search_api_v2:search_successful_requests:ratio_rate1h'
-            value: 1
+          - labels: 'search_api_v2:search_successful_requests:ratio_rate1h{}'
+            value: 1  # No requests means 100% success rate
+      - expr: search_api_v2:search_successful_requests:ratio_rate1h
+        eval_time: 2h
+        exp_samples:
+          - labels: 'search_api_v2:search_successful_requests:ratio_rate1h{}'
+            value: 0.92
 
   # Tests for SearchDegradedMid
   - interval: 5m


### PR DESCRIPTION
- Use more naturally divisible numbers and remove rounding
- Make labelling consistent between tests
- Consolidate some positive and negative tests into one and check at different times for different conditions