### PR TITLE
Increase threshold for argo workflows alarm to 2 failed workflows an hour

### DIFF
--- a/charts/monitoring-config/rules/argo_workflows.yaml
+++ b/charts/monitoring-config/rules/argo_workflows.yaml
@@ -3,13 +3,13 @@ groups:
     rules:
       - alert: WorkflowRunsFailing
         expr: |
-          increase(argo_workflows_gauge{status="Failed"}[1h]) > 0
+          increase(argo_workflows_gauge{status="Failed"}[1h]) >= 2
         labels:
           severity: warning
           destination: slack-platform-engineering-low-priority
         annotations:
           summary: Argo Workflow runs have Failed
           description: >-
-            One or more workflow runs in Argo Workflows ({{ .ExternalLabels.environment }}) have failed in the past hour
+            Two or more workflow runs in Argo Workflows ({{ .ExternalLabels.environment }}) have failed in the past hour
 
             https://argo-workflows.eks.{{ .ExternalLabels.environment }}.govuk.digital

--- a/charts/monitoring-config/rules/argo_workflows_tests.yaml
+++ b/charts/monitoring-config/rules/argo_workflows_tests.yaml
@@ -31,6 +31,6 @@ tests:
             exp_annotations:
               summary: Argo Workflow runs have Failed
               description: >-
-                One or more workflow runs in Argo Workflows (test) have failed in the past hour
+                Two or more workflow runs in Argo Workflows (test) have failed in the past hour
 
                 https://argo-workflows.eks.test.govuk.digital


### PR DESCRIPTION
The alarm is too noisy right now.

https://github.com/alphagov/govuk-infrastructure/issues/2138