### PR TITLE
Mirror drift checker: correct the syntax for using a secret in an env var

### DIFF
--- a/charts/mirror/templates/drift-cronjob.yaml
+++ b/charts/mirror/templates/drift-cronjob.yaml
@@ -51,7 +51,8 @@ spec:
                 - name: SLACK_WEBHOOK
                   valueFrom:
                     secretKeyRef:
-                      key: mirror-drift-detection-slack-webhook
+                      name: mirror-drift-detection-slack-webhook
+                      key: SLACK_WEBHOOK
                 {{- with .Values.extraEnv }}
                   {{- (tpl (toYaml .) $) | trim | nindent 16 }}
                 {{- end }}


### PR DESCRIPTION
Uses the correct syntax for setting an environment variable using a secret.