### PR TITLE
Enable GOV.UK Chat Slack cron job

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1658,11 +1658,10 @@ govukApplications:
           task: "bigquery:export"
           schedule: "5 * * * *"
           timeZone: "Europe/London"
-        # cron task disabled while application is not available to public
-        # - name: slack-daily-report
-        #   task: "slack:send_previous_days_activity"
-        #   schedule: "3 7 * * *"
-        #   timeZone: "Europe/London"
+        - name: slack-daily-report
+          task: "slack:send_previous_days_activity"
+          schedule: "3 7 * * *"
+          timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:


### PR DESCRIPTION
We now wish to turn on this daily job that will trigger a Slack notification to test it prior to going live with a pilot in the GOV.UK app.