### PR TITLE
Set govuk-e2e-tests cron schedule to a valid value

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1812,7 +1812,7 @@ govukApplications:
           memory: 1Gi
       cronJobs:
         - name: govuk-e2e-tests
-          schedule: "@never"
+          schedule: "*/10 7-19 * * 1-5" # 10 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
           project: main
           suspend: true
 


### PR DESCRIPTION
`"@never"` raises an error:
`one or more objects failed to apply, reason: CronJob.batch "govuk-e2e-tests" is invalid: spec.schedule: Invalid value: "@never": unrecognized descriptor: @never`

Setting it to what it was previously but it's currently suspended.

https://github.com/alphagov/govuk-infrastructure/issues/2896