### PR TITLE
Remove reindex-with-new-schema cronTask

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2939,12 +2939,6 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
-        - name: reindex-with-new-schemas
-          task: "search:migrate_schema"
-          schedule: "5 21 * * 1"
-          env:
-            - name: SEARCH_INDEX
-              value: all
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
           schedule: "50 2 * * *"


### PR DESCRIPTION
This cronTask was lifted from Jenkins in 2023 on #1101 but has never worked. 

Removing the scheduling of this task - if we needed it we'd have noticed before now that it wasn't working. Keeping the rake task itself within search-api, as this could be useful in the future.