### PR TITLE
[PNP-5235] Allow smart-answers to access emergency banner redis in production, staging

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3322,10 +3322,6 @@ govukApplications:
     repoName: smart-answers
     helmValues:
       arch: arm64
-      uploadAssets:
-        # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
-        path: /app/public/assets/smartanswers
-        s3Directory: "smartanswers"
       appResources:
         limits:
           memory: 2Gi
@@ -3333,7 +3329,15 @@ govukApplications:
         requests:
           memory: 1Gi
           cpu: "2"
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
+      uploadAssets:
+        # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
+        path: /app/public/assets/smartanswers
+        s3Directory: "smartanswers"
       extraEnv:
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3295,11 +3295,15 @@ govukApplications:
         requests:
           cpu: 50m
           memory: 512Mi
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       uploadAssets:
         # https://github.com/alphagov/smart-answers/blob/9b65057/config/application.rb#L50
         path: /app/public/assets/smartanswers
         s3Directory: "smartanswers"
       extraEnv:
+        - name: EMERGENCY_BANNER_REDIS_URL
+          value: *emergency-banner-redis
         - name: LINK_CHECKER_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- when the slimmer-free version of smart-answers is deployed it will need access to the emergency banner redis, and the healthcheck/ready endpoint will be updated to require emergency banner access. (this has already been done on integration in https://github.com/alphagov/govuk-helm-charts/pull/3448)

[Jira Work Item](https://gov-uk.atlassian.net/browse/PNP-5235)