### PR TITLE
Enable `serverSideApply` for select apps

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -38,3 +38,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true

--- a/charts/app-config/templates/release.yaml
+++ b/charts/app-config/templates/release.yaml
@@ -23,3 +23,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true

--- a/charts/app-config/templates/reloader.yaml
+++ b/charts/app-config/templates/reloader.yaml
@@ -33,3 +33,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -237,6 +237,7 @@ govukApplications:
   - name: argo-services
     chartPath: charts/argo-services
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: true
     helmValues:
       nextEnvironment: staging
 
@@ -1800,6 +1801,7 @@ govukApplications:
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
+    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -3319,6 +3321,7 @@ govukApplications:
     # See ../charts/search-index-env-sync/values.yaml for job configuration.
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -894,6 +894,7 @@ govukApplications:
   - name: db-backup
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
     helmValues:
       arch: arm64
       appResources:
@@ -1730,6 +1731,7 @@ govukApplications:
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
+    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -1755,12 +1757,14 @@ govukApplications:
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-dependency-checker
 
   - name: mirror
     chartPath: charts/mirror
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-mirror
     helmValues:
@@ -3215,6 +3219,7 @@ govukApplications:
     # See ../charts/search-index-env-sync/values.yaml for job configuration.
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -908,6 +908,7 @@ govukApplications:
   - name: db-backup
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
     helmValues:
       arch: arm64
       appResources:
@@ -1785,6 +1786,7 @@ govukApplications:
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
+    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -1810,12 +1812,14 @@ govukApplications:
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-dependency-checker
 
   - name: mirror
     chartPath: charts/mirror
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-mirror
     helmValues:
@@ -3252,6 +3256,7 @@ govukApplications:
     # See ../charts/search-index-env-sync/values.yaml for job configuration.
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: "true"
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/mirror/templates/externalsecret.yaml
+++ b/charts/mirror/templates/externalsecret.yaml
@@ -13,3 +13,6 @@ spec:
   dataFrom:
     - extract:
         key: govuk/govuk-mirror/rate-limit-token
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
Description:
- Add additional fields to mirror `external-secret`
- Turn on serverSideApply for cluster-autoscaler, release, reloader, govuk-jobs, db-backup, search-index-env-sync, argo-services in integration, govuk-e2e-tests
- https://github.com/alphagov/govuk-infrastructure/issues/2803