### PR TITLE
[PNP-9687] Scale down email-alert-api in Production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -930,6 +930,7 @@ govukApplications:
   - name: email-alert-api
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 2


### PR DESCRIPTION
PR 3 (out of 3), it depends on:
1. https://github.com/alphagov/govuk-helm-charts/pull/3720
2. https://github.com/alphagov/govuk-helm-charts/pull/3721

We want to scale down email-alert-api whilst we carry out the database upgrade to PG14.

Jira card: https://gov-uk.atlassian.net/browse/PNP-9687