### PR TITLE
[351] Add cron job to GOV.UK Chat to delete old data

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1736,6 +1736,10 @@ govukApplications:
           task: "bigquery:export"
           schedule: "0 10 * * 4"
           timeZone: "Europe/London"
+        - name: delete-old-questions
+          task: "data_retention:delete_old_questions"
+          schedule: "0 9 * * *"
+          timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1684,6 +1684,10 @@ govukApplications:
           task: "bigquery:export"
           schedule: "5 * * * *"
           timeZone: "Europe/London"
+        - name: delete-old-questions
+          task: "data_retention:delete_old_questions"
+          schedule: "0 2 * * *"
+          timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1673,6 +1673,11 @@ govukApplications:
       uploadAssets:
         s3Directory: chat
         path: /app/public/assets/chat
+      cronTasks:
+        - name: delete-old-questions
+          task: "data_retention:delete_old_questions"
+          schedule: "0 9 * * *"
+          timeZone: "Europe/London"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:
@@ -1789,7 +1794,6 @@ govukApplications:
                   - type: Pods
                     value: 1
                     periodSeconds: 30
-      cronTasks: []
   - name: govuk-e2e-tests
     chartPath: charts/govuk-e2e-tests
     helmValues:


### PR DESCRIPTION
## Description

We have a data retention policy to delete data after 1 year. We've got the `data_retention:delete_old_questions` in GOV.UK Chat, which will delete old data from the db when run.

This commit adds a cron job to run this task on a daily basis. The production one runs at 2am to avoid peak hours. The staging and integration ones run at 9am to avoid the data sync and shortly before standup so if any issues occur we can discuss them in the standup and fix them before the next run.

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-351

