### PR TITLE
[DO NOT MERGE] Run bigquery:export cron job weekly on chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1574,6 +1574,10 @@ govukApplications:
         s3Directory: chat
         path: /app/public/assets/chat
       cronTasks:
+        - name: bigquery-export
+          task: "bigquery:export"
+          schedule: "0 5 * * 4"
+          timeZone: "Europe/London"
         # cron tasks disabled while application is not available to public
         # - name: promote-waiting-list
         #   task: "users:promote_waiting_list"


### PR DESCRIPTION
**Don't merge until https://github.com/alphagov/govuk-chat/pull/414 has been merged as it applies some related fixes**

We ran into an issue where we wanted to run the bigquery:export rake task to export data used in manual evluation to BigQuery and the rake task failed due to data integrity issues.

Had we not run it due to manual evaluation, we wouldn't have caught that there were issues with our application data for a lengthy period of time.

To try and avoid this in the future, we are going to run the rake task weekly on the integration environment on Thursday at 5am so that issues will trigger a Sentry alert and we can fix them.

We've chosedn to run it on Thursday at 5am for a couple of reasons:

- Our database gets synced with prod on Monday am. This means that we lose all data from the previous week. Running it on Thursday am gives us time to work on the fix before the next sync.
- Since the sync happens on Monday, we will have a reasonable amount of data to export and check for issues since API consumers will have had a couple of days to use the application.