### PR TITLE
Set more sensible resources for govuk-e2e-tests

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1713,10 +1713,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 2
-          memory: 8Gi
+          memory: 4Gi
         requests:
           cpu: 1
-          memory: 8Gi
+          memory: 2Gi
       cronJobs:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5" # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday


### PR DESCRIPTION
The large values were set out of hours to avoid having to adjust the values again, if they proven not to be sufficient to run the test suite.

They may need to be adjusted again. Staging and production will be updated once those are confirmed to work.