### PR TITLE
ILLUSTRATIVE Add reusable anonymous_user_id env var

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -906,6 +906,8 @@ govukApplications:
           memory: 200Mi
       redis:
         enabled: true
+      anonymous_user_ids:
+        enabled: true
       ingress:
         enabled: true
         annotations:
@@ -2200,6 +2202,8 @@ govukApplications:
           memory: 200Mi
       redis:
         enabled: true
+      anonymous_user_ids:
+        enabled: true
       cronTasks:
         - name: mail-fetcher
           command: "script/mail_fetcher"
@@ -3303,6 +3307,8 @@ govukApplications:
           memory: 200Mi
       redis:
         enabled: true
+      anonymous_user_ids:
+        enabled: true
       ingress:
         enabled: true
         annotations:
@@ -4060,6 +4066,8 @@ govukApplications:
           cpu: 10m
           memory: 512Mi
       redis:
+        enabled: true
+      anonymous_user_ids:
         enabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -106,6 +106,13 @@ spec:
             - name: SENTRY_RELEASE
               value: "{{ .Values.appImage.tag }}"
             {{- end }}
+            {{- if .Values.anonymous_user_ids.enabled }}
+            - name: ANONYMOUS_USER_ID_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: anonymous-user-id
+                  key: ANONYMOUS_USER_ID_SECRET
+            {{- end }}
             {{- if .Values.redis.enabled }}
             - name: REDIS_URL
               value: {{ .Values.redis.redisUrlOverride.app | default (printf "redis://%s-redis" $fullName) }}

--- a/charts/generic-govuk-app/values.yaml
+++ b/charts/generic-govuk-app/values.yaml
@@ -8,6 +8,9 @@ service:
 ingress:
   enabled: false
 
+anonymous_user_ids:
+  enabled: false
+
 # appEnabled determines whether the web app Deployment is created.
 appEnabled: true
 replicaCount: 2


### PR DESCRIPTION
https://github.com/alphagov/govuk-helm-charts/pull/3441 shows an approach of repeating the env var from external secret config across several publishing apps (we'd need about 13 I think).

This is another way of doing the same thing, a bit more similar to how we do Sentry etc.

I'm interested in which people think is better.