### PR TITLE
Switch `search-api` over to new Elasticache instance

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3019,6 +3019,9 @@ govukApplications:
           memory: 512Mi
       rails:
         enabled: false
+        redisUrlOverride:
+          app: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
+          workers: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
       nginxClientMaxBodySize: 20M
       uploadAssets:
         enabled: false


### PR DESCRIPTION
## What

Switch `search-api` service over to new Elasticache instance `search-api-valkey.integration.govuk-internal.digital`

## Why

So that testing can be carried out for this service