### PR TITLE
BAU - Provide correct secret name to Fastly Prometheus Exporter

### DIFF
--- a/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
+++ b/charts/monitoring-config/templates/fastly-prometheus-exporter/fastly-prometheus-exporter-application.yaml
@@ -17,7 +17,7 @@ spec:
       values: |
         {{ $envValues | nindent 8 }}
         existingSecret:
-          name: "fastly-api-token"
+          name: "govuk-fastly-api"
           key: "fastly-api-token"
         serviceMonitor:
           enabled: true


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3196 provided the incorrect secret name
- Secret name should be [govuk-fastly-api](https://github.com/alphagov/govuk-helm-charts/blob/1998239619cf4f37881e37241271cad518b3e3b1/charts/cluster-secrets/templates/fastly-api.yaml#L16)