### PR TITLE
🔧 Improve mirror-sync job resilience against disruptions

### DIFF
--- a/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
@@ -22,6 +22,8 @@ spec:
           labels:
             app: "govuk-mirror-sync"
             app.kubernetes.io/component: "mirror-sync"
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           enableServiceLinks: false
           serviceAccountName: govuk-mirror-sync

--- a/charts/govuk-jobs/templates/govuk-mirror-sync-pdb.yaml
+++ b/charts/govuk-jobs/templates/govuk-mirror-sync-pdb.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "govuk-mirror-sync"
+  namespace: "apps"
+  labels:
+    app: "govuk-mirror-sync"
+    app.kubernetes.io/component: "mirror-sync"
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: "govuk-mirror-sync"
+      app.kubernetes.io/component: "mirror-sync"
+


### PR DESCRIPTION
Add cluster autoscaler [safe-to-evict](https://kubernetes.io/docs/reference/labels-annotations-taints/#cluster-autoscaler-kubernetes-io-safe-to-evict) annotation and PodDisruptionBudget to prevent unwanted pod evictions during mirror sync operations.

As an example on the impact of this fail, please see the [alert](https://gds.slack.com/archives/C06KVNS8UU8/p1749849779039159), and [investigation](https://gds.slack.com/archives/C079ULB1UEP/p1750079062765349).
