### PR TITLE
Set min: 0 on Average GraphQL Response Time gauge

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -636,6 +636,7 @@
           "fieldMinMax": false,
           "mappings": [],
           "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [


### PR DESCRIPTION
... Otherwise it calculates the minimum from the data, and the gauge ends up being really confusing.

| Before | After |
|---|---|
| <img width="565" height="346" alt="image" src="https://github.com/user-attachments/assets/37d56351-2bcf-47b4-94d4-c2ca90f0f50e" /> | <img width="547" height="351" alt="image" src="https://github.com/user-attachments/assets/7ea7cbe1-3c78-427b-af4a-d50569ac6647" /> |