### PR TITLE
Increase memory for Link Checker API workers

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1969,7 +1969,7 @@ govukApplications:
       workerResources:
         limits:
           cpu: 1
-          memory: 1Gi
+          memory: 2Gi
         requests:
           cpu: 10m
           memory: 175Mi

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1962,7 +1962,7 @@ govukApplications:
       workerResources:
         limits:
           cpu: 1
-          memory: 1Gi
+          memory: 2Gi
         requests:
           cpu: 10m
           memory: 256Mi


### PR DESCRIPTION
In 9b08baa3f2db63e792a7113f950124071c061a01, the memory for Link Checker API workers was increased in production.

We are now seeing the workers failing to start in integration and staging due to being out of memory.

Therefore increasing their memory.