### PR TITLE
Increase publishing-api redis memory in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2395,10 +2395,10 @@ govukApplications:
       redis:
         enabled: true
         config:
-          maxmemory: 2500mb
+          maxmemory: 5500mb
         resources:
           limits:
-            memory: 3000Mi
+            memory: 6000Mi
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
- 6GB pod memory
- 5.5GB max redis memory

So that we can investigate max memory usage by a bulk republishing from Whitehall in staging.
