### PR TITLE
Set ClusterRole and Role bindings for govuk-synthetic-test-app

### DIFF
--- a/charts/govuk-synthetic-test-app/Chart.yaml
+++ b/charts/govuk-synthetic-test-app/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: govuk-synthetic-test-app
+description: GOV.UK Synthetic Test App
+version: 1.0.0

--- a/charts/govuk-synthetic-test-app/templates/assumed_clusterrole.yaml
+++ b/charts/govuk-synthetic-test-app/templates/assumed_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: synthetic-test-assumed
+rules:
+  - apiGroups: [argoproj.io]
+    resources: [applications]
+    verbs: [get, watch, list]
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, watch, list]
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, watch, list]

--- a/charts/govuk-synthetic-test-app/templates/assumed_rolebinding.yaml
+++ b/charts/govuk-synthetic-test-app/templates/assumed_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: synthetic-test-assumed
+  namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: synthetic-test-assumed
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: synthetic-test-assumed

--- a/charts/govuk-synthetic-test-app/templates/assumed_rolebinding_cluster_services.yaml
+++ b/charts/govuk-synthetic-test-app/templates/assumed_rolebinding_cluster_services.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: synthetic-test-assumed-cluster-services
+  namespace: cluster-services
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: synthetic-test-assumed
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: synthetic-test-assumed

--- a/charts/govuk-synthetic-test-app/templates/assumer_serviceaccount.yaml
+++ b/charts/govuk-synthetic-test-app/templates/assumer_serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: synthetic-test-assumer
+  namespace: apps
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.awsAccountId }}:role/synthetic-test-assumer

--- a/charts/govuk-synthetic-test-app/values.yaml
+++ b/charts/govuk-synthetic-test-app/values.yaml
@@ -1,0 +1,1 @@
+awsAccountId: ""


### PR DESCRIPTION
This will give the govuk-synthetic-test-app access to the kubernetes API.

https://github.com/alphagov/govuk-infrastructure/issues/2724