### PR TITLE
Add new bearer token for Publisher to Fact-check-manager communication

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2406,6 +2406,11 @@ govukApplications:
             secretKeyRef:
               name: signon-token-publisher-signon-api
               key: bearer_token
+        - name: FACT_CHECK_MANAGER_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-publisher-fact-check-manager
+              key: bearer_token
         - name: FACT_CHECK_USERNAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The Fact Check Manager app is a new app in development (currently only deployed on integration). 
To enable Mainstream Publisher to send fact check requests to the app, we have created a new bearer token and added the settings to the relevant helm chart config. 