### PR TITLE
[PNP-9772] Add nginx redirects in frontend for /government/uploads

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1391,6 +1391,11 @@ govukApplications:
           value: '4'
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
+      nginxConfigMap:
+        extraServerConf: |
+          location ~ /government/uploads/(?<item_path>.+) {
+            return 301 https://assets.publishing.service.gov.uk/government/uploads/$item_path;
+          }
       cronTasks: []
   - name: draft-finder-frontend
     repoName: finder-frontend
@@ -1495,6 +1500,11 @@ govukApplications:
             secretKeyRef:
               name: frontend-os-maps-api
               key: api_key
+      nginxConfigMap:
+        extraServerConf: |
+          location ~ /government/uploads/(?<item_path>.+) {
+            return 301 https://draft-assets.publishing.service.gov.uk/government/uploads/$item_path;
+          }
       cronTasks: []
   - name: government-frontend
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1426,6 +1426,11 @@ govukApplications:
           value: '4'
         - name: PLEK_SERVICE_PUBLISHING_API_URI
           value: "http://publishing-api-read-replica"
+      nginxConfigMap:
+        extraServerConf: |
+          location ~ /government/uploads/(?<item_path>.+) {
+            return 301 https://assets.staging.publishing.service.gov.uk/government/uploads/$item_path;
+          }
       cronTasks: []
   - name: draft-frontend
     repoName: frontend
@@ -1500,6 +1505,11 @@ govukApplications:
             secretKeyRef:
               name: frontend-os-maps-api
               key: api_key
+      nginxConfigMap:
+        extraServerConf: |
+          location ~ /government/uploads/(?<item_path>.+) {
+            return 301 https://draft-assets.staging.publishing.service.gov.uk/government/uploads/$item_path;
+          }
       cronTasks: []
   - name: government-frontend
     helmValues:


### PR DESCRIPTION
- This was done in government-frontend previously, but we need to move it to frontend to retire government-frontend and it makes sense since it's a simple redirect to do it at the nginx level rather than in the rails stack. This approach has been checked (and refined) in integration already.

[JIRA Card](https://gov-uk.atlassian.net/browse/PNP-9772)