### PR TITLE
Add govuk-e2e-tests cronJob to integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1810,6 +1810,11 @@ govukApplications:
         requests:
           cpu: 1
           memory: 1Gi
+      cronJobs:
+        - name: govuk-e2e-tests
+          schedule: "@never"
+          project: main
+          suspend: true
 
   - name: hmrc-manuals-api
     helmValues:


### PR DESCRIPTION
It currently doesn't appear on the list of cronjobs (`kubectl get cronjobs --all-namespaces`).  
Attempt on running returns an error:
```
kubectl create job govuk-e2e-tests-manual-run --from=cronjob/govuk-e2e-tests
Error from server (NotFound): cronjobs.batch "govuk-e2e-tests" not found
```

This set the `schedule` property to something invalid prevent the CronJob from running on schedule as we only want to run it manually for now.

https://github.com/alphagov/govuk-infrastructure/issues/2896