### PR TITLE
Add support for websockets in nginx config for Chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1652,6 +1652,12 @@ govukApplications:
             proxy_buffering off;
             proxy_cache off;
           }
+          location /cable {
+              proxy_pass http://govuk-chat:8080/cable;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+          }
       podAutoscaling:
         - name: govuk-chat
           enabled: true


### PR DESCRIPTION
**This is for testing and will be reverted once we have determined the ease of using websockets to stream content**

## Description

After some investigation, it seems that the Nginx config for Chat needs to be modified to support websockets properly. The changes involve adding a new location block for /cable that correctly proxies websocket connections to the Chat service.

I've found a couple of examples which have led my approach:

https://gist.github.com/SunDi3yansyah/5978a1737d08f4abda46f1176a039cc2 https://stackoverflow.com/questions/67696655/what-do-i-need-to-do-to-hook-up-actioncable-on-nginx-and-puma

One thing i noticed and had to tweak is that when i do "kubectl describe svc govuk-chat" the port is listed as 8080, not 3000 as i had assumed. So I've updated the configuration to reflect that.

## Trello card

https://trello.com/c/KDNGuNqL/2851-spike-a-static-streamed-sse-and-web-socket-responses-in-the-chat-app