### PR TITLE
Add last_over_time recording rule to search quality alerts

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -146,11 +146,18 @@ groups:
   - name: SearchApiV2QualityMetrics
     interval: 15m
     rules:
+      - record: search_api_v2:quality_metrics:last_binary_recall
+        expr: last_over_time(search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}[26h])
+      - record: search_api_v2:quality_metrics:last_clickstream_ndcg
+        expr: last_over_time(search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}[26h])
       - alert: SearchQualityDegradedBinaryRecall
-        expr: search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"} < 0.90
+        expr: search_api_v2:quality_metrics:last_binary_recall < 0.90
         labels:
           severity: warning
           destination: slack-search-team
+          top: 3
+          dataset: binary
+          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
           grafana_path: >-
@@ -160,10 +167,13 @@ groups:
           description: >-
             Top 3 recall for binary query set has dropped below 90%.
       - alert: SearchQualityDegradedBinaryRecall
-        expr: search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"} < 0.80
+        expr: search_api_v2:quality_metrics:last_binary_recall < 0.80
         labels:
           severity: critical
           destination: slack-search-team
+          top: 3
+          dataset: binary
+          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
           grafana_path: >-
@@ -173,10 +183,13 @@ groups:
           description: >-
             Top 3 recall for binary query set has dropped below 80%.
       - alert: SearchQualityDegradedClickstreamNDCG
-        expr: search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"} < 0.85
+        expr: search_api_v2:quality_metrics:last_clickstream_ndcg < 0.85
         labels:
           severity: warning
           destination: slack-search-team
+          top: 10
+          dataset: clickstream
+          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
           grafana_path: >-
@@ -186,10 +199,13 @@ groups:
           description: >-
             Top 10 NDCG for clickstream query set has dropped below 85%.
       - alert: SearchQualityDegradedClickstreamNDCG
-        expr: search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"} < 0.75
+        expr: search_api_v2:quality_metrics:last_clickstream_ndcg < 0.75
         labels:
           severity: critical
           destination: slack-search-team
+          top: 10
+          dataset: clickstream
+          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"
           grafana_path: >-

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -300,15 +300,12 @@ tests:
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "24 hour rolling success rate for search requests has dropped below 99.99% for more than 24 hours."
 
-    # Tests for SearchQualityDegradedBinaryRecall
+    # Tests for SearchQualityDegradedBinaryRecall (data below threshold)
   - interval: 15m
     input_series:
       - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}'
         values: '0.95x2 0.89 0.79'
     alert_rule_test:
-      - eval_time: 30m
-        alertname: SearchQualityDegradedBinaryRecall
-        exp_alerts: []
       - eval_time: 35m
         alertname: SearchQualityDegradedBinaryRecall
         exp_alerts: []
@@ -357,16 +354,45 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "Top 3 recall for binary query set has dropped below 80%."
+      - eval_time: 27h
+        alertname: SearchQualityDegradedBinaryRecall
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-search-team
+              dataset: binary
+              month: last_month
+              top: 3
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 3 recall for binary query set has dropped below 90%."
+          - exp_labels:
+              severity: critical
+              destination: slack-search-team
+              dataset: binary
+              month: last_month
+              top: 3
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 3 recall for binary query set has dropped below 80%."
+      - eval_time: 28h
+        alertname: SearchQualityDegradedBinaryRecall
+        exp_alerts: []
 
-  # Tests for SearchQualityDegradedClickstreamNDCG
+  # Tests for SearchQualityDegradedClickstreamNDCG (data below threshold)
   - interval: 15m
     input_series:
       - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}'
         values: '0.9x2 0.84 0.74'
     alert_rule_test:
-      - eval_time: 30m
-        alertname: SearchQualityDegradedClickstreamNDCG
-        exp_alerts: []
       - eval_time: 35m
         alertname: SearchQualityDegradedClickstreamNDCG
         exp_alerts: []
@@ -415,3 +441,35 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "Top 10 NDCG for clickstream query set has dropped below 75%."
+      - eval_time: 27h
+        alertname: SearchQualityDegradedClickstreamNDCG
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: slack-search-team
+              dataset: clickstream
+              month: last_month
+              top: 10
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 10 NDCG for clickstream query set has dropped below 85%."
+          - exp_labels:
+              severity: critical
+              destination: slack-search-team
+              dataset: clickstream
+              month: last_month
+              top: 10
+            exp_annotations:
+              summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Top 10 NDCG for clickstream query set has dropped below 75%."
+      - eval_time: 28h
+        alertname: SearchQualityDegradedClickstreamNDCG
+        exp_alerts: []


### PR DESCRIPTION
Our alerts are flapping off and on because of data dropouts in Prometheus. Prometheus treats a lack of data as “everything is ok” by default, so when we’re having an incident and then there’s a data dropout, the alert stops firing (and is marked as resolved). When we start getting data again and it’s below the threshold, the alert becomes active again.
    
Adding a last_over_time recording rule allows us to smooth over data gaps by looking at the last metric received over a specified period. In this case we've chosen 26 hours because data drops outs that are roughly 24 hours in length appear to be quite common for the clickstream query set.

See Prometheus docs on \<aggregation\>_over_time() recording rules:
https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1477

Example of data drop outs in Prometheus: 
<img width="2326" height="918" alt="Screenshot 2025-09-29 at 17 49 52" src="https://github.com/user-attachments/assets/3304447c-a160-4f39-9b34-1d144ab8f68c" />
