### PR TITLE
Increase renovate's log level to debug

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: renovate
 spec:
-  schedule: '@hourly'
+  schedule: "@hourly"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -24,9 +24,9 @@ spec:
                 - name: RENOVATE_PLATFORM
                   value: github
                 - name: RENOVATE_AUTODISCOVER
-                  value: 'false'
+                  value: "false"
                 - name: RENOVATE_GIT_AUTHOR
-                  value: 'Renovate Bot <govuk-ci@users.noreply.github.com>'
+                  value: "Renovate Bot <govuk-ci@users.noreply.github.com>"
                 - name: RENOVATE_TOKEN
                   valueFrom:
                     secretKeyRef:
@@ -36,6 +36,8 @@ spec:
                   value: /opt/renovate/config.json
                 - name: RENOVATE_PR_BODY_TEMPLATE
                   value: '{{ "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}" }}'
+                - name: LOG_LEVEL
+                  value: debug
               securityContext:
                 allowPrivilegeEscalation: false
                 seccompProfile:


### PR DESCRIPTION
Renovate opened a PR to update a dependency it shouldn't have access to. Lets enable debug logging so we can try to figure out how it did that