### PR TITLE
Move tempo ephemeral config template back to monitoring-config

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_ephemeral-config.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_ephemeral-config.tpl
@@ -142,25 +142,3 @@
             "requests":
               "storage": "50Gi"
 {{- end }}
-
-{{- define "monitoring-config.ephemeral-tempo-config" }}
-{{- $clusterId := .Values.clusterId }}
-storage:
-  trace:
-    backend: s3
-    s3:
-      bucket: govuk-{{ $clusterId }}-tempo
-      region: eu-west-1
-      endpoint: s3.dualstack.eu-west-1.amazonaws.com
-serviceAccount:
-  name: tempo
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.awsAccountId }}:role/tempo-{{ $clusterId }}"
-metricsGenerator:
-  enabled: true
-  config:
-    storage:
-      remote_write:
-        - url: >-
-            http://prometheus-kube-prometheus-stack-prometheus-0.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write
-{{- end }}

--- a/charts/monitoring-config/templates/_ephemeral-config.tpl
+++ b/charts/monitoring-config/templates/_ephemeral-config.tpl
@@ -1,0 +1,21 @@
+{{- define "monitoring-config.ephemeral-tempo-config" }}
+{{- $clusterId := .Values.clusterId }}
+storage:
+  trace:
+    backend: s3
+    s3:
+      bucket: govuk-{{ $clusterId }}-tempo
+      region: eu-west-1
+      endpoint: s3.dualstack.eu-west-1.amazonaws.com
+serviceAccount:
+  name: tempo
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.awsAccountId }}:role/tempo-{{ $clusterId }}"
+metricsGenerator:
+  enabled: true
+  config:
+    storage:
+      remote_write:
+        - url: >-
+            http://prometheus-kube-prometheus-stack-prometheus-0.prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/write
+{{- end }}


### PR DESCRIPTION
This was moved over to the KPS bootstrap chart, but tempo is still managed by monitoring-config, so it needs moving back over

https://github.com/alphagov/govuk-infrastructure/issues/2044