### PR TITLE
[PNP-9722] Simplify /government/uploads redirect in frontend

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1416,12 +1416,8 @@ govukApplications:
           value: "http://publishing-api-read-replica"
       nginxConfigMap:
         extraServerConf: |
-          server {
-            server_name ~^www.{{ .Values.k8sExternalDomainSuffix }}
-
-            location /government/uploads/(?<item_path>.+) {
-              return 301 https://assets.{{ .Values.publishingDomainSuffix }}/government/upload/$item_path;
-            }
+          location /government/uploads/(?<item_path>.+) {
+            return 301 https://assets.{{ .Values.publishingDomainSuffix }}/government/upload/$item_path;
           }
   - name: draft-frontend
     repoName: frontend
@@ -1504,12 +1500,8 @@ govukApplications:
               key: bearer_token
       nginxConfigMap:
         extraServerConf: |
-          server {
-            server_name ~^draft-www.{{ .Values.k8sExternalDomainSuffix }}
-
-            location /government/uploads/(?<item_path>.+) {
-              return 301 https://draft-assets.{{ .Values.publishingDomainSuffix }}/government/upload/$item_path;
-            }
+          location /government/uploads/(?<item_path>.+) {
+            return 301 https://draft-assets.{{ .Values.publishingDomainSuffix }}/government/upload/$item_path;
           }
   - name: fact-check-manager
     helmValues:


### PR DESCRIPTION
- Previous version led to us creating a nested server directive, not what we wanted.

https://gov-uk.atlassian.net/browse/PNP-9772