### PR TITLE
Fix cluster-autoscaler pod monitor port to a string

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -42,7 +42,7 @@ spec:
               matchLabels:
                 app.kubernetes.io/name: aws-cluster-autoscaler
             podMetricsEndpoints:
-              - port: 8085
+              - port: "8085"
                 path: "/metrics"
         replicaCount: {{ .Values.replicaCount }}
   destination:


### PR DESCRIPTION
Description:
- Needs to be a string
- See https://github.com/alphagov/govuk-helm-charts/pull/3973