### PR TITLE
Quote awsAccountId value for release app

### DIFF
--- a/charts/app-config/templates/release.yaml
+++ b/charts/app-config/templates/release.yaml
@@ -13,7 +13,7 @@ spec:
     targetRevision: HEAD
     helm:
       values: |
-        awsAccountId: {{ .Values.awsAccountId }}
+        awsAccountId: "{{ .Values.awsAccountId }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Values.argoNamespace }}


### PR DESCRIPTION
Helm was interpreting this as a number and was converting it to e notation, quotes should stop this

https://github.com/alphagov/govuk-infrastructure/issues/1980