### PR TITLE
Revert "humans.txt for Richard Towers"

### DIFF
--- a/charts/app-config/humans.txt
+++ b/charts/app-config/humans.txt
@@ -1,13 +1,2 @@
-Today we’re saying goodbye to Richard Towers.
-
-Richard joined GDS 10 years ago, and immediately made a huge impact in the office, using his booming voice to disrupt standups across the wider Holborn area. He’s only improved his capabilities in this area, scoring an unprecedented 15 out of 3 on the GDaD scale.
-
-He joined GOV.UK at the start of the COVID-19 pandemic after stints with Verify, Pay and PaaS (as tech lead). He was immediately central to our efforts building services to support and get food to vulnerable people, and his contributions have only grown.
-
-His exceptional technical ability and leadership were soon rewarded with a spell as GOV.UK’s Head of Software Engineering. He’s since reacquainted himself with a terminal and has been Lead Developer across our teams working on publishing tools. Despite being a hands-on engineer, he's never quite managed to let go of his beloved spreadsheets.
-
-He’s come a long way since being the man that vowed to never own anything he couldn’t carry. His dog Rory surely now exceeds his lifting capacity, though continues to feature prominently in our prototypes. We’re going to miss him loads.
-
-
 GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London,
 Bristol and Manchester.  If you’d like to join us, see https://gdscareers.gov.uk/


### PR DESCRIPTION
This is now [in the National Archives](https://webarchive.nationalarchives.gov.uk/ukgwa/20260114160327/https://www.gov.uk/humans.txt), so we can remove it.

Reverts alphagov/govuk-helm-charts#3991