### PR TITLE
♻️ Add Prometheus url and port

### DIFF
--- a/charts/monitoring-config/prometheus-adapter-integration-values.yaml
+++ b/charts/monitoring-config/prometheus-adapter-integration-values.yaml
@@ -10,6 +10,10 @@ serviceMonitor:
 rules:
   default: false
 
+prometheus:
+  url: http://kube-prometheus-stack-prometheus.monitoring.svc
+  port: 9090
+
   # Custom external metric for the Chat-AI sidekiq backlog
   external:
     - seriesQuery: 'sidekiq_queue_backlog{job=~"govuk-chat-worker"}'


### PR DESCRIPTION
This fixes the error from prometheus-adapter that complains the Prometheus instance is incorrect. It's making an unclear assertion on the prom url, this commit clears up the confusion.

Error in full:
```bash
unable to fetch metrics for query ... 
dial tcp: lookup prometheus.default.svc ... no such host
```
