### PR TITLE
Update `publish-api` and `whitehall-admin` to use test redis instances in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2584,6 +2584,9 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "publishing-api-valkey.integration.govuk-internal.digital:6379"
+          workers: "publishing-api-valkey.integration.govuk-internal.digital:6379"
       cronTasks:
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"
@@ -4077,6 +4080,9 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "redis://whitehall-admin-redis.integration.govuk-internal.digital:6379"
+          workers: "redis://whitehall-admin-redis.integration.govuk-internal.digital:6379"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
## What

Update `publish-api` and `whitehall-admin` to use test redis instances in Integration

## Why

This is to test if using Elasticache rather than K8s hosted Redis instances will be a viable option for our services