### PR TITLE
Enable serverSideApply for renovate

### DIFF
--- a/charts/app-config/templates/renovate.yaml
+++ b/charts/app-config/templates/renovate.yaml
@@ -20,4 +20,5 @@ spec:
       selfHeal: true
     syncOptions:
     - ApplyOutOfSyncOnly=true
+    - ServerSideApply=true
 {{ end }}


### PR DESCRIPTION
Description:
- Renovate has an `external-secret` to set the application to use ServerSideApply
- https://github.com/alphagov/govuk-infrastructure/issues/2803