### PR TITLE
Increase memory limit for link-checker-api workers to 4GB

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1899,10 +1899,10 @@ govukApplications:
       workerResources:
         limits:
           cpu: 1
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 10m
-          memory: 2Gi
+          memory: 4Gi
       redis:
         enabled: true
       extraEnv:


### PR DESCRIPTION
2GB isn't enough. If this doesn't work, I'll let the team know and leave it