### PR TITLE
Add kubernetes-events-shipper chart for shipping k8s events to logit

### DIFF
--- a/charts/kubernetes-events-shipper/.helmignore
+++ b/charts/kubernetes-events-shipper/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kubernetes-events-shipper/Chart.yaml
+++ b/charts/kubernetes-events-shipper/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kubernetes-events-shipper
+description: Creates a fluent bit stateful set which will send all kuberenetes events in a cluster to logit
+type: application
+version: "1.0.0"

--- a/charts/kubernetes-events-shipper/templates/_helpers.tpl
+++ b/charts/kubernetes-events-shipper/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-events-shipper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-events-shipper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-events-shipper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-events-shipper.labels" -}}
+helm.sh/chart: {{ include "kubernetes-events-shipper.chart" . }}
+{{ include "kubernetes-events-shipper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubernetes-events-shipper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-events-shipper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kubernetes-events-shipper/templates/cluster-role-binding.yaml
+++ b/charts/kubernetes-events-shipper/templates/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "kubernetes-events-shipper"
+  labels:
+    {{- include "kubernetes-events-shipper.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "kubernetes-events-shipper"
+subjects:
+- kind: ServiceAccount
+  name: "kubernetes-events-shipper"
+  namespace: "cluster-services"

--- a/charts/kubernetes-events-shipper/templates/cluster-role.yaml
+++ b/charts/kubernetes-events-shipper/templates/cluster-role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "kubernetes-events-shipper"
+  labels:
+    {{- include "kubernetes-events-shipper.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: 
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - watch
+      - list

--- a/charts/kubernetes-events-shipper/templates/config-map.yaml
+++ b/charts/kubernetes-events-shipper/templates/config-map.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "kubernetes-events-shipper"
+data:
+  fluent-bit.yaml: |
+    service:
+      flush: 1
+      log_level: info
+
+    pipeline:
+      inputs:
+        - name: kubernetes_events
+          tag: k8s_events
+          db: /mnt/k8s-events/k8s-events.db
+
+      outputs:
+        - name: stdout # We probably want to ditch this when it's working
+          match: '*'
+        - name: opensearch
+          match: '*'
+          host: "${OPENSEARCH_HOST}"
+          port: 443
+          tls: true
+          tls.verify: true
+          http_user: "${OPENSEARCH_USER}"
+          http_passwd: "${OPENSEARCH_PASS}"
+          logstash_format: true # This causes the index to be suffixed with -YYYY.MM.DD and an @timestamp field to be added
+          logstash_prefix: kubernetes-events
+          suppress_type_name: true

--- a/charts/kubernetes-events-shipper/templates/config-map.yaml
+++ b/charts/kubernetes-events-shipper/templates/config-map.yaml
@@ -15,8 +15,6 @@ data:
           db: /mnt/k8s-events/k8s-events.db
 
       outputs:
-        - name: stdout # We probably want to ditch this when it's working
-          match: '*'
         - name: opensearch
           match: '*'
           host: "${OPENSEARCH_HOST}"

--- a/charts/kubernetes-events-shipper/templates/service-account.yaml
+++ b/charts/kubernetes-events-shipper/templates/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "kubernetes-events-shipper"
+  namespace: "cluster-services"
+  labels:
+    {{- include "kubernetes-events-shipper.labels" . | nindent 4 }}

--- a/charts/kubernetes-events-shipper/templates/stateful-set.yaml
+++ b/charts/kubernetes-events-shipper/templates/stateful-set.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "kubernetes-events-shipper"
+  labels:
+    {{- include "kubernetes-events-shipper.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "kubernetes-events-shipper.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kubernetes-events-shipper.labels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: 600
+      serviceAccountName: kubernetes-events-shipper
+      containers:
+        - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          name: fluentbit
+          volumeMounts:
+            - name: fluentbit-config
+              subPath: fluent-bit.yaml
+              mountPath: /fluent-bit/etc/fluent-bit.yaml
+            - name: kubernetes-events-shipper-data
+              mountPath: /mnt/k8s-events/
+          env:
+            - name: OPENSEARCH_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: logit-opensearch
+                  key: host
+            - name: OPENSEARCH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: logit-opensearch
+                  key: user
+            - name: OPENSEARCH_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: logit-opensearch
+                  key: pass
+          command: ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.yaml"]
+      restartPolicy: Always
+      volumes:
+        - name: fluentbit-config
+          configMap:
+            name: kubernetes-events-shipper
+  volumeClaimTemplates:
+    - metadata: 
+        name: kubernetes-events-shipper-data
+      spec:
+        storageClassName: ebs-gp3
+        resources:
+          requests:
+            storage: 100Gi
+        accessModes:
+          - ReadWriteOncePod

--- a/charts/kubernetes-events-shipper/values.yaml
+++ b/charts/kubernetes-events-shipper/values.yaml
@@ -1,0 +1,4 @@
+image:
+  repository: cr.fluentbit.io/fluent/fluent-bit
+  tag: "4.0.5"
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
Add a helm chart which deploys a kubernetes events shipper.

* Uses fluent bit to:
  * read events from the kubernetes api
  * write them directly into opensearch in logit with index names of `kubernetes-events-YYYY-MM-DD`
  * Keep track of the status of events sent in a persistent volume (ebs gp3 volume)
* Deployed as a stateful set so we only have 1 running in a cluster. The logs get back populated by fluent bit as far back as needed (as tracked in it's DB file on the PV) or as far back as the events go from the kubernetes API.

Requires:

* https://github.com/alphagov/govuk-helm-charts/pull/3369
* The secrets to be populated for staging and production (test and integration are already done)

I've deployed this into an ephemeral cluster in test (using the integration stack). You can see some of the events it sent in [logit](https://kibana.logit.io/s/42f4d2d5-e9ce-451f-8ffc-cdb25bd624f8/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!t,sort:!()),metadata:(indexPattern:'8ac115c0-aac1-11e8-88ea-0383c11b333a',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-07-29T15:25:24.590Z',to:'2025-07-29T15:27:37.823Z'))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',key:_index,negate:!f,params:(query:kubernetes-events-2025.07.29),type:phrase),query:(match_phrase:(_index:kubernetes-events-2025.07.29)))),query:(language:kuery,query:'')))