### PR TITLE
Add repository-name label to licensify and asset manager

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app: {{ $fullName }}
+    app.govuk/repository-name: {{ .Values.repoName | default .Release.Name  }}
     app.kubernetes.io/name: {{ $fullName }}
     app.kubernetes.io/component: app
   annotations:

--- a/charts/licensify/templates/_helpers.tpl
+++ b/charts/licensify/templates/_helpers.tpl
@@ -42,6 +42,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 app.kubernetes.io/part-of: "licensify"
+app.govuk/repository-name: {{ .Values.repoName | default .Release.Name  }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## What

These apps are showing in the Release app but do not use the govuk-generic-app chart so for the Release app to locate these apps the `repository-name` needs to be available.

https://github.com/alphagov/govuk-infrastructure/issues/2237