### PR TITLE
Demo 3: Revert externalsecret

### DIFF
--- a/charts/external-secrets/templates/fact-check-manager/jwt-auth-secret.yaml
+++ b/charts/external-secrets/templates/fact-check-manager/jwt-auth-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fact-check-manager-jwt-auth-secret
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Encryption key for fact check manager JWT token
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: fact-check-manager-jwt-auth-secret
+  dataFrom:
+    - extract:
+        key: govuk/fact-check-manager/jwt-auth-secret
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
[As agreed earlier](https://gds.slack.com/archives/C013F737737/p1774268452987959), this is to support a training session, introducing a fault on purpose to give a live demo of interrogating the resulting logs. This PR reverts the second of the errors introduced