### PR TITLE
Remove static in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -176,17 +176,10 @@ govukApplications:
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             paths:
-              - path: /government/uploads/
-              - path: /government/assets/
-              - path: /media/
-              - path: /auth/gds # Viewing draft assets requires user auth.
+              - path: /
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             paths:
-              - path: /government/uploads/
-              - path: /government/assets/
-              - path: /media/
-              - path: /auth/gds # Viewing draft assets requires user auth.
-              - path: /robots.txt
+              - path: /
       assetManagerNFS: &assets-nfs assets.integration.govuk-internal.digital
       clamMountConfigPath: /usr/local/etc
       nginxConfigMap:
@@ -3365,110 +3358,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-smart-answers-publishing-api
               key: bearer_token
-  - name: static
-    helmValues:
-      arch: arm64
-      appEnabled: false
-      appResources:
-        limits:
-          cpu: 1
-          memory: 1Gi
-        requests:
-          cpu: 10m
-          memory: 256Mi
-      ingress:
-        enabled: true
-        annotations:
-          !!merge <<: [*alb-ingress-defaults, *alb-ingress-waf-ruleset-www]
-          alb.ingress.kubernetes.io/load-balancer-name: assets-origin
-          alb.ingress.kubernetes.io/group.name: assets-origin
-          alb.ingress.kubernetes.io/group.order: "30"
-          alb.ingress.kubernetes.io/load-balancer-attributes: *assets-lb-attributes
-          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: *assets-lb-conditions
-        hosts:
-          - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
-            path: /
-      kubernetesProbeEndpoints:
-        startupProbe: "/healthcheck/ready"
-      extraEnv:
-        # These GA/GTM values are not secrets (not even the the gtm_auth one).
-        # https://github.com/alphagov/govuk-puppet/pull/8041
-        - name: RAILS_SERVE_STATIC_FILES
-          value: "true"
-        - name: GA_UNIVERSAL_ID
-          value: &ga-universal-id UA-26179049-22
-        - name: GOOGLE_TAG_MANAGER_ID
-          value: &static-gtm-id GTM-MG7HG5W
-        - name: GOOGLE_TAG_MANAGER_AUTH # Non-prod only.
-          value: &static-gtm-auth C7iYdcsOlYgGmiUJjZKrHQ
-        - name: GOOGLE_TAG_MANAGER_PREVIEW # Non-prod only.
-          value: &static-gtm-preview env-4
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-static-publishing-api
-              key: bearer_token
-        - name: EMERGENCY_BANNER_REDIS_URL
-          value: *emergency-banner-redis
-        - name: USE_TMPDIR_PAGE_CACHE
-          value: "true"
-      nginxConfigMap:
-        extraServerConf: |
-          # 1stline use this URL in their zendesk template
-          location = /static/gov.uk_logotype_crown.png {
-            absolute_redirect off;
-            return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
-          }
-          # Google site verification
-          location = /googlec908b3bc32386239.html {
-            return 200 'google-site-verification: googlec908b3bc32386239.html';
-          }
-          # Favicon now that static isn't serving it
-          location = /favicon.ico {
-            return 301 https://www.integration.publishing.service.gov.uk/favicon.ico;
-          }
-  - name: draft-static
-    repoName: static
-    helmValues:
-      arch: arm64
-      appEnabled: false
-      appResources:
-        limits:
-          cpu: 1
-          memory: 1Gi
-        requests:
-          cpu: 100m
-          memory: 320Mi
-      rails:
-        createKeyBaseSecret: false
-      sentry:
-        createSecret: false
-      uploadAssets:
-        enabled: false
-      kubernetesProbeEndpoints:
-        startupProbe: "/healthcheck/ready"
-      extraEnv:
-        - name: DRAFT_ENVIRONMENT
-          value: "1"
-        - name: PLEK_HOSTNAME_PREFIX
-          value: draft-
-        - name: GA_UNIVERSAL_ID
-          value: *ga-universal-id
-        - name: GOOGLE_TAG_MANAGER_ID
-          value: *static-gtm-id
-        - name: GOOGLE_TAG_MANAGER_AUTH # Non-prod only.
-          value: *static-gtm-auth
-        - name: GOOGLE_TAG_MANAGER_PREVIEW # Non-prod only.
-          value: *static-gtm-preview
-        - name: PUBLISHING_API_BEARER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: signon-token-static-publishing-api
-              key: bearer_token
-        - name: EMERGENCY_BANNER_REDIS_URL
-          value: *emergency-banner-redis
-        - name: USE_TMPDIR_PAGE_CACHE
-          value: "true"
   - name: short-url-manager
     helmValues:
       arch: arm64

--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -228,5 +228,19 @@ data:
         location = /readyz {
           return 200 'ok\n';
         }
+
+        # 1stline use this URL in their zendesk template
+        location = /static/gov.uk_logotype_crown.png {
+          absolute_redirect off;
+          return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
+        }
+        # Google site verification
+        location = /googlec908b3bc32386239.html {
+          return 200 'google-site-verification: googlec908b3bc32386239.html';
+        }
+        # Favicon now that static isn't serving it
+        location = /favicon.ico {
+          return 301 https://www.integration.publishing.service.gov.uk/favicon.ico;
+        }
       }
     }


### PR DESCRIPTION
Remove static and draft-static completely from integration

Add the config that was present in static's nginx config file to asset-manager.

Update the assets ELB rules to have asset-manager serve all traffic that frontend doesn't serve

https://github.com/alphagov/govuk-infrastructure/issues/3469