### PR TITLE
Switch on maintenance mode for Publisher in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2340,7 +2340,7 @@ govukApplications:
         - name: GOOGLE_TAG_MANAGER_PREVIEW  # Non-prod only
           value: &publishing-bootstrap-gtm-preview env-18
         - name: MAINTENANCE_MODE
-          value: "false"
+          value: "true"
 
   - name: publisher-on-pg
     helmValues:


### PR DESCRIPTION
- To allow us to import the data we exported from production yesterday