### PR TITLE
Direct search-api Prometheus alert to search team

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -106,14 +106,6 @@ spec:
       groupWait: 5m
       groupInterval: 30m
     - matchers:
-      - name: destination
-        value: slack-cronjob-notifications
-        matchType: =
-      receiver: 'slack-cronjob-notifications'
-      repeatInterval: 1d
-      groupWait: 5m
-      groupInterval: 30m
-    - matchers:
         - name: destination
           value: slack-whitehall-notifications
           matchType: =
@@ -144,12 +136,6 @@ spec:
       text: |-
         {{- include "slack.expiringtokenstext" . | nindent 8 }}
   - name: 'slack-chat-notifications'
-    slackConfigs:
-    - channel: '#dev-notifications-ai-govuk'
-      {{- include "slack.template" . | nindent 6 }}
-      text: |-
-        {{- include "slack.text" . | nindent 8 }}
-  - name: 'slack-cronjob-notifications'
     slackConfigs:
     - channel: '#dev-notifications-ai-govuk'
       {{- include "slack.template" . | nindent 6 }}

--- a/charts/monitoring-config/rules/search_api_cronjobs.yaml
+++ b/charts/monitoring-config/rules/search_api_cronjobs.yaml
@@ -10,7 +10,7 @@ groups:
         for: 5m
         labels:
           severity: critical
-          destination: slack-cronjob-notifications
+          destination: slack-search-team
         annotations:
           summary: search-api-load-page-traffic cronjob failing
           description: >-

--- a/charts/monitoring-config/rules/search_api_cronjobs_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_cronjobs_tests.yaml
@@ -31,7 +31,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: CronjobFailed
-              destination: slack-cronjob-notifications
+              destination: slack-search-team
               cronjob: search-api-load-page-traffic
               severity: critical
             exp_annotations:


### PR DESCRIPTION
The search team is taking over responsibility of search-api from the AI team, so alerts need to be updated to route to the search team Slack channels instead of #dev-notifications-ai-govuk.

To do this, we're changing the destination label on the only search-api related alert (which alerts to a failure in the cronJob "load-page-traffic") from "slack-cronjob-notifications" to "slack-search-team". Because the label "slack-cronjob-notifications" is not used for any other routing, routing for that destination label is also removed.

The routes for the "slack-search-team" destination label are configured with slightly different alert intervals than "slack-cronjob-notifications". For simplicity of the configuration, intervals for "slack-search-team" are reused. This results in slightly faster notification of alerts in-hours, but removes alerting out of hours. This is acceptable because of the nature of the search-api alert, which is not critical enough to need to be addressed out of hours.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1618