### PR TITLE
Add runbook URL

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -48,6 +48,8 @@ groups:
           summary: "Search API v2: Degraded search performance (acute)"
           grafana_path: >-
             d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             5 minute rolling success rate for search requests has dropped below 99% for more than 10
             minutes.
@@ -61,6 +63,8 @@ groups:
           summary: "Search API v2: Degraded autocomplete performance (acute)"
           grafana_path: >-
             d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             5 minute rolling success rate for autocomplete requests has dropped below 90% for more
             than 10 minutes.
@@ -96,6 +100,8 @@ groups:
           summary: "Search API v2: Degraded search performance (mid)"
           grafana_path: >-
             d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             1 hour rolling success rate for search requests has dropped below 99.9% for more than 2
             hours.
@@ -131,6 +137,8 @@ groups:
           summary: "Search API v2: Degraded search performance (long)"
           grafana_path: >-
             d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             24 hour rolling success rate for search requests has dropped below 99.99% for more than 24
             hours.

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -122,6 +122,8 @@ tests:
               summary: "Search API v2: Degraded search performance (acute)"
               grafana_path: >-
                 d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "5 minute rolling success rate for search requests has dropped below 99% for more than 10 minutes."
 
   # Tests for AutocompleteDegradedAcute alert
@@ -152,6 +154,8 @@ tests:
               summary: "Search API v2: Degraded autocomplete performance (acute)"
               grafana_path: >-
                 d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "5 minute rolling success rate for autocomplete requests has dropped below 90% for more than 10 minutes."
 
   # Tests for search_api_v2:search_requests:rate1h
@@ -221,6 +225,8 @@ tests:
               summary: "Search API v2: Degraded search performance (mid)"
               grafana_path: >-
                 d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "1 hour rolling success rate for search requests has dropped below 99.9% for more than 2 hours."
 
   # Tests for search_api_v2:search_requests:rate24h
@@ -290,4 +296,6 @@ tests:
               summary: "Search API v2: Degraded search performance (long)"
               grafana_path: >-
                 d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "24 hour rolling success rate for search requests has dropped below 99.99% for more than 24 hours."


### PR DESCRIPTION
For search alerts.

Follow up to https://github.com/alphagov/govuk-helm-charts/pull/3361 where I added the link to the runbook button, but this PR adds it to the bullet point under **Links:**

<img width="669" height="437" alt="Screenshot 2025-07-30 at 10 00 44" src="https://github.com/user-attachments/assets/1b16b2a5-e319-434a-861e-2bcc4a042a28" />
