### PR TITLE
Rename job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3106,13 +3106,13 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
-        - name: quality-report-quality-metrics-clickstream
+        - name: report-quality-metrics-clickstream
           task: "quality:report_quality_metrics[clickstream]"
           schedule: "0 6 * * *" # 06:00am GMT daily
-        - name: quality-report-quality-metrics-explicit
+        - name: report-quality-metrics-explicit
           task: "quality:report_quality_metrics[explicit]"
           schedule: "0 7 * * *" # 07:00am GMT daily
-        - name: quality-report-quality-metrics-binary
+        - name: report-quality-metrics-binary
           task: "quality:report_quality_metrics[binary]"
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3082,13 +3082,13 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
-        - name: quality-report-quality-metrics-clickstream
+        - name: report-quality-metrics-clickstream
           task: "quality:report_quality_metrics[clickstream]"
           schedule: "0 6 * * *" # 06:00am GMT daily
-        - name: quality-report-quality-metrics-explicit
+        - name: report-quality-metrics-explicit
           task: "quality:report_quality_metrics[explicit]"
           schedule: "0 7 * * *" # 07:00am GMT daily
-        - name: quality-report-quality-metrics-binary
+        - name: report-quality-metrics-binary
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
         - name: quality-setup-sample-query-sets

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3054,13 +3054,13 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
-        - name: quality-report-quality-metrics-clickstream
+        - name: report-quality-metrics-clickstream
           task: "quality:report_quality_metrics[clickstream]"
           schedule: "0 6 * * *" # 06:00am GMT daily
-        - name: quality-report-quality-metrics-explicit
+        - name: report-quality-metrics-explicit
           task: "quality:report_quality_metrics[explicit]"
           schedule: "0 7 * * *" # 07:00am GMT daily
-        - name: quality-report-quality-metrics-binary
+        - name: report-quality-metrics-binary
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
         - name: quality-setup-sample-query-sets


### PR DESCRIPTION
Reduce name of task to below the 50char limit
When the cron task is run by argo, the prefix `search-api-v2` is added
to the task, which gives a task name that exceeds the 50character limit.

This is raising an error and preventing the task from running.