### PR TITLE
Enable `serverSideApply` on integration and staging

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -66,6 +66,10 @@ spec:
     - ApplyOutOfSyncOnly=true
   {{- if .serverSideApplyEnabled }}
     - ServerSideApply=true
+  {{- else if eq $.Values.govukEnvironment "production" }}
+    - ServerSideApply=false
+  {{- else }}
+    - ServerSideApply=true
   {{- end }}
   {{- if gt (len $podAutoscaling) 0 }}
   ignoreDifferences:


### PR DESCRIPTION
Description:
- Enable `serverSideApply` if `serverSideApplyEnabled` is true in the values file
- Enable `serverSideApply` if the environments are non-production (e.g. integration and staging)
- https://github.com/alphagov/govuk-infrastructure/issues/2803