### PR TITLE
Bump Publishing API's client_max_body_size in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2560,7 +2560,7 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 512Mi
-      nginxClientMaxBodySize: 2M
+      nginxClientMaxBodySize: 3M
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false


### PR DESCRIPTION
A Whitehall user is currently unable to save a draft of an existing document and it seems likely that the cause is the payload having crept to just over 2MB. (Whitehall is receiving a "413 Request Entity Too Large" response from Publishing API's Put Content endpoint, but the page has previously been updated multiple times without issue.)

We do have some thoughts about how we might be able to stop this from just increasing further in the long run, but for now 3MB doesn't sound too bad for an internal API (??) and it'll unblock the user.

We're planning to test this change in integration to find out if it solves the problem before rolling it out into the other envs.