### PR TITLE
Add the govuk-synthetic-test-app to app-config  to add clusterrole and service account

### DIFF
--- a/charts/app-config/templates/govuk-synthetic-test-app.yaml
+++ b/charts/app-config/templates/govuk-synthetic-test-app.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: govuk-synthetic-test-app
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com/alphagov/govuk-helm-charts
+    path: charts/govuk-synthetic-test-app
+    targetRevision: HEAD
+    helm:
+      values: |
+        awsAccountId: "{{ .Values.awsAccountId }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.argoNamespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true


### PR DESCRIPTION
This should trigger Argo to create the cluster role and service account for the synthetic test app

https://github.com/alphagov/govuk-infrastructure/issues/2724