### PR TITLE
chore: 🤖 remove deployed_sha, as it's unused in release app

### DIFF
--- a/charts/argo-services/templates/workflows/notify-release/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-release/workflow.yaml
@@ -27,7 +27,6 @@ spec:
               "repo": "alphagov/{{"{{inputs.parameters.repositoryName}}"}}",
               "deployment": {
                 "environment": "{{"{{inputs.parameters.environment}}"}}",
-                "deployed_sha": "{{"{{inputs.parameters.commitSha}}"}}",
                 "version": "{{"{{inputs.parameters.commitSha}}"}}"
               }
             }'


### PR DESCRIPTION
Now that we have removed the references to `deployed_sha` (we pull the latest deployed sha from the commits now), we can safely stop sending this data from argo.

related: https://github.com/alphagov/release/pull/1899
closes: https://github.com/alphagov/govuk-infrastructure/issues/2249