### PR TITLE
search-api: revert to using in-cluster Redis in integration, staging

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3015,9 +3015,6 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
-          workers: "redis://search-api-valkey.integration.govuk-internal.digital:6379"
       cronTasks:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2791,9 +2791,6 @@ govukApplications:
         enabled: false
       redis:
         enabled: true
-        redisUrlOverride:
-          app: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
-          workers: "redis://search-api-valkey.staging.govuk-internal.digital:6379"
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"


### PR DESCRIPTION
We want to make all of the Redis usage across all of the apps consistent once again. We previously moved some integration and staging deployments to using Valkey from AWS Elasticache.

Part of https://github.com/alphagov/govuk-infrastructure/issues/2331