### PR TITLE
Rename DB backup job

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -100,7 +100,7 @@ cronjobs:
       operations:
         - op: backup
 
-    content-block-manager:
+    content-block-manager-postgres:
       schedule: "43 0 * * *"
       db: content_block_manager_production
       operations:


### PR DESCRIPTION
This should be suffixed with the dbms type, as this is hw the correct executable gets picked up to carry out the database backup