### PR TITLE
Reset Content Store `payload_version` to 0 in integration

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -576,6 +576,8 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
+        - op: transform
+          script: content-store.sql
         - op: backup
 
     # TODO: stop copying draft content into integration once the design quirks
@@ -587,6 +589,8 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
+        - op: transform
+          script: content-store.sql
         - op: backup
 
     content-tagger-postgres:


### PR DESCRIPTION
In a377d7a624963fdb5ffa4fb614fa6f763e2054cb, we added a script to reset the `payload_version` to zero in staging.

This typically cascades down to integration, as there is not normally any publishing activity in staging, so the dump retains the zero values when restored to integration.

However if any publishing activity occurs in staging, the `payload_version` gets incremented and can then be out of sync with Publishing API when restored to integration.

Therefore running the transformation script in integration, so the values are reset to zero, even if there has been publishing activity in staging.