### PR TITLE
Revert "Revert "Change pagerduty drill to run on Tuesday""

### DIFF
--- a/charts/monitoring-config/rules/pagerdutydrill.yaml
+++ b/charts/monitoring-config/rules/pagerdutydrill.yaml
@@ -4,7 +4,7 @@ groups:
     rules:
       - alert: PagerDutyDrill
         expr: |
-          (day_of_week() == 1) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
+          (day_of_week() == 2) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
         labels:
           severity: page
         annotations:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#4176 (ie puts back the initial change to the pagerduty test page as made here https://github.com/alphagov/govuk-helm-charts/pull/4158)

DO NOT MERGE UNTIL EITHER AFTERNOON 31ST MAR OR LATER!)