### PR TITLE
Bump version of cluster-secret-store chart

### DIFF
--- a/charts/cluster-secret-store/Chart.yaml
+++ b/charts/cluster-secret-store/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secret-store
 description: An external-secrets ClusterSecretStore backed by AWS SecretsManager.
-version: 0.1.1
+version: 0.2.0


### PR DESCRIPTION
0.1.1 seems to not have been deployed to the chart repo properly as it still contains a v1alpha1 ClusterSecretStore resource, and that API version has been removed from external-secrets