### PR TITLE
Add external secrets charts for new postgres DB in Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2334,6 +2334,11 @@ govukApplications:
             secretKeyRef:
               name: publisher-docdb
               key: MONGODB_URI
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publisher-postgres
+              key: DATABASE_URL
         - name: EMAIL_GROUP_BUSINESS
           value: mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk
         - name: EMAIL_GROUP_CITIZEN

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2306,6 +2306,11 @@ govukApplications:
             secretKeyRef:
               name: publisher-docdb
               key: MONGODB_URI
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publisher-postgres
+              key: DATABASE_URL
         - name: EMAIL_GROUP_BUSINESS
           value: publisher-alerts-business@digital.cabinet-office.gov.uk
         - name: EMAIL_GROUP_CITIZEN

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2306,6 +2306,11 @@ govukApplications:
             secretKeyRef:
               name: publisher-docdb
               key: MONGODB_URI
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publisher-postgres
+              key: DATABASE_URL
         - name: EMAIL_GROUP_BUSINESS
           value: mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk
         - name: EMAIL_GROUP_CITIZEN

--- a/charts/external-secrets/templates/publisher/postgresql.yaml
+++ b/charts/external-secrets/templates/publisher/postgresql.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: publisher
+  name: publisher-postgres
   labels:
     {{- include "external-secrets.labels" . | nindent 4 }}
   annotations:
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
-    name: publisher
+    name: publisher-postgres
     template:
       data:
         DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/psql-conn-string.tpl" | trim }}/publisher_production'


### PR DESCRIPTION
We already had secrets setup for the publisher-on-pg sub branch, but now we need these brought over to the main app trunk in preperation for delivery.

Related to https://trello.com/c/bXzPPew8/749-create-postgres-db-in-staging-and-production