### PR TITLE
Add additional fields `account-api-notify` external secret

### DIFF
--- a/charts/external-secrets/templates/account-api/notify.yaml
+++ b/charts/external-secrets/templates/account-api/notify.yaml
@@ -18,3 +18,6 @@ spec:
   dataFrom:
     - extract:
         key: govuk/account-api/notify
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
Description:
- ArgoCD seems to be removing these fields preventing syncing properly. Adding them in will fix this