### PR TITLE
Change CPU limit on govuk-chat pod autoscaling

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1668,7 +1668,7 @@ govukApplications:
                   name: cpu
                   target:
                     type: Utilization
-                    averageUtilization: 65
+                    averageUtilization: 80
         - name: govuk-chat-worker
           enabled: true
           spec:


### PR DESCRIPTION
## What

Increase CPU limit for autoscaling govuk-chat from 65 to 80

## Why

Autoscaling is triggering when pods are well below capacity