### PR TITLE
Make database swap in backup-postgres more resilient

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -51,23 +51,57 @@ db_exists () {
 }
 
 rename_db () {
-  psql -1v ON_ERROR_STOP=1 <<EOF
+  psql -v ON_ERROR_STOP=1 <<EOF
+BEGIN;
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
 WHERE pid <> pg_backend_pid() AND usename <> 'rdsadmin' AND datname = '$1';
 ALTER DATABASE "$1" OWNER TO session_user;
 ALTER DATABASE "$1" RENAME TO "$2";
+COMMIT;
 EOF
 }
 
 swap_dbs () {
-  psql -1v ON_ERROR_STOP=1 <<EOF
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-WHERE pid <> pg_backend_pid() AND usename <> 'rdsadmin'
-  AND datname IN ('$1', '$2');
-ALTER DATABASE "$2" OWNER TO session_user;
-ALTER DATABASE "$2" RENAME TO "$3";
-ALTER DATABASE "$1" RENAME TO "$2";
+  local RETRY_COUNT=0
+  local MAX_RETRIES=10
+  local SLEEP_SECONDS_BETWEEN_RETRIES=5
+  local TERMINATION_TIMEOUT_MILLISECONDS=10000
+
+  # We will do the session termination between each command to give maximum chance all clients are not
+  # connected
+  QUERY=$(cat <<EOF
+  BEGIN;
+
+  ALTER DATABASE "$2" OWNER TO session_user;
+
+  SELECT pg_terminate_backend(pid, $TERMINATION_TIMEOUT_MILLISECONDS) FROM pg_stat_activity
+  WHERE pid <> pg_backend_pid() AND usename <> 'rdsadmin'
+    AND datname = '$2';
+
+  ALTER DATABASE "$2" RENAME TO "$3";
+
+  SELECT pg_terminate_backend(pid, $TERMINATION_TIMEOUT_MILLISECONDS) FROM pg_stat_activity
+  WHERE pid <> pg_backend_pid() AND usename <> 'rdsadmin'
+    AND datname = '$1';
+
+  ALTER DATABASE "$1" RENAME TO "$2";
+  COMMIT;
 EOF
+  )
+
+  while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+    if psql --set ON_ERROR_STOP=1 <<<"$QUERY"; then
+      echo "Database swap successful" >&2
+      return 0
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    echo "Database swap failed, sleeping for $SLEEP_SECONDS_BETWEEN_RETRIES seconds before trying again" >&2
+    sleep "$SLEEP_SECONDS_BETWEEN_RETRIES"
+  done
+
+  echo "Terminal Error: Database swap failed after $MAX_RETRIES retries!" >&2
+  return 1
 }
 
 restore () {


### PR DESCRIPTION
Essentially this PR boils down to "Do the 'database swap' with retries". However the following detail applies:

* The `-1` argument for psql is being supplied with the expectation it runs the script in a transaction, but this only works for files executed by -f, not for scripts provided by stdin, so I've wrapped both cases scripts in a BEGIN and COMMIT. Given the scripts are executed with STOP_ON_ERROR=1 it will automatically rollback in the event of a failure
* I've renamed the `-v` argument to one of the longer aliases `--set` which makes it harder to confuse with a verbose flag for people not used to the psql cli semantics
* I've provided the second argument (timeout) to pg_terminate_backend, without it the signal is sent and the execution returns successfully immediately, but the client may not have terminated and disconnected yet. Providing the timeout (which I've set to 10 seconds) will have pg_terminate_backend wait until the timeout for the client to actually be terminated. If it doesn't happen in that time an error will be returned
* I've moved the session termination closer to the statement they apply to in order to reduce any race condition to the minimum
* Ive introduced retries for the db swap command with a sleep between retries, and some basic logging so we can see what's going on in the event of a failure

I need to make the same changes to the rename_db function, but I want this to have actually executed successfully in "real life" before making a similar change