### PR TITLE
Increase publishing-api redis memory in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2399,10 +2399,10 @@ govukApplications:
       redis:
         enabled: true
         config:
-          maxmemory: 2500mb
+          maxmemory: 5500mb
         resources:
           limits:
-            memory: 3000Mi
+            memory: 6000Mi
       workerResources:
         limits:
           cpu: 4


### PR DESCRIPTION
- 6GB pod memory
- 5.5GB max redis memory

Following #3734 we are sure that this is enough to deal with a bulk
republish of all GOV.UK content, without being wasteful.
