### PR TITLE
ci: 🎡 add explicit permissions to gha workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,10 @@ name: Lint GitHub Actions
 on:
   push:
     paths: ['.github/**']
+
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref_name }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   render-charts:
     runs-on: ubuntu-latest
@@ -85,6 +88,8 @@ jobs:
           SHELLCHECK_OPTS: -xP SCRIPTDIR
 
   yamllint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8   # v6.0.1

--- a/.github/workflows/sqlfluff.yml
+++ b/.github/workflows/sqlfluff.yml
@@ -5,6 +5,10 @@ on:
       - charts/db-backup/scripts/*.sql
       - charts/db-backup/.sqlfluff
       - .github/workflows/sqlfluff.yml
+
+permissions:
+  contents: read
+
 jobs:
   sqlfluff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes:

- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/42
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/43
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/44
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/45
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/46
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/47
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/48
- https://github.com/alphagov/govuk-helm-charts/security/code-scanning/49

reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions