### PR TITLE
[PNP-9923] Update startup probe endpoint for account-api on Staging and Production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -80,6 +80,8 @@ govukApplications:
           alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=3
         hosts:
           - name: account-api.{{ .Values.k8sExternalDomainSuffix }}
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -87,6 +87,8 @@ govukApplications:
           alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=3
         hosts:
           - name: account-api.{{ .Values.k8sExternalDomainSuffix }}
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
This has been tested on Integration.

`kubectl exec -it deploy/account-api -- curl -v http://127.0.0.1:3000/healthcheck/ready; echo`:

```
{"status":"ok","checks":{"database_connectivity":{"status":"ok"},"rails_cache":{"status":"ok"},"redis_connectivity":{"status":"ok"}}}
```

Related PRs:
- https://github.com/alphagov/govuk-helm-charts/pull/4201

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9923)