### PR TITLE
Disable GOV.UK Chat production -> staging syncing

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -260,6 +260,7 @@ cronjobs:
         - op: backup
 
     chat-postgres:
+      suspend: true # Disabled until 2025-08-15 while pen test is in progress on GOV.UK Chat.
       schedule: "47 1 * * 1-5"
       db: govuk_chat_production
       operations:

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -50,6 +50,7 @@ cronjobs:
         - name: SUBDOMAIN
           value: elasticsearch6
     chat-engine-cp-prod:
+      suspend: true # Disabled until 2025-08-15 while pen test is in progress on GOV.UK Chat.
       schedule: "12 2 * * *"
       args: [restore_latest]
       extraEnv:


### PR DESCRIPTION
We've got a pen test starting on 2025-08-08 for GOV.UK Chat and we 
want staging to be a consistent environment for the analysts to perform 
the test on.

This disables the production -> staging syncing for the databases and
OpenSearch indexes so that the data on staging doesn't get overwritten.
