### PR TITLE
Fix govuk-synthetic-test-app-cronjob image

### DIFF
--- a/charts/govuk-synthetic-test-app/templates/cronjob.yaml
+++ b/charts/govuk-synthetic-test-app/templates/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: govuk-synthetic-test-app-cronjob
-              image: '172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk//govuk-synthetic-test-app:{{ .Values.image_tag }}'
+              image: '172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/govuk-synthetic-test-app:{{ .Values.image_tag }}'
               imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
Remove the additional forward slash on image as this makes it invalid.

https://github.com/alphagov/govuk-infrastructure/issues/2736