### PR TITLE
Run --trace on db:migrate for govuk-chat

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1611,6 +1611,7 @@ govukApplications:
           cpu: 500m
           memory: 1Gi
       dbMigrationEnabled: true
+      dbMigrationCommand: ["rails", "db:migrate", "--trace"]
       kubernetesProbeEndpoints:
         readinessProbe: "/healthcheck/ready"
       workers:


### PR DESCRIPTION
We're currently getting a cryptic error with the db:migrate process when Chat is deployed to the integration environment:

```
bin/rails aborted!
ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)
/app/config/environment.rb:5:in '<main>'
Tasks: TOP => db:migrate => db:load_config => environment
(See full trace by running task with --trace)
```

I've not been able to replicate this error so I'm adding this trace argument temporarily so that we can have hopefully some more insight into what the cause is.