### PR TITLE
Set group times for generic-platform-engineering route in AlertManager to something more reasonable

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -44,9 +44,9 @@ spec:
         value: slack-platform-engineering
         matchType: =
       receiver: 'generic-slack-platform-engineering'
-      repeatInterval: 1d
-      groupWait: 12h
-      groupInterval: 12h
+      repeatInterval: 3h
+      groupWait: 1m
+      groupInterval: 30m
       activeTimeIntervals:
         - inhours
     - matchers:


### PR DESCRIPTION
These are set way too high to be actually useful

https://github.com/alphagov/govuk-infrastructure/issues/2138