### PR TITLE
Purposefully try and deploy a bad emergency banner redis url for draft-static

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3542,7 +3542,7 @@ govukApplications:
               name: signon-token-static-publishing-api
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
-          value: *emergency-banner-redis
+          value: "$(REDIS_URL)/1"
         - name: USE_TMPDIR_PAGE_CACHE
           value: "true"
 


### PR DESCRIPTION
Follow on to test again after https://github.com/alphagov/govuk-helm-charts/pull/3454 and https://github.com/alphagov/govuk-helm-charts/pull/3452 both didn't trigger the alert