### PR TITLE
Increase requested memory for Frontend apps

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1392,7 +1392,7 @@ govukApplications:
           memory: 4Gi
         requests:
           cpu: 500m
-          memory: 1.5Gi
+          memory: 2Gi
       kubernetesProbeEndpoints:
         startupProbe: "/healthcheck/ready"
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1435,7 +1435,7 @@ govukApplications:
           memory: 4Gi
         requests:
           cpu: 500m
-          memory: 1.5Gi
+          memory: 2Gi
       kubernetesProbeEndpoints:
         startupProbe: "/healthcheck/ready"
       extraEnv:


### PR DESCRIPTION
The [steady state memory requirement for frontend apps](https://grafana.eks.production.govuk.digital/d/a164a7f0339f99e89cea5cb47e9be617/kubernetes-compute-resources-workload?orgId=1&from=now-7d&to=now&timezone=Europe%2FLondon&var-datasource=default&var-cluster=&var-namespace=apps&var-type=deployment&var-workload=frontend&refresh=10s&viewPanel=panel-3) looks to be settling just below 2GB at the moment. Requesting this ahead of time will help with allocation, and hopefully reduce the number of OOM kills.

<img width="836" height="513" alt="Screenshot 2025-10-13 at 15 05 00" src="https://github.com/user-attachments/assets/a1e92a5b-f926-4aa3-97b3-36c3d6a24cab" />


In the last week we've had 27 events, and it feels like we could reduce this a little.

Interestingly we seem to get clumps of these events at around 09:08 on certain days (as revealed by the following query).

```
fields @timestamp, responseObject.metadata.labels.app
| filter responseObject.metadata.labels.app="frontend"
| filter stage="ResponseComplete"
| filter responseObject.status.containerStatuses.0 like /OOMKilled/
| filter userAgent like /kube-controller-manager/
| sort @timestamp
| limit 500
```

I had wondered whether increased demands from other apps, such as scheduled publishing, or email compilation might have been increasing memory pressure causing these evictions, but I haven't been able to back that up with evidence yet.