### PR TITLE
Fix-forward - remove logic from YAML Lists

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -27,6 +27,16 @@
   • *{{`{{ .Annotations.summary }}`}}*: {{`{{ .Annotations.description }}`}}
   {{`{{ end }}`}}
 {{`{{ end }}`}}
+*Links:*
+{{`{{- if .CommonAnnotations.grafana_path }}`}}
+• <https://grafana.eks.{{`{{ .CommonLabels.environment }}`}}.govuk.digital/{{`{{ .CommonAnnotations.grafana_path }}`}}|:mag: View Dashboard>
+{{`{{- end -}}`}}
+{{`{{- if .CommonAnnotations.runbook_url }}`}}
+• <{{`{{ .CommonAnnotations.runbook_url }}`}}|:orange_book: View Runbook>
+{{`{{- end -}}`}}
+{{`{{- if .CommonAnnotations.cronjob_uri }}`}}
+• <{{`{{ .CommonAnnotations.cronjob_uri }}`}}|:link: View Cronjob>
+{{`{{- end -}}`}}
 {{- end -}}
 
 {{- define "slack.title" -}}

--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-template.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-template.tpl
@@ -7,45 +7,30 @@ sendResolved: true
 color: |-
   {{ include "slack.color" . }}
 username: "Prometheus Alertmanager"
-iconUrl: "https://avatars3.githubusercontent.com/u/3380462"
+iconURL: "https://avatars3.githubusercontent.com/u/3380462"
 pretext: |-
   {{ include "slack.pretext" . }}
 title: |-
   {{ include "slack.emoji" . }} {{ include "slack.title" . }}: {{ "{{ .CommonLabels.alertname }}" }}
-fields: |
-  - title: "Status"
-    value: {{ include "slack.status" . }}
-    short: true
-  - title: "Severity"
-    value: {{ include "slack.emoji" . }} {{ "{{ .CommonLabels.severity | title }}" }}
-    short: true
-  - title: "Environment"
-    value: {{ "{{ .CommonLabels.environment | title }}" }}
-    short: true
-actions: |
-  {{`{{- if .CommonAnnotations.grafana_path }}`}}
-  - text: ":mag: Dashboard"
-    type: button
-    url: {{`https://grafana.eks.{{ .CommonLabels.environment }}.govuk.digital/{{ .CommonAnnotations.grafana_path }}`}}
-  {{`{{- end -}}`}}
+fields:
+- title: "Status"
+  value: '{{ include "slack.status" . }}'
+  short: true
+- title: "Severity"
+  value: '{{ include "slack.emoji" . }} {{ "{{ .CommonLabels.severity | title }}" }}'
+  short: true
+- title: "Environment"
+  value: '{{ "{{ .CommonLabels.environment | title }}" }}'
+  short: true
+actions:
   - text: ":mag: View Alert"
     type: button
-    url: {{`{{ .ExternalURL }}/#/alerts?filter={{ range .CommonLabels.SortedPairs }}{{ .Name }}%3D"{{ .Value | urlquery }}"%2C{{ end }}`}}
-  {{`{{- if .CommonAnnotations.runbook_url }}`}}
-  - text: ":orange_book: Runbook"
-    type: button
-    url: {{ "{{ .CommonAnnotations.runbook_url }}" }}
-  {{`{{- end }}`}}
-  {{`{{- if .CommonAnnotations.cronjob_uri }}`}}
-  - text: ":link: Cronjob URL"
-    type: button
-    url: {{ "{{ .CommonAnnotations.cronjob_uri }}" }}
-  {{`{{- end }}`}}
+    url: '{{`{{ .ExternalURL }}/#/alerts?filter={{ range .CommonLabels.SortedPairs }}{{ .Name }}%3D"{{ .Value | urlquery }}"%2C{{ end }}`}}'
   - text: ":no_bell: Silence Alert (2h)"
     type: button
-    url: {{`{{ .ExternalURL }}/#/silences/new?filter={{ range .CommonLabels.SortedPairs }}{{ .Name }}%3D"{{ .Value | urlquery }}"%2C{{ end }}`}}
-  footer: "Sent by Alertmanager"
-  apiURL:
-    name: alertmanager-receivers
-    key: slack_api_url
+    url: '{{`{{ .ExternalURL }}/#/silences/new?filter={{ range .CommonLabels.SortedPairs }}{{ .Name }}%3D"{{ .Value | urlquery }}"%2C{{ end }}`}}'
+footer: "Sent by Alertmanager"
+apiURL:
+  name: alertmanager-receivers
+  key: slack_api_url
   {{- end -}}


### PR DESCRIPTION
## What?
This fixes some invalid YAML that was somehow missed by helm template but not Argo. To stop Argo from complaining that our Go Template handlebars are "invalid YAML", we will just remove those conditionals and add them to the Message Body. It might not look at pretty, but at least it might work.