### PR TITLE
BAU - Fix event binding `generateName`

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
@@ -8,7 +8,8 @@ spec:
   submit:
     workflowTemplateRef:
       name: deploy-image
-    generateName: "deploy-{{`{{payload.repoName}}`}}-{{`{{payload.environment}}`}}-{{`{{payload.imageTag | substr 0 8}}`}}-"
+    metadata:
+      generateName: "deploy-{{`{{payload.repoName}}`}}-{{`{{payload.environment}}`}}-{{`{{payload.imageTag | substr 0 8}}`}}-"
     arguments:
       parameters:
         - name: environment


### PR DESCRIPTION
Description:
- `WorkflowEventBinding.submit` doesn't have a `generateName` field but a `metadata` field where `generateName` is. See https://argo-workflows.readthedocs.io/en/latest/fields/#submit