### PR TITLE
Use environment variables for Collections GraphQL traffic rates

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -356,6 +356,14 @@ govukApplications:
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: GRAPHQL_RATE_MINISTERS_INDEX
+          value: "0.5"
+        - name: GRAPHQL_RATE_ROLE
+          value: "0.5"
+        - name: GRAPHQL_RATE_TOPICAL_EVENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_WORLD_INDEX
+          value: "0.5"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
 

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -350,6 +350,14 @@ govukApplications:
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: GRAPHQL_RATE_MINISTERS_INDEX
+          value: "0.5"
+        - name: GRAPHQL_RATE_ROLE
+          value: "0.5"
+        - name: GRAPHQL_RATE_TOPICAL_EVENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_WORLD_INDEX
+          value: "0.5"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
 

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -357,6 +357,14 @@ govukApplications:
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
+        - name: GRAPHQL_RATE_MINISTERS_INDEX
+          value: "0.5"
+        - name: GRAPHQL_RATE_ROLE
+          value: "0.5"
+        - name: GRAPHQL_RATE_TOPICAL_EVENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_WORLD_INDEX
+          value: "0.5"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
 


### PR DESCRIPTION
The rate of GraphQL traffic for each schema is currently hardcoded into the application. This means we have the same traffic rate in every environment.

Switching to use environment variables, so we can adjust traffic rates to be different across the environments.