### PR TITLE
Update cost per query for search dashboard

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-search.json
+++ b/charts/monitoring-config/dashboards/govuk-search.json
@@ -278,7 +278,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum (increase(http_requests_total{\n    namespace=\"apps\",\n    job=\"search-api-v2\",\n    controller=\"searches\"\n}[$__range])) * (2/1000)",
+          "expr": "sum (increase(http_requests_total{\n    namespace=\"apps\",\n    job=\"search-api-v2\",\n    controller=\"searches\"\n}[$__range])) * (1.5/1000)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
The cost has reduced from $2 to $1.5 per 1000 queries

[Trello](https://trello.com/c/YICAuUBD/888-update-costs-on-search-dashboard)

<img width="1307" height="559" alt="Screenshot 2025-07-21 at 11 44 09" src="https://github.com/user-attachments/assets/dfd2c1bd-cf49-4187-96e0-0df8ea60a25f" />
