### PR TITLE
Remove index-consultations cron job for whitehall-admin

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4079,9 +4079,6 @@ govukApplications:
         runAsUser: 2899
         runAsGroup: 2899
       cronTasks:
-        - name: index-consultations
-          task: "search:index:consultations"
-          schedule: "0 2-22 * * *"
         - name: send-notifications
           task: "publisher_notifications:send"
           schedule: "18 1 * * *"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3901,9 +3901,6 @@ govukApplications:
         runAsUser: 2899
         runAsGroup: 2899
       cronTasks:
-        - name: index-consultations
-          task: "search:index:consultations"
-          schedule: "0 2-22 * * *"
         - name: send-notifications
           task: "publisher_notifications:send"
           schedule: "33 1 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3868,9 +3868,6 @@ govukApplications:
         runAsUser: 2899
         runAsGroup: 2899
       cronTasks:
-        - name: index-consultations
-          task: "search:index:consultations"
-          schedule: "0 2-22 * * *"
         - name: send-notifications
           task: "publisher_notifications:send"
           schedule: "14 1 * * *"


### PR DESCRIPTION
## What
Remove index-consultations cron job for whitehall-admin in all environments

## Why
The rake task that this job calls was removed in Whitehall already but the job itself remains and should be removed, as it continues to run and fail.