### PR TITLE
Pass value of promote_deployment to post-sync workflow in Argo Workflows

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -2,6 +2,7 @@
 {{- $reponame := .repoName | default .name }}
 {{- $imageTagConfig := $.Files.Get (printf "image-tags/%s/%s" $.Values.govukEnvironment $reponame) | fromYaml }}
 {{- $imageTag := $imageTagConfig.image_tag }}
+{{- $promoteDeployment := default "false" $imageTagConfig.promote_deployment }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -13,6 +14,7 @@ metadata:
     slackChannel: "{{ .slackChannel }}"
     repoName: "{{ $reponame }}"
     imageTag: "{{ $imageTag }}"
+    promoteDeployment: "{{ $promoteDeployment }}"
     notifications.argoproj.io/subscribe.on-deployed.argo_events: ""
     notifications.argoproj.io/subscribe.deployment.grafana: "deployment|{{ .name }}"
     postSyncWorkflowEnabled: "{{ .postSyncWorkflowEnabled | default "true" }}"

--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -19,7 +19,8 @@ template.send-argo-events-webhook: |
           "application": "{{.app.metadata.name}}",
           "state": "{{.app.status.operationState.phase}}",
           "repoName": "{{.app.metadata.annotations.repoName}}",
-          "imageTag": "{{.app.metadata.annotations.imageTag}}"
+          "imageTag": "{{.app.metadata.annotations.imageTag}}",
+          "promoteDeployment": "{{.app.metadata.annotations.promoteDeployment}}"
         }
       method: "POST"
       path: "/api/v1/events/apps/post-sync"

--- a/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
@@ -19,3 +19,6 @@ spec:
         - name: imageTag
           valueFrom:
             event: payload.imageTag
+        - name: promoteDeployment
+          valueFrom:
+            event: payload.promoteDeployment

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -8,6 +8,7 @@ spec:
       repoName: "{{ `{{workflow.parameters.repoName}}` }}"
       application: "{{ `{{workflow.parameters.application}}` }}"
       imageTag: "{{ `{{workflow.parameters.imageTag}}` }}"
+      promoteDeployment: "{{ `{{workflow.parameters.promoteDeployment}}` }}"
   entrypoint: handle-sync-event
   onExit: exit-handler
   retryStrategy:
@@ -22,6 +23,7 @@ spec:
       - name: application
       - name: repoName
       - name: imageTag
+      - name: promoteDeployment
   podSpecPatch: |
     containers:
       - name: main


### PR DESCRIPTION
This is the first step to fixing a race condition in the deployment pipeline where deployments could be promoted unintentionally in some situations

https://github.com/alphagov/govuk-infrastructure/issues/2010