### PR TITLE
High5xxRate alert: use fastly_origin_status_group_total

### DIFF
--- a/charts/monitoring-config/rules/fastly.yaml
+++ b/charts/monitoring-config/rules/fastly.yaml
@@ -47,7 +47,7 @@ groups:
       - alert: High5xxRate
         expr: |
           (
-            sum by(service_name)(rate(fastly_rt_status_group_total{status_group="5xx", service_name !~ ".*data.gov.uk"}[2m]))
+            sum by(service_name)(rate(fastly_origin_status_group_total{status_group="5xx", service_name !~ ".*data.gov.uk"}[2m]))
           / sum by(service_name)(rate(fastly_rt_origin_fetches_total{service_name !~ ".*data.gov.uk"}[2m]))
           ) >= 0.0125
         for: 6m
@@ -68,7 +68,7 @@ groups:
       - alert: High5xxRate_DataGovUk
         expr: |
           (
-            sum by(service_name)(rate(fastly_rt_status_group_total{status_group="5xx", service_name =~ ".*data.gov.uk"}[2m]))
+            sum by(service_name)(rate(fastly_origin_status_group_total{status_group="5xx", service_name =~ ".*data.gov.uk"}[2m]))
           / sum by(service_name)(rate(fastly_rt_origin_fetches_total{service_name =~ ".*data.gov.uk"}[2m]))
           ) >= 0.10
         for: 20m

--- a/charts/monitoring-config/rules/fastly_tests.yaml
+++ b/charts/monitoring-config/rules/fastly_tests.yaml
@@ -13,7 +13,7 @@ tests:
         values: '0+10000x30' # 10k change per minute
 
 
-      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="example"}'
+      - series: 'fastly_origin_status_group_total{status_group="5xx", service_name="example"}'
         values: '0x10 0+50x10 50+150x10' # 0 + 0/min change (0%); 0 + 50/min (0.5%) change; 50 + 150/min change (1.5%)
 
     alert_rule_test:
@@ -62,7 +62,7 @@ tests:
         values: '0+10000x20' # 10k change per minute
 
 
-      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="environment data.gov.uk"}'
+      - series: 'fastly_origin_status_group_total{status_group="5xx", service_name="environment data.gov.uk"}'
         values: '50+150x20' # 50 + 150/min change (1.5%)
 
     alert_rule_test:
@@ -80,7 +80,7 @@ tests:
         values: '0+10000x60' # 10k change per minute
 
 
-      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="environment data.gov.uk"}'
+      - series: 'fastly_origin_status_group_total{status_group="5xx", service_name="environment data.gov.uk"}'
         values: '0x10 0+50x10 50+1500x40' # 0 + 0/min change (0%); 0 + 50/min (0.5%) change; 50 + 1000/min change (10.5%)
 
     alert_rule_test:
@@ -130,7 +130,7 @@ tests:
         values: '0+10000x30' # 10k change per minute
 
 
-      - series: 'fastly_rt_status_group_total{status_group="5xx", service_name="example"}'
+      - series: 'fastly_origin_status_group_total{status_group="5xx", service_name="example"}'
         values: '1000+1000x30' # 1000 + 100/min change (1%)
 
     alert_rule_test:


### PR DESCRIPTION
"fastly_origin_status_group_total" is a reasonably new metric which reports the number of responses from origins, grouped by their status group. Previously we used "fastly_rt_status_group_total" which was reporting the total number of responses sent by Fastly, including cached responses.

This was causing situations where the number of 5xx's being reported was a multiple of the total number of origin requests, because Fastly was serving 3 cached responses for every request that made it to the origin, for example. This resulted in an alerts reporting error rates in excess of 100%.