### PR TITLE
Standardise and reduce govuk-chat resource requests

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1625,12 +1625,9 @@ govukApplications:
     helmValues:
       arch: arm64
       appResources:
-        limits:
-          cpu: 2
-          memory: 1.5Gi
         requests:
-          cpu: 10m
-          memory: 768Mi
+          cpu: 500m
+          memory: 1Gi
       dbMigrationEnabled: true
       workers:
         enabled: true
@@ -1641,6 +1638,10 @@ govukApplications:
             name: default-worker
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
+      workerResources:
+        requests:
+          cpu: 666m
+          memory: 2Gi
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1624,12 +1624,9 @@ govukApplications:
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
       workerResources:
-        limits:
-          cpu: 1
-          memory: 1.5Gi
         requests:
-          cpu: 10m
-          memory: 256Mi
+          cpu: 0.66
+          memory: 2Gi
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1615,11 +1615,8 @@ govukApplications:
     helmValues:
       arch: arm64
       appResources:
-        limits:
-          cpu: 4
-          memory: 2Gi
         requests:
-          cpu: 2
+          cpu: 500m
           memory: 1Gi
       dbMigrationEnabled: true
       workers:
@@ -1632,11 +1629,8 @@ govukApplications:
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
       workerResources:
-        limits:
-          cpu: 8
-          memory: 4Gi
         requests:
-          cpu: 4
+          cpu: 666m
           memory: 2Gi
       ingress:
         enabled: true


### PR DESCRIPTION
The chat worker pods were requesting an extremely large amount of CPU, causing the k8s worker nodes to scale up.

We're now allocating 2 vCPUs per worker pod (2/3 vCPUs per container) and 1/2 vCPUs to the app itself

Limits have been removed, so if the app or workers need more CPU time, they will get it as the avg CPU utilisation on our k8s nodes is extremely low