### PR TITLE
Increase Frontend's replica count in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1385,7 +1385,7 @@ govukApplications:
             path: /assets/frontend/
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             path: /government/placeholder/
-      replicaCount: 4
+      replicaCount: 6
       appResources:
         limits:
           cpu: 4


### PR DESCRIPTION
while we investigate further to the same value as government-frontend.

- At a flawed and rough estimate (based on search-api-v1), frontend now renders
  >80% of pages, and the trend is towards consolidating on that app.
- App resources (barring the migration to Arm) haven't been recently tweaked.
- Each pod is likely to be able to cope with 20 concurrent connections (I think?) based on the default RAILS_MAX_THREADS x the configured WEB_CONCURRENCY (4)
- The errors seem to arise in the night and look to coincide with the Mirror crawler, so are likely a feature of low cache hit rate