### PR TITLE
Disable release workers in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2488,7 +2488,7 @@ govukApplications:
         hosts:
           - name: release.{{ .Values.k8sExternalDomainSuffix }}
       workers:
-        enabled: true
+        enabled: false
       workerResources:
         limits:
           cpu: 250m


### PR DESCRIPTION
This app isn't meant to have workers in non-prod environments