### PR TITLE
Update generic-govuk-app helper.tpl

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1765,6 +1765,7 @@ govukApplications:
       - "licensify-feed"
       - "licensify-frontend"
     helmValues:
+      repoName: licensify
       arch: arm64
       assetManagerNFS: *assets-nfs
       apps:
@@ -4055,6 +4056,7 @@ govukApplications:
   - name: whitehall-admin
     repoName: whitehall
     helmValues:
+      repoName: whitehall
       arch: arm64
       appResources:
         limits:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1739,6 +1739,7 @@ govukApplications:
       - "licensify-feed"
       - "licensify-frontend"
     helmValues:
+      repoName: licensify
       arch: arm64
       assetManagerNFS: *assets-nfs
       apps:
@@ -3755,6 +3756,7 @@ govukApplications:
   - name: whitehall-admin
     repoName: whitehall
     helmValues:
+      repoName: whitehall
       arch: arm64
       assetManagerNFS: *assets-nfs
       nfsStorage: 15Gi

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1741,6 +1741,7 @@ govukApplications:
       - "licensify-feed"
       - "licensify-frontend"
     helmValues:
+      repoName: licensify
       arch: arm64
       assetManagerNFS: *assets-nfs
       apps:
@@ -3735,6 +3736,7 @@ govukApplications:
   - name: whitehall-admin
     repoName: whitehall
     helmValues:
+      repoName: whitehall
       arch: arm64
       appResources:
         limits:

--- a/charts/generic-govuk-app/templates/_helpers.tpl
+++ b/charts/generic-govuk-app/templates/_helpers.tpl
@@ -41,7 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
-app.govuk/repository-name: {{ .repoName | default .Release.Name  }}
+app.govuk/repository-name: {{ .Values.repoName | default .Release.Name  }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## What

Use .Values.repoName as the .repoName value is not available so it will always default to the .Release.Name.

Add the repoName for licensify and whitehall as these apps do not have matching repo names to the kubernetes app names.

Once the repository-name label is correctly set for these repos, the Release app should be able to locate the right app on the cluster to get information about its status.

https://github.com/alphagov/govuk-infrastructure/issues/2237