### PR TITLE
Update router-probe-backend paths to be under the /__probe__ sub path

### DIFF
--- a/charts/router-probe-backend/files/openresty.conf
+++ b/charts/router-probe-backend/files/openresty.conf
@@ -59,33 +59,33 @@ http {
       return 404;
     }
 
-    location = /ok {
+    location = /__probe__/ok {
       return 200 '200 OK\n';
     }
 
-    location = /redirect {
+    location = /__probe__/redirect {
       return 301 $scheme://$host/redirected;
     }
 
-    location = /redirected {
+    location = /__probe__/redirected {
       default_type text/plain;
       
       return 200 '200 Redirected landing page\n';
     }
 
-    location = /not-found {
+    location = /__probe__/not-found {
       default_type text/plain;
 
       return 404 '404 Not Found\n';
     }
 
-    location = /internal-server-error {
+    location = /__probe__/internal-server-error {
       default_type text/plain;
 
       return 500 '500 Internal Server Error\n';
     }
 
-    location = /get {
+    location = /__probe__/get {
       default_type text/plain;
       
       limit_except GET { deny all; }
@@ -93,7 +93,7 @@ http {
       return 200 '200 GET OK\n';
     }
 
-    location = /post {
+    location = /__probe__/post {
       default_type text/plain;
       
       limit_except POST { deny all; }
@@ -101,13 +101,13 @@ http {
       return 200 '200 POST OK\n';
     }
 
-    location = /headers/get {
+    location = /__probe__/headers/get {
       limit_except GET { deny all; }
 
       content_by_lua_file "/usr/local/openresty/lua/headers.lua";
     }
 
-    location = /headers/post {
+    location = /__probe__/headers/post {
       limit_except POST { deny all; }
 
       content_by_lua_file "/usr/local/openresty/lua/headers.lua";
@@ -118,7 +118,7 @@ http {
     # Endpoint that isn't cached, which is used to assert that an external
     # service can receive a response from GOV.UK origin on www hostname. It
     # is intended for pingdom monitoring
-    location = /__canary__$ {
+    location = /__probe__/__canary__$ {
       default_type application/json;
       add_header cache-control "max-age=0,no-store,no-cache";
       return 200 '{"message": "Tweet tweet"}\n';

--- a/charts/router-probe-backend/tests/run-tests.sh
+++ b/charts/router-probe-backend/tests/run-tests.sh
@@ -135,7 +135,7 @@ function expect_correct_header_redaction {
       >&2 echo "    Actual:   $HEADER_VALUE"
       exit 1
     fi
-    echo "OK"
+    >&2 echo "OK"
   done
 
   >&2 echo -n "Testing to ensure other headers (X-Non-Redacted specifically) are not redacted by $METHOD in $RESOURCE ... "
@@ -147,7 +147,7 @@ function expect_correct_header_redaction {
     >&2 echo "    Actual:   $HEADER_VALUE"
     exit 1
   fi
-  echo "OK"
+  >&2 echo "OK"
 }
 
 expect_correct_header_redaction "GET" "/__probe__/headers/get"

--- a/charts/router-probe-backend/tests/run-tests.sh
+++ b/charts/router-probe-backend/tests/run-tests.sh
@@ -103,14 +103,14 @@ echo "Executing Tests:"
 echo "============================================="
 {
   expect "GET" "/" "404"
-  expect "GET" "/ok" "200"
-  expect "GET" "/redirect" "301"
-  expect "GET" "/not-found" "404"
-  expect "GET" "/internal-server-error" "500"
-  expect "GET" "/get" "200"
-  expect "POST" "/get" "403"
-  expect "GET" "/post" "403"
-  expect "POST" "/post" "200"
+  expect "GET" "/__probe__/ok" "200"
+  expect "GET" "/__probe__/redirect" "301"
+  expect "GET" "/__probe__/not-found" "404"
+  expect "GET" "/__probe__/internal-server-error" "500"
+  expect "GET" "/__probe__/get" "200"
+  expect "POST" "/__probe__/get" "403"
+  expect "GET" "/__probe__/post" "403"
+  expect "POST" "/__probe__/post" "200"
 } >> /dev/null
 
 function expect_correct_header_redaction {
@@ -150,9 +150,9 @@ function expect_correct_header_redaction {
   echo "OK"
 }
 
-expect_correct_header_redaction "GET" "/headers/get"
-expect "POST" "/headers/get" "403" >>/dev/null
-expect_correct_header_redaction "POST" "/headers/post"
-expect "GET" "/headers/post" "403" >>/dev/null
+expect_correct_header_redaction "GET" "/__probe__/headers/get"
+expect "POST" "/__probe__/headers/get" "403" >>/dev/null
+expect_correct_header_redaction "POST" "/__probe__/headers/post"
+expect "GET" "/__probe__/headers/post" "403" >>/dev/null
 
 echo "============================================="


### PR DESCRIPTION
All the endpoints we intend to call in the router-probe-backend need to be under `/__probe__` which is the static prefix route added in https://github.com/alphagov/router/pull/676