### PR TITLE
Add a cronjob to Whitehall for fixing up world news story links every day

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3917,6 +3917,9 @@ govukApplications:
         - name: taxonomy-rebuild
           task: "taxonomy:rebuild_cache"
           schedule: "*/10 7-20 * * *"
+        - name: fix-world-news-story-conversions
+          task: "data_hygiene:remove_org_links_from_world_news"
+          schedule: "0 17 * * *"
       dbMigrationEnabled: true
       dbMigrationActiveDeadlineSeconds: 3700 # 1 hour + 10 min buffer to match StrongMigrations.statement_timeout
       workers:


### PR DESCRIPTION
Relates to https://gov-uk.atlassian.net/browse/WHIT-2883?atlOrigin=eyJpIjoiNmEyZGZkNDI5MzRhNDAyZmJmYmMxZjJkNTM4YWMzODAiLCJwIjoiaiJ9

The proper fix to this looks like a lot of effort for potentially not much reward, so we're considering popping this cronjob in the schedule until we have more information to make a better decision about how to generalize the problem.