### PR TITLE
Use the correct configuration parameter for Mirror drift check cron job

### DIFF
--- a/charts/mirror/templates/drift-cronjob.yaml
+++ b/charts/mirror/templates/drift-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "drift.labels" . | nindent 4 }}
 spec:
-  schedule: "{{ .Values.mirrorSchedule }}"
+  schedule: "{{ .Values.driftSchedule }}"
   jobTemplate:
     metadata:
       name: "{{ include "drift.fullname" . }}"


### PR DESCRIPTION
Previously it was using the same field as the main mirror job, but it has its own.