### PR TITLE
♻️ Change the deploy image workflow event binding name

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
@@ -8,6 +8,7 @@ spec:
   submit:
     workflowTemplateRef:
       name: deploy-image
+    generateName: "deploy-{{`{{payload.repoName}}`}}-{{`{{payload.environment}}`}}-{{`{{payload.imageTag | substr 0 8}}`}}-"
     arguments:
       parameters:
         - name: environment


### PR DESCRIPTION
Instread of the generic deploy-image-dssr2. The workfloweventbinding is what actually creates the workflow instances. This change should give us a more intuitive name like: deploy-mirror-integration-v111-dssr2
