### PR TITLE
Add cronTasks in search-api-v2 for running evaluations on binary data…

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3068,6 +3068,9 @@ govukApplications:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
           schedule: "0 7 * * *"  # 07:00am daily
+        - name: quality-report-binary-quality-metrics
+          task: "quality:report_quality_metrics[binary]"
+          schedule: "0 8-16/2 * * 1-5"  # every two hours between 8am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *"  # 02:00am first day of the month

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3051,6 +3051,9 @@ govukApplications:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
           schedule: "0 7 * * *"  # 07:00am daily
+        - name: quality-report-binary-quality-metrics
+          task: "quality:report_quality_metrics[binary]"
+          schedule: "0 8-16/2 * * 1-5"  # every two hours between 8am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *"  # 02:00am first day of the month


### PR DESCRIPTION
…sets on staging and production.

This was done for integration here: https://github.com/alphagov/govuk-helm-charts/pull/3481