### PR TITLE
Send app deploy slack alerts to team channels

### DIFF
--- a/charts/argo-services/scripts/send-slack.sh
+++ b/charts/argo-services/scripts/send-slack.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [ -n "${SLACK_MESSAGE_BLOCKS}" ]; then
+  BLOCKS="\"blocks\": ${SLACK_MESSAGE_BLOCKS},"
+else
+  BLOCKS=""
+fi
+
+function send_message() {
+  CHANNEL="${1}"
+  echo "Sending message to Slack channel: ${CHANNEL}"
+cat <<EOF | curl --json @- "${SLACK_WEBHOOK_ENDPOINT}"
+{
+  "channel": "#${CHANNEL}",
+  "username": "Argo Workflows",
+  "text": "${SLACK_MESSAGE_TEXT}",
+  ${BLOCKS}
+  "icon_emoji": ":argo:"
+}
+EOF
+}
+
+ALERTS_TEAM=$(
+  curl -s https://docs.publishing.service.gov.uk/repos.json | \
+  jq -r ".[] | select(.app_name == \"${SLACK_APP_REPO}\") | .alerts_team | ltrimstr(\"#\")"
+)
+
+echo "Alerts team: ${ALERTS_TEAM}"
+
+if [ -n "${ALERTS_TEAM}" ]; then
+  send_message "${ALERTS_TEAM}"
+fi
+
+send_message "${SLACK_CHANNEL}"

--- a/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
+++ b/charts/argo-services/templates/workflows/deploy-image/workflow.yaml
@@ -63,6 +63,8 @@ spec:
                   # NOTE: Change to {{"{{workflow.parameters.slackChannel}}"}} to
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
+                - name: appRepo
+                  value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: text
                   value: "🚀❌ {{"{{workflow.parameters.repoName}}"}} deployment failed to {{"{{workflow.parameters.environment}}"}}\n\nStatus: Image deployment failed - service may be unavailable\nImage: {{"{{workflow.parameters.imageTag}}"}} (failed to deploy)\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\n\n💡 *Next Steps:*\n• Check if previous version is still running\n• View workflow logs for deployment errors\n• May need immediate rollback if service is down\n• Click 'View workflow' button below for details"
                 - name: blocks

--- a/charts/argo-services/templates/workflows/notify-slack/workflow.yaml
+++ b/charts/argo-services/templates/workflows/notify-slack/workflow.yaml
@@ -7,6 +7,9 @@ spec:
   arguments:
     parameters:
       - name: slackChannel
+      - name: appRepo
+        description: "Name of the application repository. Used to fetch alerts channel name from developer docs."
+        default: ""
       - name: text
       - name: blocks
         description: "Provide advanced formatting for a message using Slack's Block Kit"
@@ -16,27 +19,25 @@ spec:
       inputs:
         parameters:
         - name: slackChannel
+        - name: appRepo
         - name: text
         - name: blocks
-      container:
-        image: quay.io/curl/curl
-        command:
-          - "curl"
-          - "--json"
-          # The double template tags {{"{{}}"}} is because Helm and Argo
-          # use the same templating syntax.
-          - >-
-              {
-                "channel": "#{{"{{inputs.parameters.slackChannel}}"}}",
-                "username": "Argo Workflows",
-                "text": "{{"{{inputs.parameters.text}}"}}",
-                {{`{{= inputs.parameters.blocks != "" ? "\"blocks\": " + inputs.parameters.blocks + "," : "" }}`}}
-                "icon_emoji": ":argo:"
-              }
-          - "$(SLACK_WEBHOOK_ENDPOINT)"
+      script:
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/govuk-toolbox-image:v29
+        command: ["/bin/bash"]
+        source: |
+          {{- .Files.Get "scripts/send-slack.sh" | nindent 10 }}
         env:
           - name: SLACK_WEBHOOK_ENDPOINT
             valueFrom:
               secretKeyRef:
                 name: slack-webhook-url
                 key: url
+          - name: SLACK_MESSAGE_TEXT
+            value: "{{"{{inputs.parameters.text}}"}}"
+          - name: SLACK_MESSAGE_BLOCKS
+            value: "{{"{{inputs.parameters.blocks}}"}}"
+          - name: SLACK_CHANNEL
+            value: "{{"{{inputs.parameters.slackChannel}}"}}"
+          - name: SLACK_APP_REPO
+            value: "{{"{{inputs.parameters.appRepo}}"}}"

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -137,6 +137,8 @@ spec:
                   # NOTE: Change to {{"{{workflow.parameters.slackChannel}}"}} to
                   # send to team slack channel.
                   value: "govuk-deploy-alerts"
+                - name: appRepo
+                  value: "{{"{{workflow.parameters.repoName}}"}}"
                 - name: text
                   value: "Service: {{"{{workflow.parameters.application}}"}}\nEnvironment: {{ .Values.govukEnvironment }}\nStage: Post-deploy\n\nImage: {{"{{workflow.parameters.imageTag}}"}}\nRepo: https://github.com/alphagov/{{"{{workflow.parameters.repoName}}"}}\nHelm chart: https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/image-tags/{{ .Values.govukEnvironment }}/{{"{{workflow.parameters.application}}"}}\nWhat's next: https://docs.publishing.service.gov.uk/manual/deployments.html#troubleshooting"
                 - name: blocks


### PR DESCRIPTION
Create a new script for the notify-slack WorkflowTemplate which sends Slack messages to both govuk-deploy-alerts (or some other channel) and the team's channel as defined by the alerts_team value in repos.yml in govuk-developer-docs

This has been tested by manually submitting workflow runs in integration. 

https://github.com/alphagov/govuk-infrastructure/issues/3678