### PR TITLE
Revert "Change pagerduty drill to run on Tuesday"

### DIFF
--- a/charts/monitoring-config/rules/pagerdutydrill.yaml
+++ b/charts/monitoring-config/rules/pagerdutydrill.yaml
@@ -4,7 +4,7 @@ groups:
     rules:
       - alert: PagerDutyDrill
         expr: |
-          (day_of_week() == 2) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
+          (day_of_week() == 1) and (hour() == 10) and (minute() >= 0) and (minute() <= 10)
         labels:
           severity: page
         annotations:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#4177 (This is actually a re-re-revert due to the scheduling mistake I made when I initially merged, but it does what we want and puts the drill back on the Monday - we'll have to do this again in May).