### PR TITLE
Add nginx config to GOV.UK Chat endpoint to turn off buffering

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1646,6 +1646,12 @@ govukApplications:
         name: govuk-chat
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role
+      nginxConfigMap:
+        extraServerConf: |
+          location ~ /answer_stream$ {
+            proxy_buffering off;
+            proxy_cache off;
+          }
       podAutoscaling:
         - name: govuk-chat
           enabled: true


### PR DESCRIPTION
This is a test to see whether this config works for nginx to allow it to
buffer a response.

Currently - and by default - nginx will buffer all responses, i.e. it
waits until it's got the entire response from downstream before sending
it to the client.

We're spiking out a feature in GOV.UK Chat where responses are streamed
to the client (like most chatbots do). The nginx config is preventing
that from happening.

This commit adds what I think should be enough config to turn off
buffering. It's currently just applied to one endpoint in GOV.UK Chat,
and it's only set in integration.

It might be that additional config is needed, but the plan is to hopefully just
deploy this to integration and see if it works.

I should note that we're not actually intending to support streaming in the
immediate future - this is just a spike to see if we can get it working. Once
it's verified I'll add some documentation somewhere and close this PR without
merging.

### Testing

I've verified the config here should work to allow streaming. Below is a simple 
Dockerfile which exposes two endpoints.

* `http://localhost:3001/stream` is an endpoint with the config applied, and will stream the HTTP response
* `http://localhost:3001/stream-buffered` is an endpoint with the default config applied, and will buffer the whole HTTP response

You can test this with:

```bash
$ docker build -t nginx-buffer . && docker run --rm -p 3001:80 nginx-buffer sh -c "/usr/local/bin/sse.sh & nginx -g 'daemon off;'"
```

```Dockerfile
FROM nginx:alpine

RUN apk add --no-cache bash

RUN cat > /etc/nginx/nginx.conf <<'EOF'
events {
    worker_connections 1024;
}

http {
    server {
        listen 80;
        server_name localhost;

        # SSE endpoint without buffering
        location /stream {
            proxy_pass http://127.0.0.1:8080/sse;
            proxy_buffering off;
            proxy_cache off;
        }

        # SSE endpoint with buffering
        location /stream-buffered {
            proxy_pass http://127.0.0.1:8080/sse;
            proxy_buffering on;
        }
    }
}
EOF

RUN cat > /usr/local/bin/sse.sh <<'EOF'
#!/bin/bash

while true; do
    {
        read request
        while read header; do
            [ "$header" = $'\r' ] && break
        done

        echo -ne "HTTP/1.1 200 OK\r\n"
        echo -ne "Content-Type: text/event-stream\r\n"
        echo -ne "Cache-Control: no-cache\r\n"
        echo -ne "Connection: keep-alive\r\n"
        echo -ne "\r\n"

        for i in {1..10}; do
            echo "data: Chunk $i at $(date +%H:%M:%S)"
            echo ""
            sleep 1
        done

        echo "event: done"
        echo "data: Stream complete"
        echo ""
    } | nc -l -p 8080

    sleep 0.1
done
EOF

RUN chmod +x /usr/local/bin/sse.sh

EXPOSE 80

CMD ["nginx", "-g", "daemon off"]
```