### PR TITLE
Switch search-api workers to ElastiCache (valkey) in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2846,6 +2846,8 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2850,6 +2850,7 @@ govukApplications:
         enabled: true
         redisUrlOverride:
           app: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
+          workers: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -56,7 +56,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-redis/1
+  - &emergency-banner-redis redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -3824,6 +3824,8 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
@@ -3897,7 +3899,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: redis://whitehall-admin-redis/2
+          value: redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379/2
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2401,6 +2401,8 @@ govukApplications:
         enabled: true
       redis:
         enabled: true
+        redisUrlOverride:
+          app: "redis://publishing-api-valkey.staging.govuk-internal.digital:6379"
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
Includes commits of https://github.com/alphagov/govuk-helm-charts/pull/3218 which will be merged first.

https://github.com/alphagov/govuk-infrastructure/issues/1995