### PR TITLE
Purposefully try and deploy a bad emergency banner redis url for static in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3513,7 +3513,7 @@ govukApplications:
               name: signon-token-static-publishing-api
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
-          value: *emergency-banner-redis
+          value: "$(REDIS_URL)/1"
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
 


### PR DESCRIPTION
This is for a demo in our tech fortnightly meeting. The actual deployment will correctly fail since the startupProbe now ensures redis needs to be available.

The emergency banner healthcheck startupProbe has been deployed to integration for static and draft-static.

This change introduces the same breaking change that caused a previous incident, but this time intentionally and only for draft-static in integration. The change is to use a kubernetes dependent environment variable, but with the dependency undefined.

When argocd syncs this manifest it should fail to deploy and the old deployment should live on. During this time it should not serve any traffic to the new (broken) pods which can't pass a startup check.

As soon as this is merged I will open a revert PR so we can rectify the issue very quickly should the testing not go as planned.