### PR TITLE
Update publisher-api redis memory in prod 

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2466,6 +2466,11 @@ govukApplications:
         replicaCount: 3
       redis:
         enabled: true
+        config:
+          maxmemory: 2500mb
+        resources:
+          limits:
+            memory: 3000Mi
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
Set publisher-api reids to 3GB pod memory and 2.5GB max redis memory