### PR TITLE
[PP-7465] Use environment variables for Frontend GraphQL traffic rates

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1391,6 +1391,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_RATE_NEWS_ARTICLE
+          value: "0.5"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1346,6 +1346,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_RATE_NEWS_ARTICLE
+          value: "0.5"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1385,6 +1385,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_RATE_NEWS_ARTICLE
+          value: "0.5"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The rate of GraphQL traffic for each schema is currently hardcoded into the application. This means we have the same traffic rate in every environment.

Switching to use environment variables, so we can adjust traffic rates to be different across the environments.