### PR TITLE
Stop webapps integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1729,7 +1729,7 @@ govukApplications:
     #     - name: govuk-e2e-tests
     #       schedule: "*/10 7-19 * * 1-5" # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday
     #       project: main
-    #       suspend: true 
+    #       suspend: true
 
   - name: hmrc-manuals-api
     helmValues:
@@ -4031,7 +4031,7 @@ govukApplications:
       #     task: "taxonomy:rebuild_cache"
       #     schedule: "*/10 7-20 * * *"
       dbMigrationEnabled: true
-      dbMigrationActiveDeadlineSeconds: 3700 # 1 hour + 10 min buffer to match StrongMigrations.statement_timeout
+      dbMigrationActiveDeadlineSeconds: 3700  # 1 hour + 10 min buffer to match StrongMigrations.statement_timeout
       workers:
         enabled: true
       workerResources:


### PR DESCRIPTION
Stops all user facing publishing tools, including HMRC manuals publisher, on integration.