### PR TITLE
Run search evaluations one hour later

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3243,13 +3243,13 @@ govukApplications:
       cronTasks:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
-          schedule: "0 7 * * *"  # 07:00am daily
+          schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
           task: "quality:report_quality_metrics[binary]"
-          schedule: "0 8-16/2 * * 1-5"  # every two hours between 8am and 4pm on weekdays
+          schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
-          schedule: "0 2 1 * *"  # 02:00am first day of the month
+          schedule: "0 2 1 * *" # 02:00am first day of the month
         - name: user-events-import-yesterdays-events
           task: "user_events:import_yesterdays_events"
           schedule: "30 12 * * *"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3072,13 +3072,13 @@ govukApplications:
       cronTasks:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
-          schedule: "0 7 * * *"  # 07:00am daily
+          schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
           task: "quality:report_quality_metrics[binary]"
-          schedule: "0 8-16/2 * * 1-5"  # every two hours between 8am and 4pm on weekdays
+          schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
-          schedule: "0 2 1 * *"  # 02:00am first day of the month
+          schedule: "0 2 1 * *" # 02:00am first day of the month
         - name: user-events-import-yesterdays-events
           task: "user_events:import_yesterdays_events"
           schedule: "30 12 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3118,13 +3118,13 @@ govukApplications:
       cronTasks:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
-          schedule: "0 7 * * *"  # 07:00am daily
+          schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
           task: "quality:report_quality_metrics[binary]"
-          schedule: "0 8-16/2 * * 1-5"  # every two hours between 8am and 4pm on weekdays
+          schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
-          schedule: "0 2 1 * *"  # 02:00am first day of the month
+          schedule: "0 2 1 * *" # 02:00am first day of the month
         - name: user-events-import-yesterdays-events
           task: "user_events:import_yesterdays_events"
           schedule: "30 12 * * *"


### PR DESCRIPTION
The evaluations take approximately two hours to run. This means that the binary evaluation at 8am failed every morning with an AlreadyExistsError as the evaluation started at 7am was still running.

Changing all of the evaluations to start one hour later is a temporary measure to stop them erroring whilst a way to check the status of the previous job is developed.