### PR TITLE
Search API v2: Make search-related alerts critical

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -42,7 +42,7 @@ groups:
         expr: search_api_v2:search_successful_requests:ratio_rate5m < 0.99
         for: 10m
         labels:
-          severity: warning
+          severity: critical
           destination: slack-search-team
         annotations:
           summary: "Search API v2: Degraded search performance (acute)"
@@ -86,7 +86,7 @@ groups:
         expr: search_api_v2:search_successful_requests:ratio_rate1h < 0.999
         for: 2h
         labels:
-          severity: warning
+          severity: critical
           destination: slack-search-team
         annotations:
           summary: "Search API v2: Degraded search performance (mid)"
@@ -119,7 +119,7 @@ groups:
         expr: search_api_v2:search_successful_requests:ratio_rate24h < 0.9999
         for: 24h
         labels:
-          severity: warning
+          severity: critical
           destination: slack-search-team
         annotations:
           summary: "Search API v2: Degraded search performance (long)"

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -116,7 +116,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: SearchDegradedAcute
-              severity: warning
+              severity: critical
               destination: slack-search-team
             exp_annotations:
               summary: "Search API v2: Degraded search performance (acute)"
@@ -211,7 +211,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: SearchDegradedMid
-              severity: warning
+              severity: critical
               destination: slack-search-team
             exp_annotations:
               summary: "Search API v2: Degraded search performance (mid)"
@@ -278,7 +278,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: SearchDegradedLong
-              severity: warning
+              severity: critical
               destination: slack-search-team
             exp_annotations:
               summary: "Search API v2: Degraded search performance (long)"


### PR DESCRIPTION
These should be marked critical as they represent violations of our SLO, and should come through on the main team channel.

Update alert rules and tests to set severity to critical for SearchDegradedAcute, SearchDegradedMid, and SearchDegradedLong.