### PR TITLE
Disable pod autoscaling rather than set min and max to 0

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1739,10 +1739,10 @@ govukApplications:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role
       podAutoscaling:
         - name: govuk-chat
-          enabled: true
+          enabled: false
           spec:
-            maxReplicas: 0
-            minReplicas: 0
+            maxReplicas: 10
+            minReplicas: 2
             scaleTargetRef:
               apiVersion: apps/v1
               kind: Deployment
@@ -1768,10 +1768,10 @@ govukApplications:
                     value: 1
                     periodSeconds: 30
         - name: govuk-chat-worker
-          enabled: true
+          enabled: false
           spec:
-            maxReplicas: 0
-            minReplicas: 0
+            maxReplicas: 10
+            minReplicas: 2
             scaleTargetRef:
               apiVersion: apps/v1
               kind: Deployment


### PR DESCRIPTION
HPA can't have max set to 0, so instead put them back how they were and set `enabled: false`