### PR TITLE
[PNP-9722] Redirect /government/uploads paths to assets host on integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1414,6 +1414,15 @@ govukApplications:
               key: api_key
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
+      nginxConfigMap:
+        extraServerConf: |
+          server {
+            server_name ~^www.{{ .Values.k8sExternalDomainSuffix }}
+
+            location /government/uploads/(?<item_path>.+) {
+              return 301 https://assets.{{ .Values.publishingDomainSuffix }}/government/upload/$item_path;
+            }
+          }
   - name: draft-frontend
     repoName: frontend
     helmValues:
@@ -1493,6 +1502,15 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-publishing-api
               key: bearer_token
+      nginxConfigMap:
+        extraServerConf: |
+          server {
+            server_name ~^draft-www.{{ .Values.k8sExternalDomainSuffix }}
+
+            location /government/uploads/(?<item_path>.+) {
+              return 301 https://draft-assets.{{ .Values.publishingDomainSuffix }}/government/upload/$item_path;
+            }
+          }
   - name: fact-check-manager
     helmValues:
       arch: arm64


### PR DESCRIPTION
This is a legacy path, but we still get some requests on it. It was handled in government-frontend (https://github.com/alphagov/government-frontend/commit/2c56aca6b9301547568bc0e4177044f1d64cfe02) but it's a simple redirect, so it makes sense to handle it at the nginx level. This is a test of this in integration, which we'll pair with a version of government-frontend that doesn't have the redirect, and a version of publishing-api that points /government/uploads to frontend instead of government-frontend. 

Related PRs:
- https://github.com/alphagov/publishing-api/pull/3828
- https://github.com/alphagov/government-frontend/pull/3963

Note to reviewers: I'm not sure I've got the server name regex right, nor whether I've used the domain suffix in the redirect location correctly.