### PR TITLE
[PP-7512] Restore public traffic to GraphQL endpoint in Publishing API

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1388,6 +1388,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
+        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPEECH
+          value: "0.01"
+        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1363,6 +1363,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
+        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPEECH
+          value: "0.01"
+        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1384,6 +1384,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
+        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
+          value: "0.01"
+        - name: GRAPHQL_RATE_SPEECH
+          value: "0.01"
+        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
+          value: "0.01"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION


### PR DESCRIPTION
Traffic to GraphQL endpoints was switched off to allow us to perform an upgrade of Postgres in Publishing API, which resulted in a short downtime.

Restoring the traffic now the maintenance is complete.  Also integrating some changes to the traffic levels raised in other PRs in the meantime.