### PR TITLE
Increase Fastly RequestRate threshold

### DIFF
--- a/charts/monitoring-config/rules/fastly.yaml
+++ b/charts/monitoring-config/rules/fastly.yaml
@@ -28,7 +28,7 @@ groups:
             abnormal traffic patterns.
 
       - alert: HighRequestRate
-        expr: global:fastly_global_requests:rate1d > 2 * (10 ^ 8)
+        expr: global:fastly_global_requests:rate1d > 2.2 * (10 ^ 8)
         for: 2d
         labels:
           severity: warning

--- a/charts/monitoring-config/rules/fastly.yaml
+++ b/charts/monitoring-config/rules/fastly.yaml
@@ -37,5 +37,5 @@ groups:
           summary: Fastly global request rate exceeds typical daily usage
           description: >-
             The global daily request rate for Fastly has exceeded the expected
-            threshold of 200 million requests. This may indicate abnormal
+            threshold of 220 million requests. This may indicate abnormal
             traffic patterns or unexpected spikes in usage.


### PR DESCRIPTION
We have an increased monthly allowance, so this increases the threshold for alarms in line with that. 