### PR TITLE
Move redisUrlOverride to correct stanza for `search-api`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3019,14 +3019,14 @@ govukApplications:
           memory: 512Mi
       rails:
         enabled: false
-        redisUrlOverride:
-          app: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
-          workers: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
       nginxClientMaxBodySize: 20M
       uploadAssets:
         enabled: false
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
+          workers: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"


### PR DESCRIPTION
## What

Move the redisUrlOverride settings for `search-api` to the correct stanza

## Why

They had been put in the wrong place