### PR TITLE
feat: add EMERGENCY_BANNER_REDIS_URL to feedback in prod/staging.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1157,6 +1157,8 @@ govukApplications:
           cpu: 30m
           memory: 400Mi
       extraEnv:
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: e8b2d8a6-db5f-4346-9fbd-49b16b531e1c
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
@@ -1214,6 +1216,8 @@ govukApplications:
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: e8b2d8a6-db5f-4346-9fbd-49b16b531e1c
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1171,6 +1171,8 @@ govukApplications:
           cpu: 30m
           memory: 400Mi
       extraEnv:
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: 91ee838c-ef9c-4d10-b3d6-5f73441e08b7
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
@@ -1228,6 +1230,8 @@ govukApplications:
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID
           value: 91ee838c-ef9c-4d10-b3d6-5f73441e08b7
         - name: GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID


### PR DESCRIPTION
- previously added to integration, this is to allow the non-slimmer version of feedback to access the emergency banner alert shared redis instance.

https://trello.com/c/0o6io1aA/569-remove-slimmer-feedback