### PR TITLE
Use integer not string

### DIFF
--- a/charts/app-config/templates/cluster-autoscaler.yaml
+++ b/charts/app-config/templates/cluster-autoscaler.yaml
@@ -42,7 +42,7 @@ spec:
               matchLabels:
                 app.kubernetes.io/name: aws-cluster-autoscaler
             podMetricsEndpoints:
-              - portNumber: "8085"
+              - portNumber: 8085
                 path: "/metrics"
         replicaCount: {{ .Values.replicaCount }}
   destination:


### PR DESCRIPTION
Description:
- `portNumber` expects an integer not a string