### PR TITLE
Remove opensearch secrets for now

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4196,18 +4196,3 @@ govukApplications:
             secretKeyRef:
               name: govuk-ai-accelerator-postgres
               key: DATABASE_URL
-        - name: OPENSEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: govuk/ai-accelerator/opensearch
-              key: username
-        - name: OPENSEARCH_URL
-          valueFrom:
-            secretKeyRef:
-              name: govuk/ai-accelerator/opensearch
-              key: url
-        - name: OPENSEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: govuk/ai-accelerator/opensearch
-              key: password


### PR DESCRIPTION
This needs some more work to enable parsing the secrets from secret manager. Remove for now whilst doing the work on it, so deployments unbreak.