### PR TITLE
[PNP-9683] Add MAINTENANCE_MODE for email-alert-frontend and scale down account-api in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1076,6 +1076,8 @@ govukApplications:
               key: token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: MAINTENANCE_MESSAGE
+          value: "Email subscription management will be unavailable for essential database updates. Please try again later."
 
   - name: draft-email-alert-frontend
     repoName: email-alert-frontend
@@ -1116,6 +1118,8 @@ govukApplications:
               key: token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: MAINTENANCE_MESSAGE
+          value: "Email subscription management will be unavailable for essential database updates. Please try again later."
 
   - name: email-alert-service
     helmValues:


### PR DESCRIPTION
Depends on:
- https://github.com/alphagov/govuk-helm-charts/pull/3697

We want to display a maintenance message in email-alert-frontend as well as scale down account-api so that it is unavailable during the database upgrade for email-alert-api.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9683