### PR TITLE
Search API v2: Purge old user events daily

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3222,6 +3222,9 @@ govukApplications:
         - name: user-events-import-intraday-events
           task: "user_events:import_intraday_events"
           schedule: "45 05,11,17,23 * * *"
+        - name: user-events-purge-final-week-of-retention-period
+          task: "user_events:purge_final_week_of_retention_period"
+          schedule: "0 2 * * *"
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *"  # 09:09am daily

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3037,6 +3037,9 @@ govukApplications:
         - name: user-events-import-intraday-events
           task: "user_events:import_intraday_events"
           schedule: "45 05,11,17,23 * * *"
+        - name: user-events-purge-final-week-of-retention-period
+          task: "user_events:purge_final_week_of_retention_period"
+          schedule: "0 2 * * *"
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3009,6 +3009,9 @@ govukApplications:
         - name: user-events-import-intraday-events
           task: "user_events:import_intraday_events"
           schedule: "45 05,11,17,23 * * *"
+        - name: user-events-purge-final-week-of-retention-period
+          task: "user_events:purge_final_week_of_retention_period"
+          schedule: "0 2 * * *"
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *"  # 09:09am daily


### PR DESCRIPTION
This triggers the daily task to clear out all user events from the final week of the retention period.

We're calling this task daily even though it deals with a week's worth of data so we have some breathing room if it fails at a really inconvenient time (say, in the middle of long holidays) without violating our data protection agreements.

see https://github.com/alphagov/search-api-v2/pull/424 for the implementation.