### PR TITLE
Disable post-sync for Publishing API read replica

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2659,6 +2659,7 @@ govukApplications:
 
   - name: publishing-api-read-replica
     repoName: publishing-api
+    postSyncWorkflowEnabled: "false"
     helmValues:
       arch: arm64
       appResources:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2477,6 +2477,7 @@ govukApplications:
 
   - name: publishing-api-read-replica
     repoName: publishing-api
+    postSyncWorkflowEnabled: "false"
     helmValues:
       arch: arm64
       appResources:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2471,6 +2471,7 @@ govukApplications:
 
   - name: publishing-api-read-replica
     repoName: publishing-api
+    postSyncWorkflowEnabled: "false"
     helmValues:
       arch: arm64
       appResources:


### PR DESCRIPTION
The Publishing API and its read replica use the same repository. There's a single image tag for the repository. Currently both apps run the post-sync workflow, but the read replica runs it with zero end-to-end tests and therefore always passes. Once it passes, it updates the shared image tag regardless of the status of the main app's workflow run (the end-to-end tests could and often do fail). This promotes the deployment to the next environment for both apps

Ideally, we'd like to run some custom frontend end-to-end tests for the read replica, and then only promote the release if both the main app and the read replica's end-to-end tests pass, but this might be a challenge if we're executing them in separate workflow runs, since the deployment promotion is embedded in the workflow. Perhaps we could run those GraphQL-focused end-to-end tests in the main app's workflow instead, so that it's all contained within a single workflow. We'll explore this separately - for now this closes the loophole

[Trello](https://trello.com/c/yUr7WYg3/1696-plug-loophole-whereby-publishing-api-deployments-are-unconditionally-promoted)