### PR TITLE
Switch Elasticsearch to the green cluster

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2960,7 +2960,7 @@ govukApplications:
         - name: AWS_S3_SITEMAPS_BUCKET_NAME
           value: govuk-production-sitemaps
         - name: ELASTICSEARCH_URI
-          value: https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com
+          value: https://vpc-green-elasticsearch6-domain-y4xd7c6mh2vucmkgtcit6h222u.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
           value: info
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
We are upgrading Elasticsearch to v6.8, which is the 'green' cluster.

This commit switches the ELASTICSEARCH_URI variable from the old 'blue' to the new 'green' cluster so that the Search API will start using the upgraded cluster