### PR TITLE
🔧 Fix Grafana-Tempo integration port mismatch causing query failures

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values.yaml
@@ -48,7 +48,7 @@
       "name": "Tempo"
       "type": "tempo"
       "uid": "tempo"
-      "url": "http://tempo-query-frontend.monitoring.svc.cluster.local:3100"
+      "url": "http://tempo-query-frontend.monitoring.svc.cluster.local:3200"
   "admin":
     "existingSecret": "grafana-admin-user"
     "passwordKey": "password"


### PR DESCRIPTION
🐛 Problem
---

Grafana was unable to query Tempo, failing with connection timeouts and generic "Query error. Please check the server logs for more details." The issue was traced to a port mismatch:

- **Grafana data source**: Configured to connect to `**.**.***.***:3100`
- **Tempo query-frontend**: Actually running on `172.**.***.***:3200`

🔍 Root Cause Analysis
---

```bash
# Error logs showed connection timeouts
logger=data-proxy-log userId=21 orgId=1 uname=jason.birchall@***.*** 
path=/api/datasources/proxy/uid/tempo/api/status/buildinfo 
t=2025-06-13T09:56:16.623246168Z level=error 
msg="Proxy request failed" err="dial tcp ***.***.***.***:3100: i/o timeout"

# But Tempo was actually accessible on port 3200
kubectl exec -n monitoring deployment/kube-prometheus-stack-grafana -- \
  wget -qO- --timeout=5 http://tempo-query-frontend:3200/ready
# Output: ready ✅
```

✅ Solution
---

**Updated Grafana Tempo data source configuration:**
- **Before**: `http://1**.***.***.**:3100`
- **After**: `http://tempo-query-frontend:3200`

🧪 Testing
---

**Before fix:**
```bash
# All Tempo API calls failed with 502 errors and 10s timeouts
GET /api/datasources/proxy/uid/tempo/api/status/buildinfo → 502
GET /api/datasources/proxy/uid/tempo/api/search → 502  
GET /api/datasources/proxy/uid/tempo/api/v2/search/tags → 502
```

**After fix:**
```bash
# Connectivity verified
kubectl exec -n monitoring deployment/kube-prometheus-stack-grafana -- \
  curl -s http://tempo-query-frontend:3200/api/status/buildinfo
# Output: {"version":"v2.8.0","revision":"ab76780c6","branch":"HEAD",...}

# Data source test in Grafana UI: ✅ "Data source is working"
```

### 📝 Post-Deployment Steps
1. **Verify** Grafana data source shows "Data source is working" ✅
2. **Test** trace queries in Grafana Explore work without errors
3. **Validate** existing dashboards and alerts using Tempo data source
4. **Monitor** for any remaining connection issues

### 🚀 Rollback Plan
If issues arise, revert data source URL to previous value:
```
http://***.***.***.***:3100
```