### PR TITLE
Add places-manager ExternalSecret only

### DIFF
--- a/charts/external-secrets/templates/places-manager/postgres.yaml
+++ b/charts/external-secrets/templates/places-manager/postgres.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: places-manager-postgres
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for places-manager's Postgres DB hosted in RDS.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: places-manager-postgres
+    template:
+      data:
+        # places-manager was previously called imminence, the RDS instance has been renamed, but the database within it has
+        # not, so for now it's sill imminence_production
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/postgis-conn-string.tpl" | trim }}/imminence_production'
+  dataFrom:
+    - extract:
+        key: govuk/places-manager/postgres
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
The previous attempt at this (https://github.com/alphagov/govuk-helm-charts/pull/4003) failed and caused the db migration jobs to try and create a new database within the postgres instance named places-manager_production.

I realised that the DATABASE_URL has a hardcoded database name on the end, and in creating the previous external secret I had changed it to places-manager_production, so this PR creates only the secret and sets it to imminence_production with a comment for future readers to understand why it's called that.

It's on the list of @KludgeKML's team to rename the database, but it's quite the pain, so for now lets stick with it being called imminence.