### PR TITLE
Add GOV.UK Notify API keys to Fact check manager (integration)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1607,6 +1607,11 @@ govukApplications:
             secretKeyRef:
               name: fact-check-manager-postgres
               key: DATABASE_URL
+        - name: GOVUK_NOTIFY_TEAM_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fact-check-manager-notify-team
+              key: notify-team
         - name: GOVUK_NOTIFY_TEST_API_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1607,6 +1607,11 @@ govukApplications:
             secretKeyRef:
               name: fact-check-manager-postgres
               key: DATABASE_URL
+        - name: GOVUK_NOTIFY_TEST_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fact-check-manager-notify-test
+              key: notify-test
         - name: GDS_SSO_OAUTH_ID
           valueFrom:
             secretKeyRef:

--- a/charts/external-secrets/templates/fact-check-manager/notify-team.yaml
+++ b/charts/external-secrets/templates/fact-check-manager/notify-team.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fact-check-manager-notify-team
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Notify API team key - allows real messages to be sent to team members for testing
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: fact-check-manager-notify-team
+  dataFrom:
+    - extract:
+        key: govuk/fact-check-manager/notify-team
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/charts/external-secrets/templates/fact-check-manager/notify-test.yaml
+++ b/charts/external-secrets/templates/fact-check-manager/notify-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fact-check-manager-notify-test
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Notify API test key - allows integration with GOV.UK Notify to be tested
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: fact-check-manager-notify-test
+  dataFrom:
+    - extract:
+        key: govuk/fact-check-manager/notify-test
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
This adds a Notify test API key to allow us to add and test the Notify service integration with Fact check manager