### PR TITLE
✨ Add PoC Deployment of Prometheus Adapter

### DIFF
--- a/charts/monitoring-config/helm-versions/integration
+++ b/charts/monitoring-config/helm-versions/integration
@@ -1,4 +1,5 @@
 # $repo_url $chart_name: "$chart_version"
-https://prometheus-community.github.io/helm-charts prometheus-pushgateway: "3.3.0"
+https://prometheus-community.github.io/helm-charts prometheus-adapter: "4.14.1"
 https://prometheus-community.github.io/helm-charts prometheus-fastly-exporter: "0.7.0"
+https://prometheus-community.github.io/helm-charts prometheus-pushgateway: "3.3.0"
 https://grafana.github.io/helm-charts tempo-distributed: "1.41.0" 

--- a/charts/monitoring-config/prometheus-adapter-integration-values.yaml
+++ b/charts/monitoring-config/prometheus-adapter-integration-values.yaml
@@ -5,7 +5,6 @@
 # Expose the adapter’s own /metrics endpoint to Prometheus.
 serviceMonitor:
   enabled: true
-  # scrapeInterval: 30s        # uncomment if you want a custom frequency
 
 # Don’t install the chart’s big bundle of default rules.
 rules:

--- a/charts/monitoring-config/prometheus-adapter-integration-values.yaml
+++ b/charts/monitoring-config/prometheus-adapter-integration-values.yaml
@@ -1,0 +1,23 @@
+# Prometheus Adapter – integration environment
+# -------------------------------------------
+# These values are consumed by the Application
+
+# Expose the adapter’s own /metrics endpoint to Prometheus.
+serviceMonitor:
+  enabled: true
+  # scrapeInterval: 30s        # uncomment if you want a custom frequency
+
+# Don’t install the chart’s big bundle of default rules.
+rules:
+  default: false
+
+  # Custom external metric for the Chat-AI sidekiq backlog
+  external:
+    - seriesQuery: 'sidekiq_queue_backlog{job=~"govuk-chat-worker"}'
+      resources:
+        overrides:
+          namespace:
+            resource: apps
+      name:
+        as: ai_sidekiq_queue_backlog
+      metricsQuery: 'max(sidekiq_queue_backlog{job=~"govuk-chat-worker"})'

--- a/charts/monitoring-config/templates/prometheus-adapter/prometheus-adapter-application.yaml
+++ b/charts/monitoring-config/templates/prometheus-adapter/prometheus-adapter-application.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.govukEnvironment "integration" }}
+{{ $envValues := toYaml (fromYaml (.Files.Get "prometheus-adapter-values-integration.yaml")) }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prometheus-adapter
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    {{- include "monitoring-config.helm-release"
+        ( merge (deepCopy .)
+          (dict "repoURL" "https://prometheus-community.github.io/helm-charts"
+                "chart"   "prometheus-adapter") )
+        | nindent 4 }}
+    helm:
+      values: |
+        {{ $envValues | nindent 8 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.monitoringNamespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+{{- end }}


### PR DESCRIPTION
## 👀 Purpose

Enable a **proof of concept** deployment of the [Prometheus Adapter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-adapter) (https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-adapter) in the **integration** environment. This allows us to expose custom metrics to the Kubernetes HPA (Horizontal Pod Autoscaler) API, enabling workload-based autoscaling.

Initially, this is to support scaling the Chat AI service based on its Sidekiq queue backlog.

---

## ♻️ What's changed

* Pinned `prometheus-adapter` chart version (`4.14.1`) in `helm-versions/integration`.
* Created a new Argo Application manifest to install the adapter **only in integration**.
* Added `prometheus-adapter-values-integration.yaml` with:

  * `serviceMonitor.enabled: true`
  * A single external metric rule to expose:

    * `sidekiq_queue_backlog{job="govuk-chat-worker"}`
    * as `chat_ai_sidekiq_backlog` in the external metrics API.

---

## 📝 Notes

* This is a **PoC only** – if successful, we can generalise or promote to staging/prod.
* ArgoCD will install the adapter in the `monitoring` namespace.
* Metric is namespaced (`apps`) and queryable via:

  ```bash
  kubectl get --raw \
    /apis/external.metrics.k8s.io/v1beta1/namespaces/apps/chat_ai_sidekiq_backlog
  ```
* If the adapter requires kube-prometheus CRDs in future, we may need to move it out of the bootstrap chart into `monitoring-config`.