### PR TITLE
Suppress warning notifications when critical alerts are firing

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -180,6 +180,16 @@ spec:
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}
+  inhibitRules:
+  - sourceMatch:
+      severity: 'critical'
+      destination: 'slack-search-team'
+    targetMatch:
+      severity: 'warning'
+      destination: 'slack-search-team'
+    equal:
+      - environment
+      - alertname
   muteTimeIntervals:
   - name: inhours
     timeIntervals:


### PR DESCRIPTION
The search team have set up two separate alert thresholds for metrics related to search quality evaluations results, to distinguish between a "warning" level drop in quality, and a "critical" level drop in quality. When the critical alert is firing, it would be overly noisy and possibly confusing to also notify for the warning alert so this change suppresses the warning notifications when the critical alert is firing.

See Alert Manager docs: https://prometheus.io/docs/alerting/latest/configuration/#inhibition-related-settings

Alerts that will be affected by this change are being added here: https://github.com/alphagov/govuk-helm-charts/pull/3499

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1465

⚠️ Please don't assume I know what I'm doing with this change - it's a bit new to me! 😅 