### PR TITLE
[PNP-9662] Scale down local-links-manager and add maintenance mode to Frontend in Staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1376,6 +1376,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: MAINTENANCE_MESSAGE
+          value: "The system will be unavailable for essential maintenance, please try again later"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:
@@ -1918,6 +1920,7 @@ govukApplications:
 
   - name: local-links-manager
     helmValues:
+      appEnabled: false
       arch: arm64
       appResources:
         limits:


### PR DESCRIPTION
2nd attempt at scaling down local-links-manager in Staging.

We want to display a maintenance message in Frontend for services like https://www.gov.uk/garden-waste-disposal, whilst scaling down local-links-manager so that it's unavailable during the database upgrade.

Related PRs:

- https://github.com/alphagov/govuk-e2e-tests/pull/346
- https://github.com/alphagov/frontend/pull/5072

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9662