### PR TITLE
Add crontask for govuk-synthetic-test-app-runner and allow sh command

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4010,6 +4010,9 @@ govukApplications:
 
   - name: govuk-synthetic-test-app
     helmValues:
+      appImage:
+        repository: ghcr.io/alphagov/govuk/govuk-synthetic-test-app-runner
+        tag: 88bd484e0dd3c85f55592d0c8b76a6969a72eba3
       arch: arm64
       rails:
         enabled: false
@@ -4017,16 +4020,16 @@ govukApplications:
         enabled: false
       uploadAssets:
         enabled: false
-      ingress:
-        enabled: true
-        annotations:
-          <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
-          alb.ingress.kubernetes.io/group.order: "300"
-        hosts:
-          - name: govuk-synthetic-test-app.eks.integration.govuk.digital
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      cronTasks:
+        - name: run-helper-tests
+          command_sh: "ginkgo -v helpers"
+          schedule: "0 1 * * *"
       extraEnv:
-        - name: ENV_MESSAGE_EXAMPLE
-          value: message_by_example
+        - name: ENVIRONMENT_NAME
+          value: "integration"
 
   - name: govuk-synthetic-test-app-canary
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1819,6 +1819,29 @@ govukApplications:
     imageValues:
       - govuk-dependency-checker
 
+  - name: govuk-synthetic-test-app
+    helmValues:
+      appImage:
+        repository: ghcr.io/alphagov/govuk/govuk-synthetic-test-app-runner
+        tag: 88bd484e0dd3c85f55592d0c8b76a6969a72eba3
+      arch: arm64
+      rails:
+        enabled: false
+      sentry:
+        enabled: false
+      uploadAssets:
+        enabled: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      cronTasks:
+        - name: run-helper-tests
+          command_sh: "ginkgo -v helpers"
+          schedule: "0 1 * * *"
+      extraEnv:
+        - name: ENVIRONMENT_NAME
+          value: "production"
+
   - name: govuk-synthetic-test-app-canary
     helmValues:
       arch: arm64

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1813,6 +1813,29 @@ govukApplications:
     imageValues:
       - govuk-dependency-checker
 
+  - name: govuk-synthetic-test-app
+    helmValues:
+      appImage:
+        repository: ghcr.io/alphagov/govuk/govuk-synthetic-test-app-runner
+        tag: 88bd484e0dd3c85f55592d0c8b76a6969a72eba3
+      arch: arm64
+      rails:
+        enabled: false
+      sentry:
+        enabled: false
+      uploadAssets:
+        enabled: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      cronTasks:
+        - name: run-helper-tests
+          command_sh: "ginkgo -v helpers"
+          schedule: "0 1 * * *"
+      extraEnv:
+        - name: ENVIRONMENT_NAME
+          value: "staging"
+
   - name: govuk-synthetic-test-app-canary
     helmValues:
       arch: arm64

--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -64,6 +64,9 @@ spec:
               {{- else if .command }}
               command: ["/bin/bash"]
               args: ["-c", "{{ .command }}"]
+              {{- else if .command_sh }}
+              command: ["/bin/sh"]
+              args: ["-c", "{{ .command }}"]
               {{- end }}
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
This crontask will create a cronjob which will run on the cluster in the apps namespace.

At the moment I'm deploying the cronjob via the crontask in order to allow the cronjob to be deployed with different ENVIRONMENT_NAME per environment. 

I'm also just pulling the image from GHCR.

So a few questions: 

- should the cronjob be in the `apps` namespace as it is testing the release pipeline?
- should it be deployed like other govuk apps?
- should we be pulling the image from GHCR? or use ECR?

https://github.com/alphagov/govuk-infrastructure/issues/2736