### PR TITLE
Update clamav StreamMaxLength setting to stay in sync with MaxFileSize

### DIFF
--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -30,7 +30,7 @@ data:
     MaxScanTime 0
     MaxThreads 20
     SelfCheck 900
-    StreamMaxLength 500M
+    StreamMaxLength 750M
     TCPAddr 127.0.0.1
     TCPSocket 3310
   freshclam.conf: |


### PR DESCRIPTION
Update clamav StreamMaxLength setting to stay in sync with MaxFileSize [as mentioned here](https://github.com/alphagov/govuk-helm-charts/blob/91c9dfd5984ae1de036e7b8caf635fa3b8d7e9cd/charts/asset-manager/templates/clamav-configmap.yaml#L25)
