### PR TITLE
[PNP-9662] Scale down local-links-manager and add maintenance mode to Frontend in Staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1920,6 +1920,7 @@ govukApplications:
 
   - name: local-links-manager
     helmValues:
+      appEnabled: false
       arch: arm64
       appResources:
         limits:


### PR DESCRIPTION
We want to display a maintenance message in Frontend for services like https://www.gov.uk/garden-waste-disposal, whilst scaling down local-links-manager so that it's unavailable during the database upgrade.

Related PR - https://github.com/alphagov/govuk-e2e-tests/pull/346

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9662