### PR TITLE
Set podFailurePolicy on all db-backup jobs

### DIFF
--- a/charts/db-backup/templates/cronjob.yaml
+++ b/charts/db-backup/templates/cronjob.yaml
@@ -34,7 +34,6 @@ spec:
     spec:
       activeDeadlineSeconds: {{ $job.maxJobRuntimeSeconds | default 43200 }} # 43200 seconds is 12 hours
       backoffLimit: 0
-      {{- if eq $dbms "mysql" }}
       # Ignore pod disruptions, so they don't count towards the backoffLimit
       podFailurePolicy:
         rules:
@@ -42,7 +41,6 @@ spec:
             onPodConditions:
               - type: DisruptionTarget
                 status: "True"
-      {{- end }}
       template:
         metadata:
           name: {{ $jobFullName }}


### PR DESCRIPTION
This has been tested with a dummy job, and it works as we'd expect. Pod disruptions (e.g. node scaling) cause k8s to restart pods, despite backoffLimit being set to 0

https://github.com/alphagov/govuk-infrastructure/issues/4008