### PR TITLE
Enable DB sync into integration for content-data-api

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -554,7 +554,6 @@ cronjobs:
         - op: backup
 
     content-data-api-postgres:
-      suspend: true
       schedule: "35 6 * * 6"
       db: content_performance_manager_production
       operations:


### PR DESCRIPTION
This are supposed to be enabled, the assumption is that when they were suspended a few months ago we forgot to unsuspend the content-data-api restore into staging