### PR TITLE
Disable email-alert-service in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1119,6 +1119,7 @@ govukApplications:
   - name: email-alert-service
     helmValues:
       arch: arm64
+      appEnabled: false
       podDisruptionBudget: {}
       rails:
         enabled: false


### PR DESCRIPTION
This should be disabled as it only has workers