### PR TITLE
[PP-7503] Increase GraphQL rate for transactions to 10%

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1383,7 +1383,7 @@ govukApplications:
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION
-          value: "0.01"
+          value: "0.1"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1358,7 +1358,7 @@ govukApplications:
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION
-          value: "0.01"
+          value: "0.1"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1379,7 +1379,7 @@ govukApplications:
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION
-          value: "0.01"
+          value: "0.1"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
These pages have been running at 1% traffic rendered by GraphQL for the last few days with an acceptable response time.

Therefore increasing the traffic to 10%.