### PR TITLE
Remove unused Fastly Prometheus exporter Helm values

### DIFF
--- a/charts/monitoring-config/values.yaml
+++ b/charts/monitoring-config/values.yaml
@@ -8,7 +8,3 @@ monitoring:
 # ephemeral environment variables
 awsAccountId: "12345678"
 clusterId: "eph-xxxxxx"
-
-fastlyPrometheusExporter:
-  repository: ghcr.io/alphagov/fastly-exporter
-  tag: 0.5.1


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3509 used the upstream repository
- https://github.com/alphagov/govuk-infrastructure/issues/2521