### PR TITLE
Search Admin: Reimport completion denylist after DB restore

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2961,6 +2961,11 @@ govukApplications:
         enabled: true
       workers:
         enabled: true
+      cronTasks:
+        # Re-import completion denylist to Discovery Engine so it doesn't drift from local DB
+        - name: reimport-completion-denylist
+          task: "completion:import_denylist"
+          schedule: "56 4 * * 1"  # one hour after the DB is restored from staging
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2783,6 +2783,11 @@ govukApplications:
         enabled: true
       workers:
         enabled: true
+      cronTasks:
+        # Re-import completion denylist to Discovery Engine so it doesn't drift from local DB
+        - name: reimport-completion-denylist
+          task: "completion:import_denylist"
+          schedule: "56 2 * * 1-5"  # one hour after the DB is restored from production
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
This adds a cron task to Search Admin in integration and staging to re-import the completion denylist into Discovery Engine ("Vertex AI Search").

This avoids the state of Discovery Engine drifting from local state in Search Admin following the scheduled restore of production DB content.