### PR TITLE
GOV.UK Chat streaming: add custom header

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1662,6 +1662,7 @@ govukApplications:
             chunked_transfer_encoding off;
             proxy_read_timeout 3600s;
             proxy_send_timeout 3600s;
+            add_header X-My-Header "my-value";
           }
           location /cable {
               proxy_pass http://govuk-chat;


### PR DESCRIPTION

Streaming doesn't seem to be working properly on this URL, so this is to
help debugging. A custom header is added to this URL only, so we can see
if the config is being applied.
