### PR TITLE
Alter hostnames for content-data-api and imminence in db-backup config in staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -309,7 +309,7 @@ cronjobs:
 
     content-data-api-postgresql-primary:
       schedule: "35 1 * * 6"
-      host: blue-content-data-api-postgresql-primary-postgres
+      host: content-data-api-postgres
       db: content_performance_manager_production
       dbms: postgres
       operations:
@@ -359,6 +359,7 @@ cronjobs:
     imminence-postgres:
       schedule: "18 1 * * 1-5"
       db: imminence_production
+      host: places-manager-postgres
       operations:
         - op: restore
           bucket: s3://govuk-production-database-backups


### PR DESCRIPTION
We are rationalising the hostnames so they all meet a consistent naming standard. In staging only I've already made new CNAMES for places-manager (previously called imminence) and content-data-api.

This PR changes the staging db-backup jobs to use the new hostnames.