### PR TITLE
(CM-416) Enable `uploadAssets` for Content Block Manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -493,8 +493,6 @@ govukApplications:
           memory: 512Mi
       redis:
         enabled: true
-      uploadAssets:
-        enabled: false
       extraEnv:
         - name: GDS_SSO_OAUTH_ID
           valueFrom:


### PR DESCRIPTION
I mistakenly thought this was to do with publicly uploaded assets, but this is actually related to CSS/JS etc, so I do think we need this.