### PR TITLE
Add `govuk-dns-tf` and `govuk-user-reviewer` to Renovate

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -10,6 +10,8 @@ data:
         "alphagov/govuk-infrastructure",
         "alphagov/govuk-fastly",
         "alphagov/govuk-fastly-secrets",
+        "alphagov/govuk-dns-tf",
+        "alphagov/govuk-user-reviewer",
         "alphagov/terraform-govuk-infrastructure-sensitive"
       ]
     }


### PR DESCRIPTION
Description:
- Configure Renovate to open PRs for `required_version` Terraform version
- https://github.com/alphagov/govuk-infrastructure/issues/2187