### PR TITLE
Reinstate the chat cron task to export to BigQuery

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1674,6 +1674,11 @@ govukApplications:
       uploadAssets:
         s3Directory: chat
         path: /app/public/assets/chat
+      cronTasks:
+        - name: bigquery-export
+          task: "bigquery:export"
+          schedule: "5 * * * *"
+          timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:
@@ -1795,7 +1800,6 @@ govukApplications:
                   - type: Pods
                     value: 1
                     periodSeconds: 30
-      cronTasks: []
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
     helmValues:


### PR DESCRIPTION
Chat is going to start having a few production users of the web application soon and we want their data to be exported hourly.