### PR TITLE
Set startupProbe for static in production to /healthcheck/ready

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3317,6 +3317,8 @@ govukApplications:
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         # These GA/GTM values are not secrets (not even the the gtm_auth one).
         # https://github.com/alphagov/govuk-puppet/pull/8041
@@ -3368,6 +3370,8 @@ govukApplications:
         createSecret: false
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: DRAFT_ENVIRONMENT
           value: "1"


### PR DESCRIPTION
https://github.com/alphagov/govuk-helm-charts/pull/3406 has been deployed and live in integration for several days now and has seen several releases deploy.

https://github.com/alphagov/govuk-helm-charts/pull/3426 has been deployed and live in staging too.

So lets use the same probe now in production.