### PR TITLE
(CM-568) Set `DB_OWNER` in correct environment

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -105,9 +105,6 @@ cronjobs:
       db: content_block_manager_production
       operations:
         - op: backup
-      extraEnv:
-        - name: DB_OWNER
-          value: content-block-manager
 
     collections-publisher-mysql:
       schedule: "21 23 * * *"
@@ -298,6 +295,9 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-production-database-backups
         - op: backup
+      extraEnv:
+        - name: DB_OWNER
+          value: content-block-manager
 
     content-data-admin-postgres:
       schedule: "4 1 * * 1-5"
@@ -559,6 +559,9 @@ cronjobs:
         - op: restore
           bucket: s3://govuk-production-database-backups
         - op: backup
+      extraEnv:
+        - name: DB_OWNER
+          value: content-block-manager
 
     content-data-admin-postgres:
       schedule: "4 3 * * 1"


### PR DESCRIPTION
In https://github.com/alphagov/govuk-helm-charts/pull/3601 I set the `DB_OWNER` env variable in an attempt to get the database restore jobs working. However, I put this in only the production environment, where the restore job doesn’t run.

This removes the env var from production and moves it to staging and integration, where it will be used.