### PR TITLE
Add GOOGLE_CLOUD_PROJECT_ID_NUMBER for search API v2

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3153,6 +3153,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_PROJECT_ID
+        - name: GOOGLE_CLOUD_PROJECT_ID_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_PROJECT_ID_NUMBER
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3128,6 +3128,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_PROJECT_ID
+        - name: GOOGLE_CLOUD_PROJECT_ID_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_PROJECT_ID_NUMBER
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3101,6 +3101,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-v2-google-cloud-discovery-engine-configuration
               key: GOOGLE_CLOUD_PROJECT_ID
+        - name: GOOGLE_CLOUD_PROJECT_ID_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: search-api-v2-google-cloud-discovery-engine-configuration
+              key: GOOGLE_CLOUD_PROJECT_ID_NUMBER
         - name: DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We already have the human readable ID. This adds the numeric ID, which is needed for some API calls.