### PR TITLE
Update govuk-synthetic-test-app image_tag to v1756914801

### DIFF
--- a/charts/govuk-synthetic-test-app/values.yaml
+++ b/charts/govuk-synthetic-test-app/values.yaml
@@ -1,2 +1,2 @@
 awsAccountId: ""
-image_tag: v1756914799
+image_tag: v1756914801


### PR DESCRIPTION
The image doesn't exist in ECR because there isn't a pod requesting it, so to trigger the pull through update the image tag to the latest one on the govuk-synthetic-test-app repo.

https://github.com/alphagov/govuk-infrastructure/issues/3052