### PR TITLE
Mirror drift detection cronjob job

### DIFF
--- a/charts/mirror/templates/_helpers.tpl
+++ b/charts/mirror/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "drift.name" -}}
+{{- include "mirror.name" . }}-drift-check
+{{- end }}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -21,6 +25,10 @@ If release name contains chart name it will be used as a full name.
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+{{- define "drift.fullname" -}}
+{{- include "mirror.fullname" . }}-drift-check
 {{- end }}
 
 {{/*
@@ -42,11 +50,25 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "drift.labels" -}}
+helm.sh/chart: {{ include "mirror.chart" . }}
+{{ include "drift.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
 {{/*
 Selector labels
 */}}
 {{- define "mirror.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "mirror.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "drift.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "drift.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
@@ -59,4 +81,8 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{- define "drift.serviceAccountName" -}}
+{{ include "mirror.serviceAccountName" .}} {{/*Drift detection uses the same service account*/}}
 {{- end }}

--- a/charts/mirror/templates/drift-cronjob.yaml
+++ b/charts/mirror/templates/drift-cronjob.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "{{ include "drift.fullname" . }}"
+  labels:
+    {{- include "drift.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.mirrorSchedule }}"
+  jobTemplate:
+    metadata:
+      name: "{{ include "drift.fullname" . }}"
+      labels:
+        {{- include "drift.labels" . | nindent 8 }}
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          name: "{{ include "drift.fullname" . }}"
+          labels:
+            {{- include "drift.labels" . | nindent 12 }}
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        spec:
+          enableServiceLinks: false
+          serviceAccountName: {{ include "drift.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          restartPolicy: Never
+          containers:
+            - name: scrape
+              image: "{{ .Values.images.GovukMirror.repository }}:{{ .Values.images.GovukMirror.tag }}"
+              command:
+                - /bin/govuk-mirror-comparison
+              imagePullPolicy: "Always"
+              workingDir: /data
+              resources:
+                limits:
+                  cpu: 4
+                  memory: 20000Mi
+                requests:
+                  cpu: 2
+                  memory: 15000Mi
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              env:
+                - name: COMPARE_TOP_UNSAMPLED_COUNT
+                  value: '100'
+                - name: COMPARE_REMAINING_SAMPLED_COUNT
+                  value: '100'
+                {{- with .Values.extraEnv }}
+                  {{- (tpl (toYaml .) $) | trim | nindent 16 }}
+                {{- end }}

--- a/charts/mirror/templates/scraping-cronjob.yaml
+++ b/charts/mirror/templates/scraping-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "mirror.labels" . | nindent 4 }}
 spec:
-  schedule: "{{ .Values.schedule }}"
+  schedule: "{{ .Values.mirrorSchedule }}"
   jobTemplate:
     metadata:
       name: "{{ include "mirror.fullname" . }}"

--- a/charts/mirror/values.yaml
+++ b/charts/mirror/values.yaml
@@ -1,5 +1,5 @@
-# Mirror sync configuration
-schedule: "43 1 * * *"
+mirrorSchedule: "43 1 * * *"
+driftSchedule: "0 12 * * *"
 
 # Image configuration - these defaults are overridden by app-config via imageValues
 images:


### PR DESCRIPTION
In https://github.com/alphagov/govuk-mirror/pull/72 we added a new function to the mirror crawler: the ability to detect drift between live and mirror.

This PR creates a new cronjob to run that detection at midday every day. The mirror runs at 0143 each day, and will be completed by 1200.