### PR TITLE
[PP-7484] Increase some GraphQL rates to 10%

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1361,13 +1361,13 @@ govukApplications:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
         - name: GRAPHQL_RATE_ANSWER
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CALENDAR
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1336,13 +1336,13 @@ govukApplications:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
         - name: GRAPHQL_RATE_ANSWER
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CALENDAR
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1357,13 +1357,13 @@ govukApplications:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
         - name: GRAPHQL_RATE_ANSWER
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CALENDAR
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE


### PR DESCRIPTION
These four schemas have served 1% of their traffic through GraphQL since last week. The performance has been acceptable (average response times under 60ms, which is less than the 100ms target we set in the kick-off).

Therefore increasing traffic to 10%, so we can check performance at higher levels of usage.