### PR TITLE
Fix Prometheus job label format in split panel queries (DGUK-359)

### DIFF
--- a/charts/monitoring-config/dashboards/datagovuk-metrics.json
+++ b/charts/monitoring-config/dashboards/datagovuk-metrics.json
@@ -490,7 +490,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -503,11 +503,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 0.5
+                "value": 2
               },
               {
                 "color": "red",
-                "value": 2
+                "value": 3
               }
             ]
           },
@@ -564,7 +564,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Average request duration in seconds per service. Target: <0.5s (p95 SLO reference)",
+      "description": "Average request duration in seconds per service.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -601,7 +601,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -613,12 +613,8 @@
                 "value": 0
               },
               {
-                "color": "#EAB839",
-                "value": 0.5
-              },
-              {
                 "color": "red",
-                "value": 2
+                "value": 80
               }
             ]
           },

--- a/charts/monitoring-config/dashboards/datagovuk-metrics.json
+++ b/charts/monitoring-config/dashboards/datagovuk-metrics.json
@@ -490,7 +490,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -503,11 +503,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 2
+                "value": 0.5
               },
               {
                 "color": "red",
-                "value": 3
+                "value": 2
               }
             ]
           },
@@ -601,7 +601,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -613,8 +613,12 @@
                 "value": 0
               },
               {
+                "color": "#EAB839",
+                "value": 0.5
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 2
               }
             ]
           },


### PR DESCRIPTION
## Summary
- Prometheus assigns `job` labels in `namespace/job-name` format (for example like:  `datagovuk/datagovuk-find`), not just `job-name` format as originally coded

- This caused "No data" on both P95 and Average Duration split panels after merge

- Also fixes hardcoded `namespace="datagovuk"` → `${namespace}` variable and `[5m]` → `[$__rate_interval]` in P95 queries

- Corrects Average Duration panel description, unit (`none` → `s`), and thresholds to match SLO

## Test plan
- [ ] Verify P95 Response Time — Directory vs Collections shows both series
- [ ] Verify Average Request Duration — Directory vs Collections shows both series with correct legend labels
- [ ] Confirm namespace variable switch works across environments