### PR TITLE
Temporarily stop db sync for GOV.UK Chat integration env

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -502,6 +502,7 @@ cronjobs:
         - op: backup
 
     chat-postgres:
+      suspend: true  # Temporarily suspended on integration for manual evaluation of content (david.gisbey 2025-07-18)
       schedule: "47 3 * * 1"
       db: govuk_chat_production
       operations:


### PR DESCRIPTION
**Do not merge until 18/07/2025 PM**

## Description 

We're temporarily suspending the db sync for the GOV.UK Chat integration environment to allow for testing by the rainbow content team.

This will be taking place between 21/07/2025 and 25/07/2025. To ensure the data doesn't get wiped before we export the data to BigQuery (we have to run the export manually on int) we're going to suspend the sync for the duration of the testing.

## Trello card

https://trello.com/c/5PzKEFnr/2629-set-up-chat-version-in-integration-export-of-conversation-logs-for-rainbow-team-manul-eval-red-teaming