### PR TITLE
Fix syntax error in govuk-application

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -66,7 +66,7 @@ spec:
     - ApplyOutOfSyncOnly=true
   {{- if .serverSideApplyEnabled }}
     - ServerSideApply=true
-  {{- end }
+  {{- end }}
   {{- if gt (len $podAutoscaling) 0 }}
   ignoreDifferences:
   {{- range $podAutoscaling }}


### PR DESCRIPTION
Description:
- Missing 2nd closing brace