### PR TITLE
(CM-517) Add `E2E_EMAILS` env vars to Content Block Manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -539,6 +539,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-block-manager-signon-api
               key: bearer_token
+        - name: E2E_EMAILS
+          value: "2nd-line-support@digital.cabinet-office.gov.uk,govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk"
 
   - name: content-data-admin
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -530,6 +530,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-block-manager-signon-api
               key: bearer_token
+        - name: E2E_EMAILS
+          value: "2nd-line-support@digital.cabinet-office.gov.uk,govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk"
 
   - name: content-data-admin
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -537,6 +537,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-content-block-manager-signon-api
               key: bearer_token
+        - name: E2E_EMAILS
+          value: "2nd-line-support@digital.cabinet-office.gov.uk,govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk"
 
   - name: content-data-admin
     helmValues:


### PR DESCRIPTION
This will allow us to identify blocks that have been created by E2E users and hide them from standard users, cutting down on the amount of clutter (more info in the ADR here https://github.com/alphagov/content-block-manager/blob/f83f3333d3276f047d020188579f3abfb6a813c5/docs/architecture/decisions/0005-hide-e2e-related-content-from-users.md).

These aren’t secrets in the real sense of the word, so have left them in plain text, rather than storing them as secrets.