### PR TITLE
Strengthen image tag format check

### DIFF
--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure the image tag starts with a v
-if [ "${IMAGE_TAG:0:1}" != "v" ]; then
-  echo "false"
+if [[ ! "$IMAGE_TAG" =~ ^v[0-9]+$ ]]; then
+  echo "$0 - not promoting image tag ($IMAGE_TAG) as it doesn't match the required pattern (^v[0-9]+$)"
   exit 0
 fi
 


### PR DESCRIPTION
This uses bash's built in support for regular expressions to check the full IMAGE_TAG pattern, instead of just checking that the first character is v.

Only checking the first character still leaves some risk that a branch like "very-sensitive-change-do-not-deploy-to-production" could be accidentally deployed.

Checking that this does the right thing in bash:

    % IMAGE_TAG=v38274193
    % if [[ ! "$IMAGE_TAG" =~ ^v[0-9]+$ ]]; then echo "$0 - not promoting image tag ($IMAGE_TAG) as it doesn't match the required pattern (^v[0-9]+$)"; fi
    % IMAGE_TAG=vanilla
    % if [[ ! "$IMAGE_TAG" =~ ^v[0-9]+$ ]]; then echo "$0 - not promoting image tag ($IMAGE_TAG) as it doesn't match the required pattern (^v[0-9]+$)"; fi
    bash - not promoting image tag (vanilla) as it doesn't match the required pattern (^v[0-9]+$)