### PR TITLE
Add app labels for the mirror jobs

### DIFF
--- a/charts/mirror/templates/cronjob.yaml
+++ b/charts/mirror/templates/cronjob.yaml
@@ -5,6 +5,8 @@ metadata:
   name: "{{ include "mirror.fullname" . }}"
   labels:
     {{- include "mirror.labels" . | nindent 4 }}
+    app.kubernetes.io/name: mirror
+    app.kubernetes.io/component: cronjob
 spec:
   schedule: "{{ .Values.schedule }}"
   jobTemplate:
@@ -12,6 +14,8 @@ spec:
       name: "{{ include "mirror.fullname" . }}"
       labels:
         {{- include "mirror.labels" . | nindent 8 }}
+        app.kubernetes.io/name: mirror
+        app.kubernetes.io/component: job
     spec:
       backoffLimit: 0
       template:
@@ -19,6 +23,8 @@ spec:
           name: "{{ include "mirror.fullname" . }}"
           labels:
             {{- include "mirror.labels" . | nindent 12 }}
+            app.kubernetes.io/name: mirror
+            app.kubernetes.io/component: job
           annotations:
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:


### PR DESCRIPTION
## What?
This adds some missing labels to the Mirror Cron Jobs so the jobs and logs are easier to identify.

### Why?
The mirror has its own Chart rather than use the shared "generic-govuk-app" charts.