### PR TITLE
Update mirror freshness alert to use new last updated time metric

### DIFF
--- a/charts/monitoring-config/rules/mirrors.yaml
+++ b/charts/monitoring-config/rules/mirrors.yaml
@@ -3,7 +3,7 @@ groups:
     rules:
       - record: global:govuk_mirror_freshness_seconds
         expr: |
-          time() - min(govuk_mirror_last_updated_time) by (backend)
+          time() - max(govuk_mirror_last_updated_time{job="mirror_metrics"})
 
       - alert: MirrorFreshnessAlert
         expr: |

--- a/charts/monitoring-config/rules/mirrors_tests.yaml
+++ b/charts/monitoring-config/rules/mirrors_tests.yaml
@@ -6,20 +6,19 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'govuk_mirror_last_updated_time{backend="backend1"}'
+      - series: 'govuk_mirror_last_updated_time{job="mirror_metrics"}'
         values: '0x21600'
 
     promql_expr_test:
       - expr: |
-          time() - min(govuk_mirror_last_updated_time) by (backend)
+          time() - max(govuk_mirror_last_updated_time{job="mirror_metrics"})
         eval_time: 6h0m
         exp_samples:
-          - labels: '{backend="backend1"}'
-            value: 21600
+          - value: 21600
 
   - interval: 1m
     input_series:
-      - series: 'govuk_mirror_last_updated_time{backend="backend1"}'
+      - series: 'govuk_mirror_last_updated_time{job="mirror_metrics"}'
         values: '0x176400'
 
     alert_rule_test:
@@ -27,7 +26,6 @@ tests:
         alertname: MirrorFreshnessAlert
         exp_alerts:
           - exp_labels:
-              backend: backend1
               severity: warning
             exp_annotations:
               summary: Mirror freshness has exceeded two days


### PR DESCRIPTION
We're no longer writing out a last-updated.txt file to the S3 buckets. This changes the alert to check the last updated time published by mirror itself once the mirror job has completed.