### PR TITLE
Add HPA config for Chat Staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1616,11 +1616,11 @@ govukApplications:
       arch: arm64
       appResources:
         limits:
-          cpu: 2
-          memory: 1.5Gi
+          cpu: 4
+          memory: 2Gi
         requests:
-          cpu: 10m
-          memory: 768Mi
+          cpu: 2
+          memory: 1Gi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -1631,6 +1631,13 @@ govukApplications:
             name: default-worker
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
+      workerResources:
+        limits:
+          cpu: 8
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 2Gi
       ingress:
         enabled: true
         annotations:
@@ -1712,6 +1719,66 @@ govukApplications:
         name: govuk-chat
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::696911096973:role/govuk-chat-bedrock-access-role
+      podAutoscaling:
+        - name: govuk-chat
+          enabled: true
+          spec:
+            maxReplicas: 10
+            minReplicas: 3
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: govuk-chat
+            metrics:
+              - type: Resource
+                resource:
+                  name: cpu
+                  target:
+                    type: Utilization
+                    averageUtilization: 80
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 300
+                policies:
+                  - type: Pods
+                    value: 2
+                    periodSeconds: 180
+              scaleUp:
+                stabilizationWindowSeconds: 60
+                policies:
+                  - type: Pods
+                    value: 1
+                    periodSeconds: 30
+        - name: govuk-chat-worker
+          enabled: true
+          spec:
+            maxReplicas: 10
+            minReplicas: 3
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: govuk-chat-worker
+            metrics:
+              - type: External
+                external:
+                  metric:
+                    name: ai_sidekiq_queue_backlog
+                  target:
+                    type: Value
+                    value: 10
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 300
+                policies:
+                  - type: Pods
+                    value: 2
+                    periodSeconds: 180
+              scaleUp:
+                stabilizationWindowSeconds: 60
+                policies:
+                  - type: Pods
+                    value: 1
+                    periodSeconds: 30
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests


### PR DESCRIPTION
## What

Update pod specs and apply horizontal pod autoscaling for Chat service in Staging

## Why

So we can carry out load testing emulating the config we want to deploy in Production