### PR TITLE
Temporarily don't restore content-data-api in staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -311,8 +311,8 @@ cronjobs:
       db: content_performance_manager_production
       maxJobRuntimeSeconds: 86400 # 24 hours
       operations:
-        - op: restore
-          bucket: s3://govuk-production-database-backups
+        # - op: restore
+        #   bucket: s3://govuk-production-database-backups
         - op: backup
 
     content-store-postgres:


### PR DESCRIPTION
Although the job to restore and backup content-data-api in staging timed out last night, the restore did complete, it was the backup which ended up running over the time window.

I want to get a staging backup so I can restore it to integration, so for the time being comment out the restore portion of the staging content-data-api job so we can do a simple backup of it