### PR TITLE
[PP-7512] Update environment variables to send no traffic to GraphQL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -337,13 +337,13 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: GRAPHQL_RATE_MINISTERS_INDEX
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_ROLE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_WORLD_INDEX
-          value: "0.5"
+          value: "0"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
   - name: draft-collections
@@ -1361,29 +1361,29 @@ govukApplications:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
         - name: GRAPHQL_RATE_ANSWER
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CALENDAR
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
-          value: "0.01"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TRANSACTION
-          value: "0.01"
+          value: "0"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -339,13 +339,13 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: GRAPHQL_RATE_MINISTERS_INDEX
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_ROLE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_WORLD_INDEX
-          value: "0.5"
+          value: "0"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
       cronTasks: []
@@ -1336,29 +1336,29 @@ govukApplications:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
         - name: GRAPHQL_RATE_ANSWER
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CALENDAR
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
-          value: "0.01"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TRANSACTION
-          value: "0.01"
+          value: "0"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -340,13 +340,13 @@ govukApplications:
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
         - name: GRAPHQL_RATE_MINISTERS_INDEX
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_ROLE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_WORLD_INDEX
-          value: "0.5"
+          value: "0"
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
   - name: draft-collections
@@ -1357,29 +1357,29 @@ govukApplications:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
         - name: GRAPHQL_RATE_ANSWER
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CALENDAR
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
-          value: "0.01"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0.5"
+          value: "0"
         - name: GRAPHQL_RATE_TRANSACTION
-          value: "0.01"
+          value: "0"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We are upgrading the Postgres database for Publishing API. This is likely to have a few minutes downtime.

Therefore we will switch off all traffic to the GraphQL API prior to this, to remove the risk of errors being served to public users.

This will be reverted once the upgrade is complete.