### PR TITLE
Add additional fields for `google-cloud-discovery-engine-configuration` external secret

### DIFF
--- a/charts/external-secrets/templates/search-admin/google-cloud-discovery-engine-configuration.yml
+++ b/charts/external-secrets/templates/search-admin/google-cloud-discovery-engine-configuration.yml
@@ -18,3 +18,6 @@ spec:
   dataFrom:
     - extract:
         key: govuk/search-admin/google-cloud-discovery-engine-configuration
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
Description:
- `external-secrets` operator is adding these fields and ArgoCD is removing them
- Explicitly set them in to fix syncing issue