### PR TITLE
GOV.UK Chat: switch answer strategy to use OpenAI

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1622,6 +1622,8 @@ govukApplications:
           value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "0"
+        - name: ANSWER_STRATEGY
+          value: "openai_structured_answer"
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
       serviceAccount:
         enabled: true


### PR DESCRIPTION

We're having a pen test performed on GOV.UK Chat and one of the
requirements is that we need to test the OpenAI side of things.

This changes the `ANSWER_STRATEGY` env var, which will make GOV.UK Chat
use OpenAI for all its LLM calls.

We'll remove this (and so switch back to the default of using Anthropic)
after the pen test is complete.
