### PR TITLE
[PP-7484] Use GraphQL for a batch of schemas

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1360,6 +1360,14 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_RATE_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_CALENDAR
+          value: "0.01"
+        - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
+          value: "0.01"
+        - name: GRAPHQL_RATE_CASE_STUDY
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1335,6 +1335,14 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_RATE_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_CALENDAR
+          value: "0.01"
+        - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
+          value: "0.01"
+        - name: GRAPHQL_RATE_CASE_STUDY
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1356,6 +1356,14 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
+        - name: GRAPHQL_RATE_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_CALENDAR
+          value: "0.01"
+        - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
+          value: "0.01"
+        - name: GRAPHQL_RATE_CASE_STUDY
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE


### PR DESCRIPTION
This adds environment variables that will send 1% of traffic to GraphQL for four schemas in the Frontend app:
- answer
- calendar
- call_for_evidence
- case_study

Traffic rates will be increased in later PRs, once we have monitored the effect of this change.