### PR TITLE
Add ability to run GitHub action after successful deploy

### DIFF
--- a/charts/app-config/templates/govuk-application.yaml
+++ b/charts/app-config/templates/govuk-application.yaml
@@ -19,6 +19,8 @@ metadata:
     imageTag: "{{ $imageTag }}"
     promoteDeployment: "{{ $promoteDeployment }}"
     automaticDeploysEnabled: "{{ $autoDeploysEnabled }}"
+    postSyncGithubActionRepo: "{{ .postSyncGithubAction.repo | default "" }}"
+    postSyncGithubActionWorkflow: "{{ .postSyncGithubAction.workflow }}"
     notifications.argoproj.io/subscribe.on-deployed.argo_events: ""
     notifications.argoproj.io/subscribe.deployment.grafana: "deployment|{{ .name }}"
     postSyncWorkflowEnabled: "{{ .postSyncWorkflowEnabled | default "true" }}"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -548,6 +548,9 @@ govukApplications:
               key: bearer_token
         - name: E2E_USER_EMAILS
           value: "2nd-line-support@digital.cabinet-office.gov.uk,govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk"
+      postSyncGithubAction:
+        repo: "alphagov/content-modelling-e2e"
+        workflow: "playwright.yml"
   - name: content-data-admin
     helmValues:
       arch: arm64

--- a/charts/argo-services/config/argocd-notifications-config.yaml
+++ b/charts/argo-services/config/argocd-notifications-config.yaml
@@ -21,7 +21,9 @@ template.send-argo-events-webhook: |
           "repoName": "{{.app.metadata.annotations.repoName}}",
           "imageTag": "{{.app.metadata.annotations.imageTag}}",
           "promoteDeployment": "{{.app.metadata.annotations.promoteDeployment}}",
-          "automaticDeploysEnabled": "{{.app.metadata.annotations.automaticDeploysEnabled}}"
+          "automaticDeploysEnabled": "{{.app.metadata.annotations.automaticDeploysEnabled}}",
+          "postSyncGithubActionRepo": "{{.app.metadata.annotations.postSyncGithubActionRepo}}",
+          "postSyncGithubActionWorkflow": "{{.app.metadata.annotations.postSyncGithubActionWorkflow}}"
         }
       method: "POST"
       path: "/api/v1/events/apps/post-sync"

--- a/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/event-binding.yaml
@@ -25,3 +25,9 @@ spec:
         - name: automaticDeploysEnabled
           valueFrom:
             event: payload.automaticDeploysEnabled
+        - name: postSyncGithubActionRepo
+          valueFrom:
+            event: payload.postSyncGithubActionRepo
+        - name: postSyncGithubActionWorkflow
+          valueFrom:
+            event: payload.postSyncGithubActionWorkflow

--- a/charts/argo-services/templates/workflows/post-sync/workflow.yaml
+++ b/charts/argo-services/templates/workflows/post-sync/workflow.yaml
@@ -29,6 +29,8 @@ spec:
       - name: imageTag
       - name: promoteDeployment
       - name: automaticDeploysEnabled
+      - name: postSyncGithubActionRepo
+      - name: postSyncGithubActionWorkflow
   podSpecPatch: |
     containers:
       - name: main
@@ -48,6 +50,16 @@ spec:
               parameters:
                 - name: grep
                   value: "{{"@app-{{workflow.parameters.application}}"}}"
+          - name: trigger-github-action
+            depends: govuk-e2e-tests.Succeeded
+            when: "{{"'{{workflow.parameters.postSyncGithubActionRepo}}' != ''"}}"
+            template: trigger-github-action
+            arguments:
+              parameters:
+                - name: repo
+                  value: "{{"{{workflow.parameters.postSyncGithubActionRepo}}"}}"
+                - name: workflow
+                  value: "{{"{{workflow.parameters.postSyncGithubActionWorkflow}}"}}"
     {{ if .Values.nextEnvironment }}
           - name: promote-release
             depends: govuk-e2e-tests.Succeeded
@@ -98,6 +110,29 @@ spec:
                 name: deploy-image-webhook-endpoint
                 key: url
     {{- end }}
+
+    - name: trigger-github-action
+      inputs:
+        parameters:
+          - name: repo
+          - name: workflow
+      script:
+        image: quay.io/curl/curl
+        command:
+          - sh
+        source: >
+          curl --fail-with-body -sS -X POST "https://api.github.com/repos/{{"{{inputs.parameters.repo}}"}}/actions/workflows/{{"{{inputs.parameters.workflow}}"}}/dispatches" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            --json '{
+              "ref": "main"
+            }'
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: govuk-ci-github-creds
+                key: token
 
     - name: parse-failures
       inputs: {}


### PR DESCRIPTION
In Content Block Manager, we have a [suite of E2E tests](https://github.com/alphagov/content-modelling-e2e) that are more in depth than the GOV.UK E2E tests, and are only designed to be run in the integration environment. 

At the moment, these are only run on demand, and generally drift when changes are made. I'd like to run these after every successful integration deploy, so we can have confidence everything is still working as expected.

After some investigation, I found there wasn't an out of the box way to do this easily, and I had a bit of time to experiment how easy it would be to add this functionality.

This PR adds the ability to run a Github actions workflow for any application/environment during the post-sync workflow in Argo, which covers our use case, but also offers up the flexibility for any users to do the same.

I'm not super au-fait with Helm Charts / Kubernetes, but this seems like I have all the bases covered. Feedback appreciated! (even if it's just "no, this won't work" 😆 )