### PR TITLE
Added entry for new govuk-ai-graph-tools app.

### DIFF
--- a/charts/app-config/image-tags/integration/govuk-ai-graph-tools
+++ b/charts/app-config/image-tags/integration/govuk-ai-graph-tools
@@ -1,0 +1,3 @@
+image_tag: v1
+automatic_deploys_enabled: false
+promote_deployment: true

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4154,7 +4154,7 @@ govukApplications:
         create: true
         name: govuk-ai-graph-tools-app
         annotations:
-          eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-ai-accelerator-app-govuk
+          eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-ai-graph-tools-app-govuk
       rails:
         enabled: false
       sentry:
@@ -4197,3 +4197,9 @@ govukApplications:
         startupProbe: "/healthcheck/ready"
         livenessProbe: "/healthcheck/ready"
         readinessProbe: "/healthcheck/ready"
+      extraEnv:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: govuk-ai-accelerator-postgres
+              key: DATABASE_URL

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4146,3 +4146,54 @@ govukApplications:
             secretKeyRef:
               name: govuk-ai-accelerator-postgres
               key: DATABASE_URL
+  - name: govuk-ai-graph-tools-app
+    repoName: govuk-ai-graph-tools
+    helmValues:
+      serviceAccount:
+        enabled: true
+        create: true
+        name: govuk-ai-graph-tools-app
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::210287912431:role/govuk-ai-accelerator-app-govuk
+      rails:
+        enabled: false
+      sentry:
+        enabled: false
+      uploadAssets:
+        enabled: false
+      arch: arm64
+      appResources:
+        limits:
+          cpu: 4
+          memory: 5Gi
+        requests:
+          cpu: 10m
+          memory: 1.5Gi
+      nginxClientMaxBodySize: &max-upload-size 500M
+      nginxDenyCrawlers: true
+      ingress:
+        enabled: true
+        annotations:
+          !!merge <<: [*alb-ingress-group-backend, *alb-ingress-defaults]
+          alb.ingress.kubernetes.io/group.order: "300"
+          alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}: |
+            [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "govuk-ai-graph-tools-app.{{ .Values.publishingDomainSuffix }}"
+            ]}}]
+        hosts:
+          - name: govuk-ai-graph-tools-app.{{ .Values.k8sExternalDomainSuffix }}
+      nginxConfigMap:
+        extraServerConf:
+          auth_basic "Enter the GOV.UK username/password (not your personal username/password)";
+          auth_basic_user_file /etc/nginx/htpasswd/htpasswd;
+      nginxExtraVolumeMounts:
+        - name: router-nginx-htpasswd
+          mountPath: /etc/nginx/htpasswd
+      extraVolumes:
+        - name: router-nginx-htpasswd
+          secret:
+            secretName: router-nginx-htpasswd
+      kubernetesProbeEndpoints:
+        startupProbe: "/healthcheck/ready"
+        livenessProbe: "/healthcheck/ready"
+        readinessProbe: "/healthcheck/ready"


### PR DESCRIPTION
We are creating another app as part of the ongoing work in experimenting with AI and the content workflow in GOV.UK.

This PR adds the config for the new app, following very closely the patterns of the accelerator app. 

App is to be a python web app, deployed to integration, behind Nginx. It will use the same S3, Neptune, Postgres and Opensearch resources as used by the accelerator app, so has the same service account IAM as that app. The aim is to reuse those resources rather than create a whole new set of infra components. As per the AI accelerator these are experimental apps whose lifespan is as yet unclear. 

image-tag file does not promote deployments. This is an integration only app at this stage.

This PR may need adjustment if reusing resources from other apps in the manner I have done causes confusion and potential for issues.