### PR TITLE
Remove rake tasks that update popularity in the detailed index

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2881,14 +2881,6 @@ govukApplications:
             requests:
               cpu: 0.1
               memory: 800Mi
-        - name: update-detailed-index-popularity
-          task: "search:update_popularity"
-          schedule: "15 22 * * *"
-          env:
-            - name: SEARCH_INDEX
-              value: detailed
-            - name: PROCESS_ALL_DATA
-              value: "true"
         - name: update-government-index-popularity
           task: "search:update_popularity"
           schedule: "35 22 * * *"

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2931,14 +2931,6 @@ govukApplications:
           env:
             - name: AWS_SEARCH_ANALYTICS_BUCKET
               value: govuk-search-analytics-production
-        - name: update-detailed-index-popularity
-          task: "search:update_popularity"
-          schedule: "15 22 * * *"
-          env:
-            - name: SEARCH_INDEX
-              value: detailed
-            - name: PROCESS_ALL_DATA
-              value: "true"
         - name: update-government-index-popularity
           task: "search:update_popularity"
           schedule: "35 22 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2872,14 +2872,6 @@ govukApplications:
           env:
             - name: AWS_SEARCH_ANALYTICS_BUCKET
               value: govuk-search-analytics-staging
-        - name: update-detailed-index-popularity
-          task: "search:update_popularity"
-          schedule: "15 22 * * *"
-          env:
-            - name: SEARCH_INDEX
-              value: detailed
-            - name: PROCESS_ALL_DATA
-              value: "true"
         - name: update-government-index-popularity
           task: "search:update_popularity"
           schedule: "35 22 * * *"


### PR DESCRIPTION
The detailed index is being retired, so these tasks should no longer be called

Jira: https://gov-uk.atlassian.net/browse/SCH-1692