### PR TITLE
[PNP-9686] Scale down email-alert-api in Staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -938,6 +938,7 @@ govukApplications:
   - name: email-alert-api
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 2


### PR DESCRIPTION
Depends on:
1. https://github.com/alphagov/govuk-helm-charts/pull/3703
2. https://github.com/alphagov/govuk-helm-charts/pull/3704

We want to scale down email-alert-api whilst we carry out the database upgrade to PG14.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9686