### PR TITLE
Turn off maintenance mode for publisher in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2381,7 +2381,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: *publishing-bootstrap-gtm-preview
         - name: MAINTENANCE_MODE
-          value: "true"
+          value: "false"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
Re-enable the app so that it can be used again.