### PR TITLE
Add startup probe failure alertmanager rules

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -120,6 +120,12 @@ spec:
       clientURL: "https://alertmanager.{{ .Values.k8sExternalDomainSuffix }}/#/alerts?receiver={{ "{{ .Receiver | urlquery }}" }}"
       description: |-
         {{ "[{{ .Status | toUpper }}{{ if eq .Status \"firing\" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.description }}" }}
+  - name: 'slack-startup-probe-failures'
+    slackConfigs:
+    - channel: '#govuk-deploy-alerts'
+      {{- include "slack.template" . | nindent 6 }}
+      text: |-
+        {{- include "slack.text" . | nindent 8 }}
   - name: 'slack-signon-token-expiry'
     slackConfigs:
     - channel: '#govuk-publishing-platform-system-alerts'

--- a/charts/monitoring-config/rules/startup_probe_failure.yaml
+++ b/charts/monitoring-config/rules/startup_probe_failure.yaml
@@ -1,0 +1,27 @@
+groups:
+  - name: Startup Probes
+    rules:
+      - alert: StartupProbeFailure
+        expr: >-
+          label_replace(
+            prober_probe_total{
+              probe_type="Startup",
+              result="failed"
+            } >= 10,
+            "app_name",
+            "$1",
+            "pod",
+            "^(.*)-[A-Za-z0-9]+-[A-Za-z0-9]+$"
+          )
+          >= 30
+        labels:
+          severity: warning
+          destination: slack-startup-probe-failures
+        annotations:
+          summary: "{{ $labels.app_name }} is failing to start up"
+          description: >-
+            The {{ $labels.container }} container in the {{ $labels.app_name }} app is failing
+            to start up, the configured kubernetes startupProbe is failing (either timing out,
+            failing to connect, or returning an HTTP response code >= 400.
+
+            To find the exact reason you can run `kubectl -n {{ $labels.namespace }} describe pod {{ $labels.pod }}`

--- a/charts/monitoring-config/rules/startup_probe_failure_tests.yaml
+++ b/charts/monitoring-config/rules/startup_probe_failure_tests.yaml
@@ -1,0 +1,95 @@
+rule_files:
+  - startup_probe_failure.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - name: StartupProbeFailure - No alert with 29 failures
+    interval: 1m
+    input_series:
+      # No alert with 29 startupProbeFailures
+      - series: >-
+          prober_probe_total{
+          probe_type="Startup",
+          result="failed",
+          pod="draft-static-6556f687fd-94glb",
+          container="app",
+          namespace="apps"
+          }
+        values: '29x15'
+    alert_rule_test:
+      - alertname: StartupProbeFailure
+        eval_time: 5m
+        exp_alerts: []
+
+  - name: StartupProbeFailure - Alert with 30 failures correctly in apps namespace
+    interval: 1m
+    input_series:
+      # Alert with 30 startupProbeFailures in the apps namespace
+      - series: >-
+          prober_probe_total{
+          probe_type="Startup",
+          result="failed",
+          pod="draft-static-6556f687fd-94glb",
+          container="app",
+          namespace="apps"
+          }
+        values: '30x10'
+    alert_rule_test:
+      - alertname: StartupProbeFailure
+        eval_time: 5m
+        exp_alerts:
+          - exp_labels:
+              alertname: StartupProbeFailure
+              severity: warning
+              destination: slack-startup-probe-failures
+              probe_type: Startup
+              result: failed
+              pod: draft-static-6556f687fd-94glb
+              container: app
+              namespace: apps
+              app_name: draft-static
+            exp_annotations:
+              summary: draft-static is failing to start up
+              description: >-
+                The app container in the draft-static app is failing to start up, the configured
+                kubernetes startupProbe is failing (either timing out, failing to connect, or
+                returning an HTTP response code >= 400.
+
+                To find the exact reason you can run `kubectl -n apps describe pod draft-static-6556f687fd-94glb`
+
+  - name: StartupProbeFailure - Alert with 30 failures correctly in licensify namespace
+    interval: 1m
+    input_series:
+      # Alert with 30 startupProbeFailures in the licensify namespace
+      - series: >-
+          prober_probe_total{
+          probe_type="Startup",
+          result="failed",
+          pod="licensify-frontend-6556f687fd-94glb",
+          container="main",
+          namespace="licensify"
+          }
+        values: '30x10'
+    alert_rule_test:
+      - alertname: StartupProbeFailure
+        eval_time: 5m
+        exp_alerts:
+          - exp_labels:
+              alertname: StartupProbeFailure
+              severity: warning
+              destination: slack-startup-probe-failures
+              probe_type: Startup
+              result: failed
+              pod: licensify-frontend-6556f687fd-94glb
+              container: main
+              namespace: licensify
+              app_name: licensify-frontend
+            exp_annotations:
+              summary: licensify-frontend is failing to start up
+              description: >-
+                The main container in the licensify-frontend app is failing to start up, the configured
+                kubernetes startupProbe is failing (either timing out, failing to connect, or
+                returning an HTTP response code >= 400.
+
+                To find the exact reason you can run `kubectl -n licensify describe pod licensify-frontend-6556f687fd-94glb`


### PR DESCRIPTION
Add alerting to #govuk-deploy-alerts which informs us when the startProbes for an app are failing for an extended time