### PR TITLE
(CM-416) Change `dbMigrationCommand` to run`db:prepare`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -482,6 +482,7 @@ govukApplications:
           cpu: 10m
           memory: 1.5Gi
       dbMigrationEnabled: true
+      dbMigrationCommand: ["rails", "db:prepare"]
       workers:
         enabled: true
       workerResources:


### PR DESCRIPTION
The changes the `dbMigrationCommand` in Content Block Manager to `rails db:prepare`. This command creates the database if it doesn’t exist, then runs the migrations, which we will need initially. Once the database has been created, we can remove this line