### PR TITLE
Set the namespace for govuk-synthetic-test-app-cronjob to apps

### DIFF
--- a/charts/govuk-synthetic-test-app/templates/cronjob.yaml
+++ b/charts/govuk-synthetic-test-app/templates/cronjob.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: govuk-synthetic-test-app-cronjob
+  namespace: apps
   annotations:
     kubernetes.io/description: >
       This cronjob runs synthetic tests against GOV.UK cluster using a Ginkgo test framework.


### PR DESCRIPTION
The cronjob was attempting to run in the `cluster-services` namespace which doesn't have access to the `synthetic-test-assumer` service account, so set the namespace to `apps` to get the cronjob running.

https://github.com/alphagov/govuk-infrastructure/issues/2736