### PR TITLE
Increase upload file size on Licensify from 10MB to 50MB

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -138,7 +138,7 @@ http {
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 
       # Allow large uploads to licensify-frontend
-      client_max_body_size 10M;
+      client_max_body_size 50M;
     }
 
     location /assets {


### PR DESCRIPTION
This fixes an issue raised by @steven-radford at today's GDS-APTO catch up. The file size limit on Licensify's nginx is 200MB so we could even consider making this 200MB, but i've erred on the side of caution and gone a bit lower out of an abundance of caution.