### PR TITLE
Fix incorrect key name in tempo values

### DIFF
--- a/charts/monitoring-config/tempo-values.yaml
+++ b/charts/monitoring-config/tempo-values.yaml
@@ -14,7 +14,7 @@ traces:
       enabled: true
     http:
       enabled: true
-global_overrides:
+overrides:
   defaults:
     ingestion:
       burst_size_bytes: 32000000  # 32Mb


### PR DESCRIPTION
This was renamed in a chart update, but we never updated it.

https://github.com/grafana-community/helm-charts/blob/ddfed21a2a79a2a05c9ddd33937d3d8553ed25a3/charts/tempo-distributed/README.md#from-chart-versions--1330

https://github.com/alphagov/govuk-infrastructure/issues/3914