### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Anyone with write access can merge by default
+*
+
+# Platform Engineering review required
+# GitHub Actions workflows and repo config
+/.github/ @alphagov/gov-uk-platform-engineering
+# Ran as part of CI system
+/govuk-app-render.sh @alphagov/gov-uk-platform-engineering
+# Helm Charts
+/charts/ @alphagov/gov-uk-platform-engineering
+
+# Allow changes to non-prod app values
+/charts/app-config/values-integration.yaml
+/charts/app-config/values-staging.yaml


### PR DESCRIPTION
Adds an initial code owners file. This file requires a review from Platform Engineering team members for changes to Helm charts, but allows changes to app values in non-production environments.

It also protects the `.github` directory, which contains GitHub Actions workflows and repository configuration files.

https://github.com/alphagov/govuk-infrastructure/issues/2170