### PR TITLE
Add RoFS to Reloader, Drop Capabilities

### DIFF
--- a/charts/app-config/templates/reloader.yaml
+++ b/charts/app-config/templates/reloader.yaml
@@ -14,7 +14,15 @@ spec:
     helm:
       values: |
         reloader:
+          readOnlyRootFilesystem: true
           reloadStrategy: annotations
+          containerSecurityContext:
+            capabilities:
+              drop:
+                - ALL
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Values.argoNamespace }}


### PR DESCRIPTION
## What?
This sets up Reloader to use a Read-Only Root Filesystem and also tries to drop capabilities, as this isn't explicitly configured.

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/1765