### PR TITLE
Revert "Allow the synthetic-test-assumed role to be able to access the pod resource"

### DIFF
--- a/charts/govuk-synthetic-test-app/templates/assumed_clusterrole.yaml
+++ b/charts/govuk-synthetic-test-app/templates/assumed_clusterrole.yaml
@@ -7,7 +7,7 @@ rules:
     resources: [applications]
     verbs: [get, watch, list]
   - apiGroups: [""]
-    resources: [pod, pods]
+    resources: [pods]
     verbs: [get, watch, list]
   - apiGroups: [apps]
     resources: [deployments]


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#3594

It's not possible to access an individual pod using the kubernetes api so giving access to the pod resource is pointless.