### PR TITLE
Send argo workflows failure alert to low priority slack channel

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -51,6 +51,16 @@ spec:
         - inhours
     - matchers:
       - name: destination
+        value: slack-platform-engineering-low-priority
+        matchType: =
+      receiver: 'generic-slack-platform-engineering-low-priority'
+      repeatInterval: 3h
+      groupWait: 1m
+      groupInterval: 30m
+      activeTimeIntervals:
+        - inhours
+    - matchers:
+      - name: destination
         value: slack-search-team
         matchType: =
       receiver: 'slack-search-team'
@@ -165,6 +175,14 @@ spec:
   - name: 'generic-slack-platform-engineering'
     slackConfigs:
     - channel: '#govuk-platform-support'
+      sendResolved: true
+      iconURL: https://avatars3.githubusercontent.com/u/3380462
+      text: |-
+        {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
+      apiURL: *slack_api_url
+  - name: 'generic-slack-platform-engineering-low-priority'
+    slackConfigs:
+    - channel: '#govuk-platform-engineering-low-priority-alarms'
       sendResolved: true
       iconURL: https://avatars3.githubusercontent.com/u/3380462
       text: |-

--- a/charts/monitoring-config/rules/argo_workflows.yaml
+++ b/charts/monitoring-config/rules/argo_workflows.yaml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: WorkflowRunsFailing
         expr: |
-          delta(argo_workflows_gauge{status="Failed"}[1h]) > 0
+          increase(argo_workflows_gauge{status="Failed"}[1h]) > 0
         labels:
           severity: warning
           destination: slack-platform-engineering-low-priority

--- a/charts/monitoring-config/rules/argo_workflows.yaml
+++ b/charts/monitoring-config/rules/argo_workflows.yaml
@@ -6,7 +6,7 @@ groups:
           delta(argo_workflows_gauge{status="Failed"}[1h]) > 0
         labels:
           severity: warning
-          destination: slack-platform-engineering
+          destination: slack-platform-engineering-low-priority
         annotations:
           summary: Argo Workflow runs have Failed
           description: >-

--- a/charts/monitoring-config/rules/argo_workflows_tests.yaml
+++ b/charts/monitoring-config/rules/argo_workflows_tests.yaml
@@ -26,7 +26,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              destination: slack-platform-engineering
+              destination: slack-platform-engineering-low-priority
               status: Failed
             exp_annotations:
               summary: Argo Workflow runs have Failed


### PR DESCRIPTION
This is to make sure it doesn't spam the platform support channel if the alert is noisy.

It also adds a new AlertManager receiver to send alerts to the low priority channel.

https://github.com/alphagov/govuk-infrastructure/issues/2138