### PR TITLE
Add alerting for search-api-v2 search quality degradation

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -142,3 +142,59 @@ groups:
           description: >-
             24 hour rolling success rate for search requests has dropped below 99.99% for more than 24
             hours.
+
+  - name: SearchApiV2QualityMetrics
+    interval: 15m
+    rules:
+      - alert: SearchQualityDegradedBinaryRecallDrop
+        expr: search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"} < 0.90
+        labels:
+          severity: warning
+          destination: slack-search-team
+        annotations:
+          summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
+          grafana_path: >-
+            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+          description: >-
+            Top 3 recall for binary query set has dropped below 90%.
+      - alert: SearchQualityDegradedBinaryRecallCritical
+        expr: search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"} < 0.80
+        labels:
+          severity: critical
+          destination: slack-search-team
+        annotations:
+          summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
+          grafana_path: >-
+            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+          description: >-
+            Top 3 recall for binary query set has dropped below 80%.
+      - alert: SearchQualityDegradedClickstreamNDCGDrop
+        expr: search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"} < 0.85
+        labels:
+          severity: warning
+          destination: slack-search-team
+        annotations:
+          summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
+          grafana_path: >-
+            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+          description: >-
+            Top 10 NDCG for clickstream query set has dropped below 85%.
+      - alert: SearchQualityDegradedClickstreamNDCGCritical
+        expr: search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"} < 0.75
+        labels:
+          severity: critical
+          destination: slack-search-team
+        annotations:
+          summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"
+          grafana_path: >-
+            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+          description: >-
+            Top 10 NDCG for clickstream query set has dropped below 75%.

--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -146,7 +146,7 @@ groups:
   - name: SearchApiV2QualityMetrics
     interval: 15m
     rules:
-      - alert: SearchQualityDegradedBinaryRecallDrop
+      - alert: SearchQualityDegradedBinaryRecall
         expr: search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"} < 0.90
         labels:
           severity: warning
@@ -159,7 +159,7 @@ groups:
             https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             Top 3 recall for binary query set has dropped below 90%.
-      - alert: SearchQualityDegradedBinaryRecallCritical
+      - alert: SearchQualityDegradedBinaryRecall
         expr: search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"} < 0.80
         labels:
           severity: critical
@@ -172,7 +172,7 @@ groups:
             https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             Top 3 recall for binary query set has dropped below 80%.
-      - alert: SearchQualityDegradedClickstreamNDCGDrop
+      - alert: SearchQualityDegradedClickstreamNDCG
         expr: search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"} < 0.85
         labels:
           severity: warning
@@ -185,7 +185,7 @@ groups:
             https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
           description: >-
             Top 10 NDCG for clickstream query set has dropped below 85%.
-      - alert: SearchQualityDegradedClickstreamNDCGCritical
+      - alert: SearchQualityDegradedClickstreamNDCG
         expr: search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"} < 0.75
         labels:
           severity: critical

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -300,20 +300,20 @@ tests:
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "24 hour rolling success rate for search requests has dropped below 99.99% for more than 24 hours."
 
-  # Tests for SearchQualityDegradedBinaryRecallDrop
+    # Tests for SearchQualityDegradedBinaryRecall
   - interval: 15m
     input_series:
       - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}'
-        values: '0.95x3 0.89'
+        values: '0.95x2 0.89 0.79'
     alert_rule_test:
+      - eval_time: 30m
+        alertname: SearchQualityDegradedBinaryRecall
+        exp_alerts: []
+      - eval_time: 35m
+        alertname: SearchQualityDegradedBinaryRecall
+        exp_alerts: []
       - eval_time: 45m
-        alertname: SearchQualityDegradedBinaryRecallDrop
-        exp_alerts: []
-      - eval_time: 55m
-        alertname: SearchQualityDegradedBinaryRecallDrop
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: SearchQualityDegradedBinaryRecallDrop
+        alertname: SearchQualityDegradedBinaryRecall
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -328,22 +328,22 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "Top 3 recall for binary query set has dropped below 90%."
-
-    # Tests for SearchQualityDegradedBinaryRecallCritical
-  - interval: 15m
-    input_series:
-      - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}'
-        values: '0.95x2 0.89 0.79'
-    alert_rule_test:
-      - eval_time: 45m
-        alertname: SearchQualityDegradedBinaryRecallCritical
-        exp_alerts: []
-      - eval_time: 55m
-        alertname: SearchQualityDegradedBinaryRecallCritical
-        exp_alerts: []
       - eval_time: 1h
-        alertname: SearchQualityDegradedBinaryRecallCritical
+        alertname: SearchQualityDegradedBinaryRecall
         exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-search-team
+              dataset: binary
+              month: last_month
+              top: 3
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 3 recall for binary query set has dropped below 90%."
           - exp_labels:
               severity: critical
               destination: slack-search-team
@@ -358,20 +358,20 @@ tests:
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "Top 3 recall for binary query set has dropped below 80%."
 
-  # Tests for SearchQualityDegradedClickstreamNDCGDrop
+  # Tests for SearchQualityDegradedClickstreamNDCG
   - interval: 15m
     input_series:
       - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}'
-        values: '0.9x3 0.84'
+        values: '0.9x2 0.84 0.74'
     alert_rule_test:
+      - eval_time: 30m
+        alertname: SearchQualityDegradedClickstreamNDCG
+        exp_alerts: []
+      - eval_time: 35m
+        alertname: SearchQualityDegradedClickstreamNDCG
+        exp_alerts: []
       - eval_time: 45m
-        alertname: SearchQualityDegradedClickstreamNDCGDrop
-        exp_alerts: []
-      - eval_time: 55m
-        alertname: SearchQualityDegradedClickstreamNDCGDrop
-        exp_alerts: []
-      - eval_time: 1h
-        alertname: SearchQualityDegradedClickstreamNDCGDrop
+        alertname: SearchQualityDegradedClickstreamNDCG
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -386,22 +386,22 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "Top 10 NDCG for clickstream query set has dropped below 85%."
-
-  # Tests for SearchQualityDegradedClickstreamNDCGCritical
-  - interval: 15m
-    input_series:
-      - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}'
-        values: '0.9x2 0.84 0.74'
-    alert_rule_test:
-      - eval_time: 45m
-        alertname: SearchQualityDegradedClickstreamNDCGCritical
-        exp_alerts: []
-      - eval_time: 55m
-        alertname: SearchQualityDegradedClickstreamNDCGCritical
-        exp_alerts: []
       - eval_time: 1h
-        alertname: SearchQualityDegradedClickstreamNDCGCritical
+        alertname: SearchQualityDegradedClickstreamNDCG
         exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-search-team
+              dataset: clickstream
+              month: last_month
+              top: 10
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 10 NDCG for clickstream query set has dropped below 85%."
           - exp_labels:
               severity: critical
               destination: slack-search-team

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -299,3 +299,119 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "24 hour rolling success rate for search requests has dropped below 99.99% for more than 24 hours."
+
+  # Tests for SearchQualityDegradedBinaryRecallDrop
+  - interval: 15m
+    input_series:
+      - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}'
+        values: '0.95x3 0.89'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: SearchQualityDegradedBinaryRecallDrop
+        exp_alerts: []
+      - eval_time: 55m
+        alertname: SearchQualityDegradedBinaryRecallDrop
+        exp_alerts: []
+      - eval_time: 1h
+        alertname: SearchQualityDegradedBinaryRecallDrop
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-search-team
+              dataset: binary
+              month: last_month
+              top: 3
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 3 recall for binary query set has dropped below 90%."
+
+    # Tests for SearchQualityDegradedBinaryRecallCritical
+  - interval: 15m
+    input_series:
+      - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}'
+        values: '0.95x2 0.89 0.79'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: SearchQualityDegradedBinaryRecallCritical
+        exp_alerts: []
+      - eval_time: 55m
+        alertname: SearchQualityDegradedBinaryRecallCritical
+        exp_alerts: []
+      - eval_time: 1h
+        alertname: SearchQualityDegradedBinaryRecallCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              destination: slack-search-team
+              dataset: binary
+              month: last_month
+              top: 3
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 3 recall for binary query set has dropped below 80%."
+
+  # Tests for SearchQualityDegradedClickstreamNDCGDrop
+  - interval: 15m
+    input_series:
+      - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}'
+        values: '0.9x3 0.84'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: SearchQualityDegradedClickstreamNDCGDrop
+        exp_alerts: []
+      - eval_time: 55m
+        alertname: SearchQualityDegradedClickstreamNDCGDrop
+        exp_alerts: []
+      - eval_time: 1h
+        alertname: SearchQualityDegradedClickstreamNDCGDrop
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-search-team
+              dataset: clickstream
+              month: last_month
+              top: 10
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 10 NDCG for clickstream query set has dropped below 85%."
+
+  # Tests for SearchQualityDegradedClickstreamNDCGCritical
+  - interval: 15m
+    input_series:
+      - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}'
+        values: '0.9x2 0.84 0.74'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: SearchQualityDegradedClickstreamNDCGCritical
+        exp_alerts: []
+      - eval_time: 55m
+        alertname: SearchQualityDegradedClickstreamNDCGCritical
+        exp_alerts: []
+      - eval_time: 1h
+        alertname: SearchQualityDegradedClickstreamNDCGCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              destination: slack-search-team
+              dataset: clickstream
+              month: last_month
+              top: 10
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 10 NDCG for clickstream query set has dropped below 75%."


### PR DESCRIPTION
Search quality alerting thresholds have been set as:
- Binary recall top 3 < 90% (warning)
- Binary recall top 3 < 80% (critical)
- Clickstream NDCG top 10 < 85% (warning)
- Clickstream NDCG top 10 < 75% (critical)

Metrics are checked every 15mins, and an alert is raised immediately if metrics are found to be below the relevant threshold.

Edits to https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager to reflect these changes coming soon!

Jira ticket for this PR: https://gov-uk.atlassian.net/browse/SCH-1423

See Jira ticket for relevant decisions taken for this PR, and further justification here: https://docs.google.com/document/d/1uXpBrc8eE2D-hyTv0hygPnkOMqahUpaARBOtZ9NmWyg/edit?tab=t.0#heading=h.lsh5cbl1kvlj