### PR TITLE
Switch content-data-admin in production from IAM user to IAM role

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -519,6 +519,11 @@ govukApplications:
           memory: 550Mi
       redis:
         enabled: true
+      serviceAccount:
+        enabled: true
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::172025368201:role/content-data-admin-production
       ingress:
         enabled: true
         redirect: true
@@ -596,16 +601,6 @@ govukApplications:
             secretKeyRef:
               name: signon-app-content-data
               key: oauth_secret
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: content-data-admin-aws
-              key: access_key
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: content-data-admin-aws
-              key: secret_key
         - name: AWS_CSV_EXPORT_BUCKET_NAME
           value: govuk-production-content-data-csvs
         - name: DATABASE_URL


### PR DESCRIPTION
This new role has the same permissions as the old user, so shouldn't impact functionality

This has been tested in integration and staging

https://github.com/alphagov/govuk-infrastructure/issues/2171