### PR TITLE
Setup rolebinding and service account for licensify

### DIFF
--- a/charts/release/templates/assumed_rolebinding.yaml
+++ b/charts/release/templates/assumed_rolebinding.yaml
@@ -1,8 +1,9 @@
+{{ range .Values.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: release-assumed-apps
-  namespace: apps
+  name: release-assumed-{{ .namespace }}
+  namespace: {{ .namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -11,3 +12,4 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: release-assumed
+{{ end }}

--- a/charts/release/templates/licensify_pod_reader.yaml
+++ b/charts/release/templates/licensify_pod_reader.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: licensify
+  name: licensify-pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: assumer-read-licensify-pods
+  namespace: licensify
+roleRef:
+  kind: Role
+  name: licensify-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: release-assumer
+  namespace: apps

--- a/charts/release/values.yaml
+++ b/charts/release/values.yaml
@@ -1,0 +1,5 @@
+awsAccountId: ""
+
+namespaces:
+  - namespace: apps
+  - namespace: licensify


### PR DESCRIPTION
This will allow the Release app access to the kubernetes API on the licensify namespace.

I managed to test this on Integration with the Release app.

https://github.com/alphagov/govuk-infrastructure/issues/2237