### PR TITLE
Add external secret config for kubernetes-events-shipper

### DIFF
--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.9.5
+version: 0.10.0

--- a/charts/cluster-secrets/templates/logit-opensearch.yaml
+++ b/charts/cluster-secrets/templates/logit-opensearch.yaml
@@ -2,19 +2,18 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: logit-opensearch
-  labels:
-    {{- include "external-secrets.labels" . | nindent 4 }}
+  namespace: {{ .Values.clusterServicesNamespace }}
   annotations:
     kubernetes.io/description: >
       The Logit OpenSearch endpoint and HTTP Basic Auth credentials
 spec:
-  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  refreshInterval: 1h
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
   target:
-    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
     name: logit-opensearch
+    creationPolicy: Owner
   dataFrom:
     - extract:
         key: govuk/kubernetes-events-shipper/logit-opensearch

--- a/charts/external-secrets/templates/kubernetes-events-shipper/opensearch.yaml
+++ b/charts/external-secrets/templates/kubernetes-events-shipper/opensearch.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: logit-opensearch
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      The Logit OpenSearch endpoint and HTTP Basic Auth credentials
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: logit-opensearch
+  dataFrom:
+    - extract:
+        key: govuk/kubernetes-events-shipper/logit-opensearch


### PR DESCRIPTION
Add external secrets config so the kubernetes events shipper has credentials for opensearch in logit

The events shipper is going in cluster-services which means it needs the secrets provisioned in cluster-secrets.

In an ephemeral cluster I ran `help upgrade cluster-services ./` in the directory in here and end up with the expected secret

```
$ helm list
NAME                        	NAMESPACE       	REVISION	UPDATED                                	STATUS  	CHART                              	APP VERSION
...SNIP...
cluster-secrets             	cluster-services	2       	2025-07-29 14:43:30.720039 +0100 BST   	deployed	cluster-secrets-0.10.0
...SNIP...
```


```
$ kubectl get secret logit-opensearch -o yaml
apiVersion: v1
data:
  host: REDACTED
  pass: REDACTED
  user: REDACTED
kind: Secret
metadata:
  annotations:
    kubernetes.io/description: |
      The Logit OpenSearch endpoint and HTTP Basic Auth credentials
    meta.helm.sh/release-name: cluster-secrets
    meta.helm.sh/release-namespace: cluster-services
    reconcile.external-secrets.io/data-hash: REDACTED
  creationTimestamp: "2025-07-29T13:43:32Z"
  labels:
    app.kubernetes.io/managed-by: Helm
    reconcile.external-secrets.io/created-by: REDACTED
    reconcile.external-secrets.io/managed: "true"
  name: logit-opensearch
  namespace: cluster-services
  ownerReferences:
  - apiVersion: external-secrets.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ExternalSecret
    name: logit-opensearch
    uid: c70366c3-641d-4d3c-950a-e769ffcc8846
  resourceVersion: "2113609"
  uid: 3bd79e9a-0173-4423-bdf2-14c4911aae77
type: Opaque
```

Note: The secrets have not yet been provisioned in AWS so we should wait until they are before merging