### PR TITLE
Pass value of automatic_deploys_enabled to post-sync workflow in Argo Workflows

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -3,6 +3,7 @@
 {{- $imageTagConfig := $.Files.Get (printf "image-tags/%s/%s" $.Values.govukEnvironment $reponame) | fromYaml }}
 {{- $imageTag := $imageTagConfig.image_tag }}
 {{- $promoteDeployment := default "false" $imageTagConfig.promote_deployment }}
+{{- $autoDeploysEnabled := default "false" $imageTagConfig.automatic_deploys_enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -15,6 +16,7 @@ metadata:
     repoName: "{{ $reponame }}"
     imageTag: "{{ $imageTag }}"
     promoteDeployment: "{{ $promoteDeployment }}"
+    automaticDeploysEnabled: "{{ $autoDeploysEnabled }}"
     notifications.argoproj.io/subscribe.on-deployed.argo_events: ""
     notifications.argoproj.io/subscribe.deployment.grafana: "deployment|{{ .name }}"
     postSyncWorkflowEnabled: "{{ .postSyncWorkflowEnabled | default "true" }}"

--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -20,7 +20,8 @@ template.send-argo-events-webhook: |
           "state": "{{.app.status.operationState.phase}}",
           "repoName": "{{.app.metadata.annotations.repoName}}",
           "imageTag": "{{.app.metadata.annotations.imageTag}}",
-          "promoteDeployment": "{{.app.metadata.annotations.promoteDeployment}}"
+          "promoteDeployment": "{{.app.metadata.annotations.promoteDeployment}}",
+          "automaticDeploysEnabled": "{{.app.metadata.annotations.automaticDeploysEnabled}}"
         }
       method: "POST"
       path: "/api/v1/events/apps/post-sync"

--- a/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
@@ -22,3 +22,6 @@ spec:
         - name: promoteDeployment
           valueFrom:
             event: payload.promoteDeployment
+        - name: automaticDeploysEnabled
+          valueFrom:
+            event: payload.automaticDeploysEnabled

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -24,6 +24,7 @@ spec:
       - name: repoName
       - name: imageTag
       - name: promoteDeployment
+      - name: automaticDeploysEnabled
   podSpecPatch: |
     containers:
       - name: main


### PR DESCRIPTION
This value is also needed to check whether a deployment should be promoted

Related PR: https://github.com/alphagov/govuk-helm-charts/pull/3181

https://github.com/alphagov/govuk-infrastructure/issues/2010