### PR TITLE
Fix indentation in alert manager config

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -185,7 +185,7 @@ spec:
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}
-    - name: 'slack-search-team-non-production-alerts'
+  - name: 'slack-search-team-non-production-alerts'
     slackConfigs:
     - channel: "#govuk-search-alerts-nonprod"
       {{- include "slack.template" . | nindent 6 }}


### PR DESCRIPTION
The receiver slack-search-team-non-production-alerts was incorrectly indented too much, meaning it
was being read as part of the slack-search-team-production-alerts receiver, causing an error in Alert Manager.