### PR TITLE
Temporarily disable the restore portion of the db backup jobs for whitehall in staging

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -499,8 +499,8 @@ cronjobs:
       schedule: "28 1 * * 1-5"
       db: whitehall_production
       operations:
-        - op: restore
-          bucket: s3://govuk-production-database-backups
+        # - op: restore
+        #   bucket: s3://govuk-production-database-backups
         - op: transform
           script: whitehall.sql
         - op: backup


### PR DESCRIPTION
Whitehall failed to transform and backup overnight, a fix is being merged for this in https://github.com/alphagov/govuk-helm-charts/pull/4221. Once it is merged we should run the transform and backup again, so this PR will disable the restore portion of the db-backup job. Once it has run we can revert this PR and go back to the normal schedule for tomorrow