### PR TITLE
Bump frontend replica count

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1385,7 +1385,7 @@ govukApplications:
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
-      replicaCount: 4
+      replicaCount: 6
       appResources:
         limits:
           cpu: 4


### PR DESCRIPTION
Frontend has been accruing formats from government-frontend recently, but we haven't applied any more resources to support the extra work.

We're going to do some better capacity management planning to better understand the shape of the different resources required (memory, cpu, connections, etc), but for now, we just want to add some extra nodes.

This shouldn't add any particular load to downstream services, such as content-store, as the demand is the same, it's just shifted.