### PR TITLE
🔥 Remove promote_deployment

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-graphql
+++ b/charts/app-config/image-tags/integration/govuk-graphql
@@ -1,3 +1,3 @@
 image_tag: v181
 automatic_deploys_enabled: true
-promote_deployment: true
+promote_deployment: false


### PR DESCRIPTION
govuk-graphql doesn't have a staging environment. This commit stops this deployment failure from occurring: https://gds.slack.com/archives/C01EE7US9R6/p1751619063067639