### PR TITLE
Disable app deployment for `search-api-v2-beta-features`

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3174,6 +3174,7 @@ govukApplications:
   - name: search-api-v2-beta-features
     helmValues:
       arch: arm64
+      appEnabled: false
       rails:
         createKeyBaseSecret: false
         # search-api-v2-beta-features is only used for running cron tasks so it's fine to share


### PR DESCRIPTION
Description:
- Currently this spins up a Rails app for `search-api-v2-beta-features` but this repo is only used for running cron jobs
- https://gov-uk.atlassian.net/jira/software/c/projects/SCH/boards/994?selectedIssue=SCH-1492