### PR TITLE
(CM-701) Enable workers in Content Block Manager (integration)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -485,7 +485,7 @@ govukApplications:
       dbMigrationEnabled: true
       dbMigrationCommand: ["rails", "db:prepare"]
       workers:
-        enabled: false
+        enabled: true
       workerResources:
         limits:
           cpu: 2


### PR DESCRIPTION
When we replatformed, we forgot to enable workers. Hopefully this should be all we need to allow Sidekiq jobs to be picked off the queue.