### PR TITLE
Add ServiceMonitor for Argo Workflows

### DIFF
--- a/charts/monitoring-config/templates/argo-workflows-metrics/service.yaml
+++ b/charts/monitoring-config/templates/argo-workflows-metrics/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-workflows-metrics
+  labels:
+    app: argo-workflows-metrics
+  namespace: {{ .Values.argoNamespace }}
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: workflow-controller

--- a/charts/monitoring-config/templates/argo-workflows-metrics/servicemonitor.yaml
+++ b/charts/monitoring-config/templates/argo-workflows-metrics/servicemonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argo-workflows
+  namespace: {{ .Values.argoNamespace }}
+spec:
+  endpoints:
+    - port: metrics
+  selector:
+    matchLabels:
+      app: argo-workflows-metrics


### PR DESCRIPTION
This will allow us to monitor the state of Argo Workflows, such as how many workflows are failing

The new service is required so that all metrics endpoints are scraped if there are multiple workflow controllers running (we have this in prod)

https://github.com/alphagov/govuk-infrastructure/issues/2138