### PR TITLE
Fastly Prometheus Exporter uses alphagov ARM image

### DIFF
--- a/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
+++ b/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
@@ -21,6 +21,10 @@ spec:
           key: "fastly-api-token"
         serviceMonitor:
           enabled: true
+        image:
+          repository: {{ .Values.fastlyPrometheusExporter.repository }}
+          tag: {{ .Values.fastlyPrometheusExporter.tag }}
+          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 50m

--- a/charts/monitoring-config/values.yaml
+++ b/charts/monitoring-config/values.yaml
@@ -8,3 +8,7 @@ monitoring:
 # ephemeral environment variables
 awsAccountId: "12345678"
 clusterId: "eph-xxxxxx"
+
+fastlyPrometheusExporter:
+  repository: ghcr.io/alphagov/fastly-exporter
+  tag: 0.5.1


### PR DESCRIPTION
Description:
- Currently the Fastly Prometheus Exporter is failing because we are running on EKS ARM nodes and there is no ARM build available
- Fork https://github.com/fastly/fastly-exporter into https://github.com/alphagov/fastly-exporter/
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1935