### PR TITLE
Add mirror metrics from govuk-exporter to mirror

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1771,6 +1771,9 @@ govukApplications:
       serviceAccount:
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::172025368201:role/govuk-mirror-sync
+      extraEnv:
+        - name: BACKENDS
+          value: "mirrorS3,mirrorS3Replica,mirrorGCS"
 
   - name: hmrc-manuals-api
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1762,6 +1762,9 @@ govukApplications:
       serviceAccount:
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::696911096973:role/govuk-mirror-sync
+      extraEnv:
+        - name: BACKENDS
+          value: "mirrorS3,mirrorGCS"
 
   - name: hmrc-manuals-api
     helmValues:

--- a/charts/mirror/templates/cronjob.yaml
+++ b/charts/mirror/templates/cronjob.yaml
@@ -75,6 +75,13 @@ spec:
                     configMapKeyRef:
                       name: govuk-apps-env
                       key: PROMETHEUS_PUSHGATEWAY_URL
+                - name: MIRROR_FRESHNESS_URL
+                  value: https://www.{{ .Values.externalDomainSuffix }}/last-updated.txt
+                - name: MIRROR_AVAILABILITY_URL
+                  value: https://www.{{ .Values.externalDomainSuffix }}
+                {{- with .Values.extraEnv }}
+                  {{- (tpl (toYaml .) $) | trim | nindent 16 }}
+                {{- end }}
           containers:
             - name: upload-to-s3
               image: peakcom/s5cmd:v2.3.0


### PR DESCRIPTION
It was decided that the metrics from govuk-exporter, which are `govuk_mirror_last_updated_time` and `govuk_mirror_response_status_code` should be moved to govuk-mirror repo to reduce the number of repos that we have to manage.

Once the mirror is able to serve these metrics govuk-exporter will be retired.

https://github.com/alphagov/govuk-infrastructure/issues/3205