### PR TITLE
Configure 'trace to metrics' for tempo in grafana

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/kube-prometheus-stack-values.yaml
@@ -45,6 +45,15 @@
       "jsonData":
         "serviceMap":
           "datasourceUid": "prometheus"
+        "tracesToMetrics":
+          "datasourceUid": "prometheus"
+          "spanStartTimeShift": "-5m"
+          "spanEndTimeShift": "5m"
+          "tags":
+            - "key": "service.name"
+              "value": "service_name"
+            - "key": "service.namespace"
+              "value": "service_namespace"
       "name": "Tempo"
       "type": "tempo"
       "uid": "tempo"


### PR DESCRIPTION
This is required for service maps to be generated. It is used to map traces to prometheus metrics that beyla outputs

Config from: https://grafana.com/docs/grafana/next/datasources/tempo/configure-tempo-data-source/provision/#example-file

https://github.com/alphagov/govuk-infrastructure/issues/3914