### PR TITLE
Separate DGU 5xx alert

### DIFF
--- a/charts/monitoring-config/rules/fastly.yaml
+++ b/charts/monitoring-config/rules/fastly.yaml
@@ -59,7 +59,28 @@ groups:
           grafana_path: >-
             d/deqpydcv7ottse/fastly-global-traffic?orgId=1&from=now-1h&to=now&timezone=browser
           description: >-
-            The Fastly CDN service is receiving a higher proportion 5xx responses
+            The Fastly CDN service is receiving a higher proportion of 5xx responses
+            from the origin than usual.
+
+            Fastly CDN service: {{ $labels.service_name }}
+            5xx rate: {{ $value | humanizePercentage }}
+
+      - alert: High5xxRate_DataGovUk
+        expr: |
+          (
+            sum by(service_name)(rate(fastly_rt_status_group_total{status_group="5xx", service_name =~ ".*data.gov.uk"}[2m]))
+          / sum by(service_name)(rate(fastly_rt_origin_fetches_total{service_name =~ ".*data.gov.uk"}[2m]))
+          ) >= 0.10
+        for: 20m
+        labels:
+          severity: warning
+          destination: slack-platform-engineering
+        annotations:
+          summary: "Fastly CDN service {{ $labels.service_name }} is receiving elevated numbers of 5xx responses"
+          grafana_path: >-
+            d/deqpydcv7ottse/fastly-global-traffic?orgId=1&from=now-1h&to=now&timezone=browser
+          description: >-
+            The Fastly CDN service is receiving a higher proportion of 5xx responses
             from the origin than usual.
 
             Fastly CDN service: {{ $labels.service_name }}

--- a/charts/monitoring-config/rules/fastly.yaml
+++ b/charts/monitoring-config/rules/fastly.yaml
@@ -47,8 +47,8 @@ groups:
       - alert: High5xxRate
         expr: |
           (
-            sum by(service_name)(rate(fastly_rt_status_group_total{status_group="5xx"}[2m]))
-          / sum by(service_name)(rate(fastly_rt_origin_fetches_total[2m]))
+            sum by(service_name)(rate(fastly_rt_status_group_total{status_group="5xx", service_name !~ ".*data.gov.uk"}[2m]))
+          / sum by(service_name)(rate(fastly_rt_origin_fetches_total{service_name !~ ".*data.gov.uk"}[2m]))
           ) >= 0.0125
         for: 6m
         labels:

--- a/charts/monitoring-config/rules/fastly_tests.yaml
+++ b/charts/monitoring-config/rules/fastly_tests.yaml
@@ -14,7 +14,7 @@ tests:
 
 
       - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="example"}'
-        values: '0x10 0+50x10 50+150x10' # 0 + 0/min change (0%); 0 + 50/min (0.005%) change; 50 + 150/min change (1.5%)
+        values: '0x10 0+50x10 50+150x10' # 0 + 0/min change (0%); 0 + 50/min (0.5%) change; 50 + 150/min change (1.5%)
 
     alert_rule_test:
       # Not alerting to begin with
@@ -48,7 +48,7 @@ tests:
               summary: "Fastly CDN service example is receiving elevated numbers of 5xx responses"
               grafana_path: "d/deqpydcv7ottse/fastly-global-traffic?orgId=1&from=now-1h&to=now&timezone=browser"
               description: >-
-                The Fastly CDN service is receiving a higher proportion 5xx responses
+                The Fastly CDN service is receiving a higher proportion of 5xx responses
                 from the origin than usual.
 
                 Fastly CDN service: example
@@ -69,4 +69,72 @@ tests:
       # Rate is high enough but not alerting because it's data.gov.uk
       - eval_time: 10m
         alertname: High5xxRate
+        exp_alerts: []
+
+  ##
+  # Test case: High5xxRate_DataGovUk happy path
+  ##
+  - interval: 1m
+    input_series:
+      - series: 'fastly_rt_origin_fetches_total{service_name="environment data.gov.uk"}'
+        values: '0+10000x60' # 10k change per minute
+
+
+      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="environment data.gov.uk"}'
+        values: '0x10 0+50x10 50+1500x40' # 0 + 0/min change (0%); 0 + 50/min (0.5%) change; 50 + 1000/min change (10.5%)
+
+    alert_rule_test:
+      # Not alerting to begin with
+      - eval_time: 0m
+        alertname: High5xxRate_DataGovUk
+
+        exp_alerts: []
+
+      # Not alerting at 10m because the rate isn't high enough
+      - eval_time: 10m
+        alertname: High5xxRate_DataGovUk
+
+        exp_alerts: []
+
+      # Not alerting at 23m because the rate is high, but not for long enough
+      - eval_time: 23m
+        alertname: High5xxRate_DataGovUk
+
+        exp_alerts: []
+
+      # Alerting at 55m because the rate is high and has been for long enough
+      - eval_time: 55m
+        alertname: High5xxRate_DataGovUk
+
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-platform-engineering
+              service_name: environment data.gov.uk
+            exp_annotations:
+              summary: "Fastly CDN service environment data.gov.uk is receiving elevated numbers of 5xx responses"
+              grafana_path: "d/deqpydcv7ottse/fastly-global-traffic?orgId=1&from=now-1h&to=now&timezone=browser"
+              description: >-
+                The Fastly CDN service is receiving a higher proportion of 5xx responses
+                from the origin than usual.
+
+                Fastly CDN service: environment data.gov.uk
+                5xx rate: 15%
+
+  ##
+  # Test case: High5xxRate_DataGovUk does not fire for data.gov.uk
+  ##
+  - interval: 1m
+    input_series:
+      - series: 'fastly_rt_origin_fetches_total{service_name="example"}'
+        values: '0+10000x30' # 10k change per minute
+
+
+      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="example"}'
+        values: '1000+1000x30' # 1000 + 100/min change (1%)
+
+    alert_rule_test:
+      # Rate is high enough but not alerting because it's data.gov.uk
+      - eval_time: 25m
+        alertname: High5xxRate_DataGovUk
         exp_alerts: []

--- a/charts/monitoring-config/rules/fastly_tests.yaml
+++ b/charts/monitoring-config/rules/fastly_tests.yaml
@@ -4,6 +4,9 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
+  ##
+  # Test case: High5xxRate happy path
+  ##
   - interval: 1m
     input_series:
       - series: 'fastly_rt_origin_fetches_total{service_name="example"}'
@@ -50,3 +53,20 @@ tests:
 
                 Fastly CDN service: example
                 5xx rate: 1.5%
+  ##
+  # Test case: High5xxRate does not fire for data.gov.uk
+  ##
+  - interval: 1m
+    input_series:
+      - series: 'fastly_rt_origin_fetches_total{service_name="environment data.gov.uk"}'
+        values: '0+10000x20' # 10k change per minute
+
+
+      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="environment data.gov.uk"}'
+        values: '50+150x20' # 50 + 150/min change (1.5%)
+
+    alert_rule_test:
+      # Rate is high enough but not alerting because it's data.gov.uk
+      - eval_time: 10m
+        alertname: High5xxRate
+        exp_alerts: []


### PR DESCRIPTION
We found that the alert fired for data.gov.uk much more frequently than we'd like. We can tolerate a much higher error rate for that than other services.
 
Rather than remove the alert for data.gov.uk altogether, we exclude it from the original alert and define a new one with a more appropriate threshold.