### PR TITLE
Add proxy_pass for GOV.UK Chat streaming endpoint

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1649,6 +1649,7 @@ govukApplications:
       nginxConfigMap:
         extraServerConf: |
           location ~ /answer_stream$ {
+            proxy_pass http://govuk-chat;
             proxy_buffering off;
             proxy_cache off;
           }


### PR DESCRIPTION

Hitting this endpoint currently returns a 404 because we're not telling
nginx where to proxy the request to.
