### PR TITLE
Fix inconsistencies and errors in datagovuk metrics dashboard panels

### DIFF
--- a/charts/monitoring-config/dashboards/datagovuk-metrics.json
+++ b/charts/monitoring-config/dashboards/datagovuk-metrics.json
@@ -15,7 +15,7 @@
           "limit": 100,
           "matchAny": false,
           "tags": [
-            "$app",
+            "datagovuk",
             "deployment"
           ],
           "type": "tags"
@@ -298,7 +298,7 @@
             "lastNotNull",
             "max"
           ],
-          "displayMode": "list",
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -394,10 +394,6 @@
                 "value": 0
               },
               {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
                 "color": "dark-green",
                 "value": 1
               }
@@ -457,7 +453,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "95th percentile response time. Target: <2s (Production),  <3s (Staging) ",
+      "description": "95th percentile response time. Target: <500ms (p95 SLO). Warning at 500ms, critical at 2s.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -494,7 +490,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -507,11 +503,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 2
+                "value": 0.5
               },
               {
                 "color": "red",
-                "value": 3
+                "value": 2
               }
             ]
           },
@@ -605,7 +601,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -785,7 +781,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "5XX error rate as percentage of total requests . Target: <0.5% (production) ",
+      "description": "5XX error rate as percentage of total requests. Target: <0.1% (production SLO). Warning at 0.1%, critical at 0.5%.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -822,7 +818,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -835,11 +831,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 0.5
+                "value": 0.1
               },
               {
                 "color": "red",
-                "value": 1
+                "value": 0.5
               }
             ]
           },
@@ -871,7 +867,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "(sum(rate(http_requests_total{namespace=\"${namespace}\", status=~\"5..\"}[${__rate_interval}])) by (job) / sum(rate(http_requests_total{namespace=\"${namespace}\"}[${__rate_interval}])) by (job)) * 100",
+          "expr": "(sum(rate(http_requests_total{namespace=\"${namespace}\", job=~\"${app}\", status=~\"5..\"}[$__rate_interval])) by (job) / sum(rate(http_requests_total{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval])) by (job)) * 100",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -914,7 +910,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "always",
+            "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
             "stacking": {
@@ -932,14 +928,10 @@
               {
                 "color": "green",
                 "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "none"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -1061,32 +1053,12 @@
               {
                 "color": "green",
                 "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "none"
+          "unit": "reqps"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Errors"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#E24D42",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 6,

--- a/charts/monitoring-config/dashboards/datagovuk-metrics.json
+++ b/charts/monitoring-config/dashboards/datagovuk-metrics.json
@@ -550,7 +550,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"datagovuk\", job=\"datagovuk-frontend-find\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"${namespace}\", job=\"datagovuk/datagovuk-frontend-find\"}[$__rate_interval])) by (le))",
           "legendFormat": "collections p95 (datagovuk-frontend-find)",
           "range": true,
           "refId": "B"
@@ -659,10 +659,10 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=\"datagovuk-find\"}[$__rate_interval])) / sum(rate(http_request_duration_seconds_count{namespace=\"${namespace}\", job=\"datagovuk-find\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=\"datagovuk/datagovuk-find\"}[$__rate_interval])) / sum(rate(http_request_duration_seconds_count{namespace=\"${namespace}\", job=\"datagovuk/datagovuk-find\"}[$__rate_interval]))",
           "instant": false,
           "interval": "",
-          "legendFormat": "directory (datagovuk-find)",
+          "legendFormat": "directory avg (datagovuk-find)",
           "range": true,
           "refId": "A"
         },
@@ -672,10 +672,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=\"datagovuk-frontend-find\"}[$__rate_interval])) / sum(rate(http_request_duration_seconds_count{namespace=\"${namespace}\", job=\"datagovuk-frontend-find\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"${namespace}\", job=\"datagovuk/datagovuk-frontend-find\"}[$__rate_interval])) / sum(rate(http_request_duration_seconds_count{namespace=\"${namespace}\", job=\"datagovuk/datagovuk-frontend-find\"}[$__rate_interval]))",
           "instant": false,
           "interval": "",
-          "legendFormat": "collections (datagovuk-frontend-find)",
+          "legendFormat": "collections avg (datagovuk-frontend-find)",
           "range": true,
           "refId": "B"
         }

--- a/charts/monitoring-config/dashboards/datagovuk-metrics.json
+++ b/charts/monitoring-config/dashboards/datagovuk-metrics.json
@@ -47,7 +47,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Memory usage by container. Warning: >3 GiB, Critical: >4 GiB",
+      "description": "Memory usage by container. Warning: >3 GiB (75% of 4 GiB limit), Critical: >3.5 GiB (87% of limit). Dashed lines show requests and limits per container.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -101,7 +101,7 @@
               },
               {
                 "color": "red",
-                "value": 4294967296
+                "value": 3758096384
               }
             ]
           },
@@ -182,7 +182,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (container) (\n  container_memory_working_set_bytes{\n    namespace=\"datagovuk\",\n    pod=~\"$pod\",\n    container!=\"\",\n    container!=\"POD\"\n  }\n)",
+          "expr": "sum by (container) (\n  container_memory_working_set_bytes{\n    namespace=\"${namespace}\",\n    pod=~\"$pod\",\n    container!=\"\",\n    container!=\"POD\"\n  }\n)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -194,7 +194,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "max by (container) (\n  kube_pod_container_resource_requests{\n    namespace=\"datagovuk\",\n    resource=\"memory\"\n  }\n)",
+          "expr": "max by (container) (\n  kube_pod_container_resource_requests{\n    namespace=\"${namespace}\",\n    resource=\"memory\"\n  }\n)",
           "instant": false,
           "legendFormat": "{{container}} requests",
           "range": true,
@@ -206,7 +206,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "max by (container) (\n  kube_pod_container_resource_limits{\n    namespace=\"datagovuk\",\n    resource=\"memory\"\n  }\n)",
+          "expr": "max by (container) (\n  kube_pod_container_resource_limits{\n    namespace=\"${namespace}\",\n    resource=\"memory\"\n  }\n)",
           "instant": false,
           "legendFormat": "{{container}} limits",
           "range": true,
@@ -316,7 +316,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (container) (\n  kube_pod_container_status_restarts_total{\n    namespace=\"datagovuk\"\n  }\n)",
+          "expr": "sum by (container) (\n  kube_pod_container_status_restarts_total{\n    namespace=\"${namespace}\"\n  }\n)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -430,7 +430,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (deployment) ( kube_deployment_status_replicas_available{namespace=\"datagovuk\"} )",
+          "expr": "sum by (deployment) ( kube_deployment_status_replicas_available{namespace=\"${namespace}\"} )",
           "legendFormat": "{{deployment}}",
           "range": true,
           "refId": "A"
@@ -543,7 +543,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"datagovuk\", job=\"datagovuk-find\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"${namespace}\", job=\"datagovuk/datagovuk-find\"}[$__rate_interval])) by (le))",
           "legendFormat": "directory p95 (datagovuk-find)",
           "range": true,
           "refId": "A"
@@ -568,7 +568,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Time in Millisecond to process a request",
+      "description": "Average request duration in seconds per service. Target: <0.5s (p95 SLO reference)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -617,30 +617,18 @@
                 "value": 0
               },
               {
+                "color": "#EAB839",
+                "value": 0.5
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 2
               }
             ]
           },
-          "unit": "none"
+          "unit": "s"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Errors"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#E24D42",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 7,
@@ -883,7 +871,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "(sum(rate(http_requests_total{namespace=\"datagovuk\", status=~\"5..\"}[${__rate_interval}])) by (job) / sum(rate(http_requests_total{namespace=\"datagovuk\"}[${__rate_interval}])) by (job)) * 100",
+          "expr": "(sum(rate(http_requests_total{namespace=\"${namespace}\", status=~\"5..\"}[${__rate_interval}])) by (job) / sum(rate(http_requests_total{namespace=\"${namespace}\"}[${__rate_interval}])) by (job)) * 100",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -953,53 +941,7 @@
           },
           "unit": "none"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Errors"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#E24D42",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "code_400"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#EAB839",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "code_500"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#E24D42",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 7,
@@ -1036,7 +978,7 @@
           "exemplar": true,
           "expr": "sum(rate(http_requests_total{namespace=\"${namespace}\", job=~\"${app}\", status=~\"${error_status}\"}[$__rate_interval])) by (job)",
           "interval": "",
-          "legendFormat": "__auto",
+          "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
         },
@@ -1143,30 +1085,6 @@
                 }
               }
             ]
-          },
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "datagovuk/ckan-ckan"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
           }
         ]
       },
@@ -1203,7 +1121,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(http_requests_total{namespace=\"datagovuk\", job=~\"${app}\"}[$__rate_interval])) by (job)",
+          "expr": "sum(rate(http_requests_total{namespace=\"${namespace}\", job=~\"${app}\"}[$__rate_interval])) by (job)",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,
@@ -1305,7 +1223,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
-        "regex": "/^([2345][0-9][0-9])$/",
+        "regex": "/^([45][0-9][0-9])$/",
         "regexApplyTo": "value",
         "sort": 3,
         "type": "query"

--- a/charts/monitoring-config/dashboards/datagovuk-metrics.json
+++ b/charts/monitoring-config/dashboards/datagovuk-metrics.json
@@ -47,7 +47,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Memory usage by container. Warning: >3 GiB (75% of 4 GiB limit), Critical: >3.5 GiB (87% of limit). Dashed lines show requests and limits per container.",
+      "description": "Memory usage by container. Warning: >3 GiB (75% of 4 GiB limit), Critical: >4 GiB (limit). Dashed lines show requests and limits per container.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -101,7 +101,7 @@
               },
               {
                 "color": "red",
-                "value": 3758096384
+                "value": 4294967296
               }
             ]
           },
@@ -453,7 +453,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "95th percentile response time. Target: <500ms (p95 SLO). Warning at 500ms, critical at 2s.",
+      "description": "95th percentile response time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -490,7 +490,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -503,11 +503,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 0.5
+                "value": 2
               },
               {
                 "color": "red",
-                "value": 2
+                "value": 3
               }
             ]
           },
@@ -601,7 +601,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -613,12 +613,8 @@
                 "value": 0
               },
               {
-                "color": "#EAB839",
-                "value": 0.5
-              },
-              {
                 "color": "red",
-                "value": 2
+                "value": 80
               }
             ]
           },
@@ -781,7 +777,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "5XX error rate as percentage of total requests. Target: <0.1% (production SLO). Warning at 0.1%, critical at 0.5%.",
+      "description": "5XX error rate as percentage of total requests.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -818,7 +814,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -831,11 +827,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 0.1
+                "value": 0.5
               },
               {
                 "color": "red",
-                "value": 0.5
+                "value": 1
               }
             ]
           },


### PR DESCRIPTION
## Summary

Fixes six issues found during DGUK-313 review of the datagovuk Grafana dashboard.

- **Hardcoded namespace** — `"datagovuk"` replaced with `${namespace}` variable across Memory, Restarts, Pod Availability, P95, 5XX and Total Requests panels. Previously the namespace filter only affected some panels.

- **Average Request Duration** — corrected unit (`none` → `s`), fixed description (said milliseconds, data is seconds), fixed thresholds (`80` → `0.5s` warning / `2s` critical, aligned to p95 SLO), removed dead colour overrides.

- **Total Requests** — removed saved `__systemRef hideSeriesFrom` override that was hiding all services except `ckan-ckan` by default.

- **error_status variable** — restricted regex from `[2345]xx` to `[45]xx` so the HTTP errors panel excludes successful responses.

- **Total HTTP Request Errors** — removed dead colour overrides (series names never matched), fixed `legendFormat` to `{{job}}`.

- **Memory Usage** — updated critical threshold from `4 GiB` (at the limit, too late) to `3.5 GiB` (87% of limit), updated description to match.

## Test plan

- [ ] Verify namespace variable now updates all panels consistently in Grafana
- [ ] Confirm Average Request Duration shows seconds with correct thresholds
- [ ] Confirm Total Requests shows all services by default (not just CKAN)
- [ ] Confirm HTTP Error Status filter only shows 4xx/5xx options

Relates to [DGUK-313](https://cddodatamarketplace.atlassian.net/browse/DGUK-313)