### PR TITLE
Fix headers on assets

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -44,15 +44,17 @@ data:
         ''      $http_host;
       }
 
-      # This map creates a $sts_default variable for later use.
-      # If this header is already set by upstream, then $sts_default will
-      # be an empty string, which will later lead to:
-      #    add_header Strict-Transport-Security ''
-      # which will be ignored according to http://serverfault.com/a/598106
-      # If the header is not set by upstream, then $sts_default will be set
-      # and later uses in add_header will be effective.
-      map $upstream_http_strict_transport_security $sts_default {
-        '' "max-age=31536000; preload";
+      # Default values for response headers. These values are used when the
+      # header is not already set on the incoming response.
+      # https://serverfault.com/a/598106
+      map $upstream_http_strict_transport_security $strict_transport_security {
+        "" "max-age=31536000; preload";
+      }
+      map $upstream_http_permissions_policy $permissions_policy {
+        "" "interest-cohort=()";
+      }
+      map $upstream_http_x_content_type_options $x_content_type_options {
+        "" "nosniff";
       }
 
       log_format json_event escape=json '{'
@@ -87,11 +89,11 @@ data:
         server_name asset-manager asset-manager.*  ;
         listen {{ .Values.nginxPort }};
 
-        # Send the Strict-Transport-Security header
-        add_header Strict-Transport-Security $sts_default;
-
-        add_header Permissions-Policy interest-cohort=();
-        add_header X-Content-Type-Options "nosniff" always;
+        # Where the response header is already set on the incoming response,
+        # these are no-ops. https://serverfault.com/a/598106
+        add_header Strict-Transport-Security $strict_transport_security;
+        add_header Permissions-Policy $permissions_policy;
+        add_header X-Content-Type-Options $x_content_type_options always;
 
         proxy_set_header Host $http_host;
 
@@ -172,6 +174,13 @@ data:
           # this optional header refers to the asset's owning document.
           add_header Link $link_from_rails;
 
+          # because we've used add_header elsewhere in this location block, we
+          # won't inherit these headers from the parent server block, so listing
+          # them explicitly.
+          # https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+          add_header Strict-Transport-Security $strict_transport_security;
+          add_header Permissions-Policy $permissions_policy;
+          add_header X-Content-Type-Options $x_content_type_options always;
 
           # Additionally, we always prohibit passing on these headers from S3 to
           # the client as they are very likely to be wrong. There appears to be


### PR DESCRIPTION
We noticed that x-content-type-options was not being set on assets, e.g.:

```
❯ curl -Is https://assets.publishing.service.gov.uk/media/67f519ba563cc9c84bacc320/D81_0425_save.pdf | grep -i content | sort
content-disposition: inline; filename="D81_0425_save.pdf"
content-length: 293413
content-type: application/pdf
```

It is present on locations that don't set their own headers, e.g.:
```
curl -Is https://assets.publishing.service.gov.uk/ | grep -i content | sort
content-length: 4836
content-type: text/html; charset=UTF-8
x-content-type-options: nosniff
```

I noticed that nginx's `add_header`, if used in a `location`, [prevents the defaults set in the parent `server` block from being inherited](https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header). It's possible to [change this behaviour by using `add_header_inherit`](https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header_inherit), but I thought it might be less confusing for the next person if we just set these headers explicitly.

There are other location blocks in this file, but they don't set their own headers apart from the `/__canary__` endpoint, which I think is fine to ignore.

I'm using the same pattern for setting "unset" headers as in the other nginx configuration we have, as in https://github.com/alphagov/govuk-helm-charts/pull/4021