### PR TITLE
Enable maintenance mode for Publisher in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2321,7 +2321,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: &publishing-bootstrap-gtm-preview env-18
         - name: MAINTENANCE_MODE
-          value: "false"
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
We are going to run a test of the DB migration from MongoDB to PostgreSQL.