### PR TITLE
Revert "Add global variables for new fact check service account"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2327,21 +2327,6 @@ govukApplications:
             secretKeyRef:
               name: publisher-fact-check-email-account
               key: FACT_CHECK_PASSWORD
-        - name: FACT_CHECK_SERVICE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: fact-check-email-service
-              key: FACT_CHECK_SERVICE_CLIENT_ID
-        - name: FACT_CHECK_SERVICE_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: fact-check-email-service
-              key: FACT_CHECK_SERVICE_EMAIL
-        - name: FACT_CHECK_SERVICE_PRIVATE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: fact-check-email-service
-              key: FACT_CHECK_SERVICE_PRIVATE_KEY
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We have removed the values mentioned in this PR.
Reverts alphagov/govuk-helm-charts#3152