### PR TITLE
GOV.UK Chat: turn off BigQuery cronjob

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1572,11 +1572,6 @@ govukApplications:
       uploadAssets:
         s3Directory: chat
         path: /app/public/assets/chat
-      cronTasks:
-        - name: bigquery-export
-          task: "bigquery:export"
-          schedule: "5 * * * *"
-          timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:


### PR DESCRIPTION

We're not running this service in production any more, so we don't need
to be exporting the data in a daily cronjob.
