### PR TITLE
Add `METRIC_REFRESH_INTERVAL` environment variable to mirror job

### DIFF
--- a/charts/mirror/templates/cronjob.yaml
+++ b/charts/mirror/templates/cronjob.yaml
@@ -54,13 +54,15 @@ spec:
                   mountPath: /tmp
               env:
                 - name: SITE
-                  value: https://www.{{ .Values.externalDomainSuffix }}/sitemap.xml
+                  value: 'https://www.{{ .Values.externalDomainSuffix }}/sitemap.xml'
                 - name: ALLOWED_DOMAINS
-                  value: www.{{ .Values.externalDomainSuffix }},{{ .Values.assetsDomain }}
+                  value: 'www.{{ .Values.externalDomainSuffix }},{{ .Values.assetsDomain }}'
                 - name: DISALLOWED_URL_RULES
                   value: '/apply-for-a-licence(/|$),/business-finance-support(/|$),/drug-device-alerts\.atom,/drug-safety-update\.atom,/foreign-travel-advice\.atom,/government/announcements\.atom,/government/publications\.atom,/government/statistics\.atom,/licence-finder/,/search(/|$),\.csv/preview$'
                 - name: CONCURRENCY
                   value: "5"
+                - name: METRIC_REFRESH_INTERVAL
+                  value: "10s"
                 - name: RATE_LIMIT_TOKEN
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Decsription:
- Configures how often to send metrics to Prometheus Pushgateway
- https://github.com/alphagov/govuk-infrastructure/issues/3099