### PR TITLE
(CM-436) Add ANONYMOUS_USER_ID_SECRET to Content Block Manager integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -507,6 +507,8 @@ govukApplications:
       redis:
         enabled: true
       extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This will allow us to report an anonymised user ID to analytics, in much the same way as the other publishing apps.