### PR TITLE
Purposefully try and deploy a bad emergency banner redis url for draft-static in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3542,7 +3542,7 @@ govukApplications:
               name: signon-token-static-publishing-api
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
-          value: *emergency-banner-redis
+          value: "$(REDIS_URL)/1"
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
 


### PR DESCRIPTION
The previous attempt at this, the alerts didn't make it to slack. Only after I reverted did I realise I hadn't synced the alert manager routing and receivers config, so there was no receiver for the correct slack channel.