### PR TITLE
Need to specify specific mount paths, also openresty nginx config needs the tmp dir directives set

### DIFF
--- a/charts/router-probe-backend/files/openresty.conf
+++ b/charts/router-probe-backend/files/openresty.conf
@@ -14,6 +14,12 @@ http {
   lua_shared_dict rate_limit_store 10m;
   lua_shared_dict cache_store 50m;
 
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path       /tmp/proxy_temp_path;
+  fastcgi_temp_path     /tmp/fastcgi_temp;
+  uwsgi_temp_path       /tmp/uwsgi_temp;
+  scgi_temp_path        /tmp/scgi_temp;
+    
   server_tokens off;
   more_clear_headers Server;
 

--- a/charts/router-probe-backend/templates/deployment.yaml
+++ b/charts/router-probe-backend/templates/deployment.yaml
@@ -84,10 +84,10 @@ spec:
               drop: ["ALL"]
           volumeMounts:
             - name: openresty-config
-              mountPath: /usr/local/openresty/nginx/conf/
+              mountPath: /usr/local/openresty/nginx/conf/nginx.conf
               subPath: nginx.conf
             - name: headers-lua-script
-              mountPath: /usr/local/openresty/lua/
+              mountPath: /usr/local/openresty/lua/headers.lua
               subPath: headers.lua
             - name: nginx-tmp
               mountPath: /tmp


### PR DESCRIPTION
* Specify the specific filepaths to mount the files into
* Set the tmp dir directives for openresty (which match the values in our other nginx configs configured as non root)