### PR TITLE
db-backup: write a pointer file after a successful DB dump

### DIFF
--- a/charts/db-backup/scripts/backup-mongo
+++ b/charts/db-backup/scripts/backup-mongo
@@ -11,7 +11,8 @@ backup () {
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   set -o pipefail
   mongodump "$db_url" --archive \
-    | progress | gzip -1 | s5cmd pipe "$BUCKET/$s3_path"
+    | progress | gzip -1 | s5cmd pipe "$BUCKET/$s3_path" \
+    && write_pointer "${s3_path}"
   set +o pipefail
 }
 

--- a/charts/db-backup/scripts/backup-mysql
+++ b/charts/db-backup/scripts/backup-mysql
@@ -9,7 +9,8 @@ backup () {
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   set -o pipefail
   mysqldump --single-transaction "$DB_DATABASE" \
-    | progress | gzip -1 | s5cmd pipe "$BUCKET/$s3_path"
+    | progress | gzip -1 | s5cmd pipe "$BUCKET/$s3_path" \
+    && write_pointer "${s3_path}"
   set +o pipefail
 }
 

--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -14,7 +14,8 @@ backup () {
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   set -o pipefail
   PGDATABASE=$DB_DATABASE \
-    pg_dump -Fc -Z1 | progress | s5cmd pipe "$BUCKET/$s3_path"
+    pg_dump -Fc -Z1 | progress | s5cmd pipe "$BUCKET/$s3_path" \
+    && write_pointer "${s3_path}"
   set +o pipefail
 }
 

--- a/charts/db-backup/scripts/lib.sh
+++ b/charts/db-backup/scripts/lib.sh
@@ -28,6 +28,11 @@ default_db_owner () {
   echo "${1%_production}" | sed -E 's/^(draft[_-])?(.*)/\2/' | tr - _
 }
 
+# Write a pointer file for the specified file
+write_pointer () {
+  echo "${1}" | s5cmd pipe "${BUCKET}/${DB_HOST}/latest.txt"
+}
+
 : "${GOVUK_ENVIRONMENT:?required}"
 : "${DB_USER:=aws_db_admin}"
 : "${DB_PASSWORD:=}"


### PR DESCRIPTION
This pointer file contains the location of the latest successful DB backup.

It will be used in the future to determine which dump file to use when restoring databases in lower environments.

This has been tested in staging with the authenticating-proxy postgres database.

https://github.com/alphagov/govuk-infrastructure/issues/3298