### PR TITLE
fix: remove unused GOVUK_ENVIRONMENT_NAME variable

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -17,7 +17,6 @@ data:
   GOVUK_ASSET_ROOT: https://{{ .Values.assetsDomain }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
-  GOVUK_ENVIRONMENT_NAME: {{ .Values.govukEnvironment }}
   # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
   GOVUK_PROMETHEUS_EXPORTER: "true"
   GOVUK_PERSONALISATION_FEEDBACK_URI: https://signin.account.gov.uk/support


### PR DESCRIPTION
- This was only used by datagovuk_find, which is controlled by govuk-dgu-charts, not this chart. (It was used by some apps controlled by these charts, but quite a while ago). It was confusing when looking at the environment, so tidy it up.