### PR TITLE
Use `search-api-v2` secret key base for `search-api-v2-beta-features`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3176,6 +3176,9 @@ govukApplications:
       arch: arm64
       rails:
         createKeyBaseSecret: false
+        # search-api-v2-beta-features is only used for running cron tasks so it's fine to share
+        # this secret
+        secretKeyBaseName: search-api-v2-rails-secret-key-base
       sentry:
         createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:


### PR DESCRIPTION
Description:
- This is just testing out beta features for `search-api-v2` and is only used to run Rake tasks so I think it's fine to share the secret
- https://gov-uk.atlassian.net/jira/software/c/projects/SCH/boards/994?selectedIssue=SCH-1492