### PR TITLE
[CHAT-341] Update titan thresholds on chat dashboard

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -745,11 +745,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 150000
+                "value": 600000
               },
               {
                 "color": "red",
-                "value": 300000
+                "value": 1200000
               }
             ]
           },
@@ -5129,5 +5129,5 @@
   "timezone": "browser",
   "title": "GOV.UK Chat Technical",
   "uid": "govuk-chat-technical",
-  "version": 24
+  "version": 25
 }


### PR DESCRIPTION
## Description 

I realised I missed this is part of this [PR](https://github.com/alphagov/govuk-helm-charts/pull/4136)
where we bumped the titan thresholds. This now goes red when it breaches 1.2m tps and amber at 600k tps.

## Screenshots 

Before 

<img width="1229" height="495" alt="image" src="https://github.com/user-attachments/assets/e5d143fb-eb61-495c-8f5b-2289d8b76140" />

After 

<img width="1250" height="675" alt="image" src="https://github.com/user-attachments/assets/410137ef-61fb-4294-9235-e42c52a01175" />
