### PR TITLE
Remove Renovate from Publishing API

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,7 +7,6 @@ data:
     {
       "repositories": [
         "alphagov/govuk-helm-charts",
-        "alphagov/govuk-infrastructure",
-        "alphagov/publishing-api"
+        "alphagov/govuk-infrastructure"
       ]
     }


### PR DESCRIPTION
We aren't quite ready to do the work to get this right yet, so we're disabling it for now

[Trello](https://trello.com/c/KYb1Gz92/469-use-renovate-for-ruby-version-maintenance)