### PR TITLE
[PP-7520 & PP-7525] Send 50% of traffic to GraphQL for batch 2 and 4 schemas

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1383,13 +1383,13 @@ govukApplications:
         - name: GRAPHQL_RATE_HOMEPAGE
           value: "0"
         - name: GRAPHQL_RATE_LANDING_PAGE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_LOCAL_TRANSACTION
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_PLACE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_PUBLICATION
           value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1358,13 +1358,13 @@ govukApplications:
         - name: GRAPHQL_RATE_HOMEPAGE
           value: "0"
         - name: GRAPHQL_RATE_LANDING_PAGE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_LOCAL_TRANSACTION
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_PLACE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_PUBLICATION
           value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1393,13 +1393,13 @@ govukApplications:
         - name: GRAPHQL_RATE_HOMEPAGE
           value: "0"
         - name: GRAPHQL_RATE_LANDING_PAGE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_LOCAL_TRANSACTION
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_PLACE
-          value: "0"
+          value: "0.5"
         - name: GRAPHQL_RATE_PUBLICATION
           value: "0"
         - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE


### PR DESCRIPTION
The testing was temporarily stopped over the weekend.
Since the performance was fine so far we're increasing the traffic to 50%.

We collected a lot of data for `publication` so not increasing it to 50% to keep the overall traffic safely low.