### PR TITLE
[SCH-1623] Remove search analytics bucket env var from all environments

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2871,9 +2871,6 @@ govukApplications:
         - name: load-page-traffic
           command: "./bin/load_page_traffic.sh"
           schedule: "0 22 * * *"
-          env:
-            - name: AWS_SEARCH_ANALYTICS_BUCKET
-              value: govuk-search-analytics-integration
           resources:
             limits:
               cpu: 1

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2921,9 +2921,6 @@ govukApplications:
         - name: load-page-traffic
           command: "./bin/load_page_traffic.sh"
           schedule: "0 22 * * *"
-          env:
-            - name: AWS_SEARCH_ANALYTICS_BUCKET
-              value: govuk-search-analytics-production
         - name: update-detailed-index-popularity
           task: "search:update_popularity"
           schedule: "15 22 * * *"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2869,9 +2869,6 @@ govukApplications:
         - name: load-page-traffic
           command: "./bin/load_page_traffic.sh"
           schedule: "0 22 * * *"
-          env:
-            - name: AWS_SEARCH_ANALYTICS_BUCKET
-              value: govuk-search-analytics-staging
         - name: update-detailed-index-popularity
           task: "search:update_popularity"
           schedule: "15 22 * * *"


### PR DESCRIPTION
The load-page-traffic cronTask has not needed to write to `AWS_SEARCH_ANALYTICS_BUCKET` since universal analytics was retired in 2024. The environment variable therefore no longer needs to be passed through to the job.

We have a [related PR to delete the objects from the S3 buckets](https://github.com/alphagov/govuk-infrastructure/pull/3495), ahead of destroying the buckets themselves.

See [related Jira ticket](https://gov-uk.atlassian.net/browse/SCH-1623)