### PR TITLE
Slack Alerts: Drop buttons, try individual alert links.

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -6,6 +6,17 @@
 {{`{{ if and (eq .Status "firing") (eq .CommonLabels.severity "critical") }}:octagonal_sign:{{ else if eq .Status "firing" }}:warning:{{ else }}:green_tick:{{ end }}`}}
 {{- end -}}
 
+{{- define "slack.filterstring" -}}
+{{`{{- if .Labels.SortedPairs -}}`}}
+{{`{`}}{{`- $first := true -}`}}
+{{`{{- range .Labels.SortedPairs -}}`}}
+  {{`{{- if not $first -}},{{- end -}}`}}
+  {{`{{- $first = false -}}`}}
+  {{`{{- .Name -}}={{- printf "%q" .Value -}}`}}
+{{`{{- end -}}`}}{{`}`}}
+{{`{{- end }}`}}
+{{- end }}
+
 {{- define "slack.pretext" -}}
 {{`{{ if eq .Status "firing" }}The following alert is firing:{{ else }}This alert is resolved:{{ end }}`}}
 {{- end -}}
@@ -32,11 +43,16 @@
 {{`{{ end }}`}}
 
 {{`{{ if .Alerts }}`}}
-*Firing Alerts*:
+*Firing Alerts*
+================
 {{`{{ range .Alerts }}`}}
   {{`{{ if eq .Status "firing" }}`}}
   • *{{`{{ .Annotations.summary }}`}}*: 
     {{`{{ .Annotations.description }}`}}
+
+     Actions:
+     • <{{`{{ .ExternalURL }}`}}/#/alerts?filter={{- include "slack.filterstring" . -}}|:mag: View Alert>
+     • <{{`{{ .ExternalURL }}`}}/#/silences/new?filter={{- include "slack.filterstring" . -}}|:no_bell: Silence Alert (2h)>
   {{`{{ end }}`}}
 {{`{{ end }}`}}
 {{`{{ end }}`}}

--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-template.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-template.tpl
@@ -22,13 +22,6 @@ fields:
 - title: "Environment"
   value: '{{ "{{ .CommonLabels.environment | title }}" }}'
   short: true
-actions:
-  - text: ":mag: View Alert"
-    type: button
-    url: '{{`{{ .ExternalURL }}/#/alerts?filter={{ "{" }}{{- range $index, $pair := .CommonLabels.SortedPairs }}{{- if $index }}, {{ end }}{{ $pair.Name }}%3D"{{ $pair.Value | urlquery }}"{{- end }}{{ "}" }}`}}'
-  - text: ":no_bell: Silence Alert (2h)"
-    type: button
-    url: '{{`{{ .ExternalURL }}/#/silences/new?filter={{ "{" }}{{- range $index, $pair := .CommonLabels.SortedPairs }}{{- if $index }}, {{ end }}{{ $pair.Name }}%3D"{{ $pair.Value | urlquery }}"{{- end }}{{ "}" }}`}}'
 footer: "Sent by Alertmanager"
 apiURL:
   name: alertmanager-receivers


### PR DESCRIPTION
## What?
Here we go, another week of YAML and Go Template wrangling!

This removes our use of the "actions" buttons entirely, and swaps us over to using generated URLs for each individual "Alert" to see if the URL generation issue is a scope problem.