### PR TITLE
Add bearer token for Publisher to Fact Check Manager Integration ENV

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1594,6 +1594,11 @@ govukApplications:
             secretKeyRef:
               name: signon-app-fact-check-manager
               key: oauth_secret
+        - name: PUBLISHER_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: signon-token-fact-check-manager-publisher
+              key: bearer_token
   - name: government-frontend
     helmValues:
       arch: arm64


### PR DESCRIPTION
This PR adds a bearer token for Publisher to Fact Check Manager to allow returning fact check responses in Integration environment