### PR TITLE
Add repoName to the generic-govuk-app selector labels to enable release app to find matching apps.

### DIFF
--- a/charts/generic-govuk-app/templates/_helpers.tpl
+++ b/charts/generic-govuk-app/templates/_helpers.tpl
@@ -48,6 +48,7 @@ Selector labels
 */}}
 {{- define "generic-govuk-app.selectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/repoName: {{ .repoName | default .Release.Name  }}
 {{- end }}
 
 {{/*

--- a/charts/generic-govuk-app/templates/_helpers.tpl
+++ b/charts/generic-govuk-app/templates/_helpers.tpl
@@ -41,6 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+app.kubernetes.io/repoName: {{ .repoName | default .Release.Name  }}
 {{- end }}
 
 {{/*
@@ -48,7 +49,6 @@ Selector labels
 */}}
 {{- define "generic-govuk-app.selectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/repoName: {{ .repoName | default .Release.Name  }}
 {{- end }}
 
 {{/*

--- a/charts/generic-govuk-app/templates/_helpers.tpl
+++ b/charts/generic-govuk-app/templates/_helpers.tpl
@@ -41,7 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
-app.kubernetes.io/repoName: {{ .repoName | default .Release.Name  }}
+app.govuk/repository-name: {{ .repoName | default .Release.Name  }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Some apps are deployed on the cluster that fo not use their repo name as their release name, so publish the label to enable the k8s api to select it.

https://github.com/alphagov/govuk-infrastructure/issues/2237