### PR TITLE
.Alerts always exists, but it can be empty.

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_slack-body-templates.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_slack-body-templates.tpl
@@ -8,7 +8,7 @@
 {{`{{ .CommonAnnotations.description }}`}}
 {{`{{ end }}`}}
 
-{{`{{ if .Alerts }}`}}
+{{`{{ if .Alerts | len | gt 0 }}`}}
 *Expiring Tokens*
 ================
 {{`{{ range .Alerts }}`}}
@@ -45,7 +45,7 @@
 {{`{{ .CommonAnnotations.description }}`}}
 {{`{{ end }}`}}
 
-{{`{{ if .Alerts }}`}}
+{{`{{ if .Alerts | len | gt 0 }}`}}
 *Mirrors:*
 ================
 {{`{{ range .Alerts }}`}}
@@ -83,14 +83,14 @@
 {{`{{ .CommonAnnotations.description }}`}}
 {{`{{ end }}`}}
 
-{{`{{- if .CommonLabels.SortedPairs }}`}}
+{{`{{- if .CommonLabels.SortedPairs | len | gt 0 }}`}}
 *Labels*:
   {{`{{ range .CommonLabels.SortedPairs }}`}}
   • *{{`{{ .Name }}`}}*: {{`{{ .Value }}`}}
   {{`{{- end }}`}}
 {{`{{ end }}`}}
 
-{{`{{ if .Alerts }}`}}
+{{`{{ if .Alerts | len | gt 0 }}`}}
 *Firing Alerts*
 ================
 {{`{{ range .Alerts }}`}}


### PR DESCRIPTION
## What?
This changes the .Alert and .Labels.SortedPairs checks to do a length check instead - these keys are usually present but can be empty, which means it will always be true so the logic check was effectively doing nothing.

Passes a brief `helm template .` check.