### PR TITLE
Use k8s dependent env vars for non-default redis databases

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4174,7 +4174,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: "$(REDUS_URL):6379/2"
+          value: "$(REDIS_URL):6379/2"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -58,7 +58,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-redis:6379/1
+  - &emergency-banner-redis "$(REDIS_URL):6379/1"
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -4174,7 +4174,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: "redis://whitehall-admin-redis:6379/2"
+          value: "$(REDUS_URL):6379/2"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -49,7 +49,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-redis/1
+  - &emergency-banner-redis "$(REDIS_URL)/1"
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -3885,7 +3885,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: redis://whitehall-admin-redis/2
+          value: "$(REDIS_URL)/2"
         - name: SIGNON_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -56,7 +56,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
     access_logs.s3.prefix=elb/backend
 
 emergency-banner-redis:
-  - &emergency-banner-redis redis://whitehall-admin-redis:6379/1
+  - &emergency-banner-redis "$(REDIS_URL):6379/1"
 
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 
@@ -3854,7 +3854,7 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: TAXONOMY_CACHE_REDIS_URL
-          value: redis://whitehall-admin-redis:6379/2
+          value: "$(REDIS_URL):6379/2"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
When we updated to an in-cluster redis instead of elasticache we missed a couple of the env vars in integration and staging for whitehall-admin.

Instead of having to change it in multiple places we can use [kubernetes dependent environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/) so that the non-default database redis urls use the primary database url suffixed with the database number.

Given we are going to migrate everything into elasticache soon this should prevent a recurrence of the issue (which could extend into production this time)

The env vars defined in the `extraEnv` section come after the default env vars, so these extra env vars will always be resolved after the primary REDIS_URL.

I triple confirmed this by looking at the [final rendered k8s manifest in Argo CD in integration](https://argo.eks.integration.govuk.digital/applications/cluster-services/whitehall-admin?view=tree&orphaned=false&resource=&node=apps%2FReplicaSet%2Fapps%2Fwhitehall-admin-7b47685fbf%2F0) which includes the following snippet (all sensitive info removed):

```
       - env:
...SNIP....
            - name: REDIS_URL
              value: redis://whitehall-admin-redis
....SNIP....
            - name: EMERGENCY_BANNER_REDIS_URL
              value: redis://whitehall-admin-redis:6379/1
            - name: TAXONOMY_CACHE_REDIS_URL
              value: redis://whitehall-admin-redis:6379/2
```