### PR TITLE
Account API doesn't use Notify, so doesn't need any config for it

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -115,13 +115,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-account-oauth
               key: GOVUK_ACCOUNT_OAUTH_PROVIDER_URI
-        - name: GOVUK_NOTIFY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: account-api-notify
-              key: GOVUK_NOTIFY_API_KEY
-        - name: GOVUK_NOTIFY_TEMPLATE_ID
-          value: 6074fdc2-03b3-4bb6-83fe-31220779c13b
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -108,13 +108,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-account-oauth
               key: GOVUK_ACCOUNT_OAUTH_PROVIDER_URI
-        - name: GOVUK_NOTIFY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: account-api-notify
-              key: GOVUK_NOTIFY_API_KEY
-        - name: GOVUK_NOTIFY_TEMPLATE_ID
-          value: 6074fdc2-03b3-4bb6-83fe-31220779c13b
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -115,13 +115,6 @@ govukApplications:
             secretKeyRef:
               name: govuk-account-oauth
               key: GOVUK_ACCOUNT_OAUTH_PROVIDER_URI
-        - name: GOVUK_NOTIFY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: account-api-notify
-              key: GOVUK_NOTIFY_API_KEY
-        - name: GOVUK_NOTIFY_TEMPLATE_ID
-          value: 6074fdc2-03b3-4bb6-83fe-31220779c13b
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION


To-do after merging:
- [ ] Delete the keys from Secrets Manager.