### PR TITLE
Add AWS s3 bucket values to email-alert-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1010,6 +1010,8 @@ govukApplications:
           value: email-alert-api-integration@digital.cabinet-office.gov.uk
         - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
           value: email-alert-api-integration@digital.cabinet-office.gov.uk
+        - name: AWS_S3_ASSET_BUCKET_NAME
+          value: "govuk-app-assets-integration"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
To add `AWS_S3_bucket_name` config values to `email-alert-api` that will set the environment value in Integration.

Related PR https://github.com/alphagov/email-alert-api/pull/2560 
[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-5189)