### PR TITLE
Add new graphql for a count of graphql requests in the last hour

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -204,7 +204,7 @@
           "refId": "D"
         }
       ],
-      "title": "GraphQL vs. Content-Store average request times",
+      "title": "GraphQL vs. Content-Store average response times",
       "transformations": [
         {
           "id": "joinByField",
@@ -296,7 +296,10 @@
               "GraphQL time": 2,
               "document_type": 0
             },
-            "renameByName": {}
+            "renameByName": {
+              "Content Store time": "Content Store response time",
+              "GraphQL time": "GraphQL response time"
+            }
           }
         }
       ],
@@ -557,7 +560,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request Time (s)",
+            "axisLabel": "Response Time (s)",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -663,7 +666,7 @@
           "refId": "Content Store median"
         }
       ],
-      "title": "Median Request Duration",
+      "title": "Median Response Time",
       "type": "timeseries"
     },
     {
@@ -681,7 +684,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request Time (s)",
+            "axisLabel": "Response Time (s)",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -786,7 +789,7 @@
           "refId": "Content Store 99th percentile"
         }
       ],
-      "title": "99% Request Duration",
+      "title": "99% Response Times",
       "type": "timeseries"
     },
     {
@@ -925,7 +928,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Median request duration by document type",
+      "description": "Median response time by document type",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1040,7 +1043,7 @@
           "refId": "GraphQL median"
         }
       ],
-      "title": "Median Request Duration",
+      "title": "Median Response Time",
       "type": "timeseries"
     },
     {
@@ -1058,7 +1061,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request Time (s)",
+            "axisLabel": "Response Time (s)",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -1163,7 +1166,7 @@
           "refId": "GraphQL 99th percentile"
         }
       ],
-      "title": "99% Request Duration",
+      "title": "99% Response Times",
       "type": "timeseries"
     },
     {
@@ -1283,6 +1286,128 @@
       ],
       "title": "Total GraphQL requests per second ",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total requests per hour for the read-replica. Spikes should track fairly evenly with load tests. Should be helpful to compare traffic against jumps in response time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Request Count (/hr)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 300
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(job) (increase(http_requests_total{namespace=\"apps\", job=~\"publishing-api-read-replica\", controller=\"graphql\", action=\"execute\"}[1h]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "interval": "",
+          "legendFormat": "All Document types",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Total GraphQL requests per hour",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -1352,5 +1477,5 @@
   "timezone": "browser",
   "title": "Graphql stats",
   "uid": "aeh00wtwwg8owc",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
Still leaving the old per second graph in for now, both as I'm unsure of how good this new one is until it's been used more, and because the per-second graph might come in handy again once we have more traffic.

![image](https://github.com/user-attachments/assets/fa0cee3a-79d3-45e2-9ee4-7b409b35687a)


Trello: https://trello.com/c/n5smSopx/1728-improve-the-graphql-dashboard