### PR TITLE
[PP-7768] Add Slack alert for old Sidekiq locks

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -124,9 +124,9 @@ spec:
       groupInterval: 30m
     - matchers:
         - name: destination
-          value: slack-graphql-notifications
+          value: slack-content-apis-team
           matchType: =
-      receiver: 'slack-graphql-notifications'
+      receiver: 'slack-content-apis-team'
       repeatInterval: 1h
       groupWait: 5m
       groupInterval: 30m
@@ -208,7 +208,7 @@ spec:
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}
-  - name: 'slack-graphql-notifications'
+  - name: 'slack-content-apis-team'
     slackConfigs:
     - channel: '#govuk-content-apis-system-alerts'
       {{- include "slack.template" . | nindent 6 }}

--- a/charts/monitoring-config/rules/graphql.yaml
+++ b/charts/monitoring-config/rules/graphql.yaml
@@ -25,7 +25,7 @@ groups:
         for: 5m
         labels:
           severity: warning
-          destination: slack-graphql-notifications
+          destination: slack-content-apis-team
         annotations:
           summary: Elevated GraphQL request duration
           description: >-
@@ -44,7 +44,7 @@ groups:
         for: 5m
         labels:
           severity: warning
-          destination: slack-graphql-notifications
+          destination: slack-content-apis-team
         annotations:
           summary: Elevated GraphQL request duration
           description: >-
@@ -63,7 +63,7 @@ groups:
         for: 10m
         labels:
           severity: critical
-          destination: slack-graphql-notifications
+          destination: slack-content-apis-team
         annotations:
           summary: Elevated GraphQL request duration
           description: >-
@@ -82,7 +82,7 @@ groups:
         for: 10m
         labels:
           severity: critical
-          destination: slack-graphql-notifications
+          destination: slack-content-apis-team
         annotations:
           summary: Elevated GraphQL request duration
           description: >-
@@ -105,7 +105,7 @@ groups:
         for: 4m
         labels:
           severity: warning
-          destination: slack-graphql-notifications
+          destination: slack-content-apis-team
         annotations:
           summary: Elevated GraphQL error rate
           description: >-

--- a/charts/monitoring-config/rules/graphql_tests.yaml
+++ b/charts/monitoring-config/rules/graphql_tests.yaml
@@ -67,7 +67,7 @@ tests:
           - exp_labels:
               alertname: LongRequestDurationFastSchemas
               severity: warning
-              destination: slack-graphql-notifications
+              destination: slack-content-apis-team
             exp_annotations:
               summary: Elevated GraphQL request duration
               description: >-
@@ -79,7 +79,7 @@ tests:
           - exp_labels:
               alertname: LongRequestDurationFastSchemas
               severity: critical
-              destination: slack-graphql-notifications
+              destination: slack-content-apis-team
             exp_annotations:
               summary: Elevated GraphQL request duration
               description: >-
@@ -111,7 +111,7 @@ tests:
           - exp_labels:
               alertname: LongRequestDurationSlowSchemas
               severity: warning
-              destination: slack-graphql-notifications
+              destination: slack-content-apis-team
             exp_annotations:
               summary: Elevated GraphQL request duration
               description: >-
@@ -123,7 +123,7 @@ tests:
           - exp_labels:
               alertname: LongRequestDurationSlowSchemas
               severity: critical
-              destination: slack-graphql-notifications
+              destination: slack-content-apis-team
             exp_annotations:
               summary: Elevated GraphQL request duration
               description: >-
@@ -182,7 +182,7 @@ tests:
           - exp_labels:
               alertname: HighQueryFailureRate
               severity: warning
-              destination: slack-graphql-notifications
+              destination: slack-content-apis-team
             exp_annotations:
               summary: Elevated GraphQL error rate
               description: >-

--- a/charts/monitoring-config/rules/publishing_api.yaml
+++ b/charts/monitoring-config/rules/publishing_api.yaml
@@ -1,0 +1,16 @@
+groups:
+  - name: PublishingApiAlerts
+    rules:
+      - alert: PublishingApiOldLocksPresent
+        expr: >-
+          publishing_api_old_lock_count > 0
+        for: 20m
+        labels:
+          severity: warning
+          destination: slack-content-apis-team
+        annotations:
+          summary: Sidekiq jobs locked for too long in Publishing API.
+          description: >-
+            Sidekiq jobs have been locked for more than one hour in Publishing API.
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/alerts/publishing-api-old-locks-present.md

--- a/charts/monitoring-config/rules/publishing_api_tests.yaml
+++ b/charts/monitoring-config/rules/publishing_api_tests.yaml
@@ -1,0 +1,30 @@
+rule_files:
+  - publishing_api.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - input_series:
+      - series: 'publishing_api_old_lock_count'
+        values: '0x20'
+    alert_rule_test:
+      - alertname: PublishingApiOldLocksPresent
+        eval_time: 20m
+        exp_alerts: []
+  - input_series:
+      - series: 'publishing_api_old_lock_count'
+        values: '1x20'
+    alert_rule_test:
+      - alertname: PublishingApiOldLocksPresent
+        eval_time: 20m
+        exp_alerts:
+          - exp_labels:
+              alertname: PublishingApiOldLocksPresent
+              severity: warning
+              destination: slack-content-apis-team
+            exp_annotations:
+              summary: Sidekiq jobs locked for too long in Publishing API.
+              description: >-
+                Sidekiq jobs have been locked for more than one hour in Publishing API.
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/alerts/publishing-api-old-locks-present.md


### PR DESCRIPTION
The Content APIs team would like to be informed when the `sidekiq-unique-jobs` gem fails to release locks after Sidekiq jobs have completed.

Adding a Slack notification to inform our team when this occurs.

Depends on https://github.com/alphagov/publishing-api/pull/4077.