### PR TITLE
Add kubernetes-events-shipper to versioned charts release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
             charts/argo-bootstrap-ephemeral
             charts/cluster-secret-store
             charts/cluster-secrets
+            charts/kubernetes-events-shipper
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Given kubernetes-events-shipper is a chart in cluster-services we need to release it as a versioned chart so terraform can deploy it