### PR TITLE
Enable content-data-api workers in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -687,7 +687,7 @@ govukApplications:
           cpu: 10m
           memory: 650Mi
       workers:
-        enabled: false
+        enabled: true
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker


### PR DESCRIPTION
Looks like we missed re-enabling content-data-api workers in integration, this enables them again