### PR TITLE
Stop chat in staging for DB maintenance

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1618,6 +1618,7 @@ govukApplications:
 
   - name: govuk-chat
     helmValues:
+      appEnabled: false
       arch: arm64
       appResources:
         limits:
@@ -1628,7 +1629,7 @@ govukApplications:
           memory: 1Gi
       dbMigrationEnabled: true
       workers:
-        enabled: true
+        enabled: false
         types:
           - command: ["sidekiq", "-C", "config/sidekiq_answer.yml"]
             name: answer-worker
@@ -1720,7 +1721,7 @@ govukApplications:
           eks.amazonaws.com/role-arn: arn:aws:iam::696911096973:role/govuk-chat-bedrock-access-role
       podAutoscaling:
         - name: govuk-chat
-          enabled: true
+          enabled: false
           spec:
             maxReplicas: 10
             minReplicas: 3
@@ -1749,7 +1750,7 @@ govukApplications:
                     value: 1
                     periodSeconds: 30
         - name: govuk-chat-worker
-          enabled: true
+          enabled: false
           spec:
             maxReplicas: 10
             minReplicas: 3


### PR DESCRIPTION
We can now go ahead again with the maintenance. So scale chat down to allow it to have DB maintenance performed in staging