### PR TITLE
Remove task to listen to search-api-listener-publishing-queue queue

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2970,8 +2970,6 @@ govukApplications:
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker
-          - command: ['rake', 'message_queue:listen_to_publishing_queue']
-            name: publishing-queue-listener
           - command: ['rake', 'message_queue:insert_data_into_govuk']
             name: govuk-index-queue-listener
           - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2948,8 +2948,6 @@ govukApplications:
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker
-          - command: ["rake", "message_queue:listen_to_publishing_queue"]
-            name: publishing-queue-listener
           - command: ["rake", "message_queue:insert_data_into_govuk"]
             name: govuk-index-queue-listener
           - command: ["rake", "message_queue:bulk_insert_data_into_govuk"]

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2933,8 +2933,6 @@ govukApplications:
         types:
           - command: ["sidekiq", "-C", "config/sidekiq.yml"]
             name: worker
-          - command: ['rake', 'message_queue:listen_to_publishing_queue']
-            name: publishing-queue-listener
           - command: ['rake', 'message_queue:insert_data_into_govuk']
             name: govuk-index-queue-listener
           - command: ['rake', 'message_queue:bulk_insert_data_into_govuk']


### PR DESCRIPTION
As part of the work to remove the government index, this queue has been removed

Jira: https://gov-uk.atlassian.net/browse/SCH-1985
github: https://github.com/alphagov/search-api/pull/3589