### PR TITLE
Purposefully try and deploy a bad emergency banner redis url for draft-static in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3542,7 +3542,7 @@ govukApplications:
               name: signon-token-static-publishing-api
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
-          value: *emergency-banner-redis
+          value: "$(REDIS_URL)/1"
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
 


### PR DESCRIPTION
We have deployed a rule to alert on pods failing to start from their startup probe. This change purposefully deploys a known-bad config for draft-static knowing that the startupProbes will fail, this is to test the alert.