### PR TITLE
Provide a podFailurePolicy for mysql DB backup jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           entrypoint: /kubeconform
           args: >
-            -kubernetes-version 1.31.6
+            -kubernetes-version 1.34.6
             -schema-location default
             -schema-location
             "https://alphagov.github.io/govuk-crd-library/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"

--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -34,6 +34,15 @@ spec:
     spec:
       activeDeadlineSeconds: {{ $job.maxJobRuntimeSeconds | default 43200 }} # 43200 seconds is 12 hours
       backoffLimit: 0
+      {{- if eq $dbms "mysql" }}
+      # Ignore pod disruptions, so they don't count towards the backoffLimit
+      podFailurePolicy:
+        rules:
+          - action: Ignore
+            onPodConditions:
+              - type: DisruptionTarget
+                status: "True"
+      {{- end }}
       template:
         metadata:
           name: {{ $jobFullName }}


### PR DESCRIPTION
This will cause K8s to restart the job if a pod is disrupted

This should prevent broken DB restores in the case that k8s decides to kill a pod for a mysql DB restore job

MySQL restores are particularly sensitive to disruption, since they drop the existing data before restoring the new data.

https://github.com/alphagov/govuk-infrastructure/issues/4008