### PR TITLE
Adjust maxReplicas for govuk-chat-worker

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1767,7 +1767,7 @@ govukApplications:
         - name: govuk-chat-worker
           enabled: true
           spec:
-            maxReplicas: 10
+            maxReplicas: 6 # Setting to 6 for load testing
             minReplicas: 3
             scaleTargetRef:
               apiVersion: apps/v1


### PR DESCRIPTION
## What

Reduced maxReplicas for govuk-chat-worker to 6 for load testing.

## Why

To prevent the max number of database connections being hit with load testing