### PR TITLE
Bump Checkout and Download Artifact Actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   render-charts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093   # v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0   # v5
         with:
           name: rendered-charts
           path: .
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093   # v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0   # v5
         with:
           name: rendered-charts
           path: .
@@ -77,7 +77,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5
         with:
           show-progress: false
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
@@ -87,7 +87,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5
         with:
           show-progress: false
       - run: make lint
@@ -95,7 +95,7 @@ jobs:
   promtool:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5
         with:
           show-progress: false
       - name: Run promtool checks

--- a/.github/workflows/sqlfluff.yml
+++ b/.github/workflows/sqlfluff.yml
@@ -9,7 +9,7 @@ jobs:
   sqlfluff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5
         with:
           show-progress: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5


### PR DESCRIPTION
## What?
This updates actions/checkout to v5 and actions/download-artifacts to v5, as Depdendabot was getting its wires crossed.