### PR TITLE
Set SkipDryRunOnMissingResource for monitoring-config application

### DIFF
--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.0.10
+version: 0.0.11

--- a/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/monitoring-application.yaml
@@ -26,3 +26,4 @@ spec:
     syncOptions:
     - ApplyOutOfSyncOnly=true
     - ServerSideApply=true
+    - SkipDryRunOnMissingResource=true

--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -13,8 +13,6 @@ metadata:
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   project: default
   source:


### PR DESCRIPTION
Attempt 2 to fix kube-prometheus-stack not installing automatically on a fresh cluster: this should make ArgoCD ignore that there are missing CRDs and attempt to sync the application anyway

https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types

https://github.com/alphagov/govuk-infrastructure/issues/1745