### PR TITLE
[PP-7471] Send 1% traffic for Topical Event About Pages to GraphQL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1393,6 +1393,8 @@ govukApplications:
               key: bearer_token
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
+          value: "0.01"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1348,6 +1348,8 @@ govukApplications:
               key: bearer_token
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
+          value: "0.01"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1387,6 +1387,8 @@ govukApplications:
               key: bearer_token
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
+          value: "0.01"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We have confirmed that the HTML rendered version of Topical Event About Pages are the same for both GraphQL and Content Store.

Therefore allowing 1% of traffic to be served from GraphQL. This will be increased in later commits, once we confirm the response times in production are reasonable.