### PR TITLE
Correct cron expression comments

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1720,7 +1720,7 @@ govukApplications:
           memory: 1Gi
       cronJobs:
         - name: govuk-e2e-tests
-          schedule: "*/10 7-19 * * 1-5" # 10 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/10 7-19 * * 1-5" # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: main
           suspend: true
 

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1716,19 +1716,19 @@ govukApplications:
           memory: 1Gi
       cronJobs:
         - name: govuk-e2e-tests
-          schedule: "*/10 7-19 * * 1-5"  # 10 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/10 7-19 * * 1-5"  # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: main
           suspend: true
         - name: govuk-e2e-tests-mirror-s3
-          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/30 7-19 * * 1-5"  # every 30 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: mirrorS3
           suspend: true
         - name: govuk-e2e-tests-mirror-s3-replica
-          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/30 7-19 * * 1-5"  # every 30 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: mirrorS3Replica
           suspend: true
         - name: govuk-e2e-tests-mirror-gcs
-          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/30 7-19 * * 1-5"  # every 30 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: mirrorGCS
           suspend: true
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1704,19 +1704,19 @@ govukApplications:
           memory: 1Gi
       cronJobs:
         - name: govuk-e2e-tests
-          schedule: "*/10 7-19 * * 1-5"  # 10 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/10 7-19 * * 1-5"  # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: main
           suspend: true
         - name: govuk-e2e-tests-mirror-s3
-          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/30 7-19 * * 1-5"  # every 30 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: mirrorS3
           suspend: true
         - name: govuk-e2e-tests-mirror-s3-replica
-          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/30 7-19 * * 1-5"  # every 30 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: mirrorS3Replica
           suspend: true
         - name: govuk-e2e-tests-mirror-gcs
-          schedule: "*/30 7-19 * * 1-5"  # 30 minutes past every hour, between 7:00 - 19:00 UTC, Monday to Friday
+          schedule: "*/30 7-19 * * 1-5"  # every 30 minutes, between 7:00 - 19:00 UTC, Monday to Friday
           project: mirrorGCS
           suspend: true
 


### PR DESCRIPTION
Kubernetes cron syntax format also includes extended "Vixie cron" step values.

> "Step values can be used in conjunction with ranges. Following a range with /<number> specifies skips of the number's value through the range. For example, 0-23/2 can be used in the hours field to specify command execution every other hour (the alternative in the V7 standard is 0,2,4,6,8,10,12,14,16,18,20,22). Steps are also permitted after an asterisk, so if you want to say "every two hours", just use */2."

See: https://man.freebsd.org/cgi/man.cgi?crontab%285%29