### PR TITLE
[PNP-9679] Add MAINTENANCE_MESSAGE to email-alert-frontend in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1075,6 +1075,8 @@ govukApplications:
               key: token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: MAINTENANCE_MESSAGE
+          value: "Email subscription management will be unavailable for about 5 minutes for essential database updates. Please try again later."
 
   - name: draft-email-alert-frontend
     repoName: email-alert-frontend
@@ -1115,6 +1117,8 @@ govukApplications:
               key: token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: MAINTENANCE_MESSAGE
+          value: "Email subscription management will be unavailable for about 5 minutes for essential database updates. Please try again later."
 
   - name: email-alert-service
     helmValues:


### PR DESCRIPTION
- also draft-email-alert-frontend

These are needed for a user-friendly disabling of account-related activity while accounts-api is updated.

https://gov-uk.atlassian.net/browse/PNP-9679