### PR TITLE
[PP-7506] Use graphql for batch 3 schemas

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1368,6 +1368,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
+        - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
+          value: "0.01"
+        - name: GRAPHQL_RATE_GUIDE
+          value: "0.01"
+        - name: GRAPHQL_RATE_HELP_PAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_HOMEPAGE
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1343,6 +1343,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
+        - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
+          value: "0.01"
+        - name: GRAPHQL_RATE_GUIDE
+          value: "0.01"
+        - name: GRAPHQL_RATE_HELP_PAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_HOMEPAGE
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1364,6 +1364,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
+        - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
+          value: "0.01"
+        - name: GRAPHQL_RATE_GUIDE
+          value: "0.01"
+        - name: GRAPHQL_RATE_HELP_PAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_HOMEPAGE
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE


### PR DESCRIPTION
This adds environment variables that will send 1% of traffic to GraphQL for four schemas in frontend.

help_page
guide
home_page
fields_of_operation

Traffic rates will be increased once we have had time to monitor the effect of this change.

This PR does not include generic_with_related_external_links as those are in reality smart-answers and will be looked at seperately. 