### PR TITLE
Update graphql-stats dashboard

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -38,96 +38,6 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 20,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "refId": "A"
-        }
-      ],
-      "title": "New panel",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
             "mode": "thresholds"
           },
           "custom": {
@@ -161,7 +71,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 0
       },
       "id": 18,
       "options": {
@@ -304,7 +214,7 @@
         "h": 8,
         "w": 18,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "id": 16,
       "options": {
@@ -514,7 +424,7 @@
         "h": 8,
         "w": 5,
         "x": 0,
-        "y": 24
+        "y": 16
       },
       "id": 5,
       "options": {
@@ -580,7 +490,7 @@
         "h": 8,
         "w": 5,
         "x": 5,
-        "y": 24
+        "y": 16
       },
       "id": 4,
       "options": {
@@ -681,7 +591,7 @@
         "h": 8,
         "w": 5,
         "x": 10,
-        "y": 24
+        "y": 16
       },
       "id": 6,
       "options": {
@@ -751,7 +661,7 @@
         "h": 8,
         "w": 5,
         "x": 15,
-        "y": 24
+        "y": 16
       },
       "id": 19,
       "options": {
@@ -791,7 +701,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 24
       },
       "id": 11,
       "panels": [],
@@ -885,7 +795,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 25
       },
       "id": 21,
       "options": {
@@ -1011,7 +921,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 25
       },
       "id": 22,
       "options": {
@@ -1134,7 +1044,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 33
       },
       "id": 7,
       "options": {
@@ -1255,7 +1165,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 39
       },
       "id": 24,
       "options": {
@@ -1302,7 +1212,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 45
       },
       "id": 8,
       "panels": [],
@@ -1420,7 +1330,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 54
+        "y": 46
       },
       "id": 9,
       "options": {
@@ -1570,7 +1480,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 54
+        "y": 46
       },
       "id": 10,
       "options": {
@@ -1692,7 +1602,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 53
       },
       "id": 23,
       "options": {
@@ -1812,7 +1722,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 59
       },
       "id": 17,
       "options": {
@@ -1930,5 +1840,5 @@
   "timezone": "browser",
   "title": "Graphql stats",
   "uid": "aeh00wtwwg8owc",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This repairs the content-store panels, which somehow seem to have got corrupted / ended up missing from the actual Grafana dashboard, even though they were still there in the config.

I've re-imported the config file from grafana prod, and then made a series of changes in individual commits to bring things back. It's never really easy to review these, but hopefully commit-by-commit should be easier than all-at-once.