### PR TITLE
Run evaluations for all datasets at 7am

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3106,7 +3106,7 @@ govukApplications:
       cronTasks:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
-          schedule: "0 8 * * *" # 08:00am daily
+          schedule: "0 7 * * *" # 07:00am daily
         - name: quality-report-binary-quality-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3082,7 +3082,7 @@ govukApplications:
       cronTasks:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
-          schedule: "0 8 * * *" # 08:00am daily
+          schedule: "0 7 * * *" # 07:00am daily
         - name: quality-report-binary-quality-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3054,7 +3054,7 @@ govukApplications:
       cronTasks:
         - name: quality-report-quality-metrics
           task: "quality:report_quality_metrics"
-          schedule: "0 8 * * *" # 08:00am daily
+          schedule: "0 7 * * *" # 07:00am daily
         - name: quality-report-binary-quality-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 10-16/2 * * 1-5" # every two hours between 10am and 4pm on weekdays


### PR DESCRIPTION
# What's changed and why?

The evaluations for all three datasets are taking over 2 hours to run. We only need to run all three (clickstream, binary, explicit) once a day. The rest of the day we only run binary evaluations starting from 10am. To stop the 8am and 10am runs from crashing into each other, the 8am run is being moved to run an hour earlier at 7am.