### PR TITLE
Switch publishing-api and search-api workers to ElastiCache (valkey) in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2851,6 +2851,7 @@ govukApplications:
         enabled: true
         redisUrlOverride:
           app: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
+          workers: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2403,6 +2403,7 @@ govukApplications:
         enabled: true
         redisUrlOverride:
           app: "redis://publishing-api-valkey.staging.govuk-internal.digital:6379"
+          workers: "redis://publishing-api-valkey.staging.govuk-internal.digital:6379"
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
Includes commits of https://github.com/alphagov/govuk-helm-charts/pull/3218

https://github.com/alphagov/govuk-infrastructure/issues/1995