### PR TITLE
Remove chat env vars that are no longer needed

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1727,10 +1727,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-bigquery
               key: credentials
-        - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
-        - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
       serviceAccount:
         enabled: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1717,10 +1717,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-bigquery
               key: credentials
-        - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "100"
-        - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "100"
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
       serviceAccount:
         enabled: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1714,8 +1714,6 @@ govukApplications:
           value: "0"
         - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
           value: "0"
-        - name: ANSWER_STRATEGY
-          value: "openai_structured_answer"
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
       serviceAccount:
         enabled: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1710,10 +1710,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-chat-bigquery
               key: credentials
-        - name: INSTANT_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
-        - name: DELAYED_ACCESS_PLACES_SCHEDULE_INCREMENT
-          value: "0"
       # https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/chat/bedrock_iam.tf
       serviceAccount:
         enabled: true


### PR DESCRIPTION
This removes 1 env var that misconfigured chat in the staging environment and 2 other env vars that no longer have a purpose.