### PR TITLE
Test Kyverno Policy for Cosign in Integration

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kyverno-policies
+description: A Helm chart for deploying Kyverno admission and mutation policies
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/kyverno-policies/templates/policy.yaml
+++ b/charts/kyverno-policies/templates/policy.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.sigstorePolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: Policy # Or "ClusterPolicy" for cluster-wide enforcement
+metadata:
+  name: require-signed-images
+  namespace: {{ default "sigstore-test" .Release.Namespace }} # Scopes enforcement to ONLY this namespace
+  annotations:
+    policies.kyverno.io/title: Require Keyless Cosign Signatures
+    policies.kyverno.io/description: >-
+      This policy enforces that any Pod deployed to this namespace must use
+      an image signed via keyless (OIDC) signing in GitHub Actions.
+spec:
+  validationFailureAction: Enforce # Or "Audit" for non-blocking enforcement
+  background: false
+  rules:
+    - name: verify-github-actions-signature
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      verifyImages:
+      - imageReferences:
+        # Best Practice: Scope to specific regisries/images
+        # rather than "*" to avoid breaking standard sidecars or init containers.
+        - "ghcr.io/alphagov/*"
+        - "*/alphagov/*"
+        mutateDigest: true # Automatically changes mutable tags (like :latest) to the verified SHA256 digest
+        required: true
+        attestors:
+        - count: 1
+          entries:
+          - keyless:
+              # Typical: https://github.com/ORG/REPO/.github/workflows/WORKFLOW.yml@refs/heads/BRANCH
+              subject: {{ required "A valid OIDC subject is required for Sigstore" .Values.sigstorePolicy.subject | quote }}
+              issuer: "https://token.actions.githubusercontent.com"
+{{- end }}

--- a/charts/kyverno-policies/values-integration.yaml
+++ b/charts/kyverno-policies/values-integration.yaml
@@ -1,0 +1,4 @@
+sigstorePolicy:
+  enabled: true
+  # Provide the default OIDC subject:
+  subject: "https://github.com/alphagov/*/.github/workflows/*"

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -1,0 +1,4 @@
+sigstorePolicy:
+  enabled: false
+  # Provide the default OIDC subject:
+  subject: ""


### PR DESCRIPTION
## What?
This applies a Kyverno Policy that:

* Is for Integration only
* Applies to the sigstore-test Namespace only
* Aims to prove that any cosigned image will run
* Aims to prove that any unsigned image will fail to run

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/4258