### PR TITLE
Bump `kubernetes-event-shipper` to 1.1.1 for new Docker version

### DIFF
--- a/charts/kubernetes-events-shipper/Chart.yaml
+++ b/charts/kubernetes-events-shipper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: kubernetes-events-shipper
 description: Creates a fluent bit stateful set which will send all kuberenetes events in a cluster to logit
 type: application
-version: "1.1.0"
+version: "1.1.1"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-helm-charts/pull/3604 added `4.1.1` for Fluent Bit
- Bump the chart version to pick up the new docker image