### PR TITLE
chore: 🤖 remove old preStop syntax (new syntax is appled in

### DIFF
--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -136,10 +136,6 @@ spec:
             {{- with .Values.appExtraVolumeMounts }}
               {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sleep", "60"] # To allow time for ALB to deregister pod before termination
         - name: nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy | default "Always" }}
@@ -178,10 +174,6 @@ spec:
             {{- with .Values.nginxExtraVolumeMounts }}
               {{ . | toYaml | trim | nindent 12 }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sleep", "60"] # To allow time for ALB to deregister pod before termination
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
a following PR #4035)

Argo syncs by patching existing kubernetes yaml, which causes an error when changing lifecycle `preStop` keys from one to another. You can only ever have one key declared in a `preStop` block. In our case, `exec` or `sleep`

Remove the `exec` block in favour of the newer, more accurate `sleep` block.

https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3960-pod-lifecycle-sleep-action/README.md#summary