### PR TITLE
[PNP-9924] Update startup probe endpoint for email-alert-frontend on Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1071,6 +1071,8 @@ govukApplications:
           memory: 320Mi
       redis:
         enabled: true
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
@@ -1108,6 +1110,8 @@ govukApplications:
         createSecret: false # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-


### PR DESCRIPTION
We have a `healthcheck` endpoint in `email-alert-frontend` that carries out some healthchecks, but it has not been configured in this repo (the default is `/healthcheck/live`).

We will test this endpoint on Integration before proceeding to Staging and Production.

Refs:
- https://github.com/alphagov/email-alert-frontend/blob/main/config/routes.rb#L5-L7
- https://docs.publishing.service.gov.uk/kubernetes/manage-app/control-healthchecks/#startup-probe

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9924)