### PR TITLE
publishing-api: revert to using in-cluster Redis in integration, staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2576,9 +2576,6 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "redis://publishing-api-valkey.integration.govuk-internal.digital:6379"
-          workers: "redis://publishing-api-valkey.integration.govuk-internal.digital:6379"
       cronTasks:
         - name: metrics-report-to-prometheus
           task: "metrics:report_to_prometheus"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2343,9 +2343,6 @@ govukApplications:
         enabled: true
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "redis://publishing-api-valkey.staging.govuk-internal.digital:6379"
-          workers: "redis://publishing-api-valkey.staging.govuk-internal.digital:6379"
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
We want to make all of the Redis usage across all of the apps consistent once again. We previously moved some integration and staging deployments to using Valkey from AWS Elasticache.

Part of https://github.com/alphagov/govuk-infrastructure/issues/2331