### PR TITLE
Add additional sidekiq processes to GOV.UK Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1566,8 +1566,10 @@ govukApplications:
       workers:
         enabled: true
         types:
-          - command: ["sidekiq", "-C", "config/sidekiq.yml"]
-            name: worker
+          - command: ["sidekiq", "-C", "config/sidekiq_answer.yml"]
+            name: answer-worker
+          - command: ["sidekiq", "-C", "config/sidekiq_default.yml"]
+            name: default-worker
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
       ingress:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -604,8 +604,15 @@ govukApplications:
       workers:
         enabled: true
         types:
-          - command: ["sidekiq", "-C", "config/sidekiq.yml"]
-            name: worker
+          - command: ["sidekiq", "-C", "config/sidekiq_answer.yml"]
+            name: answer-worker
+            env:
+              - name: SIDEKIQ_CONCURRENCY
+                value: "25"
+              - name: DATABASE_POOL
+                value: "25"
+          - command: ["sidekiq", "-C", "config/sidekiq_default.yml"]
+            name: default-worker
           - command: ['rake', 'publishing_api:consumer']
             name: publishing-api-consumer
           - command: ['rake', 'publishing_api:bulk_import_consumer']

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -620,8 +620,10 @@ govukApplications:
       workers:
         enabled: true
         types:
-          - command: ["sidekiq", "-C", "config/sidekiq.yml"]
-            name: worker
+          - command: ["sidekiq", "-C", "config/sidekiq_answer.yml"]
+            name: answer-worker
+          - command: ["sidekiq", "-C", "config/sidekiq_default.yml"]
+            name: default-worker
           - command: ['rake', 'publishing_api:consumer']
             name: publishing-api-consumer
           - command: ['rake', 'publishing_api:bulk_import_consumer']


### PR DESCRIPTION
We're making changes to GOV.UK Chat to ensure user questions are prioritised over non-time-sensitive tasks.

We're introducing a bunch of jobs that will run after an answer is composed for analysis. These need to run on a separate Sidekiq process to ensure we don't block users from getting their questions answered.

We can remove the original worker config because the `default-worker` implements a :default queue which will be used in the meantime prior to https://github.com/alphagov/govuk-chat/pull/499 being merged

We're also scaling up the process which generates answers since that does the bulk of the work and is time critical on production ahead of the experiment we're running with the app.

The plan is:

1. merge the PR on GOV.UK Chat that adds the sidekiq config ✅ 
2. merge this PR
3. merge the PR on GOV.UK Docker that adds the new Sidekiq processes
4. merge the PR on GOV.UK Chat that uses the new Sidekiq processes
6. remove unused config on GOV.UK Chat