### PR TITLE
Disable government-frontend/draft-government-frontend in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1611,6 +1611,7 @@ govukApplications:
   - name: government-frontend
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1
@@ -1634,6 +1635,7 @@ govukApplications:
     repoName: government-frontend
     helmValues:
       arch: arm64
+      appEnabled: false
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
- As preparation for retiring government-frontend, first turn it off in integration to confirm that there are no surprise dependencies.

JIRA:  https://gov-uk.atlassian.net/browse/PNP-9853