### PR TITLE
Add time difference to graphql-content-store table

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -169,6 +169,31 @@
               "reducer": "diffperc"
             }
           }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Difference time (ms)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "graphql time"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "content-store time"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
         }
       ],
       "type": "table"
@@ -1223,5 +1248,5 @@
   "timezone": "browser",
   "title": "Graphql stats",
   "uid": "aeh00wtwwg8owc",
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
Allows us to see the difference in time in milliseconds as well as a percentage

![Screenshot 2025-05-09 at 12 45 15](https://github.com/user-attachments/assets/3adb6954-a82f-4b81-8ae5-1a9f2cd2e679)
