### PR TITLE
[PNP-9923] Update startup probe endpoint for account-api on Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -87,6 +87,8 @@ govukApplications:
           alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=3
         hosts:
           - name: account-api.{{ .Values.k8sExternalDomainSuffix }}
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
We have a `/healthcheck/ready` endpoint in account-api that carries out some healthchecks,
but it has not been configured in this repo (the default is `/healthcheck/live`).

We will test this endpoint in Integration before proceeding to Staging and Production.

Refs:
- https://github.com/alphagov/account-api/blob/main/config/routes.rb#L3-L6
- https://docs.publishing.service.gov.uk/kubernetes/manage-app/control-healthchecks/#startup-probe

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9923)