### PR TITLE
Change Pagerduty drill to run on Tuesday

### DIFF
--- a/charts/monitoring-config/rules/pagerdutydrill.yaml
+++ b/charts/monitoring-config/rules/pagerdutydrill.yaml
@@ -4,7 +4,7 @@ groups:
     rules:
       - alert: PagerDutyDrill
         expr: |
-          (day_of_week() == 1) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
+          (day_of_week() == 2) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
         labels:
           severity: page
         annotations:


### PR DESCRIPTION
Until we fix this properly (card at https://trello.com/c/jRzTJLLY/) we need to switch this to running on Tuesday next week to avoid the bank holiday.