### PR TITLE
Enable strict mode for kubeconform and fix flagged issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
             "https://alphagov.github.io/govuk-crd-library/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
             -ignore-filename-pattern ".*/Chart.yaml"
             -summary
+            -strict
             rendered-charts
 
   shellcheck:

--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -104,21 +104,23 @@ spec:
           {{- with .Values.appProbes }}
             {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
-          startupProbe: &app-probe
-            httpGet:
+          startupProbe:
+            httpGet: &app-probe
               path: /healthcheck/live
               port: http
             failureThreshold: 10
             periodSeconds: 3
             timeoutSeconds: 5
           livenessProbe:
-            <<: *app-probe
+            httpGet: *app-probe
             failureThreshold: 3
             periodSeconds: 5
+            timeoutSeconds: 5
           readinessProbe:
-            <<: *app-probe
+            httpGet: *app-probe
             failureThreshold: 2
             periodSeconds: 5
+            timeoutSeconds: 5
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/asset-manager/templates/redis-deployment.yaml
+++ b/charts/asset-manager/templates/redis-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - name: redis
               containerPort: 6379
           livenessProbe: &redisProbe
-            tcpSocket:
+            tcpSocket: &redisSocket
               port: 6379
             failureThreshold: 3
             periodSeconds: 5
@@ -63,8 +63,10 @@ spec:
           readinessProbe:
             <<: *redisProbe
           startupProbe:
-            <<: *redisProbe
+            tcpSocket: *redisSocket
             failureThreshold: 5
+            periodSeconds: 5
+            timeoutSeconds: 20
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -120,18 +120,20 @@ spec:
           {{- with .Values.appProbes }}
             {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
-          livenessProbe: &app-probe
-            httpGet:
+          livenessProbe:
+            httpGet: &app-probe
               path: /healthcheck/live
               port: http
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30
           readinessProbe:
-            <<: *app-probe  # Intentionally same path as liveness.
+            httpGet: *app-probe
             failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 30
           startupProbe:
-            <<: *app-probe
+            httpGet: *app-probe
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 2
@@ -157,8 +159,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.nginxPort }}
-          livenessProbe: &nginx-probe
-            httpGet:
+          livenessProbe:
+            httpGet: &nginx-probe
               path: /readyz
               port: http
             initialDelaySeconds: 2
@@ -166,7 +168,9 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 20
           readinessProbe:
-            <<: *nginx-probe  # Intentionally same path as liveness.
+            httpGet: *nginx-probe
+            initialDelaySeconds: 2
+            periodSeconds: 5
             failureThreshold: 2
             timeoutSeconds: 15
           {{- with .Values.nginxResources }}

--- a/charts/generic-govuk-app/templates/redis-deployment.yaml
+++ b/charts/generic-govuk-app/templates/redis-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: redis
               containerPort: 6379
           livenessProbe: &redisProbe
-            tcpSocket:
+            tcpSocket: &redisSocket
               port: 6379
             failureThreshold: 3
             periodSeconds: 5
@@ -65,8 +65,10 @@ spec:
           readinessProbe:
             <<: *redisProbe
           startupProbe:
-            <<: *redisProbe
+            tcpSocket: *redisSocket
             failureThreshold: 5
+            periodSeconds: 5
+            timeoutSeconds: 20
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/charts/govuk-exporter/templates/deployment.yaml
+++ b/charts/govuk-exporter/templates/deployment.yaml
@@ -42,18 +42,20 @@ spec:
             {{- with .Values.extraEnv }}
               {{- (tpl (toYaml .) $) | trim | nindent 12 }}
             {{- end }}
-          livenessProbe: &probe
-            httpGet:
+          livenessProbe:
+            httpGet: &probe
               path: /metrics
               port: metrics
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30
           readinessProbe:
-            <<: *probe
+            httpGet: *probe
             failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 30
           startupProbe:
-            <<: *probe
+            httpGet: *probe
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 2

--- a/charts/licensify/templates/clamav/deployment.yaml
+++ b/charts/licensify/templates/clamav/deployment.yaml
@@ -33,17 +33,19 @@ spec:
           ports:
             - name: clamav
               containerPort: {{ $app.service.port }}
-          livenessProbe: &app-probe
-            tcpSocket:
+          livenessProbe:
+            tcpSocket: &app-probe
               port: clamav
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30
           readinessProbe:
-            <<: *app-probe  # Intentionally same path as liveness.
+            tcpSocket: *app-probe
             failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 30
           startupProbe:
-            <<: *app-probe
+            tcpSocket: *app-probe
             failureThreshold: 15
             periodSeconds: 5
             timeoutSeconds: 2

--- a/charts/licensify/templates/clamav/pvc.yaml
+++ b/charts/licensify/templates/clamav/pvc.yaml
@@ -6,8 +6,6 @@ metadata:
   name: {{ include "licensify.name" . }}-{{ .Values.appName }}-db
   labels:
     {{- include "licensify.labels" . | nindent 4 }}
-    app: {{ .Values.appName }}
-    app.kubernetes.io/name: {{ .Values.appName }}
 spec:
   storageClassName: ""
   accessModes:

--- a/charts/licensify/templates/deployment.yaml
+++ b/charts/licensify/templates/deployment.yaml
@@ -70,8 +70,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .port }}
-          livenessProbe: &app-probe
-            httpGet:
+          livenessProbe:
+            httpGet: &app-probe
               path: {{ .healthcheckPath }} 
               port: http
             failureThreshold: 3
@@ -79,13 +79,17 @@ spec:
             timeoutSeconds: 30
             initialDelaySeconds: 10
           readinessProbe:
-            <<: *app-probe  # Intentionally same path as liveness.
+            httpGet: *app-probe
             failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 30
+            initialDelaySeconds: 10
           startupProbe:
-            <<: *app-probe
+            httpGet: *app-probe
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 2
+            initialDelaySeconds: 10
           {{- with .resources }}
           resources:
             {{- (tpl (toYaml .) $) | trim | nindent 12 }}
@@ -105,8 +109,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ $.Values.nginx.port }}
-          livenessProbe: &nginx-probe
-            httpGet:
+          livenessProbe:
+            httpGet: &nginx-probe
               path: /readyz
               port: http
             initialDelaySeconds: 2
@@ -114,8 +118,10 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 20
           readinessProbe:
-            <<: *nginx-probe  # Intentionally same path as liveness.
+            httpGet: *nginx-probe
+            initialDelaySeconds: 2
             failureThreshold: 2
+            periodSeconds: 5
             timeoutSeconds: 15
           {{- with $.Values.nginx.resources }}
           resources:


### PR DESCRIPTION
This enables strict mode for kubeconform, which will catch more issues with our K8s manifests before they make it on to a cluster. This also fixes various issues that were flagged by kubeconform.

https://github.com/alphagov/govuk-infrastructure/issues/2287