### PR TITLE
Add Publisher-on-PG app to Production and Staging

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2330,6 +2330,122 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-bootstrap-gtm-id
 
+  - name: publisher-on-pg
+    helmValues:
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
+      dbMigrationEnabled: true
+      workers:
+        enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
+      redis:
+        enabled: true
+      cronTasks:
+        - name: reports-generate
+          task: "reports:generate"
+          schedule: "0 * * * *"
+        - name: publish-missed-scheduled-editions
+          task: "editions:publish_missed_scheduled_editions"
+          schedule: "11 1 * * *"
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "150"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "publisher-on-pg.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: publisher-on-pg.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 30s
+      extraEnv:
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publisher-on-pg
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publisher-on-pg
+              key: oauth_secret
+        - name: ASSET_MANAGER_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-asset-manager
+              key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-publishing-api
+              key: bearer_token
+        - name: FACT_CHECK_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_USERNAME
+        - name: FACT_CHECK_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_PASSWORD
+        - name: GOVUK_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publisher-notify
+              key: GOVUK_NOTIFY_API_KEY
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
+        - name: LINK_CHECKER_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-link-checker-api
+              key: bearer_token
+        - name: LINK_CHECKER_API_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: publisher-link-checker-api-callback-token
+              key: LINK_CHECKER_API_SECRET_TOKEN
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publisher-postgres
+              key: DATABASE_URL
+        - name: EMAIL_GROUP_BUSINESS
+          value: publisher-alerts-business@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_CITIZEN
+          value: publisher-alerts-citizen@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_DEV
+          value: govuk-dev@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
+          value: mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk
+        - name: FACT_CHECK_REPLY_TO_ADDRESS
+          value: govuk-fact-check@digital.cabinet-office.gov.uk
+        - name: FACT_CHECK_REPLY_TO_ID
+          value: e739d23a-b761-44af-9a99-a1eba0b75c7e
+        - name: GOVUK_NOTIFY_TEMPLATE_ID
+          value: *publishing-notify-template
+        - name: REPORTS_S3_BUCKET_NAME
+          value: govuk-production-publisher-csvs
+        - name: GOOGLE_TAG_MANAGER_ID
+          value: *publishing-bootstrap-gtm-id
+
   - name: publishing-api
     helmValues:
       arch: arm64

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2330,6 +2330,125 @@ govukApplications:
         - name: REPORTS_S3_BUCKET_NAME
           value: govuk-staging-publisher-csvs
 
+  - name: publisher-on-pg
+    helmValues:
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 1
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
+      dbMigrationEnabled: true
+      workers:
+        enabled: true
+      workerResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 200Mi
+      redis:
+        enabled: true
+      cronTasks:
+        - name: reports-generate
+          task: "reports:generate"
+          schedule: "0 * * * *"
+        - name: reschedule-pubs-after-db-restore  # non-prod only
+          task: "editions:requeue_scheduled_for_publishing"
+          schedule: "47 7 * * 1-5"
+        - name: publish-missed-scheduled-editions
+          task: "editions:publish_missed_scheduled_editions"
+          schedule: "23 5 * * *"
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "150"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "publisher-on-pg.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: publisher-on-pg.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 30s
+      extraEnv:
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publisher-on-pg
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-publisher-on-pg
+              key: oauth_secret
+        - name: ASSET_MANAGER_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-asset-manager
+              key: bearer_token
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-publishing-api
+              key: bearer_token
+        - name: FACT_CHECK_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_USERNAME
+        - name: FACT_CHECK_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: publisher-fact-check-email-account
+              key: FACT_CHECK_PASSWORD
+        - name: GOVUK_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: publisher-notify
+              key: GOVUK_NOTIFY_API_KEY
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
+        - name: LINK_CHECKER_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-link-checker-api
+              key: bearer_token
+        - name: LINK_CHECKER_API_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: publisher-link-checker-api-callback-token
+              key: LINK_CHECKER_API_SECRET_TOKEN
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: publisher-postgres
+              key: DATABASE_URL
+        - name: EMAIL_GROUP_BUSINESS
+          value: mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_CITIZEN
+          value: mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_DEV
+          value: mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk
+        - name: EMAIL_GROUP_FORCE_PUBLISH_ALERTS
+          value: mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk
+        - name: FACT_CHECK_SUBJECT_PREFIX  # TODO: remove in production.
+          value: staging
+        - name: FACT_CHECK_REPLY_TO_ADDRESS
+          value: govuk-fact-check-staging@digital.cabinet-office.gov.uk
+        - name: FACT_CHECK_REPLY_TO_ID
+          value: 88f713ff-7de0-43a6-8221-8721bedd103c
+        - name: GOVUK_NOTIFY_TEMPLATE_ID
+          value: *publishing-notify-template
+        - name: REPORTS_S3_BUCKET_NAME
+          value: govuk-staging-publisher-csvs
+
   - name: publishing-api
     helmValues:
       arch: arm64


### PR DESCRIPTION
Mirrors the config from Integration to enable migration on the main environements.