### PR TITLE
Fix case of `GraphQL` in the GraphQL dashboard

### DIFF
--- a/charts/monitoring-config/dashboards/graphql-stats.json
+++ b/charts/monitoring-config/dashboards/graphql-stats.json
@@ -1217,7 +1217,7 @@
       },
       "id": 8,
       "panels": [],
-      "title": "Graphql visualisations",
+      "title": "GraphQL visualisations",
       "type": "row"
     },
     {
@@ -1839,7 +1839,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Graphql stats",
+  "title": "GraphQL stats",
   "uid": "aeh00wtwwg8owc",
   "version": 2
 }


### PR DESCRIPTION
This has been inconsistently written as `Graphql` and `GraphQL` throughout the dashboard. Updating to `GraphQL` for correctness and consistency.