### PR TITLE
Revert changes for GOV.UK Chat ITHC

### DIFF
--- a/charts/app-config/image-tags/staging/govuk-chat
+++ b/charts/app-config/image-tags/staging/govuk-chat
@@ -1,3 +1,3 @@
 image_tag: v1288
 promote_deployment: true
-automatic_deploys_enabled: false
+automatic_deploys_enabled: true

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -258,7 +258,6 @@ cronjobs:
         - op: backup
 
     chat-postgres:
-      suspend: true # Disabled until 2025-08-15 while pen test is in progress on GOV.UK Chat.
       schedule: "47 1 * * 1-5"
       db: govuk_chat_production
       operations:
@@ -458,7 +457,6 @@ cronjobs:
           db: govuk_assets_production
 
     signon-mysql:
-      suspend: true # Disabled until 2025-08-15 while pen test is in progress on GOV.UK Chat.
       schedule: "3 1 * * 1-5"
       db: signon_production
       operations:

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -50,7 +50,6 @@ cronjobs:
         - name: SUBDOMAIN
           value: elasticsearch6
     chat-engine-cp-prod:
-      suspend: true # Disabled until 2025-08-15 while pen test is in progress on GOV.UK Chat.
       schedule: "12 2 * * *"
       args: [restore_latest]
       extraEnv:


### PR DESCRIPTION
This removes changes that were made for the GOV.UK Chat IT Healthcheck in the following pull requests:

- https://github.com/alphagov/govuk-helm-charts/pull/3396
- https://github.com/alphagov/govuk-helm-charts/pull/3398
- https://github.com/alphagov/govuk-helm-charts/pull/3399

We did find that some of the changes we introduced to the last one were automatically changed, much to our surprise [1]

[1]: https://github.com/alphagov/govuk-helm-charts/commit/9b18bb04335e64add337f3d7ba3dcf3b521c2567