### PR TITLE
Update slack channel following team name change

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -156,7 +156,7 @@ spec:
         {{- include "slack.text" . | nindent 8 }}
   - name: 'slack-signon-token-expiry'
     slackConfigs:
-    - channel: '#govuk-publishing-platform-system-alerts'
+    - channel: '#govuk-content-apis-system-alerts'
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.expiringtokenstext" . | nindent 8 }}
@@ -210,7 +210,7 @@ spec:
         {{- include "slack.text" . | nindent 8 }}
   - name: 'slack-graphql-notifications'
     slackConfigs:
-    - channel: '#govuk-publishing-platform-system-alerts'
+    - channel: '#govuk-content-apis-system-alerts'
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}


### PR DESCRIPTION
The team is focusing on APIs so the name was changed to reflect that.