### PR TITLE
Add default worker to GOV.UK Chat prod config

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1551,6 +1551,8 @@ govukApplications:
                 value: "25"
               - name: DATABASE_POOL
                 value: "25"
+          - command: ["sidekiq", "-C", "config/sidekiq_default.yml"]
+            name: default-worker
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
       workerResources:


### PR DESCRIPTION
While reverting the changes to content-data-api i managed to miss setting the default worker in the production config for chat.