### PR TITLE
[PNP-9687] Scale down apps for email-alert-api database upgrade in Production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3508,6 +3508,7 @@ govukApplications:
   - name: specialist-publisher
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
This is PR 1 (out of 3), we will also have PRs in this repo to:

- https://github.com/alphagov/govuk-helm-charts/pull/3721
- https://github.com/alphagov/govuk-helm-charts/pull/3723

They will need to be merged in order.

We want to scale down email-alert-service, travel-advice-publisher, and specialist-publisher ahead of the database upgrade in Production for email-alert-api so that we don't lose any messages.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9687