### PR TITLE
Set rollout strategy to Recreate for asset-manager's redis deployment

### DIFF
--- a/charts/asset-manager/templates/redis-deployment.yaml
+++ b/charts/asset-manager/templates/redis-deployment.yaml
@@ -18,6 +18,8 @@ spec:
     matchLabels:
       app: {{ $fullName }}-redis
       app.kubernetes.io/component: redis
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
This is required since the deployment has a PV attached.

This corrects the definition to match the one in generic-govuk-app