### PR TITLE
(CM-416) Disable `uploadAssets` for Content Block Manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -493,6 +493,8 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
+      uploadAssets:
+        enabled: false
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
We don't need this functionality for our app