### PR TITLE
Add cron jobs for the set sample query set task

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3198,6 +3198,9 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: evaluation-setup-sample-query-sets
+          task: "evaluation:setup_sample_query_sets"
+          schedule: "0 2 1 * *"
         - name: user-events-import-yesterdays-events
           task: "user_events:import_yesterdays_events"
           schedule: "30 12 * * *"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2972,6 +2972,9 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: evaluation-setup-sample-query-sets
+          task: "evaluation:setup_sample_query_sets"
+          schedule: "0 2 1 * *"
         - name: user-events-import-yesterdays-events
           task: "user_events:import_yesterdays_events"
           schedule: "30 12 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2961,6 +2961,9 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: evaluation-setup-sample-query-sets
+          task: "evaluation:setup_sample_query_sets"
+          schedule: "0 2 1 * *"
         - name: user-events-import-yesterdays-events
           task: "user_events:import_yesterdays_events"
           schedule: "30 12 * * *"


### PR DESCRIPTION
The setup sample query sets jobs run on the first of the month at 2am. They set up sample query sets for Vertex evaluations.

This job runs in all three environments for consistency