### PR TITLE
Remove Notify related env vars and secret for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1644,17 +1644,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-postgres
               key: DATABASE_URL
-        - name: EMAIL_ADDRESS_OVERRIDE
-          value: govuk-chat-notifications-integration@digital.cabinet-office.gov.uk
-        - name: GOVUK_NOTIFY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-notify
-              key: GOVUK_NOTIFY_API_KEY
-        - name: GOVUK_NOTIFY_TEMPLATE_ID
-          value: 346cdea0-9d4e-4de1-a528-cded6713bc61
-        - name: GOVUK_NOTIFY_REPLY_TO_ID
-          value: f8669f4d-4923-4006-8b44-cbda1f3bc166
         - name: MEMCACHE_SERVERS
           value: "chat-memcached-h4kg8u.serverless.euw1.cache.amazonaws.com:11211"
         - name: OPENAI_ACCESS_TOKEN

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1629,15 +1629,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-postgres
               key: DATABASE_URL
-        - name: GOVUK_NOTIFY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-notify
-              key: GOVUK_NOTIFY_API_KEY
-        - name: GOVUK_NOTIFY_TEMPLATE_ID
-          value: 7eb37ba5-f331-43e2-95fa-28d7405eb90b
-        - name: GOVUK_NOTIFY_REPLY_TO_ID
-          value: c30aaa89-4fac-4889-b1a0-6d4c74fbcd93
         - name: MEMCACHE_SERVERS
           value: "chat-memcached-ufglhk.serverless.euw1.cache.amazonaws.com:11211"
         - name: OPENAI_ACCESS_TOKEN

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1629,17 +1629,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-postgres
               key: DATABASE_URL
-        - name: EMAIL_ADDRESS_OVERRIDE
-          value: govuk-chat-notifications-staging@digital.cabinet-office.gov.uk
-        - name: GOVUK_NOTIFY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-notify
-              key: GOVUK_NOTIFY_API_KEY
-        - name: GOVUK_NOTIFY_TEMPLATE_ID
-          value: 70883fba-853d-487a-9580-3ea1931ecb49
-        - name: GOVUK_NOTIFY_REPLY_TO_ID
-          value: d980e316-2338-4a8f-a318-12c827db6f5c
         - name: MEMCACHE_SERVERS
           value: "chat-memcached-tx6sx5.serverless.euw1.cache.amazonaws.com:11211"
         - name: OPENAI_ACCESS_TOKEN


### PR DESCRIPTION
## Description

We've removed out Notify integration from GOV.UK Chat, so we no longer need the associated environment variables and secret.

## Trello card

https://trello.com/c/RxzQTX8Z/2534-remove-notify-integration