### PR TITLE
GOV.UK Chat: turn off send_previous_days_activity cron job

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1577,10 +1577,6 @@ govukApplications:
           task: "bigquery:export"
           schedule: "5 * * * *"
           timeZone: "Europe/London"
-        - name: slack-daily-report
-          task: "slack:send_previous_days_activity"
-          schedule: "30 9 * * *"
-          timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:


### PR DESCRIPTION

The pilot has finished running now, so we no longer want this cronjob to
run.
