### PR TITLE
Return content-data-api to restoring in staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -314,8 +314,8 @@ cronjobs:
       db: content_performance_manager_production
       maxJobRuntimeSeconds: 86400 # 24 hours
       operations:
-        # - op: restore
-        #   bucket: s3://govuk-production-database-backups
+        - op: restore
+          bucket: s3://govuk-production-database-backups
         - op: backup
 
     content-store-postgres:


### PR DESCRIPTION
We're running an ad-hoc backup of content-data-api in staging, once that is finished we can merge this change to return it to a restore & backup mode