### PR TITLE
GOV.UK Mirror: set a Slack webhook URL as a secret

### DIFF
--- a/charts/external-secrets/templates/mirror/slack-webhook.yaml
+++ b/charts/external-secrets/templates/mirror/slack-webhook.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mirror-drift-detection-slack-webhook
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Slack webhook used to alert when drift is detected
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: mirror-drift-detection-slack-webhook
+  dataFrom:
+    - extract:
+        key: govuk/mirror/slack-webhook
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/charts/mirror/templates/drift-cronjob.yaml
+++ b/charts/mirror/templates/drift-cronjob.yaml
@@ -48,6 +48,10 @@ spec:
                   value: '100'
                 - name: COMPARE_REMAINING_SAMPLED_COUNT
                   value: '100'
+                - name: SLACK_WEBHOOK
+                  valueFrom:
+                    secretKeyRef:
+                      key: mirror-drift-detection-slack-webhook
                 {{- with .Values.extraEnv }}
                   {{- (tpl (toYaml .) $) | trim | nindent 16 }}
                 {{- end }}


### PR DESCRIPTION
We use incoming Slack webhooks to send an alert when drift has been detected. 

This PR creates a secret which will have an initially empty value. This is OK and the secret value will be set out of band before the code next runs.