### PR TITLE
Update the requested memory for frontend in all envs

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1350,7 +1350,7 @@ govukApplications:
           memory: 1Gi
         requests:
           cpu: 10m
-          memory: 400Mi
+          memory: 500Mi
       uploadFrontendErrorPagesEnabled: true
       ingress:
         enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1320,7 +1320,7 @@ govukApplications:
           memory: 4Gi
         requests:
           cpu: 500m
-          memory: 1Gi
+          memory: 1.5Gi
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1363,7 +1363,7 @@ govukApplications:
           memory: 4Gi
         requests:
           cpu: 500m
-          memory: 1Gi
+          memory: 1.5Gi
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital


### PR DESCRIPTION
Since we enabled ruby JIT compilation frontend is using more memory and keeps getting it's app container OOMKilled. It has plenty of headroom in the limit, but the requested is a touch too low. Update this in prod and staging to 1.5GiB, and in integration to 500MiB