### PR TITLE
Update GOV.UK Chat Worker autoscaling to target answer queue

### DIFF
--- a/charts/monitoring-config/prometheus-adapter-values-integration.yaml
+++ b/charts/monitoring-config/prometheus-adapter-values-integration.yaml
@@ -15,11 +15,11 @@ rules:
   default: false
   # Custom external metric for the Chat-AI sidekiq backlog
   external:
-    - seriesQuery: 'sidekiq_queue_backlog{job=~"govuk-chat-worker"}'
+    - seriesQuery: 'sidekiq_queue_backlog{job="govuk-chat-worker", queue="answer"}'
       resources:
         overrides:
           namespace:
             resource: namespace
       name:
         as: ai_sidekiq_queue_backlog
-      metricsQuery: 'max(sidekiq_queue_backlog{job=~"govuk-chat-worker"})'
+      metricsQuery: 'max by(job, queue) (sidekiq_queue_backlog{job="govuk-chat-worker", queue="answer"})'

--- a/charts/monitoring-config/prometheus-adapter-values-production.yaml
+++ b/charts/monitoring-config/prometheus-adapter-values-production.yaml
@@ -15,11 +15,11 @@ rules:
   default: false
   # Custom external metric for the Chat-AI sidekiq backlog
   external:
-    - seriesQuery: 'sidekiq_queue_backlog{job=~"govuk-chat-worker"}'
+    - seriesQuery: 'sidekiq_queue_backlog{job="govuk-chat-worker", queue="answer"}'
       resources:
         overrides:
           namespace:
             resource: namespace
       name:
         as: ai_sidekiq_queue_backlog
-      metricsQuery: 'max(sidekiq_queue_backlog{job=~"govuk-chat-worker"})'
+      metricsQuery: 'max by(job, queue) (sidekiq_queue_backlog{job="govuk-chat-worker", queue="answer"})'

--- a/charts/monitoring-config/prometheus-adapter-values-staging.yaml
+++ b/charts/monitoring-config/prometheus-adapter-values-staging.yaml
@@ -15,11 +15,11 @@ rules:
   default: false
   # Custom external metric for the Chat-AI sidekiq backlog
   external:
-    - seriesQuery: 'sidekiq_queue_backlog{job=~"govuk-chat-worker"}'
+    - seriesQuery: 'sidekiq_queue_backlog{job="govuk-chat-worker", queue="answer"}'
       resources:
         overrides:
           namespace:
             resource: namespace
       name:
         as: ai_sidekiq_queue_backlog
-      metricsQuery: 'max(sidekiq_queue_backlog{job=~"govuk-chat-worker"})'
+      metricsQuery: 'max by(job, queue) (sidekiq_queue_backlog{job="govuk-chat-worker", queue="answer"})'


### PR DESCRIPTION
## Description 

At the moment, the autoscaling for the GOV.UK Chat Worker is targeting the queue length for the max length of all queues. We're adding a bunch of jobs which will be run each time an answer is generated which implement auto-evaluation. These will be processed by the default-worker process. We don't want the autoscaling to respond to the backlog of these auto-evaluation jobs as they're not time sensitive.

This updates the MetricsQuery and SeriesQuery in the Prometheus Adapter values files to only target the answer queue.

## Trello card

https://trello.com/c/OTiMe25p/2991-plan-for-integrating-auto-evaluation-into-ruby-codebase