### PR TITLE
Switch Whitehall from Elasticache Redis to Valkey in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -58,7 +58,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-redis/1
+  - &emergency-banner-redis redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -4116,8 +4116,8 @@ govukApplications:
       redis:
         enabled: true
         redisUrlOverride:
-          app: "redis://whitehall-admin-redis.integration.govuk-internal.digital:6379"
-          workers: "redis://whitehall-admin-redis.integration.govuk-internal.digital:6379"
+          app: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379"
+          workers: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
@@ -4191,7 +4191,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: redis://whitehall-admin-redis/2
+          value: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/2"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
to make it consistent with staging and Valkey is cheaper. Also switches emergency banner redis and taxonomy cache.
https://github.com/alphagov/govuk-infrastructure/issues/1995

### Prerequisites 
Provisioned in: alphagov/govuk-infrastructure@4d549ce 

### Testing
Previously DNS record wasn't created so the app couldn't connect to it. The record now exists:
<img width="556" alt="Screenshot 2025-05-28 at 16 17 14" src="https://github.com/user-attachments/assets/7b81f3b0-d8bb-477e-a030-65805e10dd22" />

Tested that the connection can be made in the Rails console in Static:
```
redis = Redis.new(url: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/1")
redis.hgetall("emergency_banner").try(:symbolize_keys)
```

### Other considerations
There're no jobs in the queues at the moment so ok to switch the app and worker at the same time.


