### PR TITLE
♻️ Reduce post-sync workflow slack alert verbosity

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -132,14 +132,14 @@ spec:
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
                 - name: text
-                  value: "🔴 {{"{{workflow.parameters.application}}"}} post-deploy workflow failed in {{ .Values.govukEnvironment }}\n\nService Status: {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\nImage: {{"{{workflow.parameters.imageTag}}"}}\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
+                  value: "Service: {{"{{workflow.parameters.application}}"}}\nStage: Post-deploy :x:\nImage: {{"{{workflow.parameters.imageTag}}"}}\nEnvironment: {{ .Values.govukEnvironment }}\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\nHelm Chart: {{ .Chart.Name }}\nTroubleshooting: https://docs.publishing.service.gov.uk/manual/deployments.html#troubleshooting"
                 - name: blocks
                   value: |
                     [{
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "🔴 *{{"{{workflow.parameters.application}}"}}* post-deploy workflow failed in *{{ .Values.govukEnvironment }}*\n\n*Service Status:* {{"{{workflow.parameters.application}}"}} deployment succeeded but post-deploy checks failed\n*Image:* {{"{{workflow.parameters.imageTag}}"}}\n*Repo:* https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n{{"{{ steps.parse-failures.outputs.parameters.message }}"}}\n\n💡 *Next Steps:*\n• Click 'View workflow' button below to see detailed test results\n• Check the pod logs for specific test failures (e.g., Playwright output)\n• Look for failed test names and error details in the logs\n• Service should still be operational on previous version"
+                          "text": "*Service:* {{"{{workflow.parameters.application}}"}}\n*Stage:* Post-deploy :x:\n*Image:* {{"{{workflow.parameters.imageTag}}"}}\n*Environment:* {{ .Values.govukEnvironment }}\n*Repo:* https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n*Helm Chart:* {{ .Chart.Name }}\n*Troubleshooting:* <https://docs.publishing.service.gov.uk/manual/deployments.html#troubleshooting|Troubleshooting Guide>"
                       },
                       "accessory": {
                         "type": "button",


### PR DESCRIPTION
Replace verbose failure details and lengthy next steps with concise format showing only essential information: service, stage, image, environment, repo, helm chart, and troubleshooting link.

This addresses user feedback that alerts were too long and difficult to scan quickly when multiple alerts are present.

See the following conversation for more info:
https://gds.slack.com/archives/C01EE7US9R6/p1752832387670359
