### PR TITLE
Disable connections for database being renamed

### DIFF
--- a/charts/db-backup/scripts/backup-postgres
+++ b/charts/db-backup/scripts/backup-postgres
@@ -69,7 +69,7 @@ swap_dbs () {
 
   local INCOMING_DB_NAME="$1"
   local DB_NAME="$2"
-  local OUTGOING_DB_NAME="$2"
+  local OUTGOING_DB_NAME="$3"
 
   # We will do the session termination between each command to give maximum chance all clients are not
   # connected


### PR DESCRIPTION
CKAN failed to restore this weekend, even with 10 retries, and waiting for pg_terminate_backend to succeed, the database was still being accessed and couldn't be renamed, it's likely the ckan application very quickly reconnects.

A reminder, the restore process goes:

1. Restore database dump into `db-restore`
2. Change owner of the `db` to aws_db_admin
3. Terminate connections to `db`
4. Rename `db` to `db-old`
5. Terminate connections to `db-restore`
6. Rename `db-restore` to `db`

To deal with this, this PR:

* Disables new connections to `db` before doing anything
* Enables them again whether the restore succeeds or fails
* Makes some locals for $1, $2, and $3 to make the SQL queries clearer