### PR TITLE
Create regular snapshot of integration

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -80,6 +80,12 @@ cronjobs:
           value: govuk-staging
         - name: SUBDOMAIN
           value: elasticsearch6
+    green-es6-snapshot: # This would be too long as green-elasticsearch6-domain-snapshot
+      schedule: "37 5 * * 1"
+      args: [create_and_clean_up]
+      extraEnv:
+        - name: SUBDOMAIN
+          value: elasticsearch6
     chat-engine-cp-prod:
       schedule: "12 4 * * *"
       args: [restore_latest]


### PR DESCRIPTION
The [govuk-docker/bin/replicate-elasticsearch.sh](https://github.com/alphagov/govuk-docker/blob/main/bin/replicate-elasticsearch.sh) script allows a user to replicate integration data locally. We do not currently run a regular job to create a snapshot of integration, so the latest available snapshots are from November 2025. 

Adding a cronTask to create a weekly snapshot of integration, for use locally by developers.