### PR TITLE
Scope chat error status alert to answer-worker container

### DIFF
--- a/charts/monitoring-config/rules/chat_ai.yaml
+++ b/charts/monitoring-config/rules/chat_ai.yaml
@@ -213,7 +213,8 @@ groups:
           sum(
             rate(
               govuk_chat_answer_count{
-                status=~"error_.*"
+                status=~"error_.*",
+                container="answer-worker"
               }[20m]
             )
           ) >= (3 / 1200)

--- a/charts/monitoring-config/rules/chat_ai_tests.yaml
+++ b/charts/monitoring-config/rules/chat_ai_tests.yaml
@@ -599,23 +599,35 @@ tests:
   - interval: 1m
     input_series:
       # No alert: total answers with error status > 3
-      - series: 'govuk_chat_answer_count{status="error_answer_service_error"}'
-        values: '1 2'
+      - series: 'govuk_chat_answer_count{status="error_answer_service_error", container="answer-worker"}'
+        values: '0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 2'
     alert_rule_test:
       - alertname: ElevatedAnswerErrorStatuses
-        eval_time: 2m
+        eval_time: 20m
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # No alert: total answers with error status > 3 but not all from the answer-worker container
+      - series: 'govuk_chat_answer_count{status="error_answer_guardrails", container="answer-worker"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 2'
+      - series: 'govuk_chat_answer_count{status="error_answer_guardrails", container="default-worker"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 2'
+    alert_rule_test:
+      - alertname: ElevatedAnswerErrorStatuses
+        eval_time: 20m
         exp_alerts: []
 
   - interval: 1m
     input_series:
       # Alert: aggregate total answers with error status >= 3 in 20 minutes
-      - series: 'govuk_chat_answer_count{status="error_answer_guardrails"}'
-        values: '0 1 2'
-      - series: 'govuk_chat_answer_count{status="error_answer_service_error"}'
-        values: '0 1 1'
+      - series: 'govuk_chat_answer_count{status="error_answer_guardrails", container="answer-worker"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 2'
+      - series: 'govuk_chat_answer_count{status="error_answer_service_error", container="answer-worker"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1'
     alert_rule_test:
       - alertname: ElevatedAnswerErrorStatuses
-        eval_time: 3m
+        eval_time: 20m
         exp_alerts:
           - exp_labels:
               alertname: ElevatedAnswerErrorStatuses


### PR DESCRIPTION
## Description 

We had this alert fire for a single answer with an error status. Looking at the data in Grafana, it appears that metrics are being aggregated across all three containers in the multi-container pod:

- answer-worker
- default-worker
- published-documents-consumer

Because these containers share the same network namespace and Pod IP, the Prometheus exporter is being scraped by Prometheus in a way that attributes the same metric to every container in the Pod. This leads to "triple counting" the error rate, causing alerts to fire prematurely.

This commit updates the alert query to explicitly filter by the container="answer-worker" label to ensure that we only count  it once.

### Updates to the tests 

I've also tweaked the tests to run for 20 minutes each to fully reflect how `rate()` works. If we don't use the full 20 minutes data it calculates the rate of change based off the partial data which leads to unexpected results.

The test that previously was checking to see if the alert fired passed even with the third data point commented out. This is because `rate()` calculates the rate of change based on the data it has available. Since there were only 3 data points, it calculated the rate of change based on those alone and didn't factor in the implied 17 minutes where there were 0 errors beforehand. Using these explicitly brings the rate down below the threshold.