### PR TITLE
Test Maintenance mode for Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2380,6 +2380,8 @@ govukApplications:
           value: *publishing-bootstrap-gtm-auth
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
+        - name: MAINTENANCE_MODE
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
[Trello card](https://trello.com/c/2p3y2bAZ/759-mongo-to-postgres-migrations-maintenance-mode)

Setting MAINTENANCE_MODE var to true so we can disable Publisher (for an agreed downtime needed for Postgres migration).
Please see relevant  [PR](https://github.com/alphagov/publisher/pull/2799)