### PR TITLE
[PP-7585] Add Critical alert for high GraphQL latency 

### DIFF
--- a/charts/monitoring-config/rules/graphql.yaml
+++ b/charts/monitoring-config/rules/graphql.yaml
@@ -1,17 +1,27 @@
 groups:
   - name: GraphqlAlerts
     rules:
-      - alert: LongRequestDuration
+      - record: graphql:request_duration_seconds:mean_rate5m
+        expr: |
+          sum by (schema_name) (
+            rate(http_request_duration_seconds_sum{
+              job="publishing-api-read-replica",
+              controller="graphql"
+            }[5m])
+          )
+          /
+          sum by (schema_name) (
+            rate(http_request_duration_seconds_count{
+              job="publishing-api-read-replica",
+              controller="graphql"
+            }[5m])
+          )
+      - alert: LongRequestDurationFastSchemas
         expr: >-
           quantile(0.75,
-            sum(rate(http_request_duration_seconds_sum{
-              job="publishing-api-read-replica", controller="graphql"
-            }[5m]))
-            /
-            sum(rate(http_request_duration_seconds_count{
-              job="publishing-api-read-replica", controller="graphql"
-            }[5m]))
-          ) > 0.350
+            graphql:request_duration_seconds:mean_rate5m{
+              schema_name!~"field_of_operation|ministers_index|travel_advice_index",
+            }) > 0.075
         for: 5m
         labels:
           severity: warning
@@ -19,7 +29,64 @@ groups:
         annotations:
           summary: Elevated GraphQL request duration
           description: >-
-            75th percentile request duration to GraphQL endpoints in the Publishing API read replica has been above 350ms for 5 minutes.
+            75th percentile request duration to GraphQL endpoints in the Publishing API read replica for known fast schemas has been above 75ms for 5 minutes.
+          grafana_path: >-
+            d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/graphql.html
+
+      - alert: LongRequestDurationSlowSchemas
+        expr: >-
+          quantile(0.75,
+            graphql:request_duration_seconds:mean_rate5m{
+              schema_name=~"field_of_operation|ministers_index|travel_advice_index",
+            }) > 0.350
+        for: 5m
+        labels:
+          severity: warning
+          destination: slack-graphql-notifications
+        annotations:
+          summary: Elevated GraphQL request duration
+          description: >-
+            75th percentile request duration to GraphQL endpoints in the Publishing API read replica for known slow schemas has been above 350ms for 5 minutes.
+          grafana_path: >-
+            d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/graphql.html
+
+      - alert: LongRequestDurationFastSchemas
+        expr: >-
+          quantile(0.95,
+            graphql:request_duration_seconds:mean_rate5m{
+              schema_name!~"field_of_operation|ministers_index|travel_advice_index",
+            }) > 0.075
+        for: 10m
+        labels:
+          severity: critical
+          destination: slack-graphql-notifications
+        annotations:
+          summary: Elevated GraphQL request duration
+          description: >-
+            95th percentile request duration to GraphQL endpoints in the Publishing API read replica for known fast schemas has been above 75ms for 10 minutes.
+          grafana_path: >-
+            d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/graphql.html
+
+      - alert: LongRequestDurationSlowSchemas
+        expr: >-
+          quantile(0.95,
+            graphql:request_duration_seconds:mean_rate5m{
+              schema_name=~"field_of_operation|ministers_index|travel_advice_index",
+            }) > 0.350
+        for: 10m
+        labels:
+          severity: critical
+          destination: slack-graphql-notifications
+        annotations:
+          summary: Elevated GraphQL request duration
+          description: >-
+            95th percentile request duration to GraphQL endpoints in the Publishing API read replica for known slow schemas has been above 350ms for 10 minutes.
           grafana_path: >-
             d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
           runbook_url: >-

--- a/charts/monitoring-config/rules/graphql_tests.yaml
+++ b/charts/monitoring-config/rules/graphql_tests.yaml
@@ -7,7 +7,7 @@ tests:
 # LongRequestDuration alert tests
   - interval: 1m
     input_series:
-      # No alert for LongRequestDuration (mean = 1ms)
+      # No alert for LongRequestDuration fast schemas (mean = 1ms)
       - series: >-
           http_request_duration_seconds_sum{
           job="publishing-api-read-replica",
@@ -21,13 +21,33 @@ tests:
           }
         values: '20000+1000x15'
     alert_rule_test:
-      - alertname: LongRequestDuration
+      - alertname: LongRequestDurationFastSchemas
         eval_time: 15m
         exp_alerts: []
 
   - interval: 1m
     input_series:
-      # Alert for LongRequestDuration (mean = 500ms)
+      # No alert for LongRequestDuration slow schemas
+      - series: >-
+          http_request_duration_seconds_sum{
+          job="publishing-api-read-replica",
+          controller="graphql", schema_name="travel_advice_index"
+          }
+        values: '50+1x15'
+      - series: >-
+          http_request_duration_seconds_count{
+          job="publishing-api-read-replica",
+          controller="graphql", schema_name="travel_advice_index"
+          }
+        values: '20000+1000x15'
+    alert_rule_test:
+      - alertname: LongRequestDurationSlowSchemas
+        eval_time: 15m
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Alert for LongRequestDuration fast schemas
       - series: >-
           http_request_duration_seconds_sum{
           job="publishing-api-read-replica",
@@ -41,17 +61,73 @@ tests:
           }
         values: '0+10x15'
     alert_rule_test:
-      - alertname: LongRequestDuration
+      - alertname: LongRequestDurationFastSchemas
         eval_time: 15m
         exp_alerts:
           - exp_labels:
-              alertname: LongRequestDuration
+              alertname: LongRequestDurationFastSchemas
               severity: warning
               destination: slack-graphql-notifications
             exp_annotations:
               summary: Elevated GraphQL request duration
               description: >-
-                75th percentile request duration to GraphQL endpoints in the Publishing API read replica has been above 350ms for 5 minutes.
+                75th percentile request duration to GraphQL endpoints in the Publishing API read replica for known fast schemas has been above 75ms for 5 minutes.
+              grafana_path: >-
+                d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/graphql.html
+          - exp_labels:
+              alertname: LongRequestDurationFastSchemas
+              severity: critical
+              destination: slack-graphql-notifications
+            exp_annotations:
+              summary: Elevated GraphQL request duration
+              description: >-
+                95th percentile request duration to GraphQL endpoints in the Publishing API read replica for known fast schemas has been above 75ms for 10 minutes.
+              grafana_path: >-
+                d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/graphql.html
+
+  - interval: 1m
+    input_series:
+      # Alert for LongRequestDuration slow schemas
+      - series: >-
+          http_request_duration_seconds_sum{
+          job="publishing-api-read-replica",
+          controller="graphql", schema_name="travel_advice_index"
+          }
+        values: '0+5x15'
+      - series: >-
+          http_request_duration_seconds_count{
+          job="publishing-api-read-replica",
+          controller="graphql", schema_name="travel_advice_index"
+          }
+        values: '0+10x15'
+    alert_rule_test:
+      - alertname: LongRequestDurationSlowSchemas
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              alertname: LongRequestDurationSlowSchemas
+              severity: warning
+              destination: slack-graphql-notifications
+            exp_annotations:
+              summary: Elevated GraphQL request duration
+              description: >-
+                75th percentile request duration to GraphQL endpoints in the Publishing API read replica for known slow schemas has been above 350ms for 5 minutes.
+              grafana_path: >-
+                d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/graphql.html
+          - exp_labels:
+              alertname: LongRequestDurationSlowSchemas
+              severity: critical
+              destination: slack-graphql-notifications
+            exp_annotations:
+              summary: Elevated GraphQL request duration
+              description: >-
+                95th percentile request duration to GraphQL endpoints in the Publishing API read replica for known slow schemas has been above 350ms for 10 minutes.
               grafana_path: >-
                 d/aeh00wtwwg8owc/graphql-stats?orgId=1&from=now-1h&to=now&timezone=browser
               runbook_url: >-


### PR DESCRIPTION
Adds more granularity to alerting based on known slow or fast schema types, as well as a critical alert with a higher threshold. 