### PR TITLE
Mirror drift checker: set missing SITE env var

### DIFF
--- a/charts/mirror/templates/drift-cronjob.yaml
+++ b/charts/mirror/templates/drift-cronjob.yaml
@@ -48,6 +48,8 @@ spec:
                   value: '100'
                 - name: COMPARE_REMAINING_SAMPLED_COUNT
                   value: '100'
+                - name: SITE
+                  value: 'https://{{ .Values.externalDomainSuffix }}'
                 - name: SLACK_WEBHOOK
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
It was added as a requirement in code, and missed in the deployment.