### PR TITLE
Expose cluster-autoscaler metrics

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -28,6 +28,22 @@ spec:
           scale-down-utilization-threshold: "0.55"
           skip-nodes-with-local-storage: false
           v: "0"
+        extraObjects:
+        - apiVersion: monitoring.coreos.com/v1
+          kind: PodMonitor
+          metadata:
+            name: aws-cluster-autoscaler
+            labels:
+              app.kubernetes.io/instance: cluster-autoscaler
+              app.kubernetes.io/name: aws-cluster-autoscaler
+          spec:
+            jobLabel: app.kubernetes.io/name
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: aws-cluster-autoscaler
+            podMetricsEndpoints:
+              - port: 8085
+                path: "/metrics"
         replicaCount: {{ .Values.replicaCount }}
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Description:
- Add a `PodMonitor` so that `cluster-autoscaler` metrics are scraped by Prometheus