### PR TITLE
Enable `serverSideApply` on prod

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -64,13 +64,7 @@ spec:
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
-  {{- if .serverSideApplyEnabled }}
     - ServerSideApply=true
-  {{- else if eq $.Values.govukEnvironment "production" }}
-    - ServerSideApply=false
-  {{- else }}
-    - ServerSideApply=true
-  {{- end }}
   {{- if gt (len $podAutoscaling) 0 }}
   ignoreDifferences:
   {{- range $podAutoscaling }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -237,7 +237,6 @@ govukApplications:
   - name: argo-services
     chartPath: charts/argo-services
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: true
     helmValues:
       nextEnvironment: staging
 
@@ -916,7 +915,6 @@ govukApplications:
   - name: db-backup
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -1249,7 +1247,6 @@ govukApplications:
   - name: external-secrets
     chartPath: charts/external-secrets
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
 
   - name: feedback
     helmValues:
@@ -1800,7 +1797,6 @@ govukApplications:
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
-    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -1862,7 +1858,6 @@ govukApplications:
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
-    serverSideApplyEnabled: true
     imageValues:
       - "licensify-admin"
       - "licensify-backend"
@@ -3173,7 +3168,6 @@ govukApplications:
     # See ../charts/search-index-env-sync/values.yaml for job configuration.
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -229,7 +229,6 @@ govukApplications:
   - name: argo-services
     chartPath: charts/argo-services
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: true
     helmValues:
       nextEnvironment: ""
       enableWebhookIngress: true
@@ -895,7 +894,6 @@ govukApplications:
   - name: db-backup
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
     helmValues:
       arch: arm64
       appResources:
@@ -1228,7 +1226,6 @@ govukApplications:
   - name: external-secrets
     chartPath: charts/external-secrets
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
 
   - name: feedback
     helmValues:
@@ -1790,7 +1787,6 @@ govukApplications:
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
-    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -1816,14 +1812,12 @@ govukApplications:
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-dependency-checker
 
   - name: mirror
     chartPath: charts/mirror
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-mirror
     helmValues:
@@ -3149,7 +3143,6 @@ govukApplications:
     # See ../charts/search-index-env-sync/values.yaml for job configuration.
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
 
   - name: service-manual-publisher
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -237,7 +237,6 @@ govukApplications:
   - name: argo-services
     chartPath: charts/argo-services
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       nextEnvironment: production
@@ -909,7 +908,6 @@ govukApplications:
   - name: db-backup
     chartPath: charts/db-backup
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
     helmValues:
       arch: arm64
       appResources:
@@ -1242,7 +1240,6 @@ govukApplications:
   - name: external-secrets
     chartPath: charts/external-secrets
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
 
   - name: feedback
     helmValues:
@@ -1784,7 +1781,6 @@ govukApplications:
 
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
-    serverSideApplyEnabled: true
     helmValues:
       arch: arm64
       appResources:
@@ -1810,14 +1806,12 @@ govukApplications:
   - name: govuk-jobs
     chartPath: charts/govuk-jobs
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-dependency-checker
 
   - name: mirror
     chartPath: charts/mirror
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
     imageValues:
       - govuk-mirror
     helmValues:
@@ -1876,7 +1870,6 @@ govukApplications:
   - name: licensify
     chartPath: charts/licensify
     namespace: licensify
-    serverSideApplyEnabled: true
     imageValues:
       - "licensify-admin"
       - "licensify-backend"
@@ -3123,7 +3116,6 @@ govukApplications:
     # See ../charts/search-index-env-sync/values.yaml for job configuration.
     chartPath: charts/search-index-env-sync
     postSyncWorkflowEnabled: "false"
-    serverSideApplyEnabled: "true"
 
   - name: service-manual-publisher
     helmValues:


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3546 turned on `serverSideApply` in integration and staging for several days now with no issues
- Turn on `serverSideApply` in production
- https://github.com/alphagov/govuk-infrastructure/issues/2803