### PR TITLE
Fix image tag format check

### DIFF
--- a/charts/argo-services/scripts/check-for-promotion.sh
+++ b/charts/argo-services/scripts/check-for-promotion.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ ! "$IMAGE_TAG" =~ ^v[0-9]+$ ]]; then
-  echo "$0 - not promoting image tag ($IMAGE_TAG) as it doesn't match the required pattern (^v[0-9]+$)"
+  echo "false"
   exit 0
 fi
 


### PR DESCRIPTION
Description:
- Output needs to be `echo "false"` otherwise the step won't pass
- This is because https://github.com/alphagov/govuk-helm-charts/blob/9e8c80902fc954352877fbc19d3cbb4d1a0835f7/charts/argo-services/templates/workflows/post-sync/workflow.yaml#L59 expects an output of "true" and "false" which is causing the `when` condition to fail