### PR TITLE
Add `PodMonitor` to mirror

### DIFF
--- a/charts/mirror/templates/_helpers.tpl
+++ b/charts/mirror/templates/_helpers.tpl
@@ -9,6 +9,10 @@ Expand the name of the chart.
 {{- include "mirror.name" . }}-drift-check
 {{- end }}
 
+{{- define "exporter.name" -}}
+{{- include "mirror.name" . }}-exporter
+{{- end }}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -29,6 +33,10 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "drift.fullname" -}}
 {{- include "mirror.fullname" . }}-drift-check
+{{- end }}
+
+{{- define "exporter.fullname" -}}
+{{- include "mirror.fullname" . }}-exporter
 {{- end }}
 
 {{/*
@@ -59,6 +67,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "exporter.labels" -}}
+helm.sh/chart: {{ include "mirror.chart" . }}
+{{ include "exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
 {{/*
 Selector labels
 */}}
@@ -69,6 +86,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "drift.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "drift.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/mirror/templates/deployment.yaml
+++ b/charts/mirror/templates/deployment.yaml
@@ -1,10 +1,10 @@
-{{- $fullName := include "mirror.fullname" . }}
+{{- $fullName := include "exporter.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "mirror.labels" . | nindent 4 }}
+    {{- include "exporter.labels" . | nindent 4 }}
     app: {{ $fullName }}
     app.kubernetes.io/component: app
   annotations:
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "mirror.labels" . | nindent 8 }}
+        {{- include "exporter.labels" . | nindent 8 }}
         app: {{ $fullName }}
         app.govuk/repository-name: {{ .Values.repoName | default .Release.Name  }}
         app.kubernetes.io/component: app

--- a/charts/mirror/templates/podmonitor.yaml
+++ b/charts/mirror/templates/podmonitor.yaml
@@ -1,0 +1,15 @@
+{{- $fullName := include "exporter.fullname" . }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "exporter.labels" . | nindent 4 }}
+    app: {{ $fullName }}
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app: {{ $fullName }}
+  podMetricsEndpoints:
+    - port: metrics


### PR DESCRIPTION
Description:
- Merging in `govuk-exporter` into `govuk-mirror` didn't result in Prometheus picking up these metrics because `PodMonitor` isn't present
- https://github.com/alphagov/govuk-infrastructure/issues/3205