### PR TITLE
Revert "Set content-data-api to use govuk-helm-charts ref allow-configuring-k8s-probes-per-app for generic-govuk-application"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -586,7 +586,6 @@ govukApplications:
           value: "1000"
 
   - name: content-data-api
-    targetRevision: allow-configuring-k8s-probes-per-app
     helmValues:
       arch: arm64
       appResources:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#3404

The test of this change was successful and we can revert content-data-api back to being the main branch.