### PR TITLE
Switch Whitehall from Elasticache Redis to Valkey in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -58,7 +58,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-redis/1
+  - &emergency-banner-redis redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -4116,8 +4116,8 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: "redis://whitehall-admin-redis.integration.govuk-internal.digital:6379"
-          workers: "redis://whitehall-admin-redis.integration.govuk-internal.digital:6379"
+          app: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379"
+          workers: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
@@ -4191,7 +4191,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: redis://whitehall-admin-redis/2
+          value: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/2"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
to make it consistent with staging + Valkey is cheaper.

Provisioned in: https://github.com/alphagov/govuk-infrastructure/commit/4d549ce3550500c7254f14e58ddd257754195c99

There're no jobs in the queues at the moment so ok to switch the app and worker at the same time.
I will re-queue all the scheduled jobs after the switch.

https://github.com/alphagov/govuk-infrastructure/issues/1995