### PR TITLE
Add sanity check to post-sync Argo Workflow to ensure only versioned releases are promoted

### DIFF
--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure the image tag starts with a v
+if [ "${IMAGE_TAG:0:1}" != "v" ]; then
+  echo "false"
+  exit 0
+fi
+
 # Fetch the YAML configuration
 CONFIG_URL="/repos/alphagov/govuk-helm-charts/contents/charts/app-config/image-tags/${ENVIRONMENT}/${REPO_NAME}?ref=main"
 CONFIG_CONTENT=$(gh api --cache 0 "${CONFIG_URL}" -q '.content' | base64 --decode)

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -52,6 +52,8 @@ spec:
                   value: "{{ .Values.govukEnvironment }}"
                 - name: repoName
                   value: "{{"{{workflow.parameters.repoName}}"}}"
+                - name: imageTag
+                  value: "{{"{{workflow.parameters.imageTag}}"}}"
           - name: promote-release
             depends: check-for-promotion.Succeeded
             when: "{{"'{{tasks.check-for-promotion.outputs.result}}' == 'true'"}}"
@@ -72,6 +74,7 @@ spec:
         parameters:
         - name: environment
         - name: repoName
+        - name: imageTag
       script:
         image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/toolbox:latest
         command: [/bin/bash]
@@ -80,6 +83,8 @@ spec:
             value: "{{"{{inputs.parameters.environment}}"}}"
           - name: REPO_NAME
             value: "{{"{{inputs.parameters.repoName}}"}}"
+          - name: IMAGE_TAG
+            value: "{{"{{inputs.parameters.imageTag}}"}}"
           - name: GITHUB_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This should prevent branch deploys from being unintentionally promoted beyond the environments they were originally deployed in to.

https://github.com/alphagov/govuk-infrastructure/issues/1965