### PR TITLE
Don't recursively glob for rules files

### DIFF
--- a/charts/monitoring-config/templates/prometheus-rules.yaml
+++ b/charts/monitoring-config/templates/prometheus-rules.yaml
@@ -7,13 +7,13 @@ metadata:
     app: monitoring-config
 spec:
   groups:
-{{- range $path, $_ := .Files.Glob "rules/**.yaml" }}
+{{- range $path, $_ := .Files.Glob "rules/*.yaml" }}
 {{- if not (hasSuffix "_tests.yaml" $path) }}
   # {{ $path }}
   {{- $.Files.Get $path | replace "groups:\n" "" | nindent 2  }}
 {{ end }}
 {{ end }}
-{{- range $path, $_ := .Files.Glob (printf "rules/%s/**.yaml" $.Values.govukEnvironment) }}
+{{- range $path, $_ := .Files.Glob (printf "rules/%s/*.yaml" $.Values.govukEnvironment) }}
 {{- if not (hasSuffix "_tests.yaml" $path) }}
   # {{ $path }}
   {{- $.Files.Get $path | replace "groups:\n" "" | nindent 2  }}


### PR DESCRIPTION
* Don't descend into sub directories of rules by default when loading rules

This is fine since we don't have any rules in subdirectories apart from the new one I added for production only