### PR TITLE
[WHIT-3439] Block public access to whitehall /healthcheck/* (integration)

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3984,6 +3984,12 @@ govukApplications:
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
+      nginxConfigMap:
+        # Block public access to internal healthcheck endpoints.
+        extraServerConf: |
+          location ~ ^/healthcheck(/|$|\.) {
+            return 403;
+          }
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
## Summary
Add an nginx rule on Whitehall (integration only) that returns 403 for any request to `/healthcheck/*`. K8s liveness/readiness probes hit the pod directly on the app port, bypassing the nginx sidecar, so probes are unaffected — only external traffic is blocked.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3439)

## Why
Whitehall's healthcheck endpoints are currently reachable on the public internet at `https://whitehall-admin.integration.publishing.service.gov.uk/healthcheck/*`. The ticket flagged this alongside two Sentry alerts caused by scanners hitting `/healthcheck` and `/healthcheck.json` (which don't exist as routes, so the controller raises and returns 500).

The two legacy JSON endpoints `/healthcheck/overdue` and `/healthcheck/unenqueued_scheduled_editions` were originally consumed by Icinga and are now superseded by the Prometheus gauges `whitehall_scheduled_publishing_overdue` and `whitehall_unenqueued_scheduled_publications`, populated by `lib/collectors/scheduled_publishing_collector.rb`. Nothing external still relies on them.

90 days of Logit data show:
- 67 total hits across all `/healthcheck*` paths
- 31 of those returned 500 (the two unmapped paths)
- Top sources are a handful of IPs sending opportunistic `curl/8.5.0`
  probes — no legitimate monitoring service is involved
- K8s probe traffic does not appear in nginx logs at all, confirming it
  bypasses the sidecar

## Why integration only
Rolling out to one environment first so we can verify probes stay green and external requests do return 403 before extending to staging and production. Easy to revert by reverting this PR.

## Test plan
- [x] After deploy, `curl -i https://whitehall-admin.integration.publishing.service.gov.uk/healthcheck/live` returns 403
- [x] Same for `/healthcheck/ready`, `/healthcheck/overdue`, `/healthcheck/unenqueued_scheduled_editions`, `/healthcheck`, `/healthcheck.json`
- [x] Pod stays Ready in Argo CD (readiness probe still succeeding inside the cluster)
- [x] No new pod restarts caused by liveness probe failures
- [x] Sentry stops receiving the two `/healthcheck` / `/healthcheck.json` 500 alerts

