### PR TITLE
[PNP-9741] Disable static/draft-static in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3340,6 +3340,7 @@ govukApplications:
   - name: static
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1
@@ -3404,6 +3405,7 @@ govukApplications:
     repoName: static
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
Now that no apps are using slimmer any more, it's time to retire static. Static has been disabled in integration since https://github.com/alphagov/govuk-helm-charts/pull/3878, so try turning it off in staging.
 
[JIRA Card](https://gov-uk.atlassian.net/browse/PNP-9741)