### PR TITLE
Add cron task to send GOV.UK Chat daily activity to Slack

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1650,6 +1650,10 @@ govukApplications:
         #   task: "bigquery:export"
         #   schedule: "5 * * * *"
         #   timeZone: "Europe/London"
+        # - name: slack-daily-report
+        #   task: "slack:send_previous_days_activity"
+        #   schedule: "3 7 * * *"
+        #   timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:


### PR DESCRIPTION
This cronjob will run at 7am each morning and call the
`slack:send_previous_days_activity` Rake task in the govuk-chat
application.

It's currently commented out as the app still isn't public yet. Once we
go live, we can uncomment this and the other cronjobs too. We're adding
this in now so we don't forget about it.
