### PR TITLE
[CHAT-341] Configure AWS region for document ingestion workers

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1699,6 +1699,9 @@ govukApplications:
             name: default-worker
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
+            env:
+              - name: TITAN_AWS_REGION
+                value: "eu-west-2"
       workerResources:
         limits:
           cpu: 2

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1654,6 +1654,9 @@ govukApplications:
             name: default-worker
           - command: ["rake", "message_queue:published_documents_consumer"]
             name: published-documents-consumer
+            env:
+              - name: TITAN_AWS_REGION
+                value: "eu-west-2"
       workerResources:
         limits:
           cpu: 2

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1648,6 +1648,9 @@ govukApplications:
             name: default-worker
           - command: ['rake', 'message_queue:published_documents_consumer']
             name: published-documents-consumer
+            env:
+              - name: TITAN_AWS_REGION
+                value: "eu-west-2"
       workerResources:
         limits:
           cpu: 2


### PR DESCRIPTION
## Description 

We want to set the TITAN_AWS_REGION env var for the document ingestion workers to "eu-west-2" in all environments. This env var will be used to ensure we hit London endpoints for titan embeddings when for document ingestion and Dublin for embeddings related to user questions. Cross region requests have separate rate limits and we want to ensure that user questions are not impacted by document ingestion.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-341