### PR TITLE
Set content-data-api to use govuk-helm-charts ref allow-configuring-k8s-probes-per-app for generic-govuk-application

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -586,6 +586,7 @@ govukApplications:
           value: "1000"
 
   - name: content-data-api
+    targetRevision: allow-configuring-k8s-probes-per-app
     helmValues:
       arch: arm64
       appResources:


### PR DESCRIPTION
I need to test https://github.com/alphagov/govuk-helm-charts/pull/3403 but as soon as it's merged it will apply to all apps in all envs immediately.

content-data is one of the apps our team owns, so in order to change #3403 temporarily set content-data-api to use my specific version of the generic-govuk-app chart.

I'll revert this PR later when I'm happy that everything is good.