### PR TITLE
Set additional proxy headers for GOV.UK Chat streaming

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1650,6 +1650,10 @@ govukApplications:
         extraServerConf: |
           location ~ /answer_stream$ {
             proxy_pass http://govuk-chat;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header GOVUK-Request-Id $govuk_request_id;
+            proxy_redirect off;
             proxy_buffering off;
             proxy_cache off;
           }


### PR DESCRIPTION
These headers have been copied from the top-level `location /` directive
in the nginx config (see [here](https://argo.eks.integration.govuk.digital/applications/cluster-services/govuk-chat?view=tree&node=%2FConfigMap%2Fapps%2Fgovuk-chat-nginx-conf%2F0&orphaned=false&resource=) in Argo).

Currently browsing to this path - i.e. the path ending `/answer_stream`
gives a 403 because of a disallowed host. We need to set the host in the
header to be the original host of the request.

I've also copied the other directives from the top-level `location /`
directive just in case those are needed too.
