### PR TITLE
✨ Add govuk-reports-prototype chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 helm-dist
+output

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,23 @@ check-yamllint: ## Check if yamllint is installed
 		exit 1; \
 	fi
 
-lint: check-yamllint ## Run yamllint on all YAML files
+yamllint: check-yamllint ## Run yamllint on all YAML files
 	@echo "Running yamllint..."
 	yamllint -f github .
 
+lint: check-yamllint kubeconform ## Run yamllint on all YAML files
+
 check: lint ## Alias for lint target
+
+kubeconform: ## Run kubeconform validation on rendered charts
+	@echo "Rendering charts..."
+	./govuk-app-render.sh
+	@echo "Running kubeconform..."
+	docker run --rm -v "$(PWD)/output:/workspace" ghcr.io/yannh/kubeconform:latest-alpine \
+		-kubernetes-version 1.31.6 \
+		-schema-location default \
+		-schema-location "https://alphagov.github.io/govuk-crd-library/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
+		-ignore-filename-pattern ".*/Chart.yaml" \
+		-summary \
+		-strict \
+		/workspace/rendered-charts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check-yamllint lint check help
+.PHONY: check-yamllint lint check kubeconform help
 
 # Default target
 help: ## Show this help message
@@ -17,7 +17,7 @@ yamllint: check-yamllint ## Run yamllint on all YAML files
 	@echo "Running yamllint..."
 	yamllint -f github .
 
-lint: check-yamllint kubeconform ## Run yamllint on all YAML files
+lint: check-yamllint kubeconform ## Run linting commands on all YAML files
 
 check: lint ## Alias for lint target
 

--- a/charts/app-config/image-tags/integration/govuk-reports-prototype
+++ b/charts/app-config/image-tags/integration/govuk-reports-prototype
@@ -1,0 +1,3 @@
+image_tag: v1
+automatic_deploys_enabled: true
+promote_deployment: false

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -63,6 +63,43 @@ emergency-banner-redis:
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
 govukApplications:
+  - name: govuk-reports-prototype
+    helmValues:
+      arch: arm64
+      uploadAssets:
+        enabled: false
+      appResources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      dbMigrationEnabled: false
+      workers:
+        enabled: false
+      redis:
+        enabled: false
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "10"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "govuk-reports-prototype.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: govuk-reports-prototype.{{ .Values.k8sExternalDomainSuffix }}
+      service:
+        port: 8080
+      healthcheck:
+        path: /api/v1/health
+      extraEnv:
+        - name: SERVER_PORT
+          value: "8080"
+        - name: GOVUK_ENVIRONMENT
+          value: "{{ .Values.govukEnvironment }}"
   - name: account-api
     helmValues:
       arch: arm64

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -97,7 +97,7 @@ govukApplications:
         enabled: true
         create: true
         annotations:
-          eks.amazonaws.com/role-arn: arn:aws:iam::{{ .values.awsAccountId }:role/content-data-admin-integration
+          eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-reports-govuk
       healthcheck:
         path: /api/health
       extraEnv:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -118,7 +118,7 @@ govukApplications:
         - name: LOG_TIME_FORMAT
           value: "2006-01-02T15:04:05Z07:00"
         - name: LOG_COLORIZE
-          value: false
+          value: "false"
 
   - name: account-api
     helmValues:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -93,13 +93,33 @@ govukApplications:
           - name: govuk-reports-prototype.{{ .Values.k8sExternalDomainSuffix }}
       service:
         port: 8080
+      serviceAccount:
+        enabled: true
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::{{ .values.awsAccountId }:role/content-data-admin-integration
       healthcheck:
-        path: /api/v1/health
+        path: /api/health
       extraEnv:
-        - name: SERVER_PORT
+        - name: PORT
           value: "8080"
-        - name: GOVUK_ENVIRONMENT
+        - name: ENVIRONMENT
           value: "{{ .Values.govukEnvironment }}"
+        - name: AWS_REGION
+          value: "{{ .Values.awsRegion }}"
+
+        # Logging configuration
+        - name: LOG_LEVEL
+          value: "info"
+        - name: LOG_FORMAT
+          value: "json"
+        - name: LOG_OUTPUT
+          value: "stdout"
+        - name: LOG_TIME_FORMAT
+          value: "2006-01-02T15:04:05Z07:00"
+        - name: LOG_COLORIZE
+          value: false
+
   - name: account-api
     helmValues:
       arch: arm64


### PR DESCRIPTION
This pull request introduces updates to the `Makefile` to enhance linting capabilities and adds configuration for deploying the `govuk-reports-prototype` application in Kubernetes. The most important changes include the addition of the configuration of the `govuk-reports-prototype` application to integration.

### Makefile enhancements:
* **Added `kubeconform` validation**: Introduced a new `kubeconform` target to validate rendered Kubernetes charts using the `kubeconform` tool with strict schema checks and custom schema locations. While working in this repository, I found that when pushing changes, I were failing kubeconform requirements. I wanted to test this locally before pushing, so I've added a make command that lets you either `make lint` and run all the linting locally, or, run `make kubeconform` that performs the kubeconform command for you and outputs the errors locally. This way, I was able to identify where the failure was located and fix it quickly. In this instance, it appeared in the rendered deployment.yaml file for reports-prototype.
* **Renamed `lint` target to `yamllint`**: The `lint` target was renamed to `yamllint`, and a new `lint` target was created to run both `yamllint` and `kubeconform`.

### Kubernetes configuration for `govuk-reports-prototype`:
* **Added image tag and deployment settings**: Configured the `govuk-reports-prototype` application with `image_tag: v1`, enabled automatic deployments, and disabled promotion of deployments.
* **Defined Helm values**: Added detailed Helm configuration for `govuk-reports-prototype`, including resource limits, ingress settings, service account annotations, health checks, and environment variables for logging and AWS region.