### PR TITLE
♻️ Attempt to improve the post-sync alert readability

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -110,8 +110,6 @@ spec:
         resources: {}
         source: >
           #!/usr/bin/env bash
-
-          # Enhanced failure parsing with better context
           echo {{"{{workflow.failures}}"}} | jq -r '
             group_by(.templateName) | map({
               templateName: .[0].templateName, 


### PR DESCRIPTION

## 👀 Purpose

- In an attempt to make the post-sync alerts easier to read, I thought I would add a little context around the alert. This is how it currently looks:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/69003359-43da-423b-8e52-f7586421e109" />

- I can't test the change without pushing this change and seeing how it looks. I anticipate I may need to fix forward as the formatting is probably incorrect.

## ♻️ What's changed

- Made amendments to the post-sync workflow failure error.



