### PR TITLE
Fix the namespace for router-probe-backend,

### DIFF
--- a/charts/app-config/templates/router-probe-backend.yaml
+++ b/charts/app-config/templates/router-probe-backend.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: router-probe-backend
-  namespace: {{ $.Values.appsNamespace | default .Release.Namespace }}
+  namespace: {{ $.Values.argoNamespace | default .Release.Namespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -13,7 +13,7 @@ spec:
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
-    namespace: {{ .Values.argoNamespace }}
+    namespace: {{ .Values.appsNamespace }}
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
I changed the namespace of the ArgoCD application instead of the destination of its deployment 😮‍💨 

This PR changes the namespace of the ArgoCD Application back to the argo namespace, and changes the destination namespace for the Application to the apps namespace.