### PR TITLE
Increase clamav MaxFileSize to 750M

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -25,7 +25,7 @@ data:
     # Whitehall and Specialist Publisher allow up to 500 MB uploads. Keep in
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).
-    MaxFileSize 500M
+    MaxFileSize 750M
     MaxScanSize 5000M
     MaxScanTime 0
     MaxThreads 20


### PR DESCRIPTION
An HMRC PAYE tools file on https://www.gov.uk/basic-paye-tools is triggering a 'Heuristics.Limits.Exceeded.MaxFileSize' error with the latest file supplied by the vendor. Increasing the MaxFileSize config setting should resolve this. This has been tested locally with these settings.