### PR TITLE
Suspend Signon database sync from production to staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -464,6 +464,7 @@ cronjobs:
           db: govuk_assets_production
 
     signon-mysql:
+      suspend: true # Disabled until 2025-08-15 while pen test is in progress on GOV.UK Chat.
       schedule: "3 1 * * 1-5"
       db: signon_production
       operations:


### PR DESCRIPTION

We have a pen test upcoming for GOV.UK Chat which requires Signon
accounts being created for the analysts. The test will be run on the
staging env.

These accounts were created in production and immediately suspended (as
we don't want to allow access to production). They have now been synced to
staging where the accounts will be activated so the test can be
performed.

We don't want the suspended accounts to be re-synced from production to
staging tonight otherwise the analysts won't be able to sign in.

So we'll pause the db syncing until the pen test is completed. The test
runs from 2025-08-08 until 2025-08-15.
