### PR TITLE
Adding opensearch credentials for the AI Content app

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -4191,3 +4191,18 @@ govukApplications:
             secretKeyRef:
               name: govuk-ai-accelerator-postgres
               key: DATABASE_URL
+        - name: OPENSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: govuk-ai-accelerator-opensearch
+              key: username
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: govuk-ai-accelerator-opensearch
+              key: url
+        - name: OPENSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: govuk-ai-accelerator-opensearch
+              key: password

--- a/charts/external-secrets/templates/govuk-ai-accelerator/opensearch.yaml
+++ b/charts/external-secrets/templates/govuk-ai-accelerator/opensearch.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: govuk-ai-accelerator-opensearch
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      OpenSearch credentials for the GovUK AI Accelerator OpenSearch domain
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+  dataFrom:
+    - extract:
+        key: govuk/ai-accelerator/opensearch
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
The AI Content exploration relies on opensearch. This PR adds:

(a) The secrets manager mapping config to make the secrets available
(b) adds the secrets to the ENV for integration for the app