### PR TITLE
Modify time period to 1m for Titan metrics

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -129,7 +129,7 @@
           "metricName": "InputTokenCount",
           "metricQueryType": 0,
           "namespace": "AWS/Bedrock",
-          "period": "",
+          "period": "1m",
           "queryLanguage": "CWLI",
           "queryMode": "Metrics",
           "refId": "A",
@@ -467,7 +467,7 @@
           "metricName": "InputTokenCount",
           "metricQueryType": 0,
           "namespace": "AWS/Bedrock",
-          "period": "5m",
+          "period": "1m",
           "queryLanguage": "CWLI",
           "queryMode": "Metrics",
           "refId": "A",
@@ -4217,5 +4217,5 @@
   "timezone": "browser",
   "title": "GOV.UK Chat Technical",
   "uid": "govuk-chat-technical",
-  "version": 9
+  "version": 10
 }


### PR DESCRIPTION
## What

Set the sample period to "1m" for the Titan metrics on the Chat Dashboard

## Why

When set to "auto" we do not know how long the sample period is, so this sets it explicitly 