### PR TITLE
Add host header to chat cable endpoint

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1668,6 +1668,7 @@ govukApplications:
               proxy_http_version 1.1;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "Upgrade";
+              proxy_set_header Host $http_host;
           }
       podAutoscaling:
         - name: govuk-chat


### PR DESCRIPTION
This was missed as part of the [initial implementation](https://github.com/alphagov/govuk-helm-charts/pull/3722). We need this because we have an allowlist of host headers for our chat service and cable endpoint.