### PR TITLE
Modify regex for pod count

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -2230,7 +2230,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "count(group by(pod) (kube_pod_status_phase{phase=\"Running\", pod!~\"govuk-chat-dbmigrate-.....\", pod=~\"govuk-chat-..........?-.....\"}))",
+          "expr": "count(group by(pod) (kube_pod_status_phase{phase=\"Running\", pod!~\"govuk-chat-dbmigrate-.....\", pod=~\"govuk-chat-.........?.?-.....\"}))",
           "legendFormat": "PodsRunning",
           "range": true,
           "refId": "A"
@@ -2326,7 +2326,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "count(group by(pod) (kube_pod_status_phase{phase=\"Running\", pod=~\"govuk-chat-worker-..........?-.....\"}))",
+          "expr": "count(group by(pod) (kube_pod_status_phase{phase=\"Running\", pod=~\"govuk-chat-worker-.........?.?-.....\"}))",
           "legendFormat": "PodsRunning",
           "range": true,
           "refId": "A"
@@ -4531,5 +4531,5 @@
   "timezone": "browser",
   "title": "GOV.UK Chat Technical",
   "uid": "govuk-chat-technical",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
## What

Modify the regex for the pod count graph on the Chat Grafana dashboard

## Why

To comply with the EKS pod naming scheme