### PR TITLE
[PP-7607] Add PLEK_SERVICE_PUBLISHING_API_URI to feedback

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1208,6 +1208,8 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
   - name: draft-feedback
     repoName: feedback
     helmValues:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1210,6 +1210,8 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.production.govuk-internal.digital
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
       cronTasks: []
   - name: draft-feedback
     repoName: feedback

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1215,6 +1215,8 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
+        - name: PLEK_SERVICE_PUBLISHING_API_URI
+          value: "http://publishing-api-read-replica"
       cronTasks: []
   - name: draft-feedback
     repoName: feedback


### PR DESCRIPTION
We will be conditionally requesting data from publishing-api-read-replica via GraphQL.

Note, the draft stack is handled via `PLEK_HOSTNAME_PREFIX`: https://github.com/alphagov/plek/blob/main/CHANGELOG.md#410