### PR TITLE
Enable Reloader metrics

### DIFF
--- a/charts/app-config/templates/reloader.yaml
+++ b/charts/app-config/templates/reloader.yaml
@@ -16,6 +16,8 @@ spec:
         reloader:
           readOnlyRootFilesystem: true
           reloadStrategy: annotations
+          podMonitor:
+            enabled: true
           deployment:
             containerSecurityContext:
               capabilities:


### PR DESCRIPTION
Description:
- [Service Monitor](https://github.com/stakater/Reloader/blob/c9cab4f6e0131de1676786887523f132fe42ac6f/deployments/kubernetes/chart/reloader/values.yaml#L218) is deprecrated so enable `PodMonitor` instead
- Enables Prometheus to scrape Reloader metrics
- https://github.com/alphagov/govuk-infrastructure/issues/3457