### PR TITLE
chore: 🤖 add consistent labels accross workflows

### DIFF
--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -7,6 +7,11 @@ spec:
     annotations:
       workflows.argoproj.io/title: "**deploy-image-{{ "{{workflow.parameters.repoName}}" }}-{{ "{{workflow.parameters.imageTag}}" }}**"
       workflows.argoproj.io/description: "`env: {{ "{{workflow.parameters.environment}}" }} promote: {{ "{{workflow.parameters.promoteDeployment}}" }}`"
+    labels:
+      repoName: "{{ `{{workflow.parameters.repoName}}` }}"
+      imageTag: "{{ `{{workflow.parameters.imageTag}}` }}"
+      promoteDeployment: "{{ `{{workflow.parameters.promoteDeployment}}` }}"
+      environment: "{{ `{{workflow.parameters.environment}}` }}"
   entrypoint: deploy-image
   onExit: exit-handler
   arguments:

--- a/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
+++ b/charts/argo-services/templates/workflows/update-image-tag/workflow.yaml
@@ -7,6 +7,11 @@ spec:
     annotations:
       workflows.argoproj.io/title: "**update-image-tag-{{ "{{workflow.parameters.repoName}}" }}-{{ "{{workflow.parameters.imageTag}}" }}**"
       workflows.argoproj.io/description: "`env: {{ "{{workflow.parameters.environment}}" }} promote: {{ "{{workflow.parameters.promoteDeployment}}" }}`"
+    labels:
+      repoName: "{{ `{{workflow.parameters.repoName}}` }}"
+      imageTag: "{{ `{{workflow.parameters.imageTag}}` }}"
+      promoteDeployment: "{{ `{{workflow.parameters.promoteDeployment}}` }}"
+      environment: "{{ `{{workflow.parameters.environment}}` }}"
   entrypoint: update-image-tag
   arguments:
     parameters:


### PR DESCRIPTION
Copy labels across from "post-sync" workflow to other deployment workflows.

```
      application: "{{ `{{workflow.parameters.application}}` }}"
      automaticDeploysEnabled: "{{ `{{workflow.parameters.automaticDeploysEnabled}}` }}"
```

The above labels are not available in the `update-image-tag` and the `deploy-image` workflows

closes: #https://github.com/alphagov/govuk-infrastructure/issues/1968