### PR TITLE
GOV.UK Chat dashboard: bump Sonnet 4.5 token limit

### DIFF
--- a/charts/monitoring-config/dashboards/govuk-chat-technical.json
+++ b/charts/monitoring-config/dashboards/govuk-chat-technical.json
@@ -577,7 +577,7 @@
             "uid": "cloudwatch"
           },
           "dimensions": {},
-          "expression": "(itc_sonnet_4_5 + cwitc_sonnet_4_5 + (otc_sonnet_4_5 * 5)) / 50000",
+          "expression": "(itc_sonnet_4_5 + cwitc_sonnet_4_5 + (otc_sonnet_4_5 * 5)) / 150000",
           "id": "",
           "label": "Sonnet 4.5",
           "logGroups": [],


### PR DESCRIPTION

Our quota for Sonnet 4.5 has been bumped from 5m tokens/min to 15m
tokens/min.

This changes the graph that shows the percentage of tokens used to
reflect the rate limit increase.
