### PR TITLE
Increase number of search-api-v2 replicas

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3052,7 +3052,7 @@ govukApplications:
           alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=10
         hosts:
           - name: search-api.{{ .Values.k8sExternalDomainSuffix }}
-      replicaCount: 6
+      replicaCount: 9
       uploadAssets:
         enabled: false
       workers:


### PR DESCRIPTION
We think that we're nearing a limit on search-api-v2 whereby a small increase in latency on downstream traffic can cause delays to requests from finder-frontend.

Increasing the number of search-api-v2 workers to see if this alleviates the issue.