### PR TITLE
✨ Use makefile to run yamllint command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
         with:
           show-progress: false
-      - run: yamllint --version && yamllint -f github .
+      - run: make lint
 
   promtool:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: install-yamllint lint check help
+
+# Default target
+help: ## Show this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install-yamllint: ## Install yamllint via package manager if not already installed
+	@if command -v yamllint >/dev/null 2>&1; then \
+		echo "yamllint is already installed ($(shell yamllint --version))"; \
+	elif command -v brew >/dev/null 2>&1; then \
+		echo "Installing yamllint via brew..."; \
+		brew install yamllint; \
+	elif command -v apt-get >/dev/null 2>&1; then \
+		echo "Installing yamllint via apt..."; \
+		sudo apt-get update && sudo apt-get install -y yamllint; \
+	else \
+		echo "Error: No supported package manager found (brew or apt)."; \
+		exit 1; \
+	fi
+
+lint: install-yamllint ## Run yamllint on all YAML files
+	@echo "Running yamllint..."
+	yamllint -f github .
+
+check: lint ## Alias for lint target

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,19 @@
-.PHONY: install-yamllint lint check help
+.PHONY: check-yamllint lint check help
 
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install-yamllint: ## Install yamllint via package manager if not already installed
+check-yamllint: ## Check if yamllint is installed
 	@if command -v yamllint >/dev/null 2>&1; then \
 		echo "yamllint is already installed ($(shell yamllint --version))"; \
-	elif command -v brew >/dev/null 2>&1; then \
-		echo "Installing yamllint via brew..."; \
-		brew install yamllint; \
-	elif command -v apt-get >/dev/null 2>&1; then \
-		echo "Installing yamllint via apt..."; \
-		sudo apt-get update && sudo apt-get install -y yamllint; \
 	else \
-		echo "Error: No supported package manager found (brew or apt)."; \
+		echo "Please install yamllint before running this Makefile."; \
 		exit 1; \
 	fi
 
-lint: install-yamllint ## Run yamllint on all YAML files
+lint: check-yamllint ## Run yamllint on all YAML files
 	@echo "Running yamllint..."
 	yamllint -f github .
 


### PR DESCRIPTION
While working on this repository, waiting for the pipeline to fail became frustrating before I knew my branch was ready to review. I want fast feedback when working locally, so I created a makefile containing a command to install and then run the yamllint command that was continuously failing. I also refactored the ci.yaml file that performs the GHA yamllint for consistency.
