### PR TITLE
Use externalDomainSuffix value for favicon redirect in asset-manager nginx config

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -240,7 +240,7 @@ data:
         }
         # Favicon now that static isn't serving it
         location = /favicon.ico {
-          return 301 https://www.integration.publishing.service.gov.uk/favicon.ico;
+          return 301 https://www.{{ .Values.externalDomainSuffix }}/favicon.ico;
         }
       }
     }


### PR DESCRIPTION
This was tested by rendering the charts for each of the three environments

https://github.com/alphagov/govuk-infrastructure/issues/3469