### PR TITLE
fix: 🐛 this var is no longer needed and has a syntax issue

### DIFF
--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -81,7 +81,6 @@ spec:
           curl -s "${WEBHOOK_URL}/update-image-tag" \
             -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
             --json '{
-              "application": "{{"{{inputs.parameters.application}}"}}"
               "environment": "{{"{{inputs.parameters.environment}}"}}",
               "repoName": "{{"{{inputs.parameters.repoName}}"}}",
               "imageTag": "{{"{{inputs.parameters.imageTag}}"}}",


### PR DESCRIPTION
- This var was missed when reverting an earlier descion to not pass the application var on to update.
- It also has a missing `,` which is the cause of tags not being updated in the pipelines