### PR TITLE
Adding the open search secrets to the app environemnt

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4194,3 +4194,18 @@ govukApplications:
             secretKeyRef:
               name: govuk-ai-accelerator-postgres
               key: DATABASE_URL
+        - name: OPENSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk/ai-accelerator/opensearch
+              key: username
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: govuk/ai-accelerator/opensearch
+              key: url
+        - name: OPENSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk/ai-accelerator/opensearch
+              key: password


### PR DESCRIPTION
adds the URL , username and password for the integration accelerator environments Opensearch to the new Graph tools app environment.