### PR TITLE
Bump Publishing API's client_max_body_size in staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2334,7 +2334,7 @@ govukApplications:
         requests:
           cpu: 20m
           memory: 768Mi
-      nginxClientMaxBodySize: 2M
+      nginxClientMaxBodySize: 3M
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2334,7 +2334,7 @@ govukApplications:
         requests:
           cpu: 20m
           memory: 768Mi
-      nginxClientMaxBodySize: 2M
+      nginxClientMaxBodySize: 3M
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false


### PR DESCRIPTION
This is a follow up to https://github.com/alphagov/govuk-helm-charts/pull/3273,
which made the same change but only for the integration environment.
That change solved the issue in integration, so we want to roll this out
to the other envs too.

A Whitehall user is currently unable to save a draft of an existing
document and it seems likely that the cause is the payload having crept
to just over 2MB. (Whitehall is receiving a "413 Request Entity Too
Large" response from Publishing API's Put Content endpoint, but the page
has previously been updated multiple times without issue.)

We do have some thoughts about how we might be able to stop this from
just increasing further in the long run, but for now 3MB doesn't sound
too bad for an internal API and it'll unblock the user in question.