### PR TITLE
Adds ALLOWED_GEOJSON_SLUGS value in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1389,6 +1389,8 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-account-api
               key: bearer_token
+        - name: ALLOWED_GEOJSON_SLUGS
+          value: "driving-test-centres,pfc-cdc"
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- This controls the /api/places endpoint, which will return 404 for all slugs unless they're listed in this variable.
- This means we'll be able to merge the geojson code without causing any data to be exposed until we're ready.