### PR TITLE
Allow the synthetic-test-assumed role to be able to access the pod resource

### DIFF
--- a/charts/govuk-synthetic-test-app/templates/assumed_clusterrole.yaml
+++ b/charts/govuk-synthetic-test-app/templates/assumed_clusterrole.yaml
@@ -7,7 +7,7 @@ rules:
     resources: [applications]
     verbs: [get, watch, list]
   - apiGroups: [""]
-    resources: [pods]
+    resources: [pod, pods]
     verbs: [get, watch, list]
   - apiGroups: [apps]
     resources: [deployments]


### PR DESCRIPTION
This would allow for more targeted testing by the synthetic test app rather than having to retrive the entire pods list.

It also feels safer to test other http methods like DELETE on a single pod like the, synthetic test app pod, rather than the pod list.

https://github.com/alphagov/govuk-infrastructure/issues/2724