### PR TITLE
Add router backend

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2779,6 +2779,8 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL-router-probe-backend
+          value: "http://router-probe-backend"
         - name: ROUTER_ROUTE_RELOAD_INTERVAL
           value: 5m
         - name: CONTENT_STORE_DATABASE_URL

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2779,7 +2779,7 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
-        - name: BACKEND_URL-router-probe-backend
+        - name: BACKEND_URL_router-probe-backend
           value: "http://router-probe-backend"
         - name: ROUTER_ROUTE_RELOAD_INTERVAL
           value: 5m

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2790,6 +2790,8 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL-router-probe-backend
+          value: "http://router-probe-backend"
         - name: ROUTER_ROUTE_RELOAD_INTERVAL
           value: 5m
         - name: CONTENT_STORE_DATABASE_URL

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2790,7 +2790,7 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
-        - name: BACKEND_URL-router-probe-backend
+        - name: BACKEND_URL_router-probe-backend
           value: "http://router-probe-backend"
         - name: ROUTER_ROUTE_RELOAD_INTERVAL
           value: 5m

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2761,6 +2761,8 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
+        - name: BACKEND_URL-router-probe-backend
+          value: "http://router-probe-backend"
         - name: ROUTER_ROUTE_RELOAD_INTERVAL
           value: 5m
         - name: CONTENT_STORE_DATABASE_URL

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2761,7 +2761,7 @@ govukApplications:
           value: "http://licensify-frontend.licensify"
         - name: BACKEND_URL_search-api
           value: "http://search-api"
-        - name: BACKEND_URL-router-probe-backend
+        - name: BACKEND_URL_router-probe-backend
           value: "http://router-probe-backend"
         - name: ROUTER_ROUTE_RELOAD_INTERVAL
           value: 5m

--- a/charts/router-probe-backend/templates/deployment.yaml
+++ b/charts/router-probe-backend/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         fsGroup: 1001
-        runAsNonRoot: false
+        runAsNonRoot: true
         runAsUser: 1001
         runAsGroup: 1001
       volumes:


### PR DESCRIPTION
* Add the BACKEND_URL entries for router-probe-backend to router in all envs
* Set the security context for router-probe-backend to run as non-root (I tested this in a docker desktop k8s install and it runs ok)