### PR TITLE
[SCH-1856] Delete image tag files for search-v2-evaluator

### DIFF
--- a/charts/app-config/image-tags/integration/search-v2-evaluator
+++ b/charts/app-config/image-tags/integration/search-v2-evaluator
@@ -1,3 +1,0 @@
-image_tag: v56
-automatic_deploys_enabled: true
-promote_deployment: true

--- a/charts/app-config/image-tags/production/search-v2-evaluator
+++ b/charts/app-config/image-tags/production/search-v2-evaluator
@@ -1,3 +1,0 @@
-image_tag: v56
-automatic_deploys_enabled: true
-promote_deployment: true

--- a/charts/app-config/image-tags/staging/search-v2-evaluator
+++ b/charts/app-config/image-tags/staging/search-v2-evaluator
@@ -1,3 +1,0 @@
-image_tag: v56
-automatic_deploys_enabled: true
-promote_deployment: true


### PR DESCRIPTION
The [search-v2-evaluator repo](https://github.com/alphagov/search-v2-evaluator) was archived on 06/10/2025 on GitHub, but is still showing on [Release](https://release.publishing.service.gov.uk/applications/search-v2-evaluator) and [Sentry](https://govuk.sentry.io/organizations/govuk/issues/?project=4506337255292928&statsPeriod=90d).

See [Jira ticket SCH-1856](https://gov-uk.atlassian.net/browse/SCH-1856)

Removing the image tag files in the hope that they're the final piece of the archiving puzzle.

Related:
- [slack thread discussion re archiving the repo](https://gds.slack.com/archives/C04RFV5JC6Q/p1759747836577849)
- [slack thread re removing search-v2-evaluator from Sentry](https://gds.slack.com/archives/CAB4Q3QBW/p1761040412108189)