### PR TITLE
Update publish-api to use test redis instances in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2585,8 +2585,8 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: "publishing-api-valkey.integration.govuk-internal.digital:6379"
-          workers: "publishing-api-valkey.integration.govuk-internal.digital:6379"
+          app: "redis://publishing-api-valkey.integration.govuk-internal.digital:6379"
+          workers: "redis://publishing-api-valkey.integration.govuk-internal.digital:6379"
       cronTasks:
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"


### PR DESCRIPTION
This was missed causing 
`Unknown URL scheme: "publishing-api-valkey.integration.govuk-internal.digital:6379" (ArgumentError) raise ArgumentError, "Unknown URL scheme: #{url.inspect}" `