### PR TITLE
Fix intraday event import scheduling issue

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3199,7 +3199,7 @@ govukApplications:
           schedule: "30 12 * * *"
         - name: user-events-import-intraday-events
           task: "user_events:import_intraday_events"
-          schedule: "45 05,11,17,23 * * *"
+          schedule: "45 04,10,16,22 * * *"
         - name: user-events-purge
           task: "user_events:purge_final_week_of_retention_period"
           schedule: "0 2 * * *"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2973,7 +2973,7 @@ govukApplications:
           schedule: "30 12 * * *"
         - name: user-events-import-intraday-events
           task: "user_events:import_intraday_events"
-          schedule: "45 05,11,17,23 * * *"
+          schedule: "45 04,10,16,22 * * *"
         - name: user-events-purge
           task: "user_events:purge_final_week_of_retention_period"
           schedule: "0 2 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2962,7 +2962,7 @@ govukApplications:
           schedule: "30 12 * * *"
         - name: user-events-import-intraday-events
           task: "user_events:import_intraday_events"
-          schedule: "45 05,11,17,23 * * *"
+          schedule: "45 04,10,16,22 * * *"
         - name: user-events-purge
           task: "user_events:purge_final_week_of_retention_period"
           schedule: "0 2 * * *"


### PR DESCRIPTION
[Trello card](https://trello.com/c/cVoFMlX7/836-fix-intraday-event-import-scheduling-issue-for-previous-next-day-window)


# What's changed and why?

The final run of the day should occur at 23:45. However due to BST this is actually running at 00:45 the next day.

The intraday table only contains data for the current day. This means that at 00:45 it has only had 45 minutes, which is not enough time to collect any day as the intraday import runs on a schedule.

We aren't losing data, because the full import still runs at noon to get the full import from the previous day. However it does mean that we have to wait 1/2 a day to get the last 6 hours worth of data from the previous day.

To get around the GMT / BST time issue, the import has been changed to run an hour earlier, so it will either run at 22:45 or 23:45 of the same day. We could have added time zone handling to search-api-v2, but that would required adding a bit of complicated timezone handling when the actual time the import runs doesn't really matter as long as it's at equal intervals.

The side-effect of this change is that in the winter time, an hours worth of data, from 23:00 to 00:00, will be delayed until the next full import, rather than the 6 hours of data that is being delayed now.