### PR TITLE
[PP-7525] Stop sending traffic for field_of_operation schema to GraphQL

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1374,8 +1374,6 @@ govukApplications:
           value: "0.1"
         - name: GRAPHQL_RATE_FATALITY_NOTICE
           value: "0.1"
-        - name: GRAPHQL_RATE_FIELD_OF_OPERATION
-          value: "0.1"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
           value: "0.5"
         - name: GRAPHQL_RATE_GUIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1349,8 +1349,6 @@ govukApplications:
           value: "0.1"
         - name: GRAPHQL_RATE_FATALITY_NOTICE
           value: "0.1"
-        - name: GRAPHQL_RATE_FIELD_OF_OPERATION
-          value: "0.1"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
           value: "0.5"
         - name: GRAPHQL_RATE_GUIDE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1370,8 +1370,6 @@ govukApplications:
           value: "0.1"
         - name: GRAPHQL_RATE_FATALITY_NOTICE
           value: "0.1"
-        - name: GRAPHQL_RATE_FIELD_OF_OPERATION
-          value: "0.1"
         - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
           value: "0.5"
         - name: GRAPHQL_RATE_GUIDE


### PR DESCRIPTION
It is performing slower than the expected 75ms - at 115 ms (based on 12 requests) so we need to improve the performance of the query before we can release it to production.