### PR TITLE
Set `DB_OWNER` for Content Block Manager restore

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -105,6 +105,9 @@ cronjobs:
       db: content_block_manager_production
       operations:
         - op: backup
+      extraEnv:
+        - name: DB_OWNER
+          value: content-block-manager
 
     collections-publisher-mysql:
       schedule: "21 23 * * *"


### PR DESCRIPTION
The database owner of Content Block Manager is `content-block-manager` (with dashes), but the `default_db_owner` function assumes the owner’s username is the name of the database with the dashes replaced with underscores (in this case `content_block_manager`). 

This means that when the restore cron job runs, we see the error: `ERROR:  role "content_block_manager" does not exist` ([see logs](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/app/data-explorer/discover/#?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-10-05T07:00:00.000Z',to:now))&_a=(discover:(columns:!(message),interval:auto,sort:!()),metadata:(indexPattern:'8ac115c0-aac1-11e8-88ea-0383c11b333a',view:discover))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',key:kubernetes.job.name,negate:!f,params:(query:db-backup-content-block-manager-postgres-29338723),type:phrase),query:(match_phrase:(kubernetes.job.name:db-backup-content-block-manager-postgres-29338723)))),query:(language:kuery,query:''))))

To get around this, we add an extra env variable to ensure we override the `DB_OWNER` variable, which should solve our problem.