### PR TITLE
Fix CronJob aggregate health ArgoCD

### DIFF
--- a/charts/generic-govuk-app/templates/cron-task.yaml
+++ b/charts/generic-govuk-app/templates/cron-task.yaml
@@ -5,6 +5,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "{{ $fullName }}-{{ .name }}"
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
   labels:
     {{- include "generic-govuk-app.labels" $ | nindent 4 }}
     app: "{{ $fullName }}-{{ .name }}"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/3659 introduced a [breaking change](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/3.1-3.2/#cronjob-health) to ArgoCD which meant that if a CronJob failed then the overall `Application` would be degraded. Since [argocd-notifications-config.yaml](https://github.com/alphagov/govuk-helm-charts/blob/e27f5837e749d9140132ca22fa00f84a8b5743e7/charts/argo-services/config/argocd-notifications-config.yaml) has:
```
trigger.on-deployed: |
  - send: ["send-argo-events-webhook"]
    oncePer: 'app.status.operationState.syncResult.revision'
    when: "app.status.operationState.phase in ['Succeeded'] and app.status.health.status
      == 'Healthy' and app.metadata.annotations['postSyncWorkflowEnabled'] == 'true' "
```

This meant that `app.status.health.status !== 'Healthy'` which meant that the trigger to deploy to the next environment was not sent
- To ensure that the Application remains healthy even if a CronJob fails we add `argocd.argoproj.io/ignore-healthcheck: "true"` for applications which use the `generic-govuk-app`
- https://github.com/alphagov/govuk-infrastructure/issues/3701