### PR TITLE
Only run binary evaluations every two hours

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3113,7 +3113,7 @@ govukApplications:
           task: "quality:report_quality_metrics"
           schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
-          task: "quality:report_quality_metrics"
+          task: "quality:report_quality_metrics[binary]"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3086,7 +3086,7 @@ govukApplications:
           task: "quality:report_quality_metrics"
           schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
-          task: "quality:report_quality_metrics"
+          task: "quality:report_quality_metrics[binary]"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3059,7 +3059,7 @@ govukApplications:
           task: "quality:report_quality_metrics"
           schedule: "0 8 * * *" # 08:00am daily
         - name: quality-report-binary-quality-metrics
-          task: "quality:report_quality_metrics"
+          task: "quality:report_quality_metrics[binary]"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"


### PR DESCRIPTION
Reverts: https://github.com/alphagov/govuk-helm-charts/pull/3556

Adds back the binary id so that the rake task will only fetch evaluations for the binary table every two hours, not all of them.

We have a limit of 20 evaluations per day on production, each table runs two evaluations, so we have reached our limit. We should contact Google to increase the evaluation limit to 100 as it is in integration, but it takes a few days for the requests to be actioned.

See: https://github.com/alphagov/search-api-v2/blob/main/lib/tasks/quality.rake#L23