### PR TITLE
Move the repository-name label for asset-manager to the pod spec

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "asset-manager.labels" . | nindent 4 }}
     app: {{ $fullName }}
-    app.govuk/repository-name: {{ .Values.repoName | default .Release.Name  }}
     app.kubernetes.io/name: {{ $fullName }}
     app.kubernetes.io/component: app
   annotations:
@@ -22,6 +21,7 @@ spec:
       labels:
         {{- include "asset-manager.labels" . | nindent 8 }}
         app: {{ $fullName }}
+        app.govuk/repository-name: {{ .Values.repoName | default .Release.Name  }}
         app.kubernetes.io/name: {{ $fullName }}
         app.kubernetes.io/component: app
     spec:


### PR DESCRIPTION
The label wasn't appearing for the asset-manager pod because it was setup in the wrong place.

https://github.com/alphagov/govuk-infrastructure/issues/2237