### PR TITLE
[PNP-9741] Disable static/draft-static in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3350,6 +3350,7 @@ govukApplications:
   - name: static
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1
@@ -3412,6 +3413,7 @@ govukApplications:
     repoName: static
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
- Now that no apps are using slimmer any more, it's time to retire static. First test that it's safe by disabling it in integration.

[JIRA Card](https://gov-uk.atlassian.net/browse/PNP-9741)

DO NOT MERGE BEFORE: https://github.com/alphagov/govuk-e2e-tests/pull/374