### PR TITLE
Turn on server side apply for `external-secrets` Helm chart in integration

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -64,6 +64,9 @@ spec:
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
+  {{- if .serverSideApplyEnabled }}
+    - ServerSideApply=true
+  {{- end }
   {{- if gt (len $podAutoscaling) 0 }}
   ignoreDifferences:
   {{- range $podAutoscaling }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1247,6 +1247,7 @@ govukApplications:
   - name: external-secrets
     chartPath: charts/external-secrets
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
 
   - name: feedback
     helmValues:


### PR DESCRIPTION
Description:
- This will automatically convert the client side apply `managedFields` to server side apply and correctly set them to `v1` not `v1beta1`
- https://github.com/alphagov/govuk-infrastructure/issues/2803