### PR TITLE
[PP-7520 & PP-7525] Send 10% traffic for batch 2 & 4 schemas to GraphQL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1368,6 +1368,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
+        - name: GRAPHQL_RATE_CORPORATE_INFORMATION_PAGE
+          value: "0.1"
+        - name: GRAPHQL_RATE_DOCUMENT_COLLECTION
+          value: "0.1"
+        - name: GRAPHQL_RATE_FATALITY_NOTICE
+          value: "0.1"
+        - name: GRAPHQL_RATE_FIELD_OF_OPERATION
+          value: "0.1"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
           value: "0.5"
         - name: GRAPHQL_RATE_GUIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1343,6 +1343,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
+        - name: GRAPHQL_RATE_CORPORATE_INFORMATION_PAGE
+          value: "0.1"
+        - name: GRAPHQL_RATE_DOCUMENT_COLLECTION
+          value: "0.1"
+        - name: GRAPHQL_RATE_FATALITY_NOTICE
+          value: "0.1"
+        - name: GRAPHQL_RATE_FIELD_OF_OPERATION
+          value: "0.1"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
           value: "0.5"
         - name: GRAPHQL_RATE_GUIDE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1364,6 +1364,14 @@ govukApplications:
           value: "0.5"
         - name: GRAPHQL_RATE_CASE_STUDY
           value: "0.5"
+        - name: GRAPHQL_RATE_CORPORATE_INFORMATION_PAGE
+          value: "0.1"
+        - name: GRAPHQL_RATE_DOCUMENT_COLLECTION
+          value: "0.1"
+        - name: GRAPHQL_RATE_FATALITY_NOTICE
+          value: "0.1"
+        - name: GRAPHQL_RATE_FIELD_OF_OPERATION
+          value: "0.1"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
           value: "0.5"
         - name: GRAPHQL_RATE_GUIDE


### PR DESCRIPTION
### What

Send 10% traffic for eight schemas to GraphQL

### Notes 

Batch 4 have been running at 1% traffic rendered by GraphQL for the last few hours with an acceptable response time. 

Batch 2 schemas have a relatively small number of editions, so the initial percentage of traffic is set to 10% (instead of 1%) to get meaningful metrics faster.

> - corporate_information_page: 2922 editions
> - document_collection: 7554 editions
> - fatality_notice: 513 editions
> - field_of_operation: 5 editions

## Why
These queries are already validated for correctness and had performance tested
manually. This change focuses on validating performance, both per-query and
under overall GraphQL load, to help assess GraphQL behaviour at increasing
traffic levels.