### PR TITLE
Adjust Prod DB Backup Scripts to run earlier

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -12,10 +12,10 @@ toolbox:
     tag: "v13"
 
 externalSecrets:
-  refreshInterval: 1h  # Be kind to etcd and don't set this too short.
+  refreshInterval: 1h # Be kind to etcd and don't set this too short.
   deletionPolicy: Delete
 
-arch: amd64
+arch: arm64
 
 extraEnv:
   - name: GOGC
@@ -64,10 +64,10 @@ serviceAccount:
   create: true
   name: db-backup
   annotations:
-    eks.amazonaws.com/role-arn: ""  # Overridden in ../app-config (Argo CD).
+    eks.amazonaws.com/role-arn: "" # Overridden in ../app-config (Argo CD).
 
 # govukEnvironment determines which set of jobs to use from `cronjobs` below.
-govukEnvironment: staging  # Overridden in ../app-config (Argo CD).
+govukEnvironment: staging # Overridden in ../app-config (Argo CD).
 
 # cronjobs defines a set of k8s CronJobs that should exist in each environment
 # (production, staging, integration). Each CronJob consists of one or more
@@ -81,7 +81,7 @@ govukEnvironment: staging  # Overridden in ../app-config (Argo CD).
 cronjobs:
   production:
     account-api-postgres:
-      schedule: "37 23 * * *"
+      schedule: "12 16 * * *"
       db: account-api_production
       # TODO: add an automatic test restore to somewhere in production (because
       # unlike the other DBs, we don't copy prod account-api data to staging).
@@ -89,43 +89,43 @@ cronjobs:
         - op: backup
 
     authenticating-proxy-postgres:
-      schedule: "23 23 * * *"
+      schedule: "2 16 * * *"
       db: authenticating_proxy_production
       operations:
         - op: backup
 
     chat-postgres:
-      schedule: "47 23 * * *"
+      schedule: "10 16 * * *"
       db: govuk_chat_production
       operations:
         - op: backup
 
     ckan-postgres:
-      schedule: "43 4 * * *"
+      schedule: "15 18 * * *"
       db: ckan_production
       operations:
         - op: backup
 
     content-block-manager-postgres:
-      schedule: "43 0 * * *"
+      schedule: "0 16 * * *"
       db: content_block_manager_production
       operations:
         - op: backup
 
     collections-publisher-mysql:
-      schedule: "21 23 * * *"
+      schedule: "58 15 * * *"
       db: collections_publisher_production
       operations:
         - op: backup
 
     content-data-admin-postgres:
-      schedule: "4 23 * * *"
+      schedule: "56 15 * * *"
       db: content_data_admin_production
       operations:
         - op: backup
 
     content-data-api-postgresql-primary:
-      schedule: "35 23 * * *"
+      schedule: "15 17 * * *"
       host: blue-content-data-api-postgresql-primary-postgres
       db: content_performance_manager_production
       dbms: postgres
@@ -134,80 +134,81 @@ cronjobs:
 
     content-store-postgres:
       <<: *s5cmd-ram-workaround
-      schedule: "06 21 * * *"  # Keep this before publishing-api.
+      schedule: "20 16 * * *" # Keep this before publishing-api.
       db: content_store_production
       operations:
         - op: backup
     draft-content-store-postgres:
       <<: *s5cmd-ram-workaround
-      schedule: "16 21 * * *"  # Keep this before publishing-api.
+      schedule: "50 18 * * *" # Keep this before publishing-api.
       db: draft_content_store_production
       operations:
         - op: backup
 
     content-tagger-postgres:
-      schedule: "31 23 * * *"
+      schedule: "4 16 * * *"
       db: content_tagger_production
       operations:
         - op: backup
 
     email-alert-api-postgres:
-      schedule: "54 23 * * *"
+      schedule: "25 16 * * *"
       db: email-alert-api_production
       operations:
         - op: backup
 
     imminence-postgres:
-      schedule: "18 23 * * *"
+      schedule: "14 16 * * *"
       db: imminence_production
       operations:
         - op: backup
 
     link-checker-api-postgres:
-      schedule: "43 23 * * *"
+      schedule: "16 16 * * *"
       db: link_checker_api_production
       operations:
         - op: backup
 
     local-links-manager-postgres:
-      schedule: "8 23 * * *"
+      schedule: "8 16 * * *"
       db: local-links-manager_production
       operations:
         - op: backup
 
     locations-api-postgres:
-      schedule: "32 23 * * *"
+      schedule: "50 16 * * *"
       db: locations_api_production
       operations:
         - op: backup
 
+    # Make sure Publishing API is last in the list of backups
     publishing-api-postgres:
       <<: *s5cmd-ram-workaround
-      schedule: "36 21 * * *"
+      schedule: "00 19 * * *"
       db: publishing_api_production
       operations:
         - op: backup
 
     release-mysql:
-      schedule: "11 23 * * *"
+      schedule: "10 16 * * *"
       db: release_production
       operations:
         - op: backup
 
     search-admin-mysql:
-      schedule: "56 23 * * *"
+      schedule: "54 15 * * *"
       db: search_admin_production
       operations:
         - op: backup
 
     publisher-postgres:
-      schedule: "41 23 * * *"
+      schedule: "15 16 * * *"
       db: publisher_production
       operations:
         - op: backup
 
     service-manual-publisher-postgres:
-      schedule: "49 23 * * *"
+      schedule: "6 16 * * *"
       db: service-manual-publisher_production
       operations:
         - op: backup
@@ -228,19 +229,19 @@ cronjobs:
           db: govuk_assets_production
 
     signon-mysql:
-      schedule: "3 23 * * *"
+      schedule: "18 16 * * *"
       db: signon_production
       operations:
         - op: backup
 
     support-api-postgres:
-      schedule: "38 23 * * *"
+      schedule: "20 16 * * *"
       db: support_contacts_production
       operations:
         - op: backup
 
     transition-postgresql-primary:
-      schedule: "24 3 * * *"
+      schedule: "17 16 * * *"
       db: transition_production
       dbms: postgres
       operations:
@@ -248,11 +249,10 @@ cronjobs:
 
     whitehall-mysql:
       <<: *s5cmd-ram-workaround
-      schedule: "28 0 * * *"
+      schedule: "30 16 * * *"
       db: whitehall_production
       operations:
         - op: backup
-
 
   staging:
     authenticating-proxy-postgres:
@@ -400,7 +400,7 @@ cronjobs:
         - op: backup
 
     release-mysql:
-      schedule: "11 1 * * 1"  # Daily would be overkill.
+      schedule: "11 1 * * 1" # Daily would be overkill.
       db: release_production
       operations:
         - op: restore
@@ -498,7 +498,6 @@ cronjobs:
         - op: transform
           script: whitehall.sql
         - op: backup
-
 
   integration:
     account-api-postgres:


### PR DESCRIPTION
## What?
This adjusts the Cron Schedules for the various `db-backup` scripts in Production to run earlier than they currently do now.

There shouldn't be any issues if any of these overlap, but have attempted to stagger them based on their typical run times so too many don't run at once and add any undue workload pressure to the cluster.