### PR TITLE
[PP-7502] Use GraphQL for batch 6 schemas

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1380,6 +1380,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
+        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPEECH
+          value: "0.01"
+        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1355,6 +1355,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
+        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPEECH
+          value: "0.01"
+        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1376,6 +1376,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
+        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPEECH
+          value: "0.01"
+        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION


### PR DESCRIPTION
This adds environment variables that will send 1% of traffic to GraphQL for five schemas in frontend.

simple_smart_answer
specialist_document
speech
statistical_data_set

Traffic rates will be increased once we have had time to monitor the effect of this change.