### PR TITLE
[PNP-9687] Add MAINTENANCE_MODE for email-alert-frontend and scale down account-api in Production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1061,6 +1061,8 @@ govukApplications:
               key: token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: MAINTENANCE_MESSAGE
+          value: "Email subscription management will be unavailable until 14:45 for essential database updates. Please try again later."
 
   - name: draft-email-alert-frontend
     repoName: email-alert-frontend
@@ -1101,6 +1103,8 @@ govukApplications:
               key: token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: MAINTENANCE_MESSAGE
+          value: "Email subscription management will be unavailable until 14:45 for essential database updates. Please try again later."
 
   - name: email-alert-service
     helmValues:


### PR DESCRIPTION
This is PR 2 (out of 3), it depends on:
- https://github.com/alphagov/govuk-helm-charts/pull/3720

We want to display a maintenance message in email-alert-frontend as well as scale down account-api so that it is unavailable during the database upgrade for email-alert-api.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9687