### PR TITLE
Fix redis urls for non-default database numbers

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -58,7 +58,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/1
+  - &emergency-banner-redis redis://whitehall-admin-redis:6379/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -4174,7 +4174,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: "redis://whitehall-admin-valkey.integration.govuk-internal.digital:6379/2"
+          value: "redis://whitehall-admin-redis:6379/2"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -56,7 +56,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379/1
+  - &emergency-banner-redis redis://whitehall-admin-redis:6379/1
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -3854,7 +3854,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: redis://whitehall-admin-valkey.staging.govuk-internal.digital:6379/2
+          value: redis://whitehall-admin-redis:6379/2
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Whitehall admin was migrated to in cluster redis, but 2 redis URIs were left pointing at the now-deleted valkey instances where they use non-default database numbers