### PR TITLE
Remove now unused environment variables from the Search api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3009,26 +3009,6 @@ govukApplications:
             secretKeyRef:
               name: signon-app-search-api
               key: oauth_secret
-        - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: govuk-view-id
-        - name: GOOGLE_ACCOUNT_TYPE
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: account-type
-        - name: GOOGLE_CLIENT_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: client-email
-        - name: GOOGLE_PRIVATE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: private-key
         - name: GOOGLE_BIGQUERY_CREDENTIALS
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3026,26 +3026,6 @@ govukApplications:
             secretKeyRef:
               name: signon-app-search-api
               key: oauth_secret
-        - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: govuk-view-id
-        - name: GOOGLE_ACCOUNT_TYPE
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: account-type
-        - name: GOOGLE_CLIENT_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: client-email
-        - name: GOOGLE_PRIVATE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: private-key
         - name: GOOGLE_BIGQUERY_CREDENTIALS
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2989,26 +2989,6 @@ govukApplications:
             secretKeyRef:
               name: signon-app-search-api
               key: oauth_secret
-        - name: GOOGLE_ANALYTICS_GOVUK_VIEW_ID
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: govuk-view-id
-        - name: GOOGLE_ACCOUNT_TYPE
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: account-type
-        - name: GOOGLE_CLIENT_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: client-email
-        - name: GOOGLE_PRIVATE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: search-api-google-analytics
-              key: private-key
         - name: GOOGLE_BIGQUERY_CREDENTIALS
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We recently removed the relevancy rake task from the search-api because it is no longer used. This used a number of environment variables that can now be removed.

See also: https://github.com/alphagov/search-api/pull/3511

https://gov-uk.atlassian.net/browse/SCH-1769