### PR TITLE
Reduce `replicaCount` for publishing-api in integration 

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2585,7 +2585,6 @@ govukApplications:
         enabled: false
       workers:
         enabled: true
-        replicaCount: 3
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
We can now safely reduce this number (changed in https://github.com/alphagov/govuk-helm-charts/pull/3142) in integration now Publishing API is less busy