### PR TITLE
Unsuspend db sync for GOV.UK Chat on integration

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -516,7 +516,6 @@ cronjobs:
         - op: backup
 
     chat-postgres:
-      suspend: true  # Temporarily suspended on integration for manual evaluation of content (david.gisbey 2025-07-18)
       schedule: "47 3 * * 1"
       db: govuk_chat_production
       operations:


### PR DESCRIPTION
We suspended the db sync for GOV.UK Chat on integration for manual evaluation. This has now been completed to we can unsuspend it.