### PR TITLE
Enable Renovate in alphagov/govuk-job-request-operator

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
         "alphagov/govuk-fastly-secrets",
         "alphagov/govuk-helm-charts",
         "alphagov/govuk-infrastructure",
+        "alphagov/govuk-job-request-operator",
         "alphagov/govuk-user-reviewer",
         "alphagov/router",
         "alphagov/terraform-govuk-infrastructure-sensitive"


### PR DESCRIPTION
## What

Begins running renovate against `alphagov/govuk-job-request-operator` 