### PR TITLE
Add a deployment for govuk-mirror to emit the mirror response status code

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1769,9 +1769,8 @@ govukApplications:
 
   - name: mirror
     chartPath: charts/mirror
+    repoName: govuk-mirror
     postSyncWorkflowEnabled: "false"
-    imageValues:
-      - govuk-mirror
     helmValues:
       serviceAccount:
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1760,9 +1760,8 @@ govukApplications:
 
   - name: mirror
     chartPath: charts/mirror
+    repoName: govuk-mirror
     postSyncWorkflowEnabled: "false"
-    imageValues:
-      - govuk-mirror
     helmValues:
       serviceAccount:
         annotations:

--- a/charts/mirror/templates/deployment.yaml
+++ b/charts/mirror/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+        app.kubernetes.io/name: {{ .Values.name }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+      containers:
+        - name: app
+          image: {{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}
+          command: ["/bin/govuk-mirror-resp-status-check"]
+          imagePullPolicy: "Always"
+          securityContext:
+            {{- toYaml $.Values.securityContext | nindent 16 }}
+          env:
+            - name: MIRROR_AVAILABILITY_URL
+              value: https://www.{{ .Values.externalDomainSuffix }}
+            - name: STATUS_CHECK_REFRESH_INTERVAL
+              value: "4h"
+            {{- with .Values.extraEnv }}
+              {{- (tpl (toYaml .) $) | trim | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet: &probe
+              path: /metrics
+              port: metrics
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 30
+          readinessProbe:
+            httpGet: *probe
+            failureThreshold: 2
+            periodSeconds: 5
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet: *probe
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/mirror/templates/drift-cronjob.yaml
+++ b/charts/mirror/templates/drift-cronjob.yaml
@@ -29,7 +29,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: scrape
-              image: "{{ .Values.images.GovukMirror.repository }}:{{ .Values.images.GovukMirror.tag }}"
+              image: {{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}
               command:
                 - /bin/govuk-mirror-comparison
               imagePullPolicy: "Always"

--- a/charts/mirror/templates/scraping-cronjob.yaml
+++ b/charts/mirror/templates/scraping-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
               emptyDir: {}
           containers:
             - name: scrape
-              image: "{{ .Values.images.GovukMirror.repository }}:{{ .Values.images.GovukMirror.tag }}"
+              image: {{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}
               imagePullPolicy: "Always"
               workingDir: /data
               resources:

--- a/charts/mirror/values.yaml
+++ b/charts/mirror/values.yaml
@@ -2,10 +2,10 @@ mirrorSchedule: "43 1 * * *"
 driftSchedule: "0 12 * * *"
 
 # Image configuration - these defaults are overridden by app-config via imageValues
-images:
-  GovukMirror:
-    repository: govuk-mirror
-    tag: release
+appImage:
+  repository: ""  # Dummy value, overridden in ArgoCD config.
+  pullPolicy: Always
+  tag: latest
 
 # Service account configuration
 serviceAccount:


### PR DESCRIPTION
The deployment yaml has been copied across from govuk-exporter, and after this PR has been merged in we can retitre the govuk-exporter repo as the metrics there have been moved to the govuk-mirror repo

https://github.com/alphagov/govuk-infrastructure/issues/3205