### PR TITLE
Update runbook link for search alerts

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -169,7 +169,7 @@ spec:
           url: "https://grafana.eks.{{ "{{ .CommonLabels.environment }}" }}.govuk.digital/d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser"
         - text: ":book: Runbook"
           type: button
-          url: "https://docs.publishing.service.gov.uk/repos/search-api-v2.html"
+          url: "https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager"
   - name: "slack-search-team-main-channel"
     slackConfigs:
     - <<: *slack-search-team-alerts-channel


### PR DESCRIPTION
To link out to the new monitoring documentation.

https://trello.com/c/Dlde6NEF/890-add-developer-documentation-for-alerting-and-monitoring