### PR TITLE
Create the service account

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4114,7 +4114,7 @@ govukApplications:
     helmValues:
       serviceAccount:
         enabled: true
-        create: false
+        create: true
         name: govuk-ai-accelerator-app
       rails:
         enabled: false


### PR DESCRIPTION
When I configured the service account I didn't enable the create flag. Currently the service account doesn't exist, switching the option to create to `true`