### PR TITLE
Set sync-wave for kube-prometheus-stack application so it is synced before other resources

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -13,6 +13,8 @@ metadata:
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   project: default
   source:


### PR DESCRIPTION
This should fix an issue where monitoring-config doesn't sync properly on a fresh cluster because CRDs created by kube-prometheus-stack are missing

https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/

https://github.com/alphagov/govuk-infrastructure/issues/1972