### PR TITLE
Use argo_workflows_total_count metric for failed Argo Workflows alert

### DIFF
--- a/charts/monitoring-config/rules/argo_workflows.yaml
+++ b/charts/monitoring-config/rules/argo_workflows.yaml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: WorkflowRunsFailing
         expr: |
-          increase(argo_workflows_gauge{status="Failed"}[1h]) >= 2
+          increase(argo_workflows_total_count{phase="Failed"}[1h]) >= 2
         labels:
           severity: warning
           destination: slack-platform-engineering-low-priority

--- a/charts/monitoring-config/rules/argo_workflows_tests.yaml
+++ b/charts/monitoring-config/rules/argo_workflows_tests.yaml
@@ -7,7 +7,7 @@ tests:
   - interval: 1h
     input_series:
       - series: >-
-          argo_workflows_gauge{status="Failed"}
+          argo_workflows_total_count{phase="Failed"}
         values: '0'
     alert_rule_test:
       - alertname: WorkflowRunsFailing
@@ -18,7 +18,7 @@ tests:
       environment: test
     input_series:
       - series: >-
-          argo_workflows_gauge{status="Failed"}
+          argo_workflows_total_count{phase="Failed"}
         values: '0+5x5'
     alert_rule_test:
       - alertname: WorkflowRunsFailing
@@ -27,7 +27,7 @@ tests:
           - exp_labels:
               severity: warning
               destination: slack-platform-engineering-low-priority
-              status: Failed
+              phase: Failed
             exp_annotations:
               summary: Argo Workflow runs have Failed
               description: >-


### PR DESCRIPTION
The original metric isn't working properly, probably because it's a gauge and the value can decrease. This should fix that

https://github.com/alphagov/govuk-infrastructure/issues/2138