### PR TITLE
Add global variables for new fact check service account

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2327,6 +2327,21 @@ govukApplications:
             secretKeyRef:
               name: publisher-fact-check-email-account
               key: FACT_CHECK_PASSWORD
+        - name: FACT_CHECK_SERVICE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: fact-check-email-service
+              key: FACT_CHECK_SERVICE_CLIENT_ID
+        - name: FACT_CHECK_SERVICE_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: fact-check-email-service
+              key: FACT_CHECK_SERVICE_EMAIL
+        - name: FACT_CHECK_SERVICE_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fact-check-email-service
+              key: FACT_CHECK_SERVICE_PRIVATE_KEY
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Gmail have officially deprecated and removed password based logins for apps, instead making us work with OAuth2. As part of the migration to this system we need new secrets available to Publisher for fact checking.

This includes only integration for now for further testing of the implementation before moving it to new environments.

https://trello.com/c/r8cUPjj3/675-fact-check-email-processing-fails-with-invalid-credentials-mainstream-publisher