### PR TITLE
(CM-568) Set correct bucket when restoring in integration

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -557,7 +557,7 @@ cronjobs:
       dbms: postgres
       operations:
         - op: restore
-          bucket: s3://govuk-production-database-backups
+          bucket: s3://govuk-staging-database-backups
         - op: backup
       extraEnv:
         - name: DB_OWNER


### PR DESCRIPTION
This was set to Production, which Integration does not have access to.