### PR TITLE
Try to fix the Action Buttons

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-template.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-template.tpl
@@ -25,10 +25,10 @@ fields:
 actions:
   - text: ":mag: View Alert"
     type: button
-    url: '{{`{{ .ExternalURL }}/#/alerts?filter=%7B{{- range $index, $pair := .CommonLabels.SortedPairs }}{{- if $index }}, {{ end }}{{ $pair.Name }}%3D"{{ $pair.Value | urlquery }}"{{- end }}%7D`}}'
+    url: '{{`{{ .ExternalURL }}/#/alerts?filter={{ "{" }}{{- range $index, $pair := .CommonLabels.SortedPairs }}{{- if $index }}, {{ end }}{{ $pair.Name }}%3D"{{ $pair.Value | urlquery }}"{{- end }}{{ "}" }}`}}'
   - text: ":no_bell: Silence Alert (2h)"
     type: button
-    url: '{{`{{ .ExternalURL }}/#/silences/new?filter=%7B{{- range $index, $pair := .CommonLabels.SortedPairs }}{{- if $index }}, {{ end }}{{ $pair.Name }}%3D"{{ $pair.Value | urlquery }}"{{- end }}%7D`}}'
+    url: '{{`{{ .ExternalURL }}/#/silences/new?filter={{ "{" }}{{- range $index, $pair := .CommonLabels.SortedPairs }}{{- if $index }}, {{ end }}{{ $pair.Name }}%3D"{{ $pair.Value | urlquery }}"{{- end }}{{ "}" }}`}}'
 footer: "Sent by Alertmanager"
 apiURL:
   name: alertmanager-receivers


### PR DESCRIPTION
## What?
The action buttons have stopped rendering on the test messages. Despite trying to use encoded characters, it seems like this might not be expected and should be left to Alertmanager to do the url encoding itself.

...at least as far as Copilot is concerned.