### PR TITLE
Update chat dashboard for dynamic DB naming convention

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -3432,7 +3432,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "id": "",
@@ -3544,7 +3544,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "id": "",
@@ -3655,7 +3655,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "id": "",
@@ -3767,7 +3767,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "id": "",
@@ -3791,7 +3791,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "hide": false,
@@ -3903,7 +3903,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "id": "",
@@ -3927,7 +3927,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "hide": false,
@@ -4041,7 +4041,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "id": "",
@@ -4065,7 +4065,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {
-            "DBInstanceIdentifier": "chat-postgres"
+            "DBInstanceIdentifier": "chat-GOVUKENVIRONMENT-postgres"
           },
           "expression": "",
           "hide": false,

--- a/charts/monitoring-config/templates/dashboards-configmap.yaml
+++ b/charts/monitoring-config/templates/dashboards-configmap.yaml
@@ -11,4 +11,5 @@ data:
   {{- range $path, $_ := .Files.Glob "dashboards/**.json" }}
     {{- $path | trimPrefix "dashboards/" | nindent 2 }}: |
     {{- $.Files.Get $path | replace "AWSACCOUNTID" $.Values.awsAccountId | nindent 4 }}
+    {{- $.Files.Get $path | replace "GOVUKENVIRONMENT" $.Values.govukEnvironment | nindent 4 }}
   {{ end }}


### PR DESCRIPTION
## What

Modify Helm dashboard template so that a dynamic value can be used for the environment in the JSON dashboard configuration files

## Why

The name of the RDS databases has been changed to include the environment name, so this needs to be set dynamically now instead of statically