### PR TITLE
Add an alert to alert us to a state change of failed for the db restore/transform/backup tasks

### DIFF
--- a/charts/monitoring-config/rules/database_backups_and_syncs_alerts.yaml
+++ b/charts/monitoring-config/rules/database_backups_and_syncs_alerts.yaml
@@ -1,0 +1,23 @@
+groups:
+  - name: Database Backups & Syncs
+    rules:
+      - alert: Database backup and sync operation failed
+        expr: >-
+          db_backup_job_state == 0
+        labels:
+          severity: warning
+          destination: generic-slack-platform-engineering
+        annotations:
+          summary: "Database {{ $labels.operation }} failed for {{ $labels.database_instance }}.{{ $labels.database_db_name }}"
+          # yamllint disable rule:line-length
+          description: >-
+            The {{ $labels.database_db_name }} database in the {{ $labels.database_instance }} instance failed to complete
+            its {{ $labels.operation }} operation.
+
+            You can see a snapshot of the overall status on the Grafana Dashboard:
+            https://grafana.eks.{{ .ExternalLabels.environment }}.govuk.digital/d/jfc4fnp/database-backups-and-syncs
+
+            You can see the logs for this job in this Logit search for the pod name:
+            <https://kibana.logit.io/s/{{ if eq .ExternalLabels.environment "integration" }}42f4d2d5-e9ce-451f-8ffc-cdb25bd624f8{{ else if eq .ExternalLabels.environment "staging" }}b8a10798-a30e-4611-9393-8843d2339dd2{{ else  if eq .ExternalLabels.environment "production" }}13d1a0b1-f54f-407b-a4e5-f53ba653fac3{{ else }}12345678-abcd-1234-abcd-123456789abc{{ end }}/app/data-explorer/discover#?_a=(discover:(columns:!(message),isDirty:!t,sort:!(!('@timestamp',asc))),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.pod.name,negate:!f,params:(query:{{ $labels.instance }}),type:phrase),query:(match_phrase:(kubernetes.pod.name:{{ $labels.instance }})))),query:(language:kuery,query:''))|{{ $labels.instance }}>
+          # yamllint enable rule:line-length
+          runbook_url: https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html#alerts

--- a/charts/monitoring-config/rules/database_backups_and_syncs_alerts_tests.yaml
+++ b/charts/monitoring-config/rules/database_backups_and_syncs_alerts_tests.yaml
@@ -1,0 +1,98 @@
+rule_files:
+  - database_backups_and_syncs_alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - name: Database Backups & Syncs - No Alert when all succeeded or running
+    interval: 1m
+    external_labels:
+      environment: test
+    input_series:
+      - series: >-
+          db_backup_job_state{
+          database_engine="postgres",
+          database_instance="publishing-api-postgres",
+          database_db_name="publishing-api_production",
+          operation="restore"
+          }
+        values: '2x3 1 2x26'
+      - series: >-
+          db_backup_job_state{
+          database_engine="postgres",
+          database_instance="publishing-api-postgres",
+          database_db_name="publishing-api_production",
+          operation="transform"
+          }
+        values: '2x7 1x3 2x20'
+      - series: >-
+          db_backup_job_state{
+          database_engine="postgres",
+          database_instance="publishing-api-postgres",
+          database_db_name="publishing-api_production",
+          operation="backup"
+          }
+        values: '2x15 1x7 2x8'
+    alert_rule_test:
+      - alertname: Database backup and sync operation failed
+        eval_time: 30m
+        exp_alerts: []
+
+  - name: Database Backups & Syncs - Alert when an operation failed
+    interval: 1m
+    external_labels:
+      environment: test
+    input_series:
+      - series: >-
+          db_backup_job_state{
+          database_engine="postgres",
+          database_instance="publishing-api-postgres",
+          database_db_name="publishing-api_production",
+          instance="db-backup-publishing-api-postgres-12345678-a1b2c",
+          operation="restore"
+          }
+        values: '2x3 1 2x26'
+      - series: >-
+          db_backup_job_state{
+          database_engine="postgres",
+          database_instance="publishing-api-postgres",
+          database_db_name="publishing-api_production",
+          instance="db-backup-publishing-api-postgres-12345678-a1b2c",
+          operation="transform"
+          }
+        values: '2x7 1x3 0x20'
+      - series: >-
+          db_backup_job_state{
+          database_engine="postgres",
+          database_instance="publishing-api-postgres",
+          database_db_name="publishing-api_production",
+          instance="db-backup-publishing-api-postgres-12345678-a1b2c",
+          operation="backup"
+          }
+        values: '2x30'
+
+    alert_rule_test:
+      - alertname: Database backup and sync operation failed
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              alertname: Database backup and sync operation failed
+              severity: warning
+              destination: generic-slack-platform-engineering
+              database_engine: postgres
+              database_instance: publishing-api-postgres
+              database_db_name: publishing-api_production
+              instance: db-backup-publishing-api-postgres-12345678-a1b2c
+              operation: transform
+            exp_annotations:
+              summary: Database transform failed for publishing-api-postgres.publishing-api_production
+              runbook_url: https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html#alerts
+              description: >-
+                The publishing-api_production database in the publishing-api-postgres instance failed to complete
+                its transform operation.
+
+                You can see a snapshot of the overall status on the Grafana Dashboard:
+                https://grafana.eks.test.govuk.digital/d/jfc4fnp/database-backups-and-syncs
+
+                You can see the logs for this job in this Logit search for the pod name:
+                <https://kibana.logit.io/s/12345678-abcd-1234-abcd-123456789abc/app/data-explorer/discover#?_a=(discover:(columns:!(message),isDirty:!t,sort:!(!('@timestamp',asc))),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.pod.name,negate:!f,params:(query:db-backup-publishing-api-postgres-12345678-a1b2c),type:phrase),query:(match_phrase:(kubernetes.pod.name:db-backup-publishing-api-postgres-12345678-a1b2c)))),query:(language:kuery,query:''))|db-backup-publishing-api-postgres-12345678-a1b2c>


### PR DESCRIPTION
This adds a simple alert which alerts us when a db backup job records a failing state (int 0 = failed, 1 = running, 2 = succeeded)