### PR TITLE
Update asset-manager ingress paths in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -170,17 +170,7 @@ govukApplications:
         hosts:
           - name: assets-origin.{{ .Values.k8sExternalDomainSuffix }}
             paths:
-              - path: /government/uploads/
-              - path: /government/assets/
-              - path: /media/
-              - path: /auth/gds # Viewing draft assets requires user auth.
-          - name: draft-assets.{{ .Values.k8sExternalDomainSuffix }}
-            paths:
-              - path: /government/uploads/
-              - path: /government/assets/
-              - path: /media/
-              - path: /auth/gds # Viewing draft assets requires user auth.
-              - path: /robots.txt
+              - path: /
       assetManagerNFS: &assets-nfs assets.production.govuk-internal.digital
       nginxConfigMap:
         create: false


### PR DESCRIPTION
Serve all paths from asset-manager, to prepare for removal of static

Round two. We're confident that the remaining requests for static are just bots.

https://github.com/alphagov/govuk-infrastructure/issues/3469