### PR TITLE
Fix chat dashboard dynamic naming

### DIFF
--- a/charts/monitoring-config/templates/dashboards-configmap.yaml
+++ b/charts/monitoring-config/templates/dashboards-configmap.yaml
@@ -10,6 +10,5 @@ metadata:
 data:
   {{- range $path, $_ := .Files.Glob "dashboards/**.json" }}
     {{- $path | trimPrefix "dashboards/" | nindent 2 }}: |
-    {{- $.Files.Get $path | replace "AWSACCOUNTID" $.Values.awsAccountId | nindent 4 }}
-    {{- $.Files.Get $path | replace "GOVUKENVIRONMENT" $.Values.govukEnvironment | nindent 4 }}
+    {{- $.Files.Get $path | replace "AWSACCOUNTID" $.Values.awsAccountId | replace "GOVUKENVIRONMENT" $.Values.govukEnvironment | nindent 4 }}
   {{ end }}


### PR DESCRIPTION
## What

Fix the Chat Dashboard dynamic naming

## Why

The previous attempt of having replace used on 2 lines did not work, so changing for both replace functions to be on the same line. Confirmed this does work with "helm template test" command.