### PR TITLE
Fix redirect location in router-probe-backend and add test for it

### DIFF
--- a/charts/router-probe-backend/files/openresty.conf
+++ b/charts/router-probe-backend/files/openresty.conf
@@ -55,6 +55,8 @@ http {
     access_log /dev/stdout json_event;
     error_log /dev/stderr;
 
+    absolute_redirect off;
+
     location / {
       return 404;
     }
@@ -64,7 +66,7 @@ http {
     }
 
     location = /__probe__/redirect {
-      return 301 $scheme://$host/redirected;
+      return 301 /__probe__/redirected;
     }
 
     location = /__probe__/redirected {

--- a/charts/router-probe-backend/tests/run-tests.sh
+++ b/charts/router-probe-backend/tests/run-tests.sh
@@ -93,10 +93,41 @@ function expect {
     >&2 echo "  Status Code for $RESOURCE:"
     >&2 echo "    Expected: $EXPECTED_STATUS"
     >&2 echo "    Actual:   $ACTUAL_STATUS"
+    return 1
   fi
 
   cat "$TMPFILE"
 }
+
+function expect_redirect_to_location {
+  # Args:
+  #   $1: HTTP Method
+  #   $2: Resource path to curl
+  #   $3: Redirect Location Header Expected in response
+  local METHOD="$1"
+  local RESOURCE="$2"
+  local EXPECTED_LOCATION="$3"
+  local ACTUAL_LOCATION
+
+  >&2 echo -n "Testing ${METHOD} ${RESOURCE} redirects to ${EXPECTED_LOCATION} ... "
+  ACTUAL_LOCATION=$(
+    curl --request "${METHOD}" --verbose "http://127.0.0.1:80${RESOURCE}" 2>&1 | \
+      grep -i '< location:' | \
+      tr -d '\r' | \
+      sed -E 's/.*[Ll]ocation: //'
+  )
+
+  if [ "$ACTUAL_LOCATION" == "$EXPECTED_LOCATION" ]; then
+    >&2 echo "OK"
+  else
+    >&2 echo "ERROR"
+    >&2 echo "  Redirect Location for $RESOURCE:"
+    >&2 echo "    Expected: [$EXPECTED_LOCATION]"
+    >&2 echo "    Actual:   [$ACTUAL_LOCATION]"
+    return 1
+  fi
+}
+
 
 echo "============================================="
 echo "Executing Tests:"
@@ -105,6 +136,7 @@ echo "============================================="
   expect "GET" "/" "404"
   expect "GET" "/__probe__/ok" "200"
   expect "GET" "/__probe__/redirect" "301"
+  expect_redirect_to_location "GET" "/__probe__/redirect" "/__probe__/redirected"
   expect "GET" "/__probe__/not-found" "404"
   expect "GET" "/__probe__/internal-server-error" "500"
   expect "GET" "/__probe__/get" "200"


### PR DESCRIPTION
The redirect was adding the server hostname and scheme, so it was redirecting to `http://router-probe-backend/redirected` which is incorrect, so this PR:

* Turns off absolute redirects
* Fixes the actual location to be `/__probe__/redirected`
* Adds a test which explicitly checks the location header returns is as expected