### PR TITLE
♻️ Improve deploy-image workflow naming with repo, environment, and image tag

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   entrypoint: deploy-image
   onExit: exit-handler
+  generateName: "deploy-{{"{{workflow.parameters.repoName}}"}}-{{"{{workflow.parameters.environment}}"}}-{{"{{= sprig.trunc(8, workflow.parameters.imageTag) }}"}}-"
   arguments:
     parameters:
       - name: environment


### PR DESCRIPTION
This change adds a generateName field to make workflow instances more identifiable instead of generic names like deploy-image-wet2w.

[Source](https://argo-workflows.readthedocs.io/en/latest/fields/)