### PR TITLE
Fix Template error presented by Alertmanager

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -20,7 +20,9 @@
 {{`{{ .CommonAnnotations.description }}`}}
 {{`{{- end -}}`}}
 *Labels*:
-{{`{{ .CommonLabels.SortedPairs | join ", " }}`}}
+{{`{{ range .CommonLabels.SortedPairs }}
+• *{{ .Name }}*: {{ .Value }}
+{{ end }}`}}
 *Firing Alerts*:
 {{`{{ range .Alerts }}`}}
   {{`{{ if eq .Status "firing" }}`}}


### PR DESCRIPTION
## What?
We have one more small annoying error:
```
time=2025-07-07T16:23:36.203Z level=ERROR source=dispatch.go:360 msg="Notify for alerts failed" component=dispatcher num_alerts=1 err="monitoring/alertmanagerconfig-general/generic-slack-platform-engineering-low-priority/slack[0]: notify retry canceled due to unrecoverable error after 1 attempts: template: :6:36: executing \"\" at <\", \">: wrong type for value; expected []string; got template.Pairs"
```

This is due to this line:
```
{{`{{ .CommonLabels.SortedPairs | join ", " }}`}}
```
The `SortedPairs` property is actually a set of key-value pairs, and cannot use the `| join` function in this way. Therefore we have to loop through them.