### PR TITLE
Enable maintenance mode for publisher on production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2290,7 +2290,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_ID
           value: &publishing-bootstrap-gtm-id GTM-W573BJPG
         - name: MAINTENANCE_MODE
-          value: "false"
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
- For the final migration of publisher to postgres later today