### PR TITLE
Revert "Move generateName in deploy-image workflow to metadata block"

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -2,10 +2,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: deploy-image
-  generateName: "deploy-{{"{{workflow.parameters.repoName}}"}}-{{"{{workflow.parameters.environment}}"}}-{{"{{= sprig.trunc(8, workflow.parameters.imageTag) }}"}}-"
 spec:
   entrypoint: deploy-image
   onExit: exit-handler
+  generateName: "deploy-{{"{{workflow.parameters.repoName}}"}}-{{"{{workflow.parameters.environment}}"}}-{{"{{= sprig.trunc(8, workflow.parameters.imageTag) }}"}}-"
   arguments:
     parameters:
       - name: environment


### PR DESCRIPTION
This reverts commit 8de0242d9137f659b400b9f0a7b9942bc8e6676f.