### PR TITLE
Set startupProbe for frontend in Integration to use /healthcheck/ready

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1443,6 +1443,8 @@ govukApplications:
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
@@ -1514,6 +1516,8 @@ govukApplications:
         createSecret: false
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-


### PR DESCRIPTION
As with [static](https://github.com/alphagov/govuk-helm-charts/pull/3406), we set the startupProbe for frontend in Integration to use `/healthcheck/ready` since this endpoint now verifies that the emergency banner Redis instance is available.

[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-5602?atlOrigin=eyJpIjoiNGVhMWRmNTUwMWYyNDdlYjkyMmE0NmFhNGEyODY0NjYiLCJwIjoiaiJ9)