### PR TITLE
Add labels to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "platformAutomerge": true,
+  "labels": ["dependencies", "renovate"],
   "argocd": {
     "fileMatch": [
       "charts\\/.*\\.yaml$"


### PR DESCRIPTION
This is consistent with Dependabot PRs. It will allow us to filter PRs by the label. A link to filtered search is included in the Seal tool.

It also adds `renovate` label in case we want to distinguish between the tools.

```
"labels": {
  "description": "Labels to set in Pull Request.",
  "type": "array",
  "items": {
    "type": "string"
  }
},
```