### PR TITLE
Remove the quality metrics job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3211,10 +3211,6 @@ govukApplications:
         - name: user-events-purge
           task: "user_events:purge_final_week_of_retention_period"
           schedule: "0 2 * * *"
-        - name: quality-monitoring-assert-invariants
-          task: "quality_monitoring:assert_invariants"
-          schedule: "09 9 * * *"  # 09:09am daily
-          suspend: true  # Too noisy for integration to run on schedule, but can be run manually.
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2987,9 +2987,6 @@ govukApplications:
         - name: user-events-purge
           task: "user_events:purge_final_week_of_retention_period"
           schedule: "0 2 * * *"
-        - name: quality-monitoring-assert-invariants
-          task: "quality_monitoring:assert_invariants"
-          schedule: "09 8-17 * * *"  # 9 minutes past the hour every day from 8am-5pm
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2970,10 +2970,6 @@ govukApplications:
         - name: user-events-purge
           task: "user_events:purge_final_week_of_retention_period"
           schedule: "0 2 * * *"
-        - name: quality-monitoring-assert-invariants
-          task: "quality_monitoring:assert_invariants"
-          schedule: "09 9 * * *"  # 09:09am daily
-          suspend: true  # Too noisy for staging to run on schedule, but can be run manually.
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"


### PR DESCRIPTION
The quality monitoring job was based on a manual list, however the judgement lists have been automated and new [evaluation jobs] added.

[evaluation jobs]: https://github.com/alphagov/govuk-helm-charts/blob/f615eba35e663064ab1f73b3e30e8904c8b038bc/charts/app-config/values-production.yaml#L2975