### PR TITLE
Remove SEARCH_INDEX env var

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2961,9 +2961,6 @@ govukApplications:
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
           schedule: "35 00 * * *"
-          env:
-            - name: SEARCH_INDEX
-              value: govuk
       workers:
         enabled: true
         replicaCount: 3

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2982,9 +2982,6 @@ govukApplications:
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
           schedule: "35 00 * * *"
-          env:
-            - name: SEARCH_INDEX
-              value: govuk
       extraEnv:
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-production-search-relevancy

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2925,9 +2925,6 @@ govukApplications:
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
           schedule: "35 00 * * *"
-          env:
-            - name: SEARCH_INDEX
-              value: govuk
       workers:
         enabled: true
         types:


### PR DESCRIPTION
Now that the search:update_popularity rake task in search-api has been hardcoded to refer to the govuk index, the SEARCH_INDEX environment variable is no longer required to be set for this job.

See: https://github.com/alphagov/search-api/pull/3571

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1986