### PR TITLE
Enable sqlExpressions feature flag in grafana in all envs

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-integration.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values-integration.yaml
@@ -17,8 +17,6 @@
       "token_url": "https://dex.eks.integration.govuk.digital/token"
     "server":
       "domain": "grafana.eks.integration.govuk.digital"
-    "feature_toggles":
-      "enable": "sqlExpressions"
   "ingress":
     "hosts":
       - "grafana.eks.integration.govuk.digital"

--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values.yaml
@@ -107,6 +107,8 @@
     "date_formats":
       "interval_day": "YYYY-MM-DD"
       "interval_hour": "YYYY-MM-DD HH:mm"
+    "feature_toggles":
+      "enable": "sqlExpressions"
     "server":
       "root_url": "https://%(domain)s"
   "ingress":


### PR DESCRIPTION
The sqlExpressions feature works wonderfully and completely solves the issues i was having, so lets deploy it to all environments (and I can remove the config specifically for integration since it's being set in the generalised values file)

Contributes towards https://github.com/alphagov/govuk-infrastructure/issues/2670