### PR TITLE
Change Filter String Builder, $first was invalid.

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -8,12 +8,13 @@
 
 {{- define "slack.filterstring" -}}
 {{`{{- if .Labels.SortedPairs -}}`}}
-{{`{`}}{{`- $first := true -}`}}
-{{`{{- range .Labels.SortedPairs -}}`}}
-  {{`{{- if not $first -}},{{- end -}}`}}
-  {{`{{- $first = false -}}`}}
-  {{`{{- .Name -}}={{- printf "%q" .Value -}}`}}
-{{`{{- end -}}`}}{{`}`}}
+%7B
+{{`{{- range $index, $pair := .Labels.SortedPairs -}}`}}
+  {{`{{- .Name }}%3D%22{{ .Value | urlquery }}%22`}}
+  {{`{{- if ne (add 1 $index) (len $.Labels.SortedPairs) }}%2C%20{{ end -}}`}}
+{{`{{- end -}}`}}
+%7D
+{{`{{- else -}}`}}
 {{`{{- end }}`}}
 {{- end }}
 


### PR DESCRIPTION
## What?
So the previous template was apparently not valid - even though it passed `helm template .`, Alertmanager did not like the use of $first := true in the template, so have attempted to simplify and use the range $index which Alertmanager's documentation claims to be valid.