### PR TITLE
Increase govuk-e2e-test memory in staging and production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1706,10 +1706,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 2
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 1
-          memory: 1Gi
+          memory: 2Gi
       cronTasks:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5"  # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1703,10 +1703,10 @@ govukApplications:
       appResources:
         limits:
           cpu: 2
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 1
-          memory: 1Gi
+          memory: 2Gi
       cronTasks:
         - name: govuk-e2e-tests
           schedule: "*/10 7-19 * * 1-5"  # every 10 minutes, between 7:00 - 19:00 UTC, Monday to Friday


### PR DESCRIPTION
The manual job is triggered to validate the system is working following a restart of the apps. The apps are slower after restarting (no cache) and consequently tests take longer to execute resulting in higher memory usage.

This should prevent pods from exceed its memory limit, which lead to OOMKilled.