### PR TITLE
Update startupProbeFailure alert to only alert on increases over 10 minutes

### DIFF
--- a/charts/monitoring-config/rules/startup_probe_failure.yaml
+++ b/charts/monitoring-config/rules/startup_probe_failure.yaml
@@ -4,10 +4,12 @@ groups:
       - alert: StartupProbeFailure
         expr: >-
           label_replace(
-            prober_probe_total{
-              probe_type="Startup",
-              result="failed"
-            } >= 10,
+            increase(
+              prober_probe_total{
+                probe_type="Startup",
+                result="failed"
+              }[10m]
+            ),
             "app_name",
             "$1",
             "pod",

--- a/charts/monitoring-config/rules/startup_probe_failure_tests.yaml
+++ b/charts/monitoring-config/rules/startup_probe_failure_tests.yaml
@@ -7,7 +7,6 @@ tests:
   - name: StartupProbeFailure - No alert with 29 failures
     interval: 1m
     input_series:
-      # No alert with 29 startupProbeFailures
       - series: >-
           prober_probe_total{
           probe_type="Startup",
@@ -16,7 +15,7 @@ tests:
           container="app",
           namespace="apps"
           }
-        values: '29x15'
+        values: '0 10 20 23 29 29'
     alert_rule_test:
       - alertname: StartupProbeFailure
         eval_time: 5m
@@ -25,7 +24,6 @@ tests:
   - name: StartupProbeFailure - Alert with 30 failures correctly in apps namespace
     interval: 1m
     input_series:
-      # Alert with 30 startupProbeFailures in the apps namespace
       - series: >-
           prober_probe_total{
           probe_type="Startup",
@@ -34,7 +32,7 @@ tests:
           container="app",
           namespace="apps"
           }
-        values: '30x10'
+        values: '0+10x10'
     alert_rule_test:
       - alertname: StartupProbeFailure
         eval_time: 5m
@@ -61,7 +59,6 @@ tests:
   - name: StartupProbeFailure - Alert with 30 failures correctly in licensify namespace
     interval: 1m
     input_series:
-      # Alert with 30 startupProbeFailures in the licensify namespace
       - series: >-
           prober_probe_total{
           probe_type="Startup",
@@ -70,7 +67,7 @@ tests:
           container="main",
           namespace="licensify"
           }
-        values: '30x10'
+        values: '0+10x10'
     alert_rule_test:
       - alertname: StartupProbeFailure
         eval_time: 5m
@@ -93,3 +90,20 @@ tests:
                 returning an HTTP response code >= 400.
 
                 To find the exact reason you can run `kubectl -n licensify describe pod licensify-frontend-6556f687fd-94glb`
+
+  - name: StartupProbeFailure - No alert for increases which occurred in the past, but are no longer occuring
+    interval: 1m
+    input_series:
+      - series: >-
+          prober_probe_total{
+          probe_type="Startup",
+          result="failed",
+          pod="draft-static-6556f687fd-94glb",
+          container="app",
+          namespace="apps"
+          }
+        values: '0+10x5 50+0x100'
+    alert_rule_test:
+      - alertname: StartupProbeFailure
+        eval_time: 30m
+        exp_alerts: []


### PR DESCRIPTION
We essentially alert forever on any container which fails its startup probe 30 times, but then actually launches. This is because it's probe failure metrics lives on if the container lives on, and it's always then over 30. So change this to only alert on increases over 10 minutes.

It also meant slightly adjusting the existing tests input series since `30x10` means `30+0x10` which expands to `30 30 30 30 30 30 30 30 30 30`, so making it `0+10*10` makes it `0 10 20 30 40 50 60 70 80 90 100`

I did a tiny bit of cleaning up too (removing some comments which are just duplicating the name of the rule