### PR TITLE
Enable `serverSideApply` for db-backups in integration and for external-secrets in staging and production

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -915,6 +915,7 @@ govukApplications:
   - name: db-backup
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1226,6 +1226,7 @@ govukApplications:
   - name: external-secrets
     chartPath: charts/external-secrets
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
 
   - name: feedback
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1240,6 +1240,7 @@ govukApplications:
   - name: external-secrets
     chartPath: charts/external-secrets
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
 
   - name: feedback
     helmValues:


### PR DESCRIPTION
Description:
- Enable `serverSideApply` for db backups in integration as this has an external-secret
- Enable `serverSideApply` for external-secrets in staging and production
- https://github.com/alphagov/govuk-infrastructure/issues/2803