### PR TITLE
Add Prometheus rule for when Argo Workflows runs have failed

### DIFF
--- a/charts/monitoring-config/rules/argo_workflows.yaml
+++ b/charts/monitoring-config/rules/argo_workflows.yaml
@@ -1,0 +1,15 @@
+groups:
+  - name: ArgoWorkflows
+    rules:
+      - alert: WorkflowRunsFailing
+        expr: |
+          delta(argo_workflows_gauge{status="Failed"}[1h]) > 0
+        labels:
+          severity: warning
+          destination: slack-platform-engineering
+        annotations:
+          summary: Argo Workflow runs have Failed
+          description: >-
+            One or more workflow runs in Argo Workflows ({{ .ExternalLabels.environment }}) have failed in the past hour
+
+            https://argo-workflows.eks.{{ .ExternalLabels.environment }}.govuk.digital

--- a/charts/monitoring-config/rules/argo_workflows_tests.yaml
+++ b/charts/monitoring-config/rules/argo_workflows_tests.yaml
@@ -1,0 +1,36 @@
+rule_files:
+  - argo_workflows.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: >-
+          argo_workflows_gauge{status="Failed"}
+        values: '0'
+    alert_rule_test:
+      - alertname: WorkflowRunsFailing
+        eval_time: 5m
+        exp_alerts: []
+  - interval: 30m
+    external_labels:
+      environment: test
+    input_series:
+      - series: >-
+          argo_workflows_gauge{status="Failed"}
+        values: '0+5x5'
+    alert_rule_test:
+      - alertname: WorkflowRunsFailing
+        eval_time: 2h
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-platform-engineering
+              status: Failed
+            exp_annotations:
+              summary: Argo Workflow runs have Failed
+              description: >-
+                One or more workflow runs in Argo Workflows (test) have failed in the past hour
+
+                https://argo-workflows.eks.test.govuk.digital


### PR DESCRIPTION
This will alert if any runs have failed in the last hour, we can tweak this if it gets noisy. In theory there should be no runs failing though

https://github.com/alphagov/govuk-infrastructure/issues/2138