### PR TITLE
[PNP-9663] Scale down local-links-manager and add maintenance mode to Frontend in Production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1339,6 +1339,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: MAINTENANCE_MESSAGE
+          value: "The system will be unavailable for essential maintenance from 11:15-12:15, please try again later"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We want to display a maintenance message in Frontend for services like https://www.gov.uk/garden-waste-disposal, whilst scaling down local-links-manager so that it's unavailable during the database upgrade.

Related PRs:

- https://github.com/alphagov/govuk-e2e-tests/pull/348
- https://github.com/alphagov/frontend/pull/5072

Jira card - https://gov-uk.atlassian.net/browse/PNP-9663