### PR TITLE
Update proxy_pass for /cable in chat nginx config

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1664,7 +1664,7 @@ govukApplications:
             proxy_send_timeout 3600s;
           }
           location /cable {
-              proxy_pass http://govuk-chat:8080/cable;
+              proxy_pass http://govuk-chat;
               proxy_http_version 1.1;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
It looks like it actually needs to use port 80 rather than 8080 which is what it defaults to if no port is specified.