### PR TITLE
Enable image promotion to production

### DIFF
--- a/charts/app-config/image-tags/integration/publisher-on-pg
+++ b/charts/app-config/image-tags/integration/publisher-on-pg
@@ -1,3 +1,3 @@
 image_tag: c8cca5311ad69d899cc835df93c9f3fb2f2958f1-on-pg
-automatic_deploys_enabled: false
-promote_deployment: false
+automatic_deploys_enabled: true
+promote_deployment: true


### PR DESCRIPTION
we want to be able to promote publisher-on-pg to staging and prod, this app is short lived and purpose of this is to have an app that connect to postgres db to allow data migration