### PR TITLE
Add hpa config for Chat Production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1725,6 +1725,66 @@ govukApplications:
         name: govuk-chat
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::172025368201:role/govuk-chat-bedrock-access-role
+      podAutoscaling:
+        - name: govuk-chat
+          enabled: true
+          spec:
+            maxReplicas: 10
+            minReplicas: 3
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: govuk-chat
+            metrics:
+              - type: Resource
+                resource:
+                  name: cpu
+                  target:
+                    type: Utilization
+                    averageUtilization: 80
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 300
+                policies:
+                  - type: Pods
+                    value: 2
+                    periodSeconds: 180
+              scaleUp:
+                stabilizationWindowSeconds: 60
+                policies:
+                  - type: Pods
+                    value: 1
+                    periodSeconds: 30
+        - name: govuk-chat-worker
+          enabled: true
+          spec:
+            maxReplicas: 10
+            minReplicas: 3
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: govuk-chat-worker
+            metrics:
+              - type: External
+                external:
+                  metric:
+                    name: ai_sidekiq_queue_backlog
+                  target:
+                    type: Value
+                    value: 10
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 300
+                policies:
+                  - type: Pods
+                    value: 2
+                    periodSeconds: 180
+              scaleUp:
+                stabilizationWindowSeconds: 60
+                policies:
+                  - type: Pods
+                    value: 1
+                    periodSeconds: 30
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests


### PR DESCRIPTION
## What

Add the autoscaling configuration for the Chat Service to Production

## Why

Load testing carried out in Staging has shown that this configuration should be suitable for our requirements in Production