### PR TITLE
[PP-7052 & PP-7506] Increase some GraphQL traffic rates to 50%

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1369,13 +1369,13 @@ govukApplications:
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_GUIDE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_LANDING_PAGE
           value: "0.01"
         - name: GRAPHQL_RATE_LOCAL_TRANSACTION
@@ -1397,13 +1397,13 @@ govukApplications:
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
         - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_SPEECH
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1344,13 +1344,13 @@ govukApplications:
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_GUIDE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_LANDING_PAGE
           value: "0.01"
         - name: GRAPHQL_RATE_LOCAL_TRANSACTION
@@ -1372,13 +1372,13 @@ govukApplications:
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
         - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_SPEECH
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1365,13 +1365,13 @@ govukApplications:
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_GUIDE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_LANDING_PAGE
           value: "0.01"
         - name: GRAPHQL_RATE_LOCAL_TRANSACTION
@@ -1393,13 +1393,13 @@ govukApplications:
         - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
           value: "0.5"
         - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_SPEECH
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
-          value: "0.1"
+          value: "0.5"
         - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
           value: "0.5"
         - name: GRAPHQL_RATE_TRANSACTION


### PR DESCRIPTION
These schemas have continued to perform well at 10% traffic, so we can now increase them to 50%.

Utilisation of the Publishing API read replica remains low.

Some of these make up a large amount of traffic to GOV.UK, so this change will increase traffic to GraphQL from ~5% to ~12%, based on recent traffic.