### PR TITLE
Use `search-api-v2-beta-features` Sentry DSN

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3179,8 +3179,6 @@ govukApplications:
         # search-api-v2-beta-features is only used for running cron tasks so it's fine to share
         # this secret
         secretKeyBaseName: search-api-v2-rails-secret-key-base
-      sentry:
-        createSecret: false  # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
       dbMigrationEnabled: false


### PR DESCRIPTION
Description:
- Create the `search-api-v2-beta-features` external secret for Sentry rather than using an existing one
- https://gov-uk.atlassian.net/jira/software/c/projects/SCH/boards/994?selectedIssue=SCH-1492