### PR TITLE
Add AWS_S3 bucket values to email-alert-api in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1007,6 +1007,8 @@ govukApplications:
           value: email-alert-api-alert-listener@digital.cabinet-office.gov.uk
         - name: BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT
           value: email-alert-api-bulk-migrate@digital.cabinet-office.gov.uk
+        - name: AWS_S3_ASSET_BUCKET_NAME
+          value: "govuk-app-assets-production"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
To add `AWS_S3_bucket_name` config values to `email-alert-api` that will set the environment value in production.

Related PR https://github.com/alphagov/email-alert-api/pull/2560 
[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-5189)