### PR TITLE
Run the Mirror drift checker at midday on Mondays, Wednesdays and Fridays

### DIFF
--- a/charts/mirror/values.yaml
+++ b/charts/mirror/values.yaml
@@ -1,5 +1,5 @@
 mirrorSchedule: "43 1 * * *"
-driftSchedule: "0 12 * * *"
+driftSchedule: "0 12 * * 1,3,5"
 
 # Image configuration - these defaults are overridden by app-config via imageValues
 appImage:


### PR DESCRIPTION
## What
We wanted to run in every 3 days at midday, but that's a hard (if not impossible) to express in Crontab syntax. Instead we settle for Mondays, Wednesdays, and Fridays.

## How to review
Put the expression I've used into something like https://crontab.guru and see that it comes out how I intended.