### PR TITLE
[PP-7491] Increase service manual GraphQL rates to 50%

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1373,13 +1373,13 @@ govukApplications:
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
           value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: OS_MAPS_API_KEY

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1348,13 +1348,13 @@ govukApplications:
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
           value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: OS_MAPS_API_KEY

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1369,13 +1369,13 @@ govukApplications:
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
           value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0.01"
+          value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: OS_MAPS_API_KEY


### PR DESCRIPTION
The usage of these pages is too low to get any meaningful performance data when sending only 1% of traffic to the GraphQL version of these pages.

Therefore increasing the traffic rate to 50%, in order to see some traffic actually hit the GraphQL version.