### PR TITLE
[PP-7316] Add ANONYMOUS_USER_ID_SECRET env vars to staging and prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -411,6 +411,11 @@ govukApplications:
         hosts:
           - name: collections-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: &anonymous_user_id_secret
+            secretKeyRef:
+              name: anonymous-user-id
+              key: ANONYMOUS_USER_ID_SECRET
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -512,6 +517,8 @@ govukApplications:
           cpu: 10m
           memory: 256Mi
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -717,6 +724,8 @@ govukApplications:
         hosts:
           - name: content-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -904,6 +913,8 @@ govukApplications:
           task: "metrics:taxonomy:record_all"
           schedule: "14 * * * *"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -1880,6 +1891,8 @@ govukApplications:
           schedule: "0 6 * * *"
       dbMigrationEnabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
           valueFrom:
             secretKeyRef:
@@ -2042,6 +2055,8 @@ govukApplications:
         hosts:
           - name: manuals-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2121,6 +2136,8 @@ govukApplications:
           cpu: 10m
           memory: 200Mi
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -2182,6 +2199,8 @@ govukApplications:
           - name: publisher.{{ .Values.k8sExternalDomainSuffix }}
       nginxProxyReadTimeout: 30s
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -2326,6 +2345,8 @@ govukApplications:
           - name: publisher-on-pg.{{ .Values.k8sExternalDomainSuffix }}
       nginxProxyReadTimeout: 30s
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -2578,6 +2599,8 @@ govukApplications:
           task: "post_out_of_sync_deploys"
           schedule: "30 7 * * 1-5"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -2807,6 +2830,8 @@ govukApplications:
       workers:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3124,6 +3149,8 @@ govukApplications:
         hosts:
           - name: service-manual-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3229,6 +3256,8 @@ govukApplications:
           task: "kubernetes:sync_token_secrets"
           schedule: "9 1 * * *"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GOVUK_CSP_REPORT_ONLY
           value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
@@ -3419,6 +3448,8 @@ govukApplications:
       redis:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3486,6 +3517,8 @@ govukApplications:
         hosts:
           - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -3568,6 +3601,8 @@ govukApplications:
       redis:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: AWS_S3_BUCKET_NAME
           value: govuk-production-support-api-csvs
         - name: EMERGENCY_CONTACT_DETAILS
@@ -3735,6 +3770,8 @@ govukApplications:
           task: "import:hits:refresh_materialized"
           schedule: "28 0,12 * * *"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3791,6 +3828,8 @@ govukApplications:
         hosts:
           - name: travel-advice-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -3895,6 +3934,8 @@ govukApplications:
         hosts:
           - name: whitehall-admin.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -418,6 +418,11 @@ govukApplications:
         hosts:
           - name: collections-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: &anonymous_user_id_secret
+            secretKeyRef:
+              name: anonymous-user-id
+              key: ANONYMOUS_USER_ID_SECRET
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -519,6 +524,8 @@ govukApplications:
           cpu: 10m
           memory: 256Mi
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: CONTENT_DATA_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -726,6 +733,8 @@ govukApplications:
         hosts:
           - name: content-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -918,6 +927,8 @@ govukApplications:
           task: "metrics:taxonomy:record_all"
           schedule: "14 * * * *"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -1881,6 +1892,8 @@ govukApplications:
           schedule: "0 6 * * *"
       dbMigrationEnabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
           valueFrom:
             secretKeyRef:
@@ -2043,6 +2056,8 @@ govukApplications:
         hosts:
           - name: manuals-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -2120,6 +2135,8 @@ govukApplications:
       redis:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -2184,6 +2201,8 @@ govukApplications:
           - name: publisher.{{ .Values.k8sExternalDomainSuffix }}
       nginxProxyReadTimeout: 30s
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -2331,6 +2350,8 @@ govukApplications:
           - name: publisher-on-pg.{{ .Values.k8sExternalDomainSuffix }}
       nginxProxyReadTimeout: 30s
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -2570,6 +2591,8 @@ govukApplications:
       podDisruptionBudget:
         minAvailable: 1
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -2804,6 +2827,8 @@ govukApplications:
           task: "completion:import_denylist"
           schedule: "56 2 * * 1-5"  # one hour after the DB is restored from production
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3108,6 +3133,8 @@ govukApplications:
         hosts:
           - name: service-manual-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3202,6 +3229,8 @@ govukApplications:
           task: "kubernetes:sync_token_secrets"
           schedule: "12 1 * * *"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GOVUK_CSP_REPORT_ONLY
           value: "true"
         - name: GOVUK_NOTIFY_TEMPLATE_ID
@@ -3404,6 +3433,8 @@ govukApplications:
       redis:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3469,6 +3500,8 @@ govukApplications:
         hosts:
           - name: specialist-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -3549,6 +3582,8 @@ govukApplications:
       redis:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: AWS_S3_BUCKET_NAME
           value: govuk-staging-support-api-csvs
         - name: EMERGENCY_CONTACT_DETAILS
@@ -3713,6 +3748,8 @@ govukApplications:
           task: "import:hits:refresh_materialized"
           schedule: "4 0,12 * * *"
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:
@@ -3767,6 +3804,8 @@ govukApplications:
         hosts:
           - name: travel-advice-publisher.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -3869,6 +3908,8 @@ govukApplications:
         hosts:
           - name: whitehall-admin.{{ .Values.k8sExternalDomainSuffix }}
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Follows on from https://github.com/alphagov/govuk-helm-charts/pull/3441 which did integration.

I checked I got all three values files the same with a bit of ruby:

```ruby
require "yaml"

def find_apps_with_secret(environment)
  yaml = YAML.load_file("charts/app-config/values-#{environment}.yaml", aliases: true)
  yaml["govukApplications"]
    .filter { |app|
      (app.dig("helmValues", "extraEnv") || []).map { |env| env["name"] }.include? "ANONYMOUS_USER_ID_SECRET"
    }
    .map { |app| app["name"] }
end

puts find_apps_with_secret("integration") == find_apps_with_secret("staging")
puts find_apps_with_secret("integration") == find_apps_with_secret("production")
```