### PR TITLE
[PNP-9924] Update startup probe endpoint for email-alert-frontend on Staging and…

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1070,6 +1070,8 @@ govukApplications:
           memory: 450Mi
       redis:
         enabled: true
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
@@ -1108,6 +1110,8 @@ govukApplications:
         createSecret: false # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1075,6 +1075,8 @@ govukApplications:
           memory: 450Mi
       redis:
         enabled: true
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: ACCOUNT_API_BEARER_TOKEN
           valueFrom:
@@ -1113,6 +1115,8 @@ govukApplications:
         createSecret: false # Sentry DSNs are per repo.
       uploadAssets:
         enabled: false
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-


### PR DESCRIPTION
… Production

This has been tested on Integration.

`kubectl exec -it deploy/email-alert-frontend -- curl -v http://127.0.0.1:3000/healthcheck/ready; echo`:

```
{"status":"ok","checks":{"redis_connectivity":{"status":"ok"}}}
```

`kubectl exec -it deploy/draft-email-alert-frontend -- curl -v http://127.0.0.1:3000/healthcheck/ready; echo`:

```
{"status":"ok","checks":{"redis_connectivity":{"status":"ok"}}}
```

Related PRs:
- https://github.com/alphagov/govuk-helm-charts/pull/4202

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9924)