### PR TITLE
Add govuk-e2e-test jobs to staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1714,6 +1714,23 @@ govukApplications:
         requests:
           cpu: 1
           memory: 1Gi
+      cronJobs:
+        - name: govuk-e2e-tests
+          schedule: "*/10 7-19 * * 1-5"  # 10 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: main
+          suspend: true
+        - name: govuk-e2e-tests-mirror-s3
+          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: mirrorS3
+          suspend: true
+        - name: govuk-e2e-tests-mirror-s3-replica
+          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: mirrorS3Replica
+          suspend: true
+        - name: govuk-e2e-tests-mirror-gcs
+          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: mirrorGCS
+          suspend: true
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1702,6 +1702,23 @@ govukApplications:
         requests:
           cpu: 1
           memory: 1Gi
+      cronJobs:
+        - name: govuk-e2e-tests
+          schedule: "*/10 7-19 * * 1-5"  # 10 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: main
+          suspend: true
+        - name: govuk-e2e-tests-mirror-s3
+          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: mirrorS3
+          suspend: true
+        - name: govuk-e2e-tests-mirror-s3-replica
+          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: mirrorS3Replica
+          suspend: true
+        - name: govuk-e2e-tests-mirror-gcs
+          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          project: mirrorGCS
+          suspend: true
 
   - name: govuk-exporter
     chartPath: charts/govuk-exporter


### PR DESCRIPTION
## Why

So we can run them manually.  

### Notes

Otherwise they don't appear on the list of cronjobs (`kubectl get cronjobs --all-namespaces`).  Attempt of running returns an error:

```
  kubectl create job govuk-e2e-tests-manual-run --from=cronjob/govuk-e2e-tests
  Error from server (NotFound): cronjobs.batch "govuk-e2e-tests" not found
```

The value of `schedule` also needs to be a valid cron expression so I'm setting them to what they used to be before they got removed in https://github.com/alphagov/govuk-helm-charts/commit/9dab0b5fabc7c14ec1fabc64f1317ab2c65dc576

https://github.com/alphagov/govuk-infrastructure/issues/2896