### PR TITLE
Correct schedule 

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3119,7 +3119,7 @@ govukApplications:
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
         - name: report-binary-metrics-weekend
           task: "quality:report_quality_metrics[binary]"
-          schedule: "0 8 * * 6,7" # at 08:00 GMT on saturday and sunday
+          schedule: "0 8 * * 6,0" # at 08:00 GMT on saturday and sunday
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3095,7 +3095,7 @@ govukApplications:
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
         - name: report-binary-metrics-weekend
           task: "quality:report_quality_metrics[binary]"
-          schedule: "0 8 * * 6,7" # at 08:00 GMT on saturday and sunday
+          schedule: "0 8 * * 6,0" # at 08:00 GMT on saturday and sunday
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3067,7 +3067,7 @@ govukApplications:
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
         - name: report-binary-metrics-weekend
           task: "quality:report_quality_metrics[binary]"
-          schedule: "0 8 * * 6,7" # at 08:00 GMT on saturday and sunday
+          schedule: "0 8 * * 6,0" # at 08:00 GMT on saturday and sunday
         - name: quality-setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month


### PR DESCRIPTION
In https://github.com/alphagov/govuk-helm-charts/pull/3591 we used 6,7 to represent Saturday and Sunday. Valid values are 0-6 https://crontab.guru/#0_8_*_*_6,0