### PR TITLE
Updated ai-accelerator app healthcheck endpoints

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4150,3 +4150,7 @@ govukApplications:
         - name: router-nginx-htpasswd
           secret:
             secretName: router-nginx-htpasswd
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
+        livenessProbe: "/healthcheck/ready"
+        readinessProbe: "/healthcheck/ready"


### PR DESCRIPTION
AI Accelerator app only services a single healthcheck at the momement, point k8s checks at that endpoint.