### PR TITLE
Remove superfluous labels on search quality alert rules

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -155,9 +155,6 @@ groups:
         labels:
           severity: warning
           destination: slack-search-team
-          top: 3
-          dataset: binary
-          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
           grafana_path: >-
@@ -171,9 +168,6 @@ groups:
         labels:
           severity: critical
           destination: slack-search-team
-          top: 3
-          dataset: binary
-          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
           grafana_path: >-
@@ -187,9 +181,6 @@ groups:
         labels:
           severity: warning
           destination: slack-search-team
-          top: 10
-          dataset: clickstream
-          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
           grafana_path: >-
@@ -203,9 +194,6 @@ groups:
         labels:
           severity: critical
           destination: slack-search-team
-          top: 10
-          dataset: clickstream
-          month: last_month
         annotations:
           summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"
           grafana_path: >-


### PR DESCRIPTION
When adding the last_over_time recording rule to the search quality alerts, it looked as though the
labels relating to the evaluation metrics ("dataset", "month" and "top") had to be manually readded as part of the alert rule. In fact they don't, and the "top" label is causing an error in the deploy because it's not a string. Therefore, we're removing the superfluous configuration of these labels in the alert rule.