### PR TITLE
Add authenticating-proxy-jwt-auth-secret to Content Block Manager (Integration)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -524,6 +524,11 @@ govukApplications:
             secretKeyRef:
               name: content-block-manager-jwt-auth-secret
               key: JWT_AUTH_SECRET
+        - name: AUTHENTICATING_PROXY_JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We need to be able to generate tokens for previewing draft content with content blocks. We already have a `JWT_AUTH_SECRET` for generating our own preview tokens, so we need to choose a different name.