### PR TITLE
[WHIT-3439] Block public whitehall /healthcheck/* (staging + production)

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3916,6 +3916,12 @@ govukApplications:
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
+      nginxConfigMap:
+        # Block public access to internal healthcheck endpoints.
+        extraServerConf: |
+          location ~ ^/healthcheck(/|$|\.) {
+            return 403;
+          }
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3848,6 +3848,12 @@ govukApplications:
       nginxClientMaxBodySize: *max-upload-size
       nginxDenyCrawlers: true
       nginxProxyReadTimeout: 60s
+      nginxConfigMap:
+        # Block public access to internal healthcheck endpoints.
+        extraServerConf: |
+          location ~ ^/healthcheck(/|$|\.) {
+            return 403;
+          }
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
## Summary
Mirror the nginx rule from #4278 onto `whitehall-admin` in staging and production: any external request to `/healthcheck/*` now returns 403. K8s liveness/readiness probes hit the pod directly on the app port, bypassing the nginx sidecar, so probes are unaffected — only external traffic is blocked.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3439)

## Why
Same rationale as #4278: the healthcheck endpoints are reachable on the public internet and were causing two Sentry alerts (scanners hitting `/healthcheck` and `/healthcheck.json` which don't exist as routes). Integration has been running with this rule since #4278 merged — probes stayed green, no Sentry regressions, and public requests now return 403 as expected.

The two legacy JSON endpoints `/healthcheck/overdue` and `/healthcheck/unenqueued_scheduled_editions` are superseded by the Prometheus gauges `whitehall_scheduled_publishing_overdue` and `whitehall_unenqueued_scheduled_publications`, populated by `lib/collectors/scheduled_publishing_collector.rb`. Nothing external still relies on them.

## Test plan
- [x] After deploy to staging, `curl -i https://whitehall-admin.staging.publishing.service.gov.uk/healthcheck/live` returns 403
- [x] After deploy to production, `curl -i https://whitehall-admin.publishing.service.gov.uk/healthcheck/live` returns 403
- [x] Same for `/healthcheck/ready`, `/healthcheck/overdue`, `/healthcheck/unenqueued_scheduled_editions`, `/healthcheck`, `/healthcheck.json` in both environments
- [x] Pods stay Ready in Argo CD (readiness probe still succeeding inside the cluster)
- [x] No new pod restarts caused by liveness probe failures
- [ ] Sentry stops receiving the two `/healthcheck` / `/healthcheck.json` 500 alerts on production