### PR TITLE
`add` Func is ALSO not supported by Alertmanager

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -8,13 +8,7 @@
 
 {{- define "slack.filterstring" -}}
 {{`{{- if .Labels.SortedPairs -}}`}}
-%7B
-{{`{{- range $index, $pair := .Labels.SortedPairs -}}`}}
-  {{`{{- .Name }}%3D%22{{ .Value | urlquery }}%22`}}
-  {{`{{- if ne (add 1 $index) (len $.Labels.SortedPairs) }}%2C%20{{ end -}}`}}
-{{`{{- end -}}`}}
-%7D
-{{`{{- else -}}`}}
+{{`%7B{{- range $index, $pair := .Labels.SortedPairs -}}{{- if ne $index 0 }}%2C%20{{ end -}}{{- .Name }}%3D%22{{ .Value | urlquery }}%22{{- end -}}%7D`}}
 {{`{{- end }}`}}
 {{- end }}
 


### PR DESCRIPTION
## What?
Through trial-and-error, we are slowly learning that Alertmanager's Go Templating supports far les than what it seems to imply.

```
time=2025-07-15T10:44:14.715Z level=ERROR source=dispatch.go:360 msg="Notify for alerts failed" component=dispatcher num_alerts=1 err="monitoring/alertmanagerconfig-general/generic-slack-platform-engineering/slack[0]: notify retry canceled due to unrecoverable error after 1 attempts: template: :30: function \"add\" not defined"
```

So this PR swaps the use of the `add` Go Function to try a basic "not-equal" logical operator against the range $index. Surely this can't go wrong?