### PR TITLE
SCH-1629 Change scheduling of evaluations runs in the morning

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3106,7 +3106,7 @@ govukApplications:
           schedule: "0 6 * * *" # 06:00 GMT daily
         - name: rpt-explicit-metrics
           task: "quality:report_quality_metrics[explicit]"
-          schedule: "0 7 * * *" # 07:00 GMT daily
+          schedule: "0 4 * * *" # 04:00 GMT daily
         - name: rpt-binary-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3115,7 +3115,7 @@ govukApplications:
           schedule: "0 6 * * *" # 06:00 GMT daily
         - name: rpt-explicit-metrics
           task: "quality:report_quality_metrics[explicit]"
-          schedule: "0 7 * * *" # 07:00 GMT daily
+          schedule: "0 4 * * *" # 04:00 GMT daily
         - name: rpt-binary-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3083,7 +3083,7 @@ govukApplications:
           schedule: "0 6 * * *" # 06:00 GMT daily
         - name: rpt-explicit-metrics
           task: "quality:report_quality_metrics[explicit]"
-          schedule: "0 7 * * *" # 07:00 GMT daily
+          schedule: "0 4 * * *" # 04:00 GMT daily
         - name: rpt-binary-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays


### PR DESCRIPTION
We have been tracking Vertex evaluation errors over a two-week period. We have identified through this tracking that the errors we had were in the morning & relate to evaluations runs clashing. Amending the scheduling of the evaluations runs in the morning to give each evaluation two hours run in.

As [discussed on slack](https://gds.slack.com/archives/C04RFV5JC6Q/p1764589875302929), we are also switching the order of the explicit and clickstream evaluations runs. This is to ensure that the ranking model has reset before the clickstream and binary evaluations run, as these are the most important datasets.

Background to the above paragraph:
If the ranking model resets overnight based on the latest data on what users are clicking on in search, then ideally evaluations would run after this change so that evaluations on any given day are likely to reflect the results users are seeing that day.

Related Jira ticket: [SCH-1629](https://gov-uk.atlassian.net/browse/SCH-1629)

[SCH-1629]: https://gov-uk.atlassian.net/browse/SCH-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ