### PR TITLE
Add cascading delete finaliser to all Application resources

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cluster-autoscaler
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/app-config/templates/monitoring-application.yaml
+++ b/charts/app-config/templates/monitoring-application.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
   annotations:
     repoName: monitoring-config
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: monitoring
   source:

--- a/charts/app-config/templates/reloader.yaml
+++ b/charts/app-config/templates/reloader.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: reloader
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/app-config/templates/renovate.yaml
+++ b/charts/app-config/templates/renovate.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: renovate
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: govuk
   source:

--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.9
+version: 0.0.10

--- a/charts/argo-bootstrap-ephemeral/templates/cluster-autoscaler-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/cluster-autoscaler-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cluster-autoscaler
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
   annotations:
     repoName: monitoring-config
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: monitoring
   source:

--- a/charts/argo-bootstrap-ephemeral/templates/reloader.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/reloader.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: reloader
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/argo-bootstrap/templates/argocd/apps-application.yaml
+++ b/charts/argo-bootstrap/templates/argocd/apps-application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: app-config
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
+++ b/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
@@ -5,6 +5,8 @@ kind: Application
 metadata:
   name: fastly-exporter
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -11,6 +11,8 @@ kind: Application
 metadata:
   name: kube-prometheus-stack
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: alertmanager-oauth2-proxy
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: prometheus-oauth2-proxy
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/pushgateway-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/pushgateway-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: prometheus-pushgateway
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/tempo/tempo-application.yaml
+++ b/charts/monitoring-config/templates/tempo/tempo-application.yaml
@@ -11,6 +11,8 @@ kind: Application
 metadata:
   name: tempo
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:


### PR DESCRIPTION
This adds a finaliser to all ArgoCD Application resources that causes ArgoCD to cascade delete child resources of these applications. This will allow us to easily remove all resources from the cluster when shutting down an ephemeral cluster.

https://github.com/alphagov/govuk-infrastructure/issues/1972