### PR TITLE
Enable maintenance mode for Publisher in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2273,7 +2273,7 @@ govukApplications:
         - name: REPORTS_S3_BUCKET_NAME
           value: govuk-staging-publisher-csvs
         - name: MAINTENANCE_MODE
-          value: "false"
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
Enable maintenance mode while we test database migration from MongoDB to PostgreSQL.