### PR TITLE
Remove alert notifications on search main Slack channel

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -72,22 +72,6 @@ spec:
       - name: destination
         value: slack-search-team
         matchType: =
-      - name: severity
-        value: critical
-        matchType: =
-      - name: environment
-        value: production
-        matchType: =
-      receiver: 'slack-search-team-main-channel'
-      groupBy: [alertname, severity, environment]
-      groupWait: 30s
-      groupInterval: 5m
-      repeatInterval: 6h
-      continue: true  # Allow alert to also fall through to the alerts channel receiver
-    - matchers:
-      - name: destination
-        value: slack-search-team
-        matchType: =
       receiver: 'slack-search-team-alerts-channel'
       groupBy: [alertname, severity, environment]
       groupWait: 30s
@@ -179,8 +163,7 @@ spec:
         {{- include "slack.text" . | nindent 8 }}
   - name: 'slack-search-team-alerts-channel'
     slackConfigs:
-    - &slack-search-team-alerts-channel
-      channel: "#govuk-search-alerts"
+    - channel: "#govuk-search-alerts"
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}
@@ -191,10 +174,6 @@ spec:
         - text: ":book: Runbook"
           type: button
           url: "https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager"
-  - name: "slack-search-team-main-channel"
-    slackConfigs:
-    - <<: *slack-search-team-alerts-channel
-      channel: "#govuk-search"
   - name: 'slack-whitehall-notifications'
     slackConfigs:
     - channel: '#govuk-whitehall-experience-tech'


### PR DESCRIPTION
All search alerts are already routed to the search alerts channel (govuk-search-alerts). This commit removes additional notifications sent to the search main channel (govuk-search) for critical alerts on production, since they are unnecessarily repetitive and noisy.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1461