### PR TITLE
Search API v2: Add long term success rate alert

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -93,3 +93,36 @@ groups:
           description: >-
             1 hour rolling success rate for search requests has dropped below 99.9% for more than 2
             hours.
+
+  - name: SearchApiV2LongMetrics
+    interval: 1h
+    rules:
+      - record: search_api_v2:search_requests:rate24h
+        expr: |
+          sum by (status) (
+            rate(
+              http_requests_total{
+                namespace="apps",
+                job="search-api-v2",
+                controller="searches"
+              }[24h]
+            )
+          )
+      - record: search_api_v2:search_successful_requests:ratio_rate24h
+        expr: |
+          (
+            sum (search_api_v2:search_requests:rate24h{status="200"})
+            /
+            sum (search_api_v2:search_requests:rate24h) > 0
+          ) or vector(1)
+      - alert: SearchDegradedLong
+        expr: search_api_v2:search_successful_requests:ratio_rate24h < 0.9999
+        for: 24h
+        labels:
+          severity: warning
+          destination: slack-search-team
+        annotations:
+          summary: "Search API v2: Degraded search performance (long)"
+          description: >-
+            24 hour rolling success rate for search requests has dropped below 99.99% for more than 24
+            hours.

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -176,7 +176,7 @@ tests:
           - labels: 'search_api_v2:search_requests:rate1h{status="502"}'
             value: 0.01
 
-# Tests for search_api_v2:search_successful_requests:ratio_rate1h
+  # Tests for search_api_v2:search_successful_requests:ratio_rate1h
   - interval: 5m
     input_series:
       - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
@@ -216,3 +216,70 @@ tests:
             exp_annotations:
               summary: "Search API v2: Degraded search performance (mid)"
               description: "1 hour rolling success rate for search requests has dropped below 99.9% for more than 2 hours."
+
+  # Tests for search_api_v2:search_requests:rate24h
+  - interval: 1h
+    input_series:
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
+        values: '0+3600x24'
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
+        values: '0+36x24'
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="502"}'
+        values: '0+18x24'
+    promql_expr_test:
+      - expr: search_api_v2:search_requests:rate24h{status="200"}
+        eval_time: 24h
+        exp_samples:
+          - labels: 'search_api_v2:search_requests:rate24h{status="200"}'
+            value: 1
+      - expr: search_api_v2:search_requests:rate24h{status="500"}
+        eval_time: 24h
+        exp_samples:
+          - labels: 'search_api_v2:search_requests:rate24h{status="500"}'
+            value: 0.01
+      - expr: search_api_v2:search_requests:rate24h{status="502"}
+        eval_time: 24h
+        exp_samples:
+          - labels: 'search_api_v2:search_requests:rate24h{status="502"}'
+            value: 0.005
+
+  # Tests for search_api_v2:search_successful_requests:ratio_rate24h
+  - interval: 1h
+    input_series:
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
+        values: '0x24 0+980x24'
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
+        values: '0x24 0+20x24'
+    promql_expr_test:
+      - expr: search_api_v2:search_successful_requests:ratio_rate24h
+        eval_time: 24h
+        exp_samples:
+          - labels: 'search_api_v2:search_successful_requests:ratio_rate24h{}'
+            value: 1  # No requests means 100% success rate
+      - expr: search_api_v2:search_successful_requests:ratio_rate24h
+        eval_time: 48h
+        exp_samples:
+          - labels: 'search_api_v2:search_successful_requests:ratio_rate24h{}'
+            value: 0.98
+
+  # Tests for SearchDegradedLong
+  - interval: 1h
+    input_series:
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="200"}'
+        values: '0+999x25'
+      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="searches", status="500"}'
+        values: '0+1x25'
+    alert_rule_test:
+      - eval_time: 24h
+        alertname: SearchDegradedLong
+        exp_alerts: []
+      - eval_time: 25h
+        alertname: SearchDegradedLong
+        exp_alerts:
+          - exp_labels:
+              alertname: SearchDegradedLong
+              severity: warning
+              destination: slack-search-team
+            exp_annotations:
+              summary: "Search API v2: Degraded search performance (long)"
+              description: "24 hour rolling success rate for search requests has dropped below 99.99% for more than 24 hours."


### PR DESCRIPTION
This adds a long term (24h) rate, ratio, and alert to the existing short (5m) and medium (1h) term ones.