### PR TITLE
Make `activeDeadlineSeconds` configurable for db migration job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4108,6 +4108,7 @@ govukApplications:
           task: "taxonomy:rebuild_cache"
           schedule: "*/10 7-20 * * *"
       dbMigrationEnabled: true
+      dbMigrationActiveDeadlineSeconds: 3700 # 1 hour + 10 min buffer to match StrongMigrations.statement_timeout
       workers:
         enabled: true
       workerResources:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3925,6 +3925,7 @@ govukApplications:
           task: "taxonomy:rebuild_cache"
           schedule: "*/10 7-20 * * *"
       dbMigrationEnabled: true
+      dbMigrationActiveDeadlineSeconds: 3700 # 1 hour + 10 min buffer to match StrongMigrations.statement_timeout
       workers:
         enabled: true
       redis:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3893,6 +3893,7 @@ govukApplications:
           task: "taxonomy:rebuild_cache"
           schedule: "*/10 7-20 * * *"
       dbMigrationEnabled: true
+      dbMigrationActiveDeadlineSeconds: 3700 # 1 hour + 10 min buffer to match StrongMigrations.statement_timeout
       workers:
         enabled: true
       workerResources:

--- a/charts/generic-govuk-app/templates/dbmigration-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-job.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
 spec:
-  activeDeadlineSeconds: 900
+  activeDeadlineSeconds: {{ .Values.dbMigrationActiveDeadlineSeconds }}
   backoffLimit: 1
   template:
     metadata:

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -48,6 +48,7 @@ redis:
 # dbMigrationEnabled controls whether Rails database migrations are run on install/upgrade.
 dbMigrationEnabled: false
 dbMigrationCommand: ["rails", "db:migrate"]
+dbMigrationActiveDeadlineSeconds: 900  # default deadline for migrations
 
 # cronTasks is a list of {name, command, schedule} and/or {name, task,
 # schedule}, which represent CronJobs to run either an arbitrary command or a


### PR DESCRIPTION
## Why

The strong_migrations gem recommends setting a high statement_timeout to allow long-running migrations (e.g. adding indexes concurrently). In Whitehall, [we’ve configured](https://github.com/alphagov/whitehall/pull/10298):

```
StrongMigrations.statement_timeout = 1.hour
StrongMigrations.lock_timeout = 10.seconds
```

However, the current Kubernetes Job definition for database migrations has a hardcoded `activeDeadlineSeconds: 900` (15 minutes), which means the job may be terminated before the migration completes — even if MySQL is still executing the long-running statement. This risks cutting off in-progress migrations and leaving the database in an inconsistent state.

## What

This commit:

- Adds a new configurable value: `dbMigrationActiveDeadlineSeconds` (default: 900)
- Updates dbmigration-job.yaml to use the value from `.Values.dbMigrationActiveDeadlineSeconds`
- Allows individual applications (e.g. whitehall-admin) to override this timeout via environment-specific values files (e.g. values-integration.yaml)