### PR TITLE
(CM-436) Add ANONYMOUS_USER_ID_SECRET to content block manager in staging/prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -351,76 +351,6 @@ govukApplications:
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
 
-  - name: content-block-manager
-    repoName: content-block-manager
-    helmValues:
-      repoName: content-block-manager
-      arch: arm64
-      appResources:
-        limits:
-          cpu: 4
-          memory: 5Gi
-        requests:
-          cpu: 10m
-          memory: 1.5Gi
-      ingress:
-        enabled: true
-        annotations:
-          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-          alb.ingress.kubernetes.io/group.order: "10"
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-            [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "content-block-manager.{{ .Values.publishingDomainSuffix }}"
-            ]}}]
-        hosts:
-          - name: content-block-manager.{{ .Values.k8sExternalDomainSuffix }}
-      nginxProxyReadTimeout: 60s
-      dbMigrationEnabled: true
-      workers:
-        enabled: true
-      workerResources:
-        limits:
-          cpu: 2
-          memory: 1.5Gi
-        requests:
-          cpu: 10m
-          memory: 512Mi
-      redis:
-        enabled: true
-      extraEnv:
-        - name: ANONYMOUS_USER_ID_SECRET
-          valueFrom: *anonymous_user_id_secret
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-content-block-manager
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-content-block-manager
-              key: oauth_secret
-        - name: JWT_AUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authenticating-proxy-jwt-auth-secret
-              key: JWT_AUTH_SECRET
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-content-block-manager-publishing-api
-              key: bearer_token
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: content-block-manager-postgres
-              key: DATABASE_URL
-        - name: SIGNON_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-content-block-manager-signon-api
-              key: bearer_token
-
   - name: draft-collections
     repoName: collections
     helmValues:
@@ -530,6 +460,76 @@ govukApplications:
             secretKeyRef:
               name: collections-publisher-mysql
               key: DATABASE_URL
+
+  - name: content-block-manager
+    repoName: content-block-manager
+    helmValues:
+      repoName: content-block-manager
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 4
+          memory: 5Gi
+        requests:
+          cpu: 10m
+          memory: 1.5Gi
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "10"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "content-block-manager.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: content-block-manager.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 60s
+      dbMigrationEnabled: true
+      workers:
+        enabled: true
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
+      redis:
+        enabled: true
+      extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-content-block-manager
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-content-block-manager
+              key: oauth_secret
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-content-block-manager-publishing-api
+              key: bearer_token
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: content-block-manager-postgres
+              key: DATABASE_URL
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-content-block-manager-signon-api
+              key: bearer_token
 
   - name: content-data-admin
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -358,76 +358,6 @@ govukApplications:
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
 
-  - name: content-block-manager
-    repoName: content-block-manager
-    helmValues:
-      repoName: content-block-manager
-      arch: arm64
-      appResources:
-        limits:
-          cpu: 4
-          memory: 5Gi
-        requests:
-          cpu: 10m
-          memory: 1.5Gi
-      ingress:
-        enabled: true
-        annotations:
-          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-          alb.ingress.kubernetes.io/group.order: "10"
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
-            [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "content-block-manager.{{ .Values.publishingDomainSuffix }}"
-            ]}}]
-        hosts:
-          - name: content-block-manager.{{ .Values.k8sExternalDomainSuffix }}
-      nginxProxyReadTimeout: 60s
-      dbMigrationEnabled: true
-      workers:
-        enabled: true
-      workerResources:
-        limits:
-          cpu: 2
-          memory: 1.5Gi
-        requests:
-          cpu: 10m
-          memory: 512Mi
-      redis:
-        enabled: true
-      extraEnv:
-        - name: ANONYMOUS_USER_ID_SECRET
-          valueFrom: *anonymous_user_id_secret
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-content-block-manager
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-content-block-manager
-              key: oauth_secret
-        - name: JWT_AUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authenticating-proxy-jwt-auth-secret
-              key: JWT_AUTH_SECRET
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-content-block-manager-publishing-api
-              key: bearer_token
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: content-block-manager-postgres
-              key: DATABASE_URL
-        - name: SIGNON_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-content-block-manager-signon-api
-              key: bearer_token
-
   - name: draft-collections
     repoName: collections
     helmValues:
@@ -537,6 +467,76 @@ govukApplications:
             secretKeyRef:
               name: collections-publisher-mysql
               key: DATABASE_URL
+
+  - name: content-block-manager
+    repoName: content-block-manager
+    helmValues:
+      repoName: content-block-manager
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 4
+          memory: 5Gi
+        requests:
+          cpu: 10m
+          memory: 1.5Gi
+      ingress:
+        enabled: true
+        annotations:
+          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "10"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: >
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+                "content-block-manager.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: content-block-manager.{{ .Values.k8sExternalDomainSuffix }}
+      nginxProxyReadTimeout: 60s
+      dbMigrationEnabled: true
+      workers:
+        enabled: true
+      workerResources:
+        limits:
+          cpu: 2
+          memory: 1.5Gi
+        requests:
+          cpu: 10m
+          memory: 512Mi
+      redis:
+        enabled: true
+      extraEnv:
+        - name: ANONYMOUS_USER_ID_SECRET
+          valueFrom: *anonymous_user_id_secret
+        - name: GDS_SSO_OAUTH_ID
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-content-block-manager
+              key: oauth_id
+        - name: GDS_SSO_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signon-app-content-block-manager
+              key: oauth_secret
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
+        - name: PUBLISHING_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-content-block-manager-publishing-api
+              key: bearer_token
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: content-block-manager-postgres
+              key: DATABASE_URL
+        - name: SIGNON_API_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-content-block-manager-signon-api
+              key: bearer_token
 
   - name: content-data-admin
     helmValues:


### PR DESCRIPTION
This follows on from https://github.com/alphagov/govuk-helm-charts/pull/3513 to add the same secret in staging/prod. Additionally, I've moved where the applications were defined so we can use the `anonymous_user_id_secret` alias