### PR TITLE
feat: add humans.txt directly into nginx

### DIFF
--- a/charts/app-config/humans.txt
+++ b/charts/app-config/humans.txt
@@ -1,0 +1,2 @@
+GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London,
+Bristol and Manchester.  If you’d like to join us, see https://gdscareers.gov.uk/

--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -166,6 +166,10 @@ http {
       return 200 '{"message": "Tweet tweet"}\n';
     }
 
+    location = /humans.txt {
+      root /usr/share/nginx/html;
+    }
+
     # Endpoint for liveness and readiness checks of the nginx container.
     location = /readyz {
       return 200 'ok\n';

--- a/charts/app-config/templates/router-nginx-configmap.yaml
+++ b/charts/app-config/templates/router-nginx-configmap.yaml
@@ -20,6 +20,8 @@ metadata:
     {{- include "app-config.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
 data:
+  humans.txt: |-
+    {{- $.Files.Get "humans.txt" | nindent 4 }}
   nginx.conf: |-
     {{- include "app-config.router-nginx-config" ( mergeOverwrite . ( dict "Stack" "live" ) ) | nindent 4 }}
   robots.txt: |-

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2783,6 +2783,9 @@ govukApplications:
         name: live-router-nginx-conf
       nginxExtraVolumeMounts:
         - name: live-router-nginx-conf
+          mountPath: /usr/share/nginx/html/humans.txt
+          subPath: humans.txt
+        - name: live-router-nginx-conf
           mountPath: /usr/share/nginx/html/robots.txt
           subPath: robots.txt
         - name: router-nginx-htpasswd

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2569,6 +2569,9 @@ govukApplications:
         name: live-router-nginx-conf
       nginxExtraVolumeMounts:
         - name: live-router-nginx-conf
+          mountPath: /usr/share/nginx/html/humans.txt
+          subPath: humans.txt
+        - name: live-router-nginx-conf
           mountPath: /usr/share/nginx/html/robots.txt
           subPath: robots.txt
         - name: router-nginx-htpasswd

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2564,6 +2564,9 @@ govukApplications:
         name: live-router-nginx-conf
       nginxExtraVolumeMounts:
         - name: live-router-nginx-conf
+          mountPath: /usr/share/nginx/html/humans.txt
+          subPath: humans.txt
+        - name: live-router-nginx-conf
           mountPath: /usr/share/nginx/html/robots.txt
           subPath: robots.txt
         - name: router-nginx-htpasswd

--- a/doc/humans.md
+++ b/doc/humans.md
@@ -1,0 +1,17 @@
+# humans.txt
+
+Sometimes we want to publicly celebrate someone who's leaving GOV.UK. The convention for this is to temporarily update [gov.uk/humans.txt](https://www.gov.uk/humans.txt) with some words about their time on the programme.
+
+We should be judicious about who we choose to celebrate this way, so it remains something special. This should be when someone has been working on the programme for over 5 years, or has had an exceptional (positive) impact.
+
+Anyone can write these words, but we should try to use a consistent style. Look back through the [history](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/humans.txt) and [earlier history on static](https://github.com/alphagov/static/blob/32b5743557ecc83e84908b55aab8027f2d9bf051/public/humans.txt) of `humans.txt` to see what others have written before you, and then compose your own text.
+
+## How to update the page
+
+1. Append some nice words to [`charts/app-config/humans.txt`](../charts/app-config/humans.txt).
+
+2. Raise a PR and get a technical and a content review.
+
+3. Deploy the PR to production and wait for the cache to clear.
+
+4. Raise a PR to remove the content after a few days.


### PR DESCRIPTION
- humans.txt is one of the last files to be served directly from static. Follow the pattern of robots.txt in production and make it a config file that's loaded and mounted on the relevant path.
- update documentation. Leave permalink to history in static so people can still find older versions of the file to crib from.