### PR TITLE
Set startupProbe for static in integration to /healthcheck/ready

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3498,6 +3498,8 @@ govukApplications:
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
@@ -3553,6 +3555,8 @@ govukApplications:
         createSecret: false
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: DRAFT_ENVIRONMENT
           value: "1"


### PR DESCRIPTION
Set startupProbe for static in integration to /healthcheck/ready since this healthcheck now checks the emergency banner redis instance is available since https://github.com/alphagov/static/pull/3736

In integration I exec'd into a static and a draft-static pod to check it was working as expected:

```sh
$ kubectl exec -it deploy/static -- curl -v http://127.0.0.1:3000/healthcheck/ready; echo
Defaulted container "app" out of: app, nginx
*   Trying 127.0.0.1:3000...
* Connected to 127.0.0.1 (127.0.0.1) port 3000
> GET /healthcheck/ready HTTP/1.1
> Host: 127.0.0.1:3000
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
...SNIP...
{"status":"ok","checks":{"emergency_banner_redis_connectivity":{"status":"ok"}}}


$ kubectl exec -it deploy/draft-static -- curl -v http://127.0.0.1:3000/healthcheck/ready; echo
Defaulted container "app" out of: app, nginx
*   Trying 127.0.0.1:3000...
* Connected to 127.0.0.1 (127.0.0.1) port 3000
> GET /healthcheck/ready HTTP/1.1
> Host: 127.0.0.1:3000
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
...SNIP...
{"status":"ok","checks":{"emergency_banner_redis_connectivity":{"status":"ok"}}}
```
