### PR TITLE
Alertmanager does not support the default function

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -32,7 +32,7 @@
 *Firing Alerts*:
 {{ range .Alerts }}
   {{ if eq .Status "firing" }}
-  • *{{ .Annotations.summary | default "Summary" }}*: 
+  • *{{ .Annotations.summary }}*: 
     {{ .Annotations.description }}
   {{ end }}
 {{- end }}`}}


### PR DESCRIPTION
## What?
I wanted to be clever and use the `default` function. Turns out this is only a Helm thing and not an Alertmanager thing. So it has to go.