### PR TITLE
More nginx config GOV.UK Chat streaming

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1653,9 +1653,15 @@ govukApplications:
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header GOVUK-Request-Id $govuk_request_id;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
             proxy_redirect off;
             proxy_buffering off;
             proxy_cache off;
+            proxy_set_header Accept-Encoding '';
+            chunked_transfer_encoding off;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
           }
       podAutoscaling:
         - name: govuk-chat


### PR DESCRIPTION

Streaming still isn't working on GOV.UK Chat on integration. Hopefully
this additional config will help.
