### PR TITLE
Configure router to load routes from a file in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2631,6 +2631,26 @@ govukApplications:
         - name: router-nginx-htpasswd
           secret:
             secretName: router-nginx-htpasswd
+        - name: aws-tmp
+          emptyDir: {}
+      initContainers:
+        - name: fetch-routes
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/govuk-toolbox-image:v6
+          command: ["sh", "-c", "aws s3 cp s3://govuk-router-routes-<environment>/routes.jsonl /tmp/routes.jsonl"]
+          volumeMounts:
+            - name: app-tmp
+              mountPath: /tmp
+            - name: aws-tmp
+              mountPath: /home/ubuntu/.aws
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      serviceAccount:
+        enabled: true
+        create: false
+        name: router-routes-load
       appProbes: &router-app-probes
         startupProbe: &router-probe
           httpGet:
@@ -2651,6 +2671,8 @@ govukApplications:
           failureThreshold: 2
           periodSeconds: 5
       extraEnv:
+        - name: ROUTER_ROUTES_FILE
+          value: /tmp/routes.jsonl
         - name: GOMAXPROCS
           value: "2"
         - name: SENTRY_ENVIRONMENT


### PR DESCRIPTION
This is a test of the process to switch router over to loading routes from a flat file, in preparation of content store database maintenance that is happening soon

Validation: I have rendered the router chart locally and it is generating a valid deployment with the initContainer and service account set.

https://github.com/alphagov/govuk-platform-internal/issues/76