### PR TITLE
Remove access to OPENAI_ACCESS_TOKEN from Chat Service in Integration, Staging & Production environments

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1689,11 +1689,6 @@ govukApplications:
               key: DATABASE_URL
         - name: MEMCACHE_SERVERS
           value: "chat-memcached-h4kg8u.serverless.euw1.cache.amazonaws.com:11211"
-        - name: OPENAI_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-open-ai
-              key: access_token
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1676,11 +1676,6 @@ govukApplications:
               key: DATABASE_URL
         - name: MEMCACHE_SERVERS
           value: "chat-memcached-ufglhk.serverless.euw1.cache.amazonaws.com:11211"
-        - name: OPENAI_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-open-ai
-              key: access_token
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1669,11 +1669,6 @@ govukApplications:
               key: DATABASE_URL
         - name: MEMCACHE_SERVERS
           value: "chat-memcached-tx6sx5.serverless.euw1.cache.amazonaws.com:11211"
-        - name: OPENAI_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: govuk-chat-open-ai
-              key: access_token
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## What

Remove the access from the Chat Service to the OpenAI access token values held in Secrets Manager

## Why

The values are no longer being used and the keys in Secrets Manager are no longer valid