### PR TITLE
Remove unused env vars from search-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3027,21 +3027,6 @@ govukApplications:
             secretKeyRef:
               name: search-api-google-analytics
               key: client-email
-        - name: GOOGLE_EXPORT_ACCOUNT_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-account-id
-        - name: GOOGLE_EXPORT_CUSTOM_DATA_SOURCE_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-custom-data-source-id
-        - name: GOOGLE_EXPORT_WEB_PROPERTY_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-web-property-id
         - name: GOOGLE_PRIVATE_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3049,21 +3049,6 @@ govukApplications:
             secretKeyRef:
               name: search-api-google-analytics
               key: client-email
-        - name: GOOGLE_EXPORT_ACCOUNT_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-account-id
-        - name: GOOGLE_EXPORT_CUSTOM_DATA_SOURCE_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-custom-data-source-id
-        - name: GOOGLE_EXPORT_WEB_PROPERTY_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-web-property-id
         - name: GOOGLE_PRIVATE_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3012,21 +3012,6 @@ govukApplications:
             secretKeyRef:
               name: search-api-google-analytics
               key: client-email
-        - name: GOOGLE_EXPORT_ACCOUNT_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-account-id
-        - name: GOOGLE_EXPORT_CUSTOM_DATA_SOURCE_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-custom-data-source-id
-        - name: GOOGLE_EXPORT_WEB_PROPERTY_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: export-web-property-id
         - name: GOOGLE_PRIVATE_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
These environment variables were only being used in search-api to upload data to Universal Analytics. Since this is no longer being used and this functionality is being removed from search-api these environment variables are no longer needed.

PR that removes functionality from search-api: https://github.com/alphagov/search-api/pull/3488

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1737