### PR TITLE
Enable the grafana sqlExpressions feature toggle in integration

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-integration.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-integration.yaml
@@ -17,6 +17,8 @@
       "token_url": "https://dex.eks.integration.govuk.digital/token"
     "server":
       "domain": "grafana.eks.integration.govuk.digital"
+    "feature_toggles":
+      "enable": "sqlExpressions"
   "ingress":
     "hosts":
       - "grafana.eks.integration.govuk.digital"


### PR DESCRIPTION
I'd like to try out the [grafana sqlExpressions feature](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/query-transform-data/sql-expressions/) which is in public preview, I feel it may solve a difficult problem for me when trying to render a complex table with multiple data series (some of which do not exist in all environments)