### PR TITLE
Configure router to load routes from a file in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2631,6 +2631,8 @@ govukApplications:
         - name: router-nginx-htpasswd
           secret:
             secretName: router-nginx-htpasswd
+        - name: aws-tmp
+          emptyDir: {}
       appProbes: &router-app-probes
         startupProbe: &router-probe
           httpGet:
@@ -2650,7 +2652,27 @@ govukApplications:
             port: 9394
           failureThreshold: 2
           periodSeconds: 5
+      initContainers:
+        - name: fetch-routes
+          image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/govuk-toolbox-image:v6
+          command: ["sh", "-c", "aws s3 cp s3://govuk-router-routes-<environment>/routes.jsonl /tmp/routes.jsonl"]
+          volumeMounts:
+            - name: app-tmp
+              mountPath: /tmp
+            - name: aws-tmp
+              mountPath: /home/user/.aws
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      serviceAccount:
+        enabled: true
+        create: false
+        name: router-routes-load
       extraEnv:
+        - name: ROUTER_ROUTES_FILE
+          value: /tmp/routes.jsonl
         - name: GOMAXPROCS
           value: "2"
         - name: SENTRY_ENVIRONMENT
@@ -2690,6 +2712,7 @@ govukApplications:
             secretKeyRef:
               key: DATABASE_URL
               name: content-store-postgres
+
   - name: draft-router
     repoName: router
     helmValues:


### PR DESCRIPTION
To test the process. https://github.com/alphagov/govuk-infrastructure/issues/3051

This adds:
- aws-tmp volume required for AWS CLI to function
- an initContainer which fetches the routes file from S3
- ROUTER_ROUTES_FILE env var
- service account which was created earlier