### PR TITLE
Remove finaliser from kube-prometheus-stack applications

### DIFF
--- a/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/kube-prometheus-stack-application.yaml
@@ -11,8 +11,6 @@ kind: Application
 metadata:
   name: kube-prometheus-stack
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/alertmanager-oauth2-proxy-application.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   name: alertmanager-oauth2-proxy
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
+++ b/charts/monitoring-config/templates/kube-prometheus-stack/oauth2-proxy/prometheus-oauth2-proxy-application.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   name: prometheus-oauth2-proxy
   namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:


### PR DESCRIPTION
This finaliser causes ArgoCD to cascade delete child resources, which we don't want here

https://github.com/alphagov/govuk-infrastructure/issues/2044