### PR TITLE
[PNP-9925] Update startup probe endpoint for places-manager on Integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2303,6 +2303,8 @@ govukApplications:
           memory: 200Mi
       redis:
         enabled: true
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
       extraEnv:
         - name: ANONYMOUS_USER_ID_SECRET
           valueFrom: *anonymous_user_id_secret


### PR DESCRIPTION
We have a `/healthcheck/ready` endpoint in `places-manager` that carries out some healthchecks, but it has not been configured in this repo (the default is `healthcheck/live`).

We will test this on Integration before proceeding to Staging and Production.

Refs:
- https://github.com/alphagov/places-manager/blob/main/config/routes.rb#L5-L7
- https://docs.publishing.service.gov.uk/kubernetes/manage-app/control-healthchecks/#startup-probe

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9925)

Related PRs:
- https://github.com/alphagov/places-manager/pull/1577