### PR TITLE
Update external secrets apiVersion from v1beta1 to v1 everywhere

### DIFF
--- a/charts/app-config-ephemeral/templates/repository-credentials.yaml
+++ b/charts/app-config-ephemeral/templates/repository-credentials.yaml
@@ -1,6 +1,6 @@
 # NOTE: This assumes that an AWS SecretsManager secret `govuk/alphagov-repo-creds`
 # exists with key `sshPrivateKey` (belonging to govuk-ci user).
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: alphagov-repo-creds

--- a/charts/argo-bootstrap-ephemeral/Chart.yaml
+++ b/charts/argo-bootstrap-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap-ephemeral
 description: Bootstraps ArgoCD for ephemeral environments
-version: 0.1.1
+version: 0.2.0

--- a/charts/argo-bootstrap-ephemeral/templates/repository-credentials.yaml
+++ b/charts/argo-bootstrap-ephemeral/templates/repository-credentials.yaml
@@ -1,6 +1,6 @@
 # NOTE: This assumes that an AWS SecretsManager secret `govuk/alphagov-repo-creds`
 # exists with key `sshPrivateKey` (belonging to govuk-ci user).
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: alphagov-repo-creds

--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps ArgoCD with initial configuration
-version: 0.3.4
+version: 0.4.0

--- a/charts/argo-bootstrap/templates/argocd/repository-credentials.yaml
+++ b/charts/argo-bootstrap/templates/argocd/repository-credentials.yaml
@@ -1,6 +1,6 @@
 # NOTE: This assumes that an AWS SecretsManager secret `govuk/alphagov-repo-creds`
 # exists with key `sshPrivateKey` (belonging to govuk-ci user).
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: alphagov-repo-creds

--- a/charts/argo-services/templates/notifications/secret.yaml
+++ b/charts/argo-services/templates/notifications/secret.yaml
@@ -2,7 +2,7 @@
 # both namespaces? If not, get rid of this and remove ClusterExternalSecret
 # from the list of allowed resource types in
 # charts/argo-bootstrap/templates/argocd/govuk-project.yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
 metadata:
   name: argocd-notifications-secret

--- a/charts/argo-services/templates/secrets/govuk-ci-github-creds.yaml
+++ b/charts/argo-services/templates/secrets/govuk-ci-github-creds.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-ci-github-creds

--- a/charts/argo-services/templates/secrets/slack-webhook-url.yaml
+++ b/charts/argo-services/templates/secrets/slack-webhook-url.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: slack-webhook-url

--- a/charts/argo-services/templates/workflows/post-sync/secrets.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/secrets.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.nextEnvironment }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: deploy-image-webhook-endpoint

--- a/charts/asset-manager/templates/rails-secret-key-base-external-secret.yaml
+++ b/charts/asset-manager/templates/rails-secret-key-base-external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rails.createKeyBaseSecret }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: asset-manager-rails-secret-key-base

--- a/charts/asset-manager/templates/sentry-external-secret.yaml
+++ b/charts/asset-manager/templates/sentry-external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if (and .Values.sentry.enabled .Values.sentry.createSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.repoName }}-sentry

--- a/charts/cluster-secret-store/Chart.yaml
+++ b/charts/cluster-secret-store/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secret-store
 description: An external-secrets ClusterSecretStore backed by AWS SecretsManager.
-version: 0.2.0
+version: 0.3.0

--- a/charts/cluster-secret-store/templates/cluster_secret_store.yaml
+++ b/charts/cluster-secret-store/templates/cluster_secret_store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: aws-secretsmanager

--- a/charts/cluster-secrets/Chart.yaml
+++ b/charts/cluster-secrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cluster-secrets
 description: A Helm chart for defining ExternalSecrets for cluster-wide services.
-version: 0.10.0
+version: 0.11.0

--- a/charts/cluster-secrets/templates/dex-argo-workflows.yaml
+++ b/charts/cluster-secrets/templates/dex-argo-workflows.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argo-workflows

--- a/charts/cluster-secrets/templates/dex-argocd.yaml
+++ b/charts/cluster-secrets/templates/dex-argocd.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-argocd

--- a/charts/cluster-secrets/templates/dex-github.yaml
+++ b/charts/cluster-secrets/templates/dex-github.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-github

--- a/charts/cluster-secrets/templates/dex-grafana.yaml
+++ b/charts/cluster-secrets/templates/dex-grafana.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.dexGrafanaSecretsNamespaces}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-grafana

--- a/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
+++ b/charts/cluster-secrets/templates/dex-prometheus-alertmanager.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.dexAlertManagerSecretsNamespaces}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-alertmanager
@@ -27,7 +27,7 @@ spec:
 {{- end }}
 {{- range .Values.dexPrometheusSecretsNamespaces}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-dex-prometheus

--- a/charts/cluster-secrets/templates/fastly-api.yaml
+++ b/charts/cluster-secrets/templates/fastly-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-fastly-api

--- a/charts/cluster-secrets/templates/grafana-database.yaml
+++ b/charts/cluster-secrets/templates/grafana-database.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-grafana-database

--- a/charts/cluster-secrets/templates/logit-host.yaml
+++ b/charts/cluster-secrets/templates/logit-host.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: logit-host

--- a/charts/cluster-secrets/templates/logit-opensearch.yaml
+++ b/charts/cluster-secrets/templates/logit-opensearch.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: logit-opensearch

--- a/charts/db-backup/templates/externalsecrets.yaml
+++ b/charts/db-backup/templates/externalsecrets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "db-backup.fullname" . }}-passwd

--- a/charts/external-secrets/templates/account-api/notify.yaml
+++ b/charts/external-secrets/templates/account-api/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: account-api-notify

--- a/charts/external-secrets/templates/account-api/oauth.yaml
+++ b/charts/external-secrets/templates/account-api/oauth.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-account-oauth

--- a/charts/external-secrets/templates/account-api/postgres.yaml
+++ b/charts/external-secrets/templates/account-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: account-api-postgres

--- a/charts/external-secrets/templates/account-api/session-secret.yaml
+++ b/charts/external-secrets/templates/account-api/session-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: account-api-session-secret

--- a/charts/external-secrets/templates/anonymous-user-id.yaml
+++ b/charts/external-secrets/templates/anonymous-user-id.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: anonymous-user-id

--- a/charts/external-secrets/templates/asset-manager/docdb.yaml
+++ b/charts/external-secrets/templates/asset-manager/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: asset-manager-docdb

--- a/charts/external-secrets/templates/authenticating-proxy/jwt-auth-secret.yaml
+++ b/charts/external-secrets/templates/authenticating-proxy/jwt-auth-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authenticating-proxy-jwt-auth-secret

--- a/charts/external-secrets/templates/authenticating-proxy/postgres.yaml
+++ b/charts/external-secrets/templates/authenticating-proxy/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authenticating-proxy-postgres

--- a/charts/external-secrets/templates/basic-auth.yaml
+++ b/charts/external-secrets/templates/basic-auth.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: basic-auth

--- a/charts/external-secrets/templates/bouncer/postgres.yaml
+++ b/charts/external-secrets/templates/bouncer/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: bouncer-postgres

--- a/charts/external-secrets/templates/collections-publisher/mysql.yaml
+++ b/charts/external-secrets/templates/collections-publisher/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: collections-publisher-mysql

--- a/charts/external-secrets/templates/collections-publisher/notify.yaml
+++ b/charts/external-secrets/templates/collections-publisher/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: collections-publisher-notify

--- a/charts/external-secrets/templates/content-data-admin/aws.yaml
+++ b/charts/external-secrets/templates/content-data-admin/aws.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-admin-aws

--- a/charts/external-secrets/templates/content-data-admin/notify.yaml
+++ b/charts/external-secrets/templates/content-data-admin/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-admin-notify

--- a/charts/external-secrets/templates/content-data-admin/postgres.yaml
+++ b/charts/external-secrets/templates/content-data-admin/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-admin-postgres

--- a/charts/external-secrets/templates/content-data-admin/siteimprove.yaml
+++ b/charts/external-secrets/templates/content-data-admin/siteimprove.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-admin-siteimprove-api-client

--- a/charts/external-secrets/templates/content-data-api/ga4.yaml
+++ b/charts/external-secrets/templates/content-data-api/ga4.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-api-ga4

--- a/charts/external-secrets/templates/content-data-api/google.yaml
+++ b/charts/external-secrets/templates/content-data-api/google.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-api-google-analytics

--- a/charts/external-secrets/templates/content-data-api/postgres.yaml
+++ b/charts/external-secrets/templates/content-data-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-api-postgres

--- a/charts/external-secrets/templates/content-data-api/rabbitmq.yaml
+++ b/charts/external-secrets/templates/content-data-api/rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-data-api-rabbitmq

--- a/charts/external-secrets/templates/content-publisher/notify.yaml
+++ b/charts/external-secrets/templates/content-publisher/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-publisher-notify

--- a/charts/external-secrets/templates/content-publisher/postgres.yaml
+++ b/charts/external-secrets/templates/content-publisher/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-publisher-postgres

--- a/charts/external-secrets/templates/content-store/docdb.yaml
+++ b/charts/external-secrets/templates/content-store/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-store-docdb

--- a/charts/external-secrets/templates/content-store/postgresql.yaml
+++ b/charts/external-secrets/templates/content-store/postgresql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-store-postgres

--- a/charts/external-secrets/templates/content-tagger/postgres.yaml
+++ b/charts/external-secrets/templates/content-tagger/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: content-tagger-postgres 

--- a/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
+++ b/charts/external-secrets/templates/draft-content-store-postgresql-branch/postgresql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: draft-content-store-postgres

--- a/charts/external-secrets/templates/email-alert-api/notify.yaml
+++ b/charts/external-secrets/templates/email-alert-api/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: email-alert-api-notify

--- a/charts/external-secrets/templates/email-alert-api/postgres.yaml
+++ b/charts/external-secrets/templates/email-alert-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: email-alert-api-postgres

--- a/charts/external-secrets/templates/email-alert-service/rabbitmq.yaml
+++ b/charts/external-secrets/templates/email-alert-service/rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: email-alert-service-rabbitmq

--- a/charts/external-secrets/templates/email-alert/auth.yaml
+++ b/charts/external-secrets/templates/email-alert/auth.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: email-alert-auth

--- a/charts/external-secrets/templates/feedback/assisted-digital-google-sheet.yaml
+++ b/charts/external-secrets/templates/feedback/assisted-digital-google-sheet.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: feedback-assisted-digital-google-sheet

--- a/charts/external-secrets/templates/feedback/notify.yaml
+++ b/charts/external-secrets/templates/feedback/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: feedback-notify

--- a/charts/external-secrets/templates/frontend/elections-api.yaml
+++ b/charts/external-secrets/templates/frontend/elections-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: frontend-elections-api

--- a/charts/external-secrets/templates/frontend/os-maps-api.yaml
+++ b/charts/external-secrets/templates/frontend/os-maps-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: frontend-os-maps-api

--- a/charts/external-secrets/templates/govuk-chat/bigquery.yaml
+++ b/charts/external-secrets/templates/govuk-chat/bigquery.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-bigquery

--- a/charts/external-secrets/templates/govuk-chat/notify.yaml
+++ b/charts/external-secrets/templates/govuk-chat/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-notify

--- a/charts/external-secrets/templates/govuk-chat/open-ai.yaml
+++ b/charts/external-secrets/templates/govuk-chat/open-ai.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-open-ai

--- a/charts/external-secrets/templates/govuk-chat/opensearch-test.yaml
+++ b/charts/external-secrets/templates/govuk-chat/opensearch-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-opensearch-test

--- a/charts/external-secrets/templates/govuk-chat/opensearch.yaml
+++ b/charts/external-secrets/templates/govuk-chat/opensearch.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-opensearch

--- a/charts/external-secrets/templates/govuk-chat/postgres.yaml
+++ b/charts/external-secrets/templates/govuk-chat/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-postgres

--- a/charts/external-secrets/templates/govuk-chat/rabbitmq.yaml
+++ b/charts/external-secrets/templates/govuk-chat/rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-rabbitmq

--- a/charts/external-secrets/templates/govuk-chat/slack.yaml
+++ b/charts/external-secrets/templates/govuk-chat/slack.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: govuk-chat-slack

--- a/charts/external-secrets/templates/imminence/postgres.yaml
+++ b/charts/external-secrets/templates/imminence/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: imminence-postgres

--- a/charts/external-secrets/templates/link-checker-api/google-api.yaml
+++ b/charts/external-secrets/templates/link-checker-api/google-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: link-checker-api-google-api-key

--- a/charts/external-secrets/templates/link-checker-api/postgres.yaml
+++ b/charts/external-secrets/templates/link-checker-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: link-checker-api-postgres

--- a/charts/external-secrets/templates/local-links-manager/google.yaml
+++ b/charts/external-secrets/templates/local-links-manager/google.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: local-links-manager-google

--- a/charts/external-secrets/templates/local-links-manager/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/local-links-manager/link-checker-api-callback-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: local-links-manager-link-checker-api-callback-token

--- a/charts/external-secrets/templates/local-links-manager/postgres.yaml
+++ b/charts/external-secrets/templates/local-links-manager/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: local-links-manager-postgres

--- a/charts/external-secrets/templates/locations-api/os-places.yaml
+++ b/charts/external-secrets/templates/locations-api/os-places.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: locations-api-os-places

--- a/charts/external-secrets/templates/locations-api/postgres.yaml
+++ b/charts/external-secrets/templates/locations-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: locations-api-postgres

--- a/charts/external-secrets/templates/manuals-publisher/docdb.yaml
+++ b/charts/external-secrets/templates/manuals-publisher/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: manuals-publisher-docdb

--- a/charts/external-secrets/templates/manuals-publisher/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/manuals-publisher/link-checker-api-callback-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: manuals-publisher-link-checker-api-callback-token

--- a/charts/external-secrets/templates/publisher-on-pg/postgresql.yaml
+++ b/charts/external-secrets/templates/publisher-on-pg/postgresql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publisher-on-pg

--- a/charts/external-secrets/templates/publisher/docdb.yaml
+++ b/charts/external-secrets/templates/publisher/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publisher-docdb

--- a/charts/external-secrets/templates/publisher/fact-check-email-account.yaml
+++ b/charts/external-secrets/templates/publisher/fact-check-email-account.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publisher-fact-check-email-account

--- a/charts/external-secrets/templates/publisher/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/publisher/link-checker-api-callback-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publisher-link-checker-api-callback-token

--- a/charts/external-secrets/templates/publisher/notify.yaml
+++ b/charts/external-secrets/templates/publisher/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publisher-notify

--- a/charts/external-secrets/templates/publisher/postgresql.yaml
+++ b/charts/external-secrets/templates/publisher/postgresql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publisher-postgres

--- a/charts/external-secrets/templates/publishing-api/bigquery.yaml
+++ b/charts/external-secrets/templates/publishing-api/bigquery.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publishing-api-bigquery

--- a/charts/external-secrets/templates/publishing-api/postgres.yaml
+++ b/charts/external-secrets/templates/publishing-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publishing-api-postgres

--- a/charts/external-secrets/templates/publishing-api/rabbitmq.yaml
+++ b/charts/external-secrets/templates/publishing-api/rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: publishing-api-rabbitmq

--- a/charts/external-secrets/templates/release/github.yaml
+++ b/charts/external-secrets/templates/release/github.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: release-github

--- a/charts/external-secrets/templates/release/mysql.yaml
+++ b/charts/external-secrets/templates/release/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: release-mysql

--- a/charts/external-secrets/templates/router/nginx-htpasswd.yaml
+++ b/charts/external-secrets/templates/router/nginx-htpasswd.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: router-nginx-htpasswd

--- a/charts/external-secrets/templates/search-admin/google-cloud-discovery-engine-configuration.yml
+++ b/charts/external-secrets/templates/search-admin/google-cloud-discovery-engine-configuration.yml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-admin-google-cloud-discovery-engine-configuration

--- a/charts/external-secrets/templates/search-admin/mysql.yaml
+++ b/charts/external-secrets/templates/search-admin/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-admin-mysql

--- a/charts/external-secrets/templates/search-admin/notify.yaml
+++ b/charts/external-secrets/templates/search-admin/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-admin-notify

--- a/charts/external-secrets/templates/search-api-v2/google-cloud-discovery-engine-configuration.yaml
+++ b/charts/external-secrets/templates/search-api-v2/google-cloud-discovery-engine-configuration.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-api-v2-google-cloud-discovery-engine-configuration

--- a/charts/external-secrets/templates/search-api-v2/rabbitmq.yaml
+++ b/charts/external-secrets/templates/search-api-v2/rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-api-v2-rabbitmq

--- a/charts/external-secrets/templates/search-api/google-analytics.yaml
+++ b/charts/external-secrets/templates/search-api/google-analytics.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-api-google-analytics

--- a/charts/external-secrets/templates/search-api/google-bigquery.yaml
+++ b/charts/external-secrets/templates/search-api/google-bigquery.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-api-google-bigquery

--- a/charts/external-secrets/templates/search-api/ltr-bigquery.yaml
+++ b/charts/external-secrets/templates/search-api/ltr-bigquery.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-api-ltr-bigquery

--- a/charts/external-secrets/templates/search-api/rabbitmq.yaml
+++ b/charts/external-secrets/templates/search-api/rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: search-api-rabbitmq

--- a/charts/external-secrets/templates/service-manual-publisher/notify.yaml
+++ b/charts/external-secrets/templates/service-manual-publisher/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: service-manual-publisher-notify

--- a/charts/external-secrets/templates/service-manual-publisher/postgres.yaml
+++ b/charts/external-secrets/templates/service-manual-publisher/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: service-manual-publisher-postgres

--- a/charts/external-secrets/templates/short-url-manager/docdb.yaml
+++ b/charts/external-secrets/templates/short-url-manager/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: short-url-manager-docdb

--- a/charts/external-secrets/templates/short-url-manager/notify.yaml
+++ b/charts/external-secrets/templates/short-url-manager/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: short-url-manager-notify

--- a/charts/external-secrets/templates/signon/active-record-encryption.yaml
+++ b/charts/external-secrets/templates/signon/active-record-encryption.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: active-record-encryption

--- a/charts/external-secrets/templates/signon/devise-pepper.yaml
+++ b/charts/external-secrets/templates/signon/devise-pepper.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: signon-devise-pepper

--- a/charts/external-secrets/templates/signon/devise-secret.yaml
+++ b/charts/external-secrets/templates/signon/devise-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: signon-devise-secret

--- a/charts/external-secrets/templates/signon/mysql.yaml
+++ b/charts/external-secrets/templates/signon/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: signon-mysql

--- a/charts/external-secrets/templates/signon/notify.yaml
+++ b/charts/external-secrets/templates/signon/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: signon-notify

--- a/charts/external-secrets/templates/specialist-publisher/docdb.yaml
+++ b/charts/external-secrets/templates/specialist-publisher/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: specialist-publisher-docdb

--- a/charts/external-secrets/templates/specialist-publisher/notify.yaml
+++ b/charts/external-secrets/templates/specialist-publisher/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: specialist-publisher-notify

--- a/charts/external-secrets/templates/support-api/notify.yaml
+++ b/charts/external-secrets/templates/support-api/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: support-api-notify

--- a/charts/external-secrets/templates/support-api/postgres.yaml
+++ b/charts/external-secrets/templates/support-api/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: support-api-postgres

--- a/charts/external-secrets/templates/support/emergency-contacts.yaml
+++ b/charts/external-secrets/templates/support/emergency-contacts.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: emergency-contacts

--- a/charts/external-secrets/templates/support/zendesk.yaml
+++ b/charts/external-secrets/templates/support/zendesk.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: support-zendesk

--- a/charts/external-secrets/templates/transition/aws.yaml
+++ b/charts/external-secrets/templates/transition/aws.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: transition-aws

--- a/charts/external-secrets/templates/transition/postgres.yaml
+++ b/charts/external-secrets/templates/transition/postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: transition-postgres

--- a/charts/external-secrets/templates/travel-advice-publisher/docdb.yaml
+++ b/charts/external-secrets/templates/travel-advice-publisher/docdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: travel-advice-publisher-docdb

--- a/charts/external-secrets/templates/travel-advice-publisher/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/travel-advice-publisher/link-checker-api-callback-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: travel-advice-publisher-link-checker-api-callback-token

--- a/charts/external-secrets/templates/whitehall/link-checker-api-callback-token.yaml
+++ b/charts/external-secrets/templates/whitehall/link-checker-api-callback-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: whitehall-link-checker-api-callback-token

--- a/charts/external-secrets/templates/whitehall/notify.yaml
+++ b/charts/external-secrets/templates/whitehall/notify.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: whitehall-notify

--- a/charts/external-secrets/templates/whitehall/whitehall-admin-mysql.yaml
+++ b/charts/external-secrets/templates/whitehall/whitehall-admin-mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: whitehall-admin-mysql

--- a/charts/generic-govuk-app/templates/rails-secret-key-base-external-secret.yaml
+++ b/charts/generic-govuk-app/templates/rails-secret-key-base-external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if (and .Values.rails.enabled .Values.rails.createKeyBaseSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.repoName }}-rails-secret-key-base

--- a/charts/generic-govuk-app/templates/sentry-external-secret.yaml
+++ b/charts/generic-govuk-app/templates/sentry-external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if (and .Values.sentry.enabled .Values.sentry.createSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.repoName }}-sentry

--- a/charts/govuk-e2e-tests/templates/externalsecrets.yaml
+++ b/charts/govuk-e2e-tests/templates/externalsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: test-signon-account

--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanager-secret.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanager-secret.yaml
@@ -1,5 +1,5 @@
 {{- if ne .Values.govukEnvironment "ephemeral" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: alertmanager-receivers

--- a/charts/kube-prometheus-stack-bootstrap/templates/grafana-admin-user-secret.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/grafana-admin-user-secret.yaml
@@ -1,7 +1,7 @@
 # TODO: this is probably not needed anymore
 # so we should investigate if it can be removed
 {{- if ne .Values.govukEnvironment "ephemeral" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana-admin-user

--- a/charts/kubernetes-events-shipper/Chart.yaml
+++ b/charts/kubernetes-events-shipper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: kubernetes-events-shipper
 description: Creates a fluent bit stateful set which will send all kuberenetes events in a cluster to logit
 type: application
-version: "1.0.0"
+version: "1.1.0"

--- a/charts/licensify/templates/config-externalsecret.yaml
+++ b/charts/licensify/templates/config-externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "licensify.fullname" . }}

--- a/charts/licensify/templates/envs-externalsecret.yaml
+++ b/charts/licensify/templates/envs-externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "licensify.fullname" . }}-envs

--- a/charts/mirror/templates/externalsecret.yaml
+++ b/charts/mirror/templates/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "mirror.fullname" . }}

--- a/charts/renovate/templates/github-token-secret.yaml
+++ b/charts/renovate/templates/github-token-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: renovate-github-token


### PR DESCRIPTION
# What?

1. Changes the apiVersion of everything using externalsecrets to v1 from v1beta1, this is also what [the external-secrets changelog for v0.17.0](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0) says to do.
2. Updates the version number for all the versioned charts we install via terraform instead of argo

# How to know it's safe?
We are currently on externalSecrets 0.16.2 which supports both v1beta1 and v1 apiVersions, however the CRD is set to serve both versions, but only store v1, so all our external secrets are already v1 internally in kubernetes. 

You can see in this kubectl command that if I request the yaml of all external secrets in all namespaces, they are already v1 internally.

```
$ kubectl get -A externalsecrets.external-secrets.io -o yaml | grep -- 'apiVersion: external-secrets.io/' | sort | uniq
    - apiVersion: external-secrets.io/v1
- apiVersion: external-secrets.io/v1
```

This is also true for the cluster secrets store
```
$ kubectl get -A clustersecretstores.external-secrets.io -o yaml | grep -- 'apiVersion: external-secrets.io/' | sort | uniq
- apiVersion: external-secrets.io/v1
```

and clusterexternalsecrets
```
 $ kubectl get -A clusterexternalsecrets.external-secrets.io -o yaml | grep -- 'apiVersion: external-secrets.io/' | sort | uniq
- apiVersion: external-secrets.io/v1
```

(There are other api-resources but we don't have any of them)