### PR TITLE
Remove enable option from autoscaler

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1721,7 +1721,6 @@ govukApplications:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role
       podAutoscaling:
         - name: govuk-chat
-          enabled: true
           spec:
             maxReplicas: 10
             minReplicas: 2
@@ -1737,7 +1736,6 @@ govukApplications:
                     type: Utilization
                     averageUtilization: 65
         - name: govuk-chat-worker
-          enabled: true
           spec:
             maxReplicas: 10
             minReplicas: 2

--- a/charts/generic-govuk-app/templates/pod-autoscaler.yaml
+++ b/charts/generic-govuk-app/templates/pod-autoscaler.yaml
@@ -1,5 +1,4 @@
 {{- range .Values.podAutoscaling -}}
-{{- if .enabled -}}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -7,5 +6,4 @@ metadata:
   name: {{ .name }}
 spec:
   {{- toYaml .spec | nindent 2 }}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What

Remove the enable option from the horizontal pod autoscaler

## Why

It is preventing multiple HPAs to be created