### PR TITLE
Use `portNumber` instead of `port` for cluster-autoscaler PodMonitor

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -42,7 +42,7 @@ spec:
               matchLabels:
                 app.kubernetes.io/name: aws-cluster-autoscaler
             podMetricsEndpoints:
-              - port: "8085"
+              - portNumber: "8085"
                 path: "/metrics"
         replicaCount: {{ .Values.replicaCount }}
   destination:


### PR DESCRIPTION
Description:
- `cluster-autoscaler` doesn't expose a named port which is what `port` expects so we have to use `portNumber` instead - see https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMetricsEndpoint