### PR TITLE
Update inhibit rules definitions for alert manager config

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -181,19 +181,13 @@ spec:
       text: |-
         {{- include "slack.text" . | nindent 8 }}
   inhibitRules:
-  - sourceMatch:
-      - name: 'severity'
-        value: 'critical'
-      - name: 'destination'
-        value: 'slack-search-team'
-    targetMatch:
-      - name: 'severity'
-        value: 'warning'
-      - name: 'destination'
-        value: 'slack-search-team'
-    equal:
-      - environment
-      - alertname
+  - sourceMatchers:
+      - severity = critical
+      - destination = slack-search-team
+    targetMatchers:
+      - severity = warning
+      - destination = slack-search-team
+    equal: ['environment', 'alertname']
   muteTimeIntervals:
   - name: inhours
     timeIntervals:


### PR DESCRIPTION
Inhibit rules is not working as it should (warning notifications are not being suppressed when they should be). One reason could be that the definition is written in a style that has been deprecated, so this updates the definition to the new format.

See Alertmanager docs: https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1465