### PR TITLE
whitehall-admin: revert to using in-cluster Redis in integration, staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4104,9 +4104,6 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379"
-          workers: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3784,9 +3784,6 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379"
-          workers: "redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379"
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s


### PR DESCRIPTION
We want to make all of the Redis usage across all of the apps consistent once again. We previously moved some integration and staging deployments to using Valkey from AWS Elasticache.

Part of https://github.com/alphagov/govuk-infrastructure/issues/2331