### PR TITLE
Prevent govuk-graphql from promoting

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-graphql
+++ b/charts/app-config/image-tags/integration/govuk-graphql
@@ -1,3 +1,3 @@
 image_tag: v157
 automatic_deploys_enabled: true
-promote_deployment: true
+promote_deployment: false


### PR DESCRIPTION
This only runs in integration - there is no staging environment.