### PR TITLE
Add section to DB migration failure message saying what failed

### DIFF
--- a/charts/generic-govuk-app/templates/dbmigration-notify-job.yaml
+++ b/charts/generic-govuk-app/templates/dbmigration-notify-job.yaml
@@ -86,6 +86,12 @@ spec:
                           "type": "section",
                           "text": {
                             "type": "mrkdwn",
+                            "text": "🚀💥 DB migrations for *{{ $fullName }}* failed in *{{ .Values.govukEnvironment }}*"
+                        },
+                        {
+                          "type": "section",
+                          "text": {
+                            "type": "mrkdwn",
                             "text": "*Service:* {{ $fullName }}\n*Environment:* {{ .Values.govukEnvironment }}\n*Image Tag:* {{ .Values.appImage.tag }}\n*Repo:* <https://github.com/alphagov/{{ .Values.repoName }}|{{ .Values.repoName }}>"
                           }
                         },


### PR DESCRIPTION
The current message has no context, so it's difficult to understand what went wrong at a glance. This adds a new line to the top of the message explaining that DB migrations have failed.

https://github.com/alphagov/govuk-infrastructure/issues/3678