### PR TITLE
🐛 Fix yaml multiline error

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -110,24 +110,8 @@ spec:
         resources: {}
         source: >
           #!/usr/bin/env bash
-          echo {{"{{workflow.failures}}"}} | jq -r '
-            group_by(.templateName) | map({
-              templateName: .[0].templateName, 
-              errorMessages: [.[].message | select(length > 0)] | unique,
-              phase: .[0].phase,
-              finishedAt: .[0].finishedAt
-            }) | map(
-              "🔴 *" + .templateName + "* failed\n" +
-              "   └ " + ([.errorMessages[] | 
-                (if test("timeout|timed out"; "i") then "⏰ " + .
-                 elif test("connection refused|network|dns"; "i") then "🌐 " + .
-                 elif test("permission denied|forbidden|unauthorized"; "i") then "🔐 " + .
-                 elif test("not found|404"; "i") then "❓ " + .
-                 elif test("exit code [1-9]"; "i") then "❌ " + .
-                 else . end)
-              ] | join("\n   └ "))
-            ) | join("\n\n")
-          ' > /tmp/message.txt
+
+          echo {{"{{workflow.failures}}"}} | jq -r 'group_by(.templateName) | map({templateName: .[0].templateName, errorMessages: [.[].message | select(length > 0)] | unique}) | map("🔴 *" + .templateName + "* failed\n   └ " + ([.errorMessages[] | (if test("timeout|timed out"; "i") then "⏰ " + . elif test("connection refused|network|dns"; "i") then "🌐 " + . elif test("permission denied|forbidden|unauthorized"; "i") then "🔐 " + . elif test("not found|404"; "i") then "❓ " + . elif test("database|sql|migration"; "i") then "🗄️ " + . elif test("exit code [1-9]"; "i") then "❌ " + . else . end)] | join("\n   └ "))) | join("\n\n")' > /tmp/message.txt
       volumes:
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
It appears argocd doesn't like reading from multiline yaml, displaying
the error:
```
/argo/staging/script: line 2: syntax error near unexpected token
`.templateName'
/argo/staging/script: line 2: `  group_by(.templateName) | map({'
time="2025-06-24T14:15:11 UTC" level=info msg="sub-process exited"
argo=true error="<nil>"
```

[src](https://argo-workflows.eks.integration.govuk.digital/workflows/apps/post-sync-94fdj?tab=workflow&nodeId=post-sync-94fdj-3978960931&nodePanelView=summary&sidePanel=logs:post-sync-94fdj-3978960931:main&uid=e5c48978-c43d-4d8b-97e4-702ad114343c)
This fix moves everything onto one line
