### PR TITLE
Add CPU to frontend apps requested resources

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1391,7 +1391,7 @@ govukApplications:
           cpu: 4
           memory: 4Gi
         requests:
-          cpu: 500m
+          cpu: 1
           memory: 2Gi
       kubernetesProbeEndpoints:
         startupProbe: "/healthcheck/ready"


### PR DESCRIPTION
We're still seeing frontend pods killed for OOM (17 today) more than I'd hoped. However, grafana stats for the affected pods show that memory is generally OK, but [CPU occasionally exceeds the requested values](https://grafana.eks.production.govuk.digital/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&from=2025-10-15T12:33:08.414Z&to=2025-10-15T14:20:46.705Z&timezone=Europe%2FLondon&var-datasource=default&var-cluster=&var-namespace=apps&var-pod=frontend-65dc6bb494-rbs74&refresh=10s).

<img width="1458" height="292" alt="Screenshot 2025-10-15 at 16 50 01" src="https://github.com/user-attachments/assets/627df9f7-41db-4dfe-a670-02886dec2ca1" />
<img width="1294" height="309" alt="Screenshot 2025-10-15 at 16 49 45" src="https://github.com/user-attachments/assets/e2e3d3b9-215e-4ecf-b393-20d071a85773" />



Bumping the requested CPU to get things back within the comfort zone appears to be a sensible next step.

App peaked at 0.925 CPU today, so trying 1 as a starter.