### PR TITLE
Set GOVUK_OTEL_SERVICE_NAME env var for all GOV.UK apps

### DIFF
--- a/charts/asset-manager/templates/deployment.yaml
+++ b/charts/asset-manager/templates/deployment.yaml
@@ -83,6 +83,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.repoName }}-rails-secret-key-base
                   key: secret-key-base
+            - name: GOVUK_OTEL_SERVICE_NAME
+              value: "{{ $fullName }}"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:

--- a/charts/asset-manager/templates/worker-deployment.yaml
+++ b/charts/asset-manager/templates/worker-deployment.yaml
@@ -77,6 +77,8 @@ spec:
           env:
             - name: GOVUK_UPLOADS_ROOT
               value: *uploads-path
+            - name: GOVUK_OTEL_SERVICE_NAME
+              value: "{{ $fullName }}-worker"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:

--- a/charts/generic-govuk-app/templates/deployment.yaml
+++ b/charts/generic-govuk-app/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.appPort }}"
+            - name: GOVUK_OTEL_SERVICE_NAME
+              value: "{{ $fullName }}"
             {{- if .Values.rails.enabled }}
             - name: SECRET_KEY_BASE
               valueFrom:

--- a/charts/generic-govuk-app/templates/worker-deployment.yaml
+++ b/charts/generic-govuk-app/templates/worker-deployment.yaml
@@ -63,6 +63,8 @@ spec:
             - configMapRef:
                 name: govuk-apps-env
           env:
+            - name: GOVUK_OTEL_SERVICE_NAME
+              value: "{{ $fullName }}-worker"
             {{- if $.Values.rails.enabled }}
             - name: SECRET_KEY_BASE
               valueFrom:


### PR DESCRIPTION
Apps will use this env var to set their service name correctly with https://github.com/alphagov/govuk_app_config/pull/600

If an app hasn't been updated yet, the env var will do nothing

https://github.com/alphagov/govuk-infrastructure/issues/3914