### PR TITLE
SCH-1488 add new alerts channel for monitoring and alerting

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -73,7 +73,24 @@ spec:
       - name: destination
         value: slack-search-team
         matchType: =
-      receiver: 'slack-search-team-alerts-channel'
+      - name: environment
+        value: production
+        matchType: =
+      receiver: 'slack-search-team-production-alerts'
+      groupBy: [alertname, severity, environment]
+      groupWait: 30s
+      groupInterval: 5m
+      repeatInterval: 1d
+      activeTimeIntervals:
+        - inhours
+    - matchers:
+      - name: destination
+        value: slack-search-team
+        matchType: =
+      - name: environment
+        value: production
+        matchType: !=
+      receiver: 'slack-search-team-non-production-alerts'
       groupBy: [alertname, severity, environment]
       groupWait: 30s
       groupInterval: 5m
@@ -162,9 +179,15 @@ spec:
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}
-  - name: 'slack-search-team-alerts-channel'
+  - name: 'slack-search-team-production-alerts'
     slackConfigs:
     - channel: "#govuk-search-alerts"
+      {{- include "slack.template" . | nindent 6 }}
+      text: |-
+        {{- include "slack.text" . | nindent 8 }}
+    - name: 'slack-search-team-non-production-alerts'
+    slackConfigs:
+    - channel: "#govuk-search-alerts-nonprod"
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}


### PR DESCRIPTION
Previously the search team's alerts for all environments went to a single Slack channel. To reduce noise, these will now be split across two channels: one for production alerts, and another for all other alerts.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1488

Docs on how to use matchType for Alert manager configuration: 
https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.Matcher