### PR TITLE
Increase memory limit for link-checker-api workers

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1887,10 +1887,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 1
-          memory: 1Gi
+          memory: 2Gi
         requests:
           cpu: 10m
-          memory: 320Mi
+          memory: 2Gi
       dbMigrationEnabled: true
       uploadAssets:
         enabled: false


### PR DESCRIPTION
They're currently running out of memory constantly, so doubling it to 2GB