### PR TITLE
Chat: disable OpenSearch syncing to test environment

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -95,24 +95,24 @@ cronjobs:
             secretKeyRef:
               name: govuk-chat-opensearch
               key: password
-    test-chat-cp-prod:
-      schedule: "12 5 * * *"
-      args: [restore_latest]
-      extraEnv:
-        - name: SNAPSHOT_REPO
-          value: govuk-production
-        - name: SUBDOMAIN
-          value: chat-opensearch-test
-        - name: SEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-opensearch-test
-              key: username
-        - name: SEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-opensearch-test
-              key: password
+    # test-chat-cp-prod:
+    #   schedule: "12 5 * * *"
+    #   args: [restore_latest]
+    #   extraEnv:
+    #     - name: SNAPSHOT_REPO
+    #       value: govuk-production
+    #     - name: SUBDOMAIN
+    #       value: chat-opensearch-test
+    #     - name: SEARCH_USERNAME
+    #       valueFrom:
+    #         secretKeyRef:
+    #           name: govuk-chat-opensearch-test
+    #           key: username
+    #     - name: SEARCH_PASSWORD
+    #       valueFrom:
+    #         secretKeyRef:
+    #           name: govuk-chat-opensearch-test
+    #           key: password
 
 podSecurityContext:
   fsGroup: 1001


### PR DESCRIPTION
We're having some data issues with our OpenSearch cluster for GOV.UK
Chat.

The production/staging/integration environments aren't being used at the
moment but the test environment is. So we want to temporarily disable
the nightly syncing of the production -> test env while we sort things
out.
