### PR TITLE
Tune resources for search-api-v2-beta-features

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3091,6 +3091,13 @@ govukApplications:
     helmValues:
       arch: arm64
       appEnabled: false
+      appResources:
+        limits:
+          cpu: 2
+          memory: 2.5Gi
+        requests:
+          cpu: 500m
+          memory: 800Mi
       rails:
         createKeyBaseSecret: false
         # search-api-v2-beta-features is only used for running cron tasks so it's fine to share


### PR DESCRIPTION
The rpt-clickstream-metrics took over an hour to run in production. When this job was run by search-api-v2, it look less than twenty minutes to complete.

Job times in search-api-v2:

Clickstream 7 - 7.18, and 7.18 - 7.36
Explicit 8 - 8.14 and 8.14 - 8.36
Binary 9 - 9.22 (Sept) and 9.22 - 9.39 (August)

Job times in search-api-v2-beta-features:
Clickstream 6 - 6.32 and 6.32 - 7.12
Explicit (failed because clickstream was still running) Binary 10 - 10.23 and 10.23 - 10.46

This only seems to be an issue in production, perhaps because there is less search data in the non-production environments.

To try and fix this the app resource limits have been increased to match the values in integration and staging for search-api-v2. Strangely the values for production are less than those in the lower environments.