### PR TITLE
.ExternalURL is only in the root context, use $.

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-helpers.tpl
@@ -46,8 +46,8 @@
     {{`{{ .Annotations.description }}`}}
 
      Actions:
-     • <{{`{{ .ExternalURL }}`}}/#/alerts?filter={{- include "slack.filterstring" . -}}|:mag: View Alert>
-     • <{{`{{ .ExternalURL }}`}}/#/silences/new?filter={{- include "slack.filterstring" . -}}|:no_bell: Silence Alert (2h)>
+     • <{{`{{ $.ExternalURL }}`}}/#/alerts?filter={{- include "slack.filterstring" . -}}|:mag: View Alert>
+     • <{{`{{ $.ExternalURL }}`}}/#/silences/new?filter={{- include "slack.filterstring" . -}}|:no_bell: Silence Alert (2h)>
   {{`{{ end }}`}}
 {{`{{ end }}`}}
 {{`{{ end }}`}}


### PR DESCRIPTION
## What?
This is the whack-a-mole stage now, where I missed the critical $ prefix to access the root context outside of the range loop of Alerts.

This should resolve the following error:
```
time=2025-07-15T11:15:23.578Z level=ERROR source=dispatch.go:360 msg="Notify for alerts failed" component=dispatcher num_alerts=1 err="monitoring/alertmanagerconfig-general/generic-slack-platform-engineering-low-priority/slack[0]: notify retry canceled due to unrecoverable error after 1 attempts: template: :26:13: executing \"\" at <.ExternalURL>: can't evaluate field ExternalURL in type template.Alert"
```