### PR TITLE
Add content-block-manager-jwt-auth-secret to prod

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -513,7 +513,7 @@ govukApplications:
         - name: JWT_AUTH_SECRET
           valueFrom:
             secretKeyRef:
-              name: authenticating-proxy-jwt-auth-secret
+              name: content-block-manager-jwt-auth-secret
               key: JWT_AUTH_SECRET
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:


### PR DESCRIPTION
This follows on from https://github.com/alphagov/govuk-helm-charts/pull/3817 to add the same secret to prod.