### PR TITLE
GOV.UK Chat: remove nginx streaming config

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1646,15 +1646,6 @@ govukApplications:
         name: govuk-chat
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role
-      nginxConfigMap:
-        extraServerConf: |
-          location /cable {
-              proxy_pass http://govuk-chat;
-              proxy_http_version 1.1;
-              proxy_set_header Upgrade $http_upgrade;
-              proxy_set_header Connection "Upgrade";
-              proxy_set_header Host $http_host;
-          }
       podAutoscaling:
         - name: govuk-chat
           enabled: true


### PR DESCRIPTION
This was a test to see what was needed to get nginx to stream responses.
The test is complete now so we can remove this config.
