### PR TITLE
Add pipefail option to all db backup scripts

### DIFF
--- a/charts/db-backup/scripts/backup-mongo
+++ b/charts/db-backup/scripts/backup-mongo
@@ -11,11 +11,9 @@ backup () {
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   local s3_url="$BUCKET/$s3_path"
 
-  set -o pipefail
   mongodump "$db_url" --archive \
     | progress | gzip -1 | s5cmd pipe "$s3_url" \
     && write_pointer "${s3_path}"
-  set +o pipefail
 
   get_object_size "$s3_url"
 }

--- a/charts/db-backup/scripts/backup-mysql
+++ b/charts/db-backup/scripts/backup-mysql
@@ -9,11 +9,9 @@ backup () {
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   local s3_url="$BUCKET/$s3_path"
 
-  set -o pipefail
   mysqldump --single-transaction "$DB_DATABASE" \
     | progress | gzip -1 | s5cmd pipe "$s3_url" \
     && write_pointer "${s3_path}"
-  set +o pipefail
 
   get_object_size "$s3_url"
 }

--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -14,12 +14,10 @@ backup () {
   s3_path="$DB_HOST/$(date -u +%Y-%m-%dT%H%M%SZ)-$DB_DATABASE.gz"
   local s3_url="$BUCKET/$s3_path"
 
-  set -o pipefail
   PGDATABASE=$DB_DATABASE \
     pg_dump -Fc -Z1 | progress | s5cmd pipe "$s3_url" \
     && write_pointer "${s3_path}"
 
-  set +o pipefail
   get_object_size "$s3_url"
 }
 


### PR DESCRIPTION
The scripts run pg_dump piped to other commands, without the pipefail option the return code is that of the final command of the pipe, which means when pg_dump fails the command still exits successfully and the pod still runs to successful completion. So this PR:

* Adds `pipefail` option to all backup scripts
* Remove the inline setting and unsetting of pipefail in the backup function since it's now on globally