### PR TITLE
Temporarily run task for all tables

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3117,7 +3117,7 @@ govukApplications:
           task: "quality:report_quality_metrics"
           schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
-          task: "quality:report_quality_metrics[binary]"
+          task: "quality:report_quality_metrics"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3092,7 +3092,7 @@ govukApplications:
           task: "quality:report_quality_metrics"
           schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
-          task: "quality:report_quality_metrics[binary]"
+          task: "quality:report_quality_metrics"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3064,7 +3064,7 @@ govukApplications:
           task: "quality:report_quality_metrics"
           schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
-          task: "quality:report_quality_metrics[binary]"
+          task: "quality:report_quality_metrics"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"


### PR DESCRIPTION
Remove binary table id, so that the rake task will fetch evaluations for clickstream, explicit and binary tables See https://github.com/alphagov/search-api-v2/blob/main/lib/tasks/quality.rake#L23