### PR TITLE
[PP-7471] Increase GraphQL traffic to 50% for two content types

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -361,7 +361,7 @@ govukApplications:
         - name: GRAPHQL_RATE_ROLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_WORLD_INDEX
           value: "0.5"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
@@ -1402,7 +1402,7 @@ govukApplications:
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0.1"
+          value: "0.5"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -343,7 +343,7 @@ govukApplications:
         - name: GRAPHQL_RATE_ROLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_WORLD_INDEX
           value: "0.5"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
@@ -1338,7 +1338,7 @@ govukApplications:
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0.1"
+          value: "0.5"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -362,7 +362,7 @@ govukApplications:
         - name: GRAPHQL_RATE_ROLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_WORLD_INDEX
           value: "0.5"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
@@ -1396,7 +1396,7 @@ govukApplications:
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0.1"
+          value: "0.5"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The performance of Topical Events and Topical Event About Pages rendered by GraphQL has been acceptable over the last few days, so increasing the traffic to 50%.