### PR TITLE
Enable maintenace mode for publisher in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2381,7 +2381,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
         - name: MAINTENANCE_MODE
-          value: "false"
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
This is part of a test run for the data migration from MongoDB to PostgreSQL.