### PR TITLE
Remove `govuk-chat-slack` env var

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1629,11 +1629,6 @@ govukApplications:
         #   schedule: "15 12 * * *"
         #   timeZone: "Europe/London"
       extraEnv:
-        - name: AI_SLACK_CHANNEL_WEBHOOK_URL
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-slack
-              key: AI_SLACK_CHANNEL_WEBHOOK_URL
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Description 

We've stripped out our Slack integration from Chat. So we no longer need this env var.