### PR TITLE
Run daily slack poster cron task for GOV.UK Chat

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1688,6 +1688,10 @@ govukApplications:
           task: "data_retention:delete_old_questions"
           schedule: "0 2 * * *"
           timeZone: "Europe/London"
+        - name: slack-daily-report
+          task: "slack:send_previous_days_activity"
+          schedule: "30 9 * * *"
+          timeZone: "Europe/London"
       extraEnv:
         - name: AI_SLACK_CHANNEL_WEBHOOK_URL
           valueFrom:


### PR DESCRIPTION
This configures a daily cron task to run a slack report for GOV.UK Chat to reflect it being in a released beta state right now and requires this message for monitoring.