### PR TITLE
Re-enable document sync worker

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3031,7 +3031,7 @@ govukApplications:
       uploadAssets:
         enabled: false
       workers:
-        enabled: false
+        enabled: true
         replicaCount: 3
         types:
           - command: ['bin/rake', 'document_sync_worker:run']


### PR DESCRIPTION
This was disabled during database maintenance and mistakenly not reactivated.