### PR TITLE
Switch content-data-admin in integration from IAM user to IAM role

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -527,6 +527,11 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 550Mi
+      serviceAccount:
+        enabled: true
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/content-data-admin-integration
       ingress:
         enabled: true
         redirect: true


### PR DESCRIPTION
This new role has the same permissions as the old user, so shouldn't impact functionality

https://github.com/alphagov/govuk-infrastructure/issues/2171