### PR TITLE
Search API v2 Evaluations: Update alerting configuration to use new evaluation labels

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -147,9 +147,9 @@ groups:
     interval: 15m
     rules:
       - record: search_api_v2:quality_metrics:last_binary_recall
-        expr: last_over_time(search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}[26h])
+        expr: last_over_time(search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="this_month"}[26h])
       - record: search_api_v2:quality_metrics:last_clickstream_ndcg
-        expr: last_over_time(search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}[26h])
+        expr: last_over_time(search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="this_month"}[26h])
       - alert: SearchQualityDegradedBinaryRecall
         expr: search_api_v2:quality_metrics:last_binary_recall < 0.90
         labels:

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -303,7 +303,7 @@ tests:
     # Tests for SearchQualityDegradedBinaryRecall (data below threshold)
   - interval: 15m
     input_series:
-      - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="last_month"}'
+      - series: 'search_api_v2_evaluation_monitoring_recall{top="3", dataset="binary", month="this_month"}'
         values: '0.95x2 0.89 0.79'
     alert_rule_test:
       - eval_time: 35m
@@ -316,7 +316,7 @@ tests:
               severity: warning
               destination: slack-search-team
               dataset: binary
-              month: last_month
+              month: this_month
               top: 3
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
@@ -332,7 +332,7 @@ tests:
               severity: warning
               destination: slack-search-team
               dataset: binary
-              month: last_month
+              month: this_month
               top: 3
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
@@ -345,7 +345,7 @@ tests:
               severity: critical
               destination: slack-search-team
               dataset: binary
-              month: last_month
+              month: this_month
               top: 3
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
@@ -361,7 +361,7 @@ tests:
               severity: warning
               destination: slack-search-team
               dataset: binary
-              month: last_month
+              month: this_month
               top: 3
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (binary recall top 3 has dropped)"
@@ -374,7 +374,7 @@ tests:
               severity: critical
               destination: slack-search-team
               dataset: binary
-              month: last_month
+              month: this_month
               top: 3
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (binary recall top 3 is critical)"
@@ -390,7 +390,7 @@ tests:
   # Tests for SearchQualityDegradedClickstreamNDCG (data below threshold)
   - interval: 15m
     input_series:
-      - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="last_month"}'
+      - series: 'search_api_v2_evaluation_monitoring_ndcg{dataset="clickstream", top="10", month="this_month"}'
         values: '0.9x2 0.84 0.74'
     alert_rule_test:
       - eval_time: 35m
@@ -403,7 +403,7 @@ tests:
               severity: warning
               destination: slack-search-team
               dataset: clickstream
-              month: last_month
+              month: this_month
               top: 10
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
@@ -419,7 +419,7 @@ tests:
               severity: warning
               destination: slack-search-team
               dataset: clickstream
-              month: last_month
+              month: this_month
               top: 10
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
@@ -432,7 +432,7 @@ tests:
               severity: critical
               destination: slack-search-team
               dataset: clickstream
-              month: last_month
+              month: this_month
               top: 10
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"
@@ -448,7 +448,7 @@ tests:
               severity: warning
               destination: slack-search-team
               dataset: clickstream
-              month: last_month
+              month: this_month
               top: 10
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 has dropped)"
@@ -461,7 +461,7 @@ tests:
               severity: critical
               destination: slack-search-team
               dataset: clickstream
-              month: last_month
+              month: this_month
               top: 10
             exp_annotations:
               summary: "Search API v2: Degraded search result quality (clickstream NDCG top 10 is critical)"


### PR DESCRIPTION
Jira https://gov-uk.atlassian.net/browse/SCH-1527
Update alerting rules in line with changes to labels implemented in https://github.com/alphagov/search-api-v2/pull/571