### PR TITLE
Improve Slack Alert readability by fixing some newlines

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -22,16 +22,16 @@
 {{`{{- if .CommonAnnotations.description }}`}}
 *Description*:
 {{`{{ .CommonAnnotations.description }}`}}
-{{`{{- end }}`}}
+{{`{{ end }}`}}
 
 {{`{{- if .CommonLabels.SortedPairs }}`}}
 *Labels*:
   {{`{{ range .CommonLabels.SortedPairs }}`}}
   • *{{`{{ .Name }}`}}*: {{`{{ .Value }}`}}
   {{`{{- end }}`}}
-{{`{{- end }}`}}
+{{`{{ end }}`}}
 
-{{`{{- if .Alerts -}}`}}
+{{`{{ if .Alerts }}`}}
 *Firing Alerts*:
 {{`{{ range .Alerts }}`}}
   {{`{{ if eq .Status "firing" }}`}}
@@ -39,7 +39,7 @@
     {{`{{ .Annotations.description }}`}}
   {{`{{ end }}`}}
 {{`{{ end }}`}}
-{{`{{- end }}`}}
+{{`{{ end }}`}}
 
 *Links:*
 {{`{{- if .CommonAnnotations.grafana_path }}`}}


### PR DESCRIPTION
## What?
The template appears to be working again now - this removes some of the dashes that eliminate spacing/newlines causing the template to look less appealing.