### PR TITLE
[PP-7580] Add matcher for GraphQL Slack alerts

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -113,6 +113,14 @@ spec:
       repeatInterval: 1d
       groupWait: 5m
       groupInterval: 30m
+    - matchers:
+        - name: destination
+          value: slack-graphql-notifications
+          matchType: =
+      receiver: 'slack-graphql-notifications'
+      repeatInterval: 1h
+      groupWait: 5m
+      groupInterval: 30m
   receivers:
   - name: 'null'
   - name: 'pagerduty'


### PR DESCRIPTION
An alert receiver for GraphQL alerts was added in 2b0b47e997eb7a74cb846c8234c1b2c56c5b2fee, but the matcher was missed.

This meant the alert fired, but it never posted to Slack.