### PR TITLE
Reinstate enable option and fix missing newline

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1721,6 +1721,7 @@ govukApplications:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role
       podAutoscaling:
         - name: govuk-chat
+          enabled: true
           spec:
             maxReplicas: 10
             minReplicas: 2
@@ -1736,6 +1737,7 @@ govukApplications:
                     type: Utilization
                     averageUtilization: 65
         - name: govuk-chat-worker
+          enabled: true
           spec:
             maxReplicas: 10
             minReplicas: 2

--- a/charts/generic-govuk-app/templates/pod-autoscaler.yaml
+++ b/charts/generic-govuk-app/templates/pod-autoscaler.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.podAutoscaling -}}
+{{ if .enabled }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -6,4 +7,5 @@ metadata:
   name: {{ .name }}
 spec:
   {{- toYaml .spec | nindent 2 }}
-{{- end -}}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
## What

Put the enable option back in for HPA and fix missing newline

## Why

The missing newline was causing only one HPA to be created