### PR TITLE
Bump `link-checker-api` memory request to `400Mi` in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1359,7 +1359,7 @@ govukApplications:
           memory: 1Gi
         requests:
           cpu: 10m
-          memory: 320Mi
+          memory: 400Mi
       rails:
         createKeyBaseSecret: false
       sentry:


### PR DESCRIPTION
Description:
- Grafana dashboards show it is using 400Mi but the memory request is lower
- Logs reveal that the container is OOM killed so bump the memory a bit to guarantee at least 400Mi