### PR TITLE
Add separator --- to fix the release rolebinding

### DIFF
--- a/charts/release/templates/assumed_rolebinding.yaml
+++ b/charts/release/templates/assumed_rolebinding.yaml
@@ -12,4 +12,5 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: release-assumed
+---
 {{ end }}


### PR DESCRIPTION
Without the separator only the last block of yaml will be applied when iterating through the range of values. 
This is why the rolebinding was created for the `licensify` namespace but not the `apps` namespace.

https://github.com/alphagov/govuk-infrastructure/issues/2237