### PR TITLE
Revert "Change pagerduty drill to run on Tuesday"

### DIFF
--- a/charts/monitoring-config/rules/pagerdutydrill.yaml
+++ b/charts/monitoring-config/rules/pagerdutydrill.yaml
@@ -4,7 +4,7 @@ groups:
     rules:
       - alert: PagerDutyDrill
         expr: |
-          (day_of_week() == 2) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
+          (day_of_week() == 1) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
         labels:
           severity: page
         annotations:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#4158 (it can't actually be merged until 1st April, or at least after lunchtime on 31st March)