### PR TITLE
[PP-7316] Add anonymous_user_id_secret to external secrets

### DIFF
--- a/charts/external-secrets/templates/anonymous-user-id.yaml
+++ b/charts/external-secrets/templates/anonymous-user-id.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: anonymous-user-id
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Shared secret for anonymising user ids, as per signon ADR 001
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: anonymous-user-id
+  dataFrom:
+    - extract:
+        key: govuk/publishing/anonymous_user_id_secret


### PR DESCRIPTION
This secret has been added manually in integration, staging and production. [More context for the secret here](https://github.com/alphagov/signon/blob/main/docs/arch/adr-001-pass-anonymised-user-ids-to-publishing-apps-and-analytics.md).

The secret needs to be shared between different applications (i.e. whitehall should get the same secret value as mainstream etc.). Consequently, I haven't put it in any of the app-specific directories, instead choosing to put it at the top level, alongside basic-auth.yaml which is also shared.

I'm interested in a discussion as to whether this file / directory is the right place for it - it's only going to be used in publishing apps (whitehall, travel advice, publisher, content-tagger, signon etc.), but that's not _all_ apps.