### PR TITLE
Changes to the graphql stats dashboard

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -150,7 +150,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(increase(http_requests_total{namespace=\"apps\", job=~\"publishing-api-read-replica\", controller=\"graphql\", action=\"execute\"}[30m]))",
+          "expr": "sum(increase(http_requests_total{namespace=\"apps\", job=~\"publishing-api-read-replica\", controller=\"graphql\", action=\"execute\"}[6h]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -637,5 +637,5 @@
   "timezone": "browser",
   "title": "Graphql stats",
   "uid": "aeh00wtwwg8owc",
-  "version": 1
+  "version": 3
 }

--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -164,7 +164,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "",
+      "description": "Percentage of requests in the last 6 hours which have gone to graphql vs content-store",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -181,8 +181,40 @@
                 "color": "green"
               },
               {
-                "color": "red",
+                "color": "#508642",
+                "value": 10
+              },
+              {
+                "color": "green",
+                "value": 20
+              },
+              {
+                "color": "green",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 40
+              },
+              {
+                "color": "green",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 70
+              },
+              {
+                "color": "green",
                 "value": 80
+              },
+              {
+                "color": "green",
+                "value": 90
               }
             ]
           },
@@ -222,7 +254,7 @@
           "refId": "A"
         }
       ],
-      "title": "Proportion of graphql requests",
+      "title": "Proportion of graphql vs content-store requests",
       "type": "gauge"
     },
     {
@@ -230,7 +262,6 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Average time content store has taken to respond to requests for content over the past 6 hours.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -254,7 +285,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 4,
         "x": 15,
         "y": 0
       },
@@ -284,7 +315,7 @@
           "refId": "A"
         }
       ],
-      "title": "Content Store response time (6H)",
+      "title": "Content store response time (6h)",
       "type": "gauge"
     },
     {

--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -262,67 +262,6 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 15,
-        "y": 0
-      },
-      "id": 7,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "sum by (job) (rate(http_request_duration_seconds_sum{namespace=\"apps\", job=~\"content-store\", controller=\"content_items\", action=\"show\"}[6h])) / sum by (job) (rate(http_request_duration_seconds_count{namespace=\"apps\", job=~\"content-store\", controller=\"content_items\", action=\"show\"}[6h]))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Content store response time (6h)",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "description": "Median and upper limit median request durations for both publishing-api-read-replica and content-store. \n\nThe upper limit uses the 99th percentile to avoid Prometheus weird bucket estimation.",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
A few changes at once, I've tried to space out individual modifications into their own commits to make the Json easier to review.

Note that nothing about the lower two panels in the screenshots has been changed, hence differing time ranges is not super important to the comparison.

Before: 
![image](https://github.com/user-attachments/assets/4fcaad10-146e-4a53-ba7f-a1e37e53a9c6)


After: 
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/762e4e4d-e0f5-49b4-91e3-fa4af543f7e5" />
