### PR TITLE
Allow configuring the endpoint for each k8s probe for generic-govuk-apps

### DIFF
--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -121,19 +121,23 @@ spec:
             {{- . | toYaml | trim | nindent 10 }}
           {{- else }}
           livenessProbe:
-            httpGet: &app-probe
-              path: /healthcheck/live
+            httpGet:
+              path: {{ .Values.kubernetesProbeEndpoints.livenessProbe }}
               port: http
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 30
           readinessProbe:
-            httpGet: *app-probe
+            httpGet:
+              path: {{ .Values.kubernetesProbeEndpoints.readinessProbe }}
+              port: http
             failureThreshold: 2
             periodSeconds: 5
             timeoutSeconds: 30
           startupProbe:
-            httpGet: *app-probe
+            httpGet:
+              path: {{ .Values.kubernetesProbeEndpoints.startupProbe }}
+              port: http
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 2

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -179,3 +179,8 @@ serviceAccount:
   create: false
   name: null
   annotations: {}
+
+kubernetesProbeEndpoints:
+  livenessProbe: "/healthcheck/live"
+  readinessProbe: "/healthcheck/live"
+  startupProbe: "/healthcheck/live"


### PR DESCRIPTION
Allow generic-govuk-app to have the startup, readiness, and liveness probe HTTP endpoints overridden.

For the app [static](https://github.com/alphagov/static) (to start with) we want to set the readinessProbe endpoint to /healthcheck/ready, this PR enables that configuration in a generalised way to allow any app to override the current default of /healthcheck/live for all 3 endpoints.

This PR alone should cause no change, since it's keeping the defaults. I'll do a follow on isolated PR just for static to change its behaviour

I deployed this version of the generic-govuk-app chart to integration for just content-data-api in https://github.com/alphagov/govuk-helm-charts/pull/3404, syncing argo rolled out no changes which is the intended result, so it's safe to merge this now.

However before we merge this we should merge https://github.com/alphagov/govuk-helm-charts/pull/3405 since this branch will get deleted and content-data-api sync will break