### PR TITLE
🔥 Remove the GitHub repo links, quick debug, and pod names

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -111,7 +111,7 @@ spec:
         source: >
           #!/usr/bin/env bash
 
-          echo {{"{{workflow.failures}}"}} | jq -r 'group_by(.templateName) | map({templateName: .[0].templateName, podName: .[0].id, errorMessages: [.[].message | select(length > 0)] | unique}) | map("🔴 *" + .templateName + "* failed\n   └ Pod: `" + .podName + "`\n   └ " + ([.errorMessages[] | (if test("timeout|timed out"; "i") then "⏰ " + . elif test("connection refused|network|dns"; "i") then "🌐 " + . elif test("permission denied|forbidden|unauthorized"; "i") then "🔐 " + . elif test("not found|404"; "i") then "❓ " + . elif test("database|sql|migration"; "i") then "🗄️ " + . elif test("exit code [1-9]"; "i") then "❌ " + . else . end)] | join("\n   └ "))) | join("\n\n")' > /tmp/message.txt
+          echo {{"{{workflow.failures}}"}} | jq -r 'group_by(.templateName) | map({templateName: .[0].templateName, errorMessages: [.[].message | select(length > 0)] | unique}) | map("🔴 *" + .templateName + "* failed\n   └ " + ([.errorMessages[] | (if test("timeout|timed out"; "i") then "⏰ " + . elif test("connection refused|network|dns"; "i") then "🌐 " + . elif test("permission denied|forbidden|unauthorized"; "i") then "🔐 " + . elif test("not found|404"; "i") then "❓ " + . elif test("database|sql|migration"; "i") then "🗄️ " + . elif test("exit code [1-9]"; "i") then "❌ " + . else . end)] | join("\n   └ "))) | join("\n\n")' > /tmp/message.txt
       volumes:
         - name: tmp
           emptyDir: {}
@@ -132,14 +132,14 @@ spec:
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
                 - name: text
-                  value: "🔴 <https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}|{{"{{workflow.parameters.application}}"}}> post-deploy workflow failed in {{ .Values.govukEnvironment }}\n\nService Status: {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\nImage: {{"{{workflow.parameters.imageTag}}"}}\nRepo: {{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version\n\n📋 *Quick Debug:*\nWorkflow: {{"{{workflow.name}}"}}\nNamespace: apps"
+                  value: "🔴 {{"{{workflow.parameters.application}}"}} post-deploy workflow failed in {{ .Values.govukEnvironment }}\n\nService Status: {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\nImage: {{"{{workflow.parameters.imageTag}}"}}\nRepo: {{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
                 - name: blocks
                   value: |
                     [{
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "🔴 *<https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}|{{"{{workflow.parameters.application}}"}}*> post-deploy workflow failed in *{{ .Values.govukEnvironment }}*\n\n*Service Status:* {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\n*Image:* {{"{{workflow.parameters.imageTag}}"}}\n*Repo:* {{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version\n\n📋 *Quick Debug:*\nWorkflow: {{"{{workflow.name}}"}}\nNamespace: apps"
+                          "text": "🔴 *{{"{{workflow.parameters.application}}"}}* post-deploy workflow failed in *{{ .Values.govukEnvironment }}*\n\n*Service Status:* {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\n*Image:* {{"{{workflow.parameters.imageTag}}"}}\n*Repo:* {{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
                       },
                       "accessory": {
                         "type": "button",

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -132,14 +132,14 @@ spec:
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
                 - name: text
-                  value: "🔴 {{"{{workflow.parameters.application}}"}} post-deploy workflow failed in {{ .Values.govukEnvironment }}\n\nService Status: {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\nImage: {{"{{workflow.parameters.imageTag}}"}}\nRepo: {{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
+                  value: "🔴 {{"{{workflow.parameters.application}}"}} post-deploy workflow failed in {{ .Values.govukEnvironment }}\n\nService Status: {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\nImage: {{"{{workflow.parameters.imageTag}}"}}\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
                 - name: blocks
                   value: |
                     [{
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "🔴 *{{"{{workflow.parameters.application}}"}}* post-deploy workflow failed in *{{ .Values.govukEnvironment }}*\n\n*Service Status:* {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\n*Image:* {{"{{workflow.parameters.imageTag}}"}}\n*Repo:* {{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
+                          "text": "🔴 *{{"{{workflow.parameters.application}}"}}* post-deploy workflow failed in *{{ .Values.govukEnvironment }}*\n\n*Service Status:* {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\n*Image:* {{"{{workflow.parameters.imageTag}}"}}\n*Repo:* https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
                       },
                       "accessory": {
                         "type": "button",


### PR DESCRIPTION
The formatting of a previous change ruined the structure of the alert. I need to understand how to get pod logs out of Argo a little more before we have this functionality.

This pull request refines the post-deployment workflow failure messaging in `workflow.yaml` to improve clarity and usability. The changes include simplifying the error message structure and ensuring links to repositories are consistently formatted.

### Messaging improvements:

* Removed `podName` from the failure grouping logic to focus solely on `templateName` and `errorMessages`, simplifying the output message structure. (`charts/argo-services/templates/workflows/post-sync/workflow.yaml`, [charts/argo-services/templates/workflows/post-sync/workflow.yamlL114-R114](diffhunk://#diff-e7607425afc1d4b6be198cfee72bb9b85c47030da9c41760c66f755d61832a52L114-R114))
* Updated Slack notification text to replace inline repository links with explicit URLs for better readability and consistency. (`charts/argo-services/templates/workflows/post-sync/workflow.yaml`, [charts/argo-services/templates/workflows/post-sync/workflow.yamlL135-R142](diffhunk://#diff-e7607425afc1d4b6be198cfee72bb9b85c47030da9c41760c66f755d61832a52L135-R142))