### PR TITLE
Make bars 1 hour wide

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -1302,30 +1302,18 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request Count (/hr)",
+            "axisLabel": "",
             "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 80,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
             "lineWidth": 1,
-            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1372,18 +1360,26 @@
       },
       "id": 17,
       "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
         "legend": {
           "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "width": 300
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
-        }
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
       },
       "pluginVersion": "11.6.1",
       "targets": [
@@ -1399,7 +1395,7 @@
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
-          "interval": "",
+          "interval": "1h",
           "legendFormat": "All Document types",
           "range": true,
           "refId": "D",
@@ -1407,7 +1403,7 @@
         }
       ],
       "title": "Total GraphQL requests per hour",
-      "type": "timeseries"
+      "type": "barchart"
     }
   ],
   "preload": false,
@@ -1477,5 +1473,5 @@
   "timezone": "browser",
   "title": "Graphql stats",
   "uid": "aeh00wtwwg8owc",
-  "version": 12
+  "version": 13
 }


### PR DESCRIPTION
This makes the bars on the per hour graphql bar chart 1 hour wide to more easily visualise the number of requests

## Before
![Screenshot 2025-06-12 at 10 22 41](https://github.com/user-attachments/assets/a16f8b6e-d9e3-4d89-b713-7c63e24081a5)

## After
![Screenshot 2025-06-12 at 10 22 29](https://github.com/user-attachments/assets/46bf0887-c9f7-4d5b-99dc-ed784b46bcdd)
