### PR TITLE
Update asset-manager ingress paths in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -170,17 +170,10 @@ govukApplications:
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             paths:
-              - path: /government/uploads/
-              - path: /government/assets/
-              - path: /media/
-              - path: /auth/gds # Viewing draft assets requires user auth.
+              - path: /
           - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
             paths:
-              - path: /government/uploads/
-              - path: /government/assets/
-              - path: /media/
-              - path: /auth/gds # Viewing draft assets requires user auth.
-              - path: /robots.txt
+              - path: /
       assetManagerNFS: &assets-nfs assets.production.govuk-internal.digital
       nginxConfigMap:
         create: false


### PR DESCRIPTION
Serve all paths from asset-manager, to prepare for removal of static

This is necessary to do before removing static to ensure no requests are lost while asset-manager gets updated and static gets shut down.

https://github.com/alphagov/govuk-infrastructure/issues/3469