### PR TITLE
Configure Renovate to bump Terraform dependencies for sensitive repositories

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,6 +7,9 @@ data:
     {
       "repositories": [
         "alphagov/govuk-helm-charts",
-        "alphagov/govuk-infrastructure"
+        "alphagov/govuk-infrastructure",
+        "alphagov/govuk-fastly",
+        "alphagov/govuk-fastly-secrets",
+        "alphagov/terraform-govuk-infrastructure-sensitive"
       ]
     }


### PR DESCRIPTION
Description:
- Configure Renovate to bump Terraform dependencies for `govuk-fastly`, `govuk-fastly-secrets`, `terraform-govuk-infrastructure-sensitive`
- https://github.com/alphagov/govuk-infrastructure/issues/2187