### PR TITLE
[PNP-9683] Scale down apps for email-alert-api database upgrade in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3524,6 +3524,7 @@ govukApplications:
   - name: specialist-publisher
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
This is PR 1 (out of 3), related PRs:
- https://github.com/alphagov/govuk-helm-charts/pull/3698
- https://github.com/alphagov/govuk-helm-charts/pull/3699

We want to scale down email-alert-service, travel-advice-publisher, and specialist-publisher ahead of the database upgrade for email-alert-api so that we don't lose any messages.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9683