### PR TITLE
router-probe-backend needs its service to listen on port 80, not 8080

### DIFF
--- a/charts/router-probe-backend/templates/service.yaml
+++ b/charts/router-probe-backend/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: ClusterIP
   ports:
     - name: nginx
-      port: 8080
+      port: 80
       targetPort: 80
   selector:
     app: {{ $fullName }}


### PR DESCRIPTION
Need the Service to listen on port 80, not 8080, for the service router-probe-backend