### PR TITLE
[PNP-9683] Scale down email-alert-api in Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -946,6 +946,7 @@ govukApplications:
   - name: email-alert-api
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
Depends on:
- https://github.com/alphagov/govuk-helm-charts/pull/3697
- https://github.com/alphagov/govuk-helm-charts/pull/3698

We want to scale down email-alert-api whilst we carry out the database upgrade to PG14.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9683