### PR TITLE
GOV.UK Chat: Add Slack webhook URL env var

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1576,6 +1576,11 @@ govukApplications:
         #   schedule: "5 * * * *"
         #   timeZone: "Europe/London"
       extraEnv:
+        - name: AI_SLACK_CHANNEL_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: govuk-chat-slack
+              key: AI_SLACK_CHANNEL_WEBHOOK_URL
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We are reinstating the ability to post to Slack from GOV.UK Chat, so we
need this env var back in.

This reverts commit 80b06fa82ed10b83378832d581bc17e0bf1071b5.

The secret value is still in AWS Secrets Manager, so no need to re-add it.
