### PR TITLE
[PP-7052 & PP-7506] Increase GraphQL traffic rates for two batches

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1369,13 +1369,13 @@ govukApplications:
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_GUIDE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1344,13 +1344,13 @@ govukApplications:
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_GUIDE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1365,13 +1365,13 @@ govukApplications:
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_GUIDE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0.01"
+          value: "0.1"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE


### PR DESCRIPTION
This increases the GraphQL traffic rates to 10% for a number of schemas, having seen them perform at an acceptable rate at 1%.