### PR TITLE
Enabling maintenance mode on integration for publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2381,7 +2381,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
         - name: MAINTENANCE_MODE
-          value: "false"
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
We will be enabling maintenance mode for testing of our migration of data from MongoDB to PostgreSQL.