### PR TITLE
[PNP-9741] Remove static as a backend url for router

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2686,8 +2686,6 @@ govukApplications:
           value: "http://government-frontend"
         - name: BACKEND_URL_smartanswers
           value: "http://smartanswers"
-        - name: BACKEND_URL_static
-          value: "http://static"
         - name: BACKEND_URL_account-api
           value: "http://account-api"
         - name: BACKEND_URL_feedback
@@ -2747,8 +2745,6 @@ govukApplications:
           value: "http://draft-government-frontend"
         - name: BACKEND_URL_smartanswers
           value: "http://draft-smartanswers"
-        - name: BACKEND_URL_static
-          value: "http://draft-static"
         - name: BACKEND_URL_account-api
           value: "http://account-api"
         - name: BACKEND_URL_feedback

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2719,8 +2719,6 @@ govukApplications:
           value: "http://government-frontend"
         - name: BACKEND_URL_smartanswers
           value: "http://smartanswers"
-        - name: BACKEND_URL_static
-          value: "http://static"
         - name: BACKEND_URL_account-api
           value: "http://account-api"
         - name: BACKEND_URL_feedback
@@ -2780,8 +2778,6 @@ govukApplications:
           value: "http://draft-government-frontend"
         - name: BACKEND_URL_smartanswers
           value: "http://draft-smartanswers"
-        - name: BACKEND_URL_static
-          value: "http://draft-static"
         - name: BACKEND_URL_account-api
           value: "http://account-api"
         - name: BACKEND_URL_feedback

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2695,8 +2695,6 @@ govukApplications:
           value: "http://government-frontend"
         - name: BACKEND_URL_smartanswers
           value: "http://smartanswers"
-        - name: BACKEND_URL_static
-          value: "http://static"
         - name: BACKEND_URL_account-api
           value: "http://account-api"
         - name: BACKEND_URL_feedback
@@ -2756,8 +2754,6 @@ govukApplications:
           value: "http://draft-government-frontend"
         - name: BACKEND_URL_smartanswers
           value: "http://draft-smartanswers"
-        - name: BACKEND_URL_static
-          value: "http://draft-static"
         - name: BACKEND_URL_account-api
           value: "http://account-api"
         - name: BACKEND_URL_feedback


### PR DESCRIPTION

Static doesn't exist now, and there haven't been any paths that needed routing to it for months, so remove the backend_url_ environment variable for it from router.

[JIRA Card](https://gov-uk.atlassian.net/browse/PNP-9741)