### PR TITLE
Point Integration Search API to the new green Elasticsearch cluster

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2933,7 +2933,7 @@ govukApplications:
           value: govuk-integration-sitemaps
         - name: ELASTICSEARCH_URI
           value:
-            https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com
+            https://vpc-green-elasticsearch6-domain-gqsdw3llwygomagfcrzwtjrawy.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
           value: info
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
A new Elasticsearch (green) cluster has been created as part of the upgrade process. This change updates the Search API configuration to use the new cluster in integration only, enabling a smooth blue–green switchover.