### PR TITLE
Increase prometheus disk size to 300GB in all envs

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-integration.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-integration.yaml
@@ -39,4 +39,4 @@
         "spec":
           "resources":
             "requests":
-              "storage": "250Gi"
+              "storage": "300Gi"

--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-production.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-production.yaml
@@ -39,4 +39,4 @@
         "spec":
           "resources":
             "requests":
-              "storage": "250Gi"
+              "storage": "300Gi"

--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-staging.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-staging.yaml
@@ -40,4 +40,4 @@
         "spec":
           "resources":
             "requests":
-              "storage": "250Gi"
+              "storage": "300Gi"


### PR DESCRIPTION
Prometheus is running out of disk space since we're sending more data to it now