### PR TITLE
fix: 🐛 external-secrets.io/v1beta1 -> external-secrets.io/v1

### DIFF
--- a/charts/external-secrets/templates/fact-check-manager/postgresql.yaml
+++ b/charts/external-secrets/templates/fact-check-manager/postgresql.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: fact-check-manager-postgres


### PR DESCRIPTION
v1beta1 has been removed so the secret fails to be created