### PR TITLE
generic-govuk-app: use Argo Workflows to send DB migration failure messages

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-notify-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-notify-job.yaml
@@ -62,51 +62,44 @@ spec:
               if [ "$failed" != "0" ] && [ "$failed" != "null" ]; then
                 echo "DB migration job failed. Sending Slack notification"
 
-                # Send Slack notification using Block Kit
-                curl -X POST \
-                  -H "Content-Type: application/json" \
-                  --data @- \
-                  "$SLACK_WEBHOOK_URL" <<EOF
-              {
-                "channel": "govuk-deploy-alerts",
-                "username": "DB Migrations Failed",
-                "icon_emoji": ":argo:",
-                "text": "DB Migration Failed for {{ $fullName }}",
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*Service:* {{ $fullName }}\n*Environment:* {{ .Values.govukEnvironment }}\n*Image Tag:* {{ .Values.appImage.tag }}\n*Repo:* <https://github.com/alphagov/{{ .Values.repoName }}|{{ .Values.repoName }}>"
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*What's next:*\n• <https://argo.eks.{{ .Values.govukEnvironment }}.govuk.digital/applications/{{ $fullName }}|View application in ArgoCD>\n• <https://argo.eks.{{ .Values.govukEnvironment }}.govuk.digital/applications/{{ $fullName }}?node=batch%2FJob%2Fapps%2F{{ $fullName }}-dbmigrate&orphaned=false&resource=&tab=logs|View logs in ArgoCD>"
-                    }
-                  }
-                ]
-              }
+                cat <<EOF | kubectl create -f -
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: {{ $fullName }}-dbmigrate-notify-
+                namespace: {{ .Release.Namespace }}
+              spec:
+                workflowTemplateRef:
+                  name: notify-slack
+                arguments:
+                  parameters:
+                  - name: slackChannel
+                    value: "govuk-deploy-alerts"
+                  - name: appRepo
+                    value: "{{ .Values.repoName }}"
+                  - name: text
+                    value: "DB Migration Failed for {{ $fullName }}"
+                  - name: blocks
+                    value: |
+                      [
+                        {
+                          "type": "section",
+                          "text": {
+                            "type": "mrkdwn",
+                            "text": "*Service:* {{ $fullName }}\n*Environment:* {{ .Values.govukEnvironment }}\n*Image Tag:* {{ .Values.appImage.tag }}\n*Repo:* <https://github.com/alphagov/{{ .Values.repoName }}|{{ .Values.repoName }}>"
+                          }
+                        },
+                        {
+                          "type": "section",
+                          "text": {
+                            "type": "mrkdwn",
+                            "text": "*What's next:*\n• <https://argo.eks.{{ .Values.govukEnvironment }}.govuk.digital/applications/{{ $fullName }}|View application in ArgoCD>\n• <https://argo.eks.{{ .Values.govukEnvironment }}.govuk.digital/applications/{{ $fullName }}?node=batch%2FJob%2Fapps%2F{{ $fullName }}-dbmigrate&orphaned=false&resource=&tab=logs|View logs in ArgoCD>"
+                          }
+                        }
+                      ]
               EOF
-
-                if [ $? -eq 0 ]; then
-                  echo "Slack notification sent successfully"
-                else
-                  echo "Failed to send Slack notification"
-                  exit 1
-                fi
-              else
-                echo "DB migration job succeeded, not sending notification"
               fi
           imagePullPolicy: Always
-          env:
-            - name: SLACK_WEBHOOK_URL
-              valueFrom:
-                secretKeyRef:
-                  name: slack-webhook-url
-                  key: url
           {{- with .Values.jobResources }}
           resources:
             {{- . | toYaml | trim | nindent 12 }}

--- a/charts/generic-govuk-app/templates/dbmigration-notify-role.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-notify-role.yaml
@@ -14,6 +14,9 @@ rules:
     resources: ["jobs"]
     verbs: ["get"]
     resourceNames: ["{{ $fullName }}-dbmigrate"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflows"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Replace the bash script which runs after DB migrations fail which sends a Slack message to govuk-deploy-alerts with a script that starts a notify-slack workflow in Argo Workflows

This removes the need for the job to have access to the Slack webhook URL

This has been tested in integration by:
1. Rendering the generic-govuk-app chart with values for the release app
2. Modifying the Job resource slightly to remove the ArgoCD annotations
3. Creating the Job resource and observing the result

https://github.com/alphagov/govuk-infrastructure/issues/3678