### PR TITLE
Add new secrets for Fact Check

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2345,6 +2345,11 @@ govukApplications:
             secretKeyRef:
               name: publisher-fact-check-email-account
               key: FACT_CHECK_PASSWORD
+        - name: FACT_CHECK_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_API_KEY
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2339,6 +2339,11 @@ govukApplications:
             secretKeyRef:
               name: publisher-fact-check-email-account
               key: FACT_CHECK_PASSWORD
+        - name: FACT_CHECK_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_API_KEY
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We now need to access Google via API calls. This PR adds the secrets key for that API to the ENV for publisher. Both keys exist in their respective environments in AWS Secrets.

Follow up to https://github.com/alphagov/govuk-helm-charts/pull/3183

https://trello.com/c/r8cUPjj3/