### PR TITLE
♻️ Change the deploy image workflow failure alert

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -55,7 +55,7 @@ spec:
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
                 - name: text
-                  value: "🚀💥 {{"{{workflow.parameters.repoName}}"}} deployment failed to {{"{{workflow.parameters.environment}}"}}\n\nStatus: Image deployment failed - service may be unavailable\nImage: {{"{{workflow.parameters.imageTag}}"}} (failed to deploy)\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n💡 *Next Steps:*\n• Check if previous version is still running\n• View workflow logs for deployment errors\n• May need immediate rollback if service is down\n• Click 'View workflow' button below for details"
+                  value: "🚀❌ {{"{{workflow.parameters.repoName}}"}} deployment failed to {{"{{workflow.parameters.environment}}"}}\n\nStatus: Image deployment failed - service may be unavailable\nImage: {{"{{workflow.parameters.imageTag}}"}} (failed to deploy)\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n💡 *Next Steps:*\n• Check if previous version is still running\n• View workflow logs for deployment errors\n• May need immediate rollback if service is down\n• Click 'View workflow' button below for details"
                 - name: blocks
                   value: |
                     [{


### PR DESCRIPTION
This commit reformats the message to display:

**Before**:
  Deploy image workflow for publishing-api to production has failed.

**After**:
  🚀❌ publishing-api deployment failed to production

  Status: Image deployment failed - service may be unavailable
  Image: v1.234 (failed to deploy)
  Repo: https://github.com/alphagov/publishing-api

  💡 Next Steps:
  • Check if previous version is still running
  • View workflow logs for deployment errors
  • May need immediate rollback if service is down
  • Click 'View workflow' button below for details
