### PR TITLE
Search apiv2 degraded long metrics alerting levels

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -153,7 +153,7 @@ groups:
         expr: search_api_v2:search_successful_requests:ratio_rate24h < 0.9999
         for: 24h
         labels:
-          severity: critical
+          severity: warning
           destination: slack-search-team
         annotations:
           summary: "Search API v2: Degraded search performance (long)"

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -333,7 +333,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: SearchDegradedLong
-              severity: critical
+              severity: warning
               destination: slack-search-team
             exp_annotations:
               summary: "Search API v2: Degraded search performance (long)"


### PR DESCRIPTION
A search success rate of 99.998% over 24hours is not a critical alert it's a warning that we should investigate.

JIRA https://gov-uk.atlassian.net/browse/SCH-2089