### PR TITLE
Turn off deployments for GOV.UK Chat

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-chat
+++ b/charts/app-config/image-tags/integration/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v1269
-promote_deployment: true
+promote_deployment: false
 automatic_deploys_enabled: true

--- a/charts/app-config/image-tags/staging/govuk-chat
+++ b/charts/app-config/image-tags/staging/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v1269
-promote_deployment: true
-automatic_deploys_enabled: true
+promote_deployment: false
+automatic_deploys_enabled: false


### PR DESCRIPTION
Trello: https://trello.com/c/LOigsvUH/2697-set-up-and-later-revoke-access-to-application-for-ithc-testers

We're having a pen test done on GOV.UK Chat starting on 2025-08-08 in
the staging environment. We want the environment to be consistent while
the test is being carried out.

This commit disables promotion of deployment from integration to
staging, and turns off automatic deploys on staging.
