### PR TITLE
Don't let publishing-api-read-replica app create secrets

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2663,6 +2663,10 @@ govukApplications:
       uploadAssets:
         enabled: false
       dbMigrationEnabled: false
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2490,6 +2490,10 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2484,6 +2484,10 @@ govukApplications:
       dbMigrationEnabled: false
       uploadAssets:
         enabled: false
+      rails:
+        createKeyBaseSecret: false
+      sentry:
+        createSecret: false
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
It's trying to create secrets with the same names as publishing-api, causing ArgoCD to never stop syncing changes