### PR TITLE
Cope with the expected SIGPIPE from the check to see if the backup file is readable

### DIFF
--- a/charts/db-backup/scripts/backup-mongo
+++ b/charts/db-backup/scripts/backup-mongo
@@ -19,7 +19,21 @@ backup () {
 }
 
 dump_is_readable () {
-  s5cmd cat -c 1 -p 1 "$1" | gzip -d | head -c 100 | grep -q concurrent_collections
+  # We expect the piped series to fail with error code 141 sometimes,
+  # this is because we cut off the stdout of s5cmd when it's only cat-ted
+  # part of the file, so it gets a SIGPIPE, which bubbbles up through the pipefail
+  #
+  # So we should check every return code in the PIPESTATUS array (an array of the
+  # return codes of every command in the pipe) and ignore any that were 141 SIGPIPE
+  if ! s5cmd cat -c 1 -p 1 "$1" | gzip -d | head -c 100 | grep -q concurrent_collections; then
+    for EXIT_CODE in "${PIPESTATUS[@]}"; do
+      if [[ "$EXIT_CODE" -ne 0 ]] && [[ "$EXIT_CODE" -ne 141 ]]; then
+        # We got an exit code from a command which wasn't SIGPIPE
+        # so return it as a failure exit code
+        return "$EXIT_CODE"
+      fi
+    done
+  fi
 }
 
 restore () {

--- a/charts/db-backup/scripts/backup-mysql
+++ b/charts/db-backup/scripts/backup-mysql
@@ -22,8 +22,23 @@ transform () {
 }
 
 dump_is_readable () {
-  s5cmd cat -c 1 -p 1 "$1" | gzip -d | head -n5 \
-    | tee /dev/fd/2 | grep 'MySQL dump' >/dev/null 2>&1
+  # We expect the piped series to fail with error code 141 sometimes,
+  # this is because we cut off the stdout of s5cmd when it's only cat-ted
+  # part of the file, so it gets a SIGPIPE, which bubbbles up through the pipefail
+  #
+  # So we should check every return code in the PIPESTATUS array (an array of the
+  # return codes of every command in the pipe) and ignore any that were 141 SIGPIPE
+  if ! s5cmd cat -c 1 -p 1 "$1" | gzip -d | head -n5 \
+      | tee /dev/fd/2 | grep 'MySQL dump' >/dev/null 2>&1; then
+
+    for EXIT_CODE in "${PIPESTATUS[@]}"; do
+      if [[ "$EXIT_CODE" -ne 0 ]] && [[ "$EXIT_CODE" -ne 141 ]]; then
+        # We got an exit code from a command which wasn't SIGPIPE
+        # so return it as a failure exit code
+        return "$EXIT_CODE"
+      fi
+    done
+  fi
 }
 
 restore () {

--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -27,8 +27,23 @@ transform () {
 }
 
 dump_is_readable () {
-  s5cmd cat -c 1 -p 1 "$1" | head | file - | tee /dev/fd/2 \
-    | grep -iq 'PostgreSQL custom database dump'
+  # We expect the piped series to fail with error code 141 sometimes,
+  # this is because we cut off the stdout of s5cmd when it's only cat-ted
+  # part of the file, so it gets a SIGPIPE, which bubbbles up through the pipefail
+  #
+  # So we should check every return code in the PIPESTATUS array (an array of the
+  # return codes of every command in the pipe) and ignore any that were 141 SIGPIPE
+  if ! s5cmd cat -c 1 -p 1 "$1" | head | file - | tee /dev/fd/2 \
+      | grep -iq 'PostgreSQL custom database dump'; then
+
+    for EXIT_CODE in "${PIPESTATUS[@]}"; do
+      if [[ "$EXIT_CODE" -ne 0 ]] && [[ "$EXIT_CODE" -ne 141 ]]; then
+        # We got an exit code from a command which wasn't SIGPIPE
+        # so return it as a failure exit code
+        return "$EXIT_CODE"
+      fi
+    done
+  fi
 }
 
 db_exists () {


### PR DESCRIPTION
Hopefully the comment I've put in the scripts explains what I'm doing and why here.

Annoyingly it's very difficult to DRY up because as soon as you execute another command PIPESTATUS is changed, and each type of database does a different check for if its dump is readable