### PR TITLE
Set startupProbe for static in staging to /healthcheck/ready

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3294,6 +3294,8 @@ govukApplications:
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
@@ -3349,6 +3351,8 @@ govukApplications:
         createSecret: false
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: DRAFT_ENVIRONMENT
           value: "1"


### PR DESCRIPTION
https://github.com/alphagov/govuk-helm-charts/pull/3406 has been deployed and live in integration for several days now and has seen several releases deploy.

So lets use the same probe now in staging.