### PR TITLE
Add alertmanager routing rule for startup probe failures

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -41,6 +41,15 @@ spec:
         - inhours
     - matchers:
       - name: destination
+        value: slack-startup-probe-failures
+        matchType: =
+      receiver: 'slack-startup-probe-failures'
+      repeatInterval: 3h
+      groupWait: 1m
+      groupInterval: 30m
+      groupBy: [alertname, app_name]
+    - matchers:
+      - name: destination
         value: slack-platform-engineering
         matchType: =
       receiver: 'generic-slack-platform-engineering'


### PR DESCRIPTION
I missed the routing rule and so alertmanager is logging:

```
msg="skipping creation of receiver not referenced by any route" component=configuration receiver=monitoring/alertmanagerconfig-general/slack-startup-probe-failures
```

Of course it's also not sending my alert to slack