### PR TITLE
♻️ Update promote_deployment to false in integration config

### DIFF
--- a/charts/app-config/image-tags/integration/publisher-on-pg
+++ b/charts/app-config/image-tags/integration/publisher-on-pg
@@ -1,3 +1,3 @@
 image_tag: v693-on-pg
 automatic_deploys_enabled: true
-promote_deployment: true
+promote_deployment: false


### PR DESCRIPTION
This pull request includes a small change to the `charts/app-config/image-tags/integration/publisher-on-pg` file. The change disables automatic promotion of deployments by setting `promote_deployment` to `false`.

Please see the following discussion for additional context: https://gds.slack.com/archives/C01EE7US9R6/p1749483339960969