### PR TITLE
[PP-7491] Use GraphQL for a batch of schemas

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1370,6 +1370,16 @@ govukApplications:
           value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: OS_MAPS_API_KEY

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1345,6 +1345,16 @@ govukApplications:
           value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: OS_MAPS_API_KEY

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1366,6 +1366,16 @@ govukApplications:
           value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: OS_MAPS_API_KEY


### PR DESCRIPTION
This adds environment variables that will send 1% of traffic to GraphQL for five schemas in the Frontend app:
- service_manual_guide
- service_manual_homepage
- service_manual_service_standard
- service_manual_service_toolkit
- service_manual_topic

Traffic rates will be increased in later PRs, once we have monitored the effect of this change.