### PR TITLE
Up `replicaCount` of Publishing API workers in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2575,6 +2575,7 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
+        replicaCount: 3
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
We have a big backlog of jobs in integration that the current number of workers is currently struggling to cope with. This is causing e2e tests to fail and making testing difficult.

Once the queue calms down, we can reduce this number again.