### PR TITLE
[PNP-9686] Scale down apps for email-alert-api database upgrade in Staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3476,6 +3476,7 @@ govukApplications:
   - name: specialist-publisher
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
This is PR 1 (out of 3), we also need to PRs to:
- Add maintenence message to email-alert-frontend, and scale down account-api
- Scale down email-alert-api

We want to scale down email-alert-service, travel-advice-publisher, and specialist-publisher ahead of the database upgrade for email-alert-api so that we don't lose any messages.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9686