### PR TITLE
Remove search quality monitoring route

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -61,16 +61,6 @@ spec:
         - inhours
     - matchers:
       - name: destination
-        value: slack-search-quality-monitoring
-        matchType: =
-      receiver: slack-search-quality-monitoring
-      repeatInterval: 24h
-      groupWait: 5m
-      groupInterval: 30m
-      activeTimeIntervals:
-        - inhours
-    - matchers:
-      - name: destination
         value: slack-chat-notifications
         matchType: =
       receiver: 'slack-chat-notifications'


### PR DESCRIPTION
This no longer has a receiver and is causing Alertmanager to be unhappy.