### PR TITLE
Modify Helm chart so dynamic values can be used in dashboard json config

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -1112,8 +1112,8 @@
           "label": "",
           "logGroups": [
             {
-              "accountId": "210287912431",
-              "arn": "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/bedrock:*",
+              "accountId": "AWSACCOUNTID",
+              "arn": "arn:aws:logs:eu-west-1:AWSACCOUNTID:log-group:/aws/bedrock:*",
               "name": "/aws/bedrock"
             }
           ],

--- a/charts/monitoring-config/templates/dashboards-configmap.yaml
+++ b/charts/monitoring-config/templates/dashboards-configmap.yaml
@@ -10,5 +10,5 @@ metadata:
 data:
   {{- range $path, $_ := .Files.Glob "dashboards/**.json" }}
     {{- $path | trimPrefix "dashboards/" | nindent 2 }}: |
-    {{- $.Files.Get $path | nindent 4 }}
+    {{- $.Files.Get $path | replace "AWSACCOUNTID" $.Values.awsAccountId | nindent 4 }}
   {{ end }}


### PR DESCRIPTION
## What

Modify the Helm dashboard template so that dynamic values can be used in the JSON dashboard configuration files.

## Why

When using Cloudwatch Logs as the source, the configuration requires the AWS Account Id to be included in the JSON config for the dashboard. In order to have this work for each environment, we need to use dynamic values.