### PR TITLE
[PP-7520] Send 1% traffic for batch 4 schemas to GraphQL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1376,8 +1376,16 @@ govukApplications:
           value: "0.1"
         - name: GRAPHQL_RATE_HOMEPAGE
           value: "0.1"
+        - name: GRAPHQL_RATE_LANDING_PAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_LOCAL_TRANSACTION
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_PLACE
+          value: "0.01"
+        - name: GRAPHQL_RATE_PUBLICATION
+          value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
           value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1351,8 +1351,16 @@ govukApplications:
           value: "0.1"
         - name: GRAPHQL_RATE_HOMEPAGE
           value: "0.1"
+        - name: GRAPHQL_RATE_LANDING_PAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_LOCAL_TRANSACTION
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_PLACE
+          value: "0.01"
+        - name: GRAPHQL_RATE_PUBLICATION
+          value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
           value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1372,8 +1372,16 @@ govukApplications:
           value: "0.1"
         - name: GRAPHQL_RATE_HOMEPAGE
           value: "0.1"
+        - name: GRAPHQL_RATE_LANDING_PAGE
+          value: "0.01"
+        - name: GRAPHQL_RATE_LOCAL_TRANSACTION
+          value: "0.01"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
           value: "0.5"
+        - name: GRAPHQL_RATE_PLACE
+          value: "0.01"
+        - name: GRAPHQL_RATE_PUBLICATION
+          value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
           value: "0.01"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE


### PR DESCRIPTION
## Changes proposed 

This will route 1% of non-CDN traffic for Batch 4 schemas to GraphQL in all three environments:
- landing_page
- local_transaction
- place
- publication
- ~news_article~ (already enabled)

## Why
These queries are already validated for correctness and had performance tested manually. This change focuses on validating performance, both per-query and under overall GraphQL load, to help assess GraphQL behaviour at increasing traffic levels.

## Next steps
We will monitor performance for two working days. If performance is acceptable, we will gradually increase traffic to 10% and 50%.