### PR TITLE
Update search dashboard to adjust background colours on binary recall panel

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-search.json
+++ b/charts/monitoring-config/dashboards/govuk-search.json
@@ -146,7 +146,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -214,7 +214,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -277,7 +277,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -390,7 +390,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -458,7 +458,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -612,7 +612,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -706,7 +706,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -806,7 +806,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -874,7 +874,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1028,7 +1028,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1122,7 +1122,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1205,6 +1205,10 @@
                 "value": 0
               },
               {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
                 "color": "green",
                 "value": 0.9
               }
@@ -1234,7 +1238,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1355,7 +1359,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1405,5 +1409,5 @@
   "timezone": "browser",
   "title": "GOV.UK Search",
   "uid": "govuk-search",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
When discussing Prometheus alerting levels, we decided to add an additional threshold level for Binary Recall Top 3, to align with Clickstream NDCG Top 10. This change aligns the dashboard panel colours with the agreed upon alerting levels, showing yellow for "warning" level alerts and red for "critical" alerts.

See meeting summary notes: https://gov-uk.atlassian.net/browse/SCH-1423?focusedCommentId=156016

Sister Prometheus alerts PR: https://github.com/alphagov/govuk-helm-charts/pull/3499

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1459

<img width="674" height="387" alt="Screenshot 2025-09-22 at 16 11 39" src="https://github.com/user-attachments/assets/d753fb44-ae2f-4985-a492-49a93e736302" />
