### PR TITLE
♻️ Fix missing external metrics server

### DIFF
--- a/charts/monitoring-config/prometheus-adapter-values-integration.yaml
+++ b/charts/monitoring-config/prometheus-adapter-values-integration.yaml
@@ -10,6 +10,9 @@ prometheus:
   url: http://kube-prometheus-stack-prometheus.monitoring.svc
   port: 9090
 
+extraArguments:
+  - --enable-external-metrics
+
 # Don’t install the chart’s big bundle of default rules.
 rules:
   default: false


### PR DESCRIPTION
## 👀 Purpose

Enable the `external.metrics.k8s.io` API in the Prometheus Adapter, so that Horizontal Pod Autoscalers (HPA) can scale based on custom metrics — such as `sidekiq_queue_backlog` exposed by various applications.

---

## ♻️ What's changed

* Added the flag `--enable-external-metrics` to the adapter deployment via `extraArguments` in the Helm values file.
* This allows the adapter to serve the `external.metrics.k8s.io` API group, which is required for Kubernetes to fetch external metrics for HPA.
* Confirmed that `rules.external` were already in place, which configure the metrics, but without the flag, the adapter doesn't expose the external metrics API.

---

## 📝 Notes

* Although the chart sets up the APIService and config files based on `rules.external`, the adapter binary still needs the `--enable-external-metrics` flag to register the API group internally.
* Without this flag, requests to `/apis/external.metrics.k8s.io/v1beta1` return 404, and the APIService remains in `Available=False` with a `FailedDiscoveryCheck` status.
* This flag is documented in the adapter source code and passed through using the chart's built-in `extraArguments` array.