### PR TITLE
BAU - Remove `generateName` in Argo Workflows

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/event-binding.yaml
@@ -8,8 +8,6 @@ spec:
   submit:
     workflowTemplateRef:
       name: deploy-image
-    metadata:
-      generateName: "deploy-{{`{{payload.repoName}}`}}-{{`{{payload.environment}}`}}-{{`{{payload.imageTag | substr 0 8}}`}}-"
     arguments:
       parameters:
         - name: environment

--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   entrypoint: deploy-image
   onExit: exit-handler
-  generateName: "deploy-{{"{{workflow.parameters.repoName}}"}}-{{"{{workflow.parameters.environment}}"}}-{{"{{= sprig.trunc(8, workflow.parameters.imageTag) }}"}}-"
   arguments:
     parameters:
       - name: environment


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3296 and https://github.com/alphagov/govuk-helm-charts/pull/3297 introduced `generateName`.
- https://github.com/alphagov/govuk-helm-charts/pull/3341 attempted fix but the error in ArgoCD server was that `metadata.generateName` was unrecognized
- It looks like `generateName` isn't supported for `submit.metadata` nor for `spec.generateName` and so the Argo Workflow docs seem incorrect