### PR TITLE
Enable `serverSideApply` for argo-services prod and licensify in non-prod

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1863,6 +1863,7 @@ govukApplications:
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
+    serverSideApplyEnabled: true
     imageValues:
       - "licensify-admin"
       - "licensify-backend"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -229,6 +229,7 @@ govukApplications:
   - name: argo-services
     chartPath: charts/argo-services
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: true
     helmValues:
       nextEnvironment: ""
       enableWebhookIngress: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -237,6 +237,7 @@ govukApplications:
   - name: argo-services
     chartPath: charts/argo-services
     postSyncWorkflowEnabled: "false"
+    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       nextEnvironment: production
@@ -1878,6 +1879,7 @@ govukApplications:
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
+    serverSideApplyEnabled: true
     imageValues:
       - "licensify-admin"
       - "licensify-backend"


### PR DESCRIPTION
Description:
- argo-services has been working fine in integration with `serverSideApply` turned on so turn it on in staging and production
- Enable `serverSideApply` for licensify in integration and staging
- https://github.com/alphagov/govuk-infrastructure/issues/2803