### PR TITLE
Fix AlertManager `inhibitRules` syntax

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -182,11 +182,15 @@ spec:
         {{- include "slack.text" . | nindent 8 }}
   inhibitRules:
   - sourceMatch:
-      severity: 'critical'
-      destination: 'slack-search-team'
+      - name: 'severity'
+        value: 'critical'
+      - name: 'destination'
+        value: 'slack-search-team'
     targetMatch:
-      severity: 'warning'
-      destination: 'slack-search-team'
+      - name: 'severity'
+        value: 'warning'
+      - name: 'destination'
+        value: 'slack-search-team'
     equal:
       - environment
       - alertname


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3559 used the native AlertManager syntax not the correct [AlertManager operator](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.Matcher) syntax