### PR TITLE
Enable suspension for govuk-e2e-tests CronJob

### DIFF
--- a/charts/govuk-e2e-tests/templates/cronjob.yaml
+++ b/charts/govuk-e2e-tests/templates/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 3
   successfulJobsHistoryLimit: 3
   schedule: {{ .schedule | quote }}
+  suspend: {{ .suspend | default false }}
   jobTemplate:
     metadata:
       name: {{ .name }}


### PR DESCRIPTION
The config values were not propagated.

https://github.com/alphagov/govuk-infrastructure/issues/2896