### PR TITLE
Change time of GOV.UK Chat Slack message

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1665,7 +1665,7 @@ govukApplications:
           timeZone: "Europe/London"
         - name: slack-daily-report
           task: "slack:send_previous_days_activity"
-          schedule: "3 7 * * *"
+          schedule: "30 9 * * *"
           timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL


### PR DESCRIPTION
We post a message into Slack each morning at 07:03. We want to change this to 09:30 so it's posted after people have started working.