### PR TITLE
Disabling Maintenance Mode for Publisher on Production and Staging

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2330,7 +2330,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-bootstrap-gtm-id
         - name: MAINTENANCE_MODE
-          value: "true"
+          value: "false"
 
   - name: publisher-on-pg
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2330,7 +2330,7 @@ govukApplications:
         - name: REPORTS_S3_BUCKET_NAME
           value: govuk-staging-publisher-csvs
         - name: MAINTENANCE_MODE
-          value: "true"
+          value: "false"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
After incident resolution, setting Production and Staging back live. Leaving Integration on Maintenance for postgres migration testing.