### PR TITLE
Alertmanager: Remove slack-search-quality-monitoring rule

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -188,27 +188,6 @@ spec:
       text: |-
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
       apiURL: *slack_api_url
-  - name: slack-search-quality-monitoring
-    slackConfigs:
-    - channel: '#govuk-search-improvement'
-      sendResolved: true
-      iconEmoji: '{{ `{{ if eq .Status "firing" }}:warning:{{ else }}:white_check_mark:{{ end }}` }}'
-      color: '{{ `{{ if eq .Status "firing" }}#FFFF00{{ else }}#36a64f{{ end }}` }}'
-      title: '{{ `{{ if eq .Status "firing" }}Quality monitoring warning{{ else }}Quality monitoring issues resolved{{ end }}` }}'
-      text: |
-        {{ `{{ if eq .Status "firing" }}
-          {{ len .Alerts.Firing }} invariant dataset(s) have scores lower than 0.95:
-          {{ range .Alerts.Firing }}
-            • {{ .Labels.dataset_name }}: {{ printf "%.2f" .Value }}
-          {{ end }}
-        {{ else }}
-          All invariant datasets have returned to normal levels (0.95 or above).
-        {{ end }}` }}
-      actions:
-      - type: button
-        text: 'View logs in Kibana'
-        url: "https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-quality-monitoring-assert-invariants),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-quality-monitoring-assert-invariants)))),sort:!())"
-      apiURL: *slack_api_url
   - name: 'slack-whitehall-notifications'
     slackConfigs:
       - channel: '#govuk-whitehall-experience-tech'


### PR DESCRIPTION
This is no longer used.