### PR TITLE
Fix search-api cronjob duplicate env

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2935,6 +2935,9 @@ govukApplications:
         - name: reindex-with-new-schemas
           task: "search:migrate_schema"
           schedule: "5 21 * * 1"
+          env:
+            - name: SEARCH_INDEX
+              value: all
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
           schedule: "50 2 * * *"
@@ -3002,8 +3005,6 @@ govukApplications:
             https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
           value: info
-        - name: SEARCH_INDEX
-          value: all
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Description:
- `search-api-update-detailed-index-popularity`, `search-api-update-government-index-popularity`, `search-api-update-govuk-index-popularity` are all failing to sync since `serverSideApply` is detecting a duplicate environment variable defined in the cronjob YAML
- Current setup adds `SEARCH_INDEX=all` in addition to the different values of `SEARCH_INDEX` resulting in the duplication
- https://github.com/alphagov/govuk-helm-charts/pull/1101/ introduced the change which is only for the `reindex-with-new-schemas` cronjob and https://github.com/alphagov/govuk-helm-charts/pull/1113 added the additional cronjobs with particular values of `SEARCH_INDEX`
- The error was missed due to ArgoCD using client side apply but once https://github.com/alphagov/govuk-helm-charts/pull/3546 turned on server-side apply the error surfaced
- https://github.com/alphagov/govuk-infrastructure/issues/2803