### PR TITLE
Actually deploy Kyverno Policies via ArgoCD.

### DIFF
--- a/charts/app-config/templates/kyverno-policies.yaml
+++ b/charts/app-config/templates/kyverno-policies.yaml
@@ -1,0 +1,24 @@
+{{ if eq .Values.govukEnvironment "integration" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno-policies
+  namespace: {{ .Values.argoNamespace | default .Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: govuk
+  source:
+    repoURL: git@github.com/alphagov/govuk-helm-charts
+    path: charts/kyverno-policies
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sigstore-test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ApplyOutOfSyncOnly=true
+    - ServerSideApply=true
+{{ end }}


### PR DESCRIPTION
## What?
In a [previous PR](https://github.com/alphagov/govuk-helm-charts/pull/4294), we added a chat to deploy Kyverno Policies (currently to test enforcing signed images in `sigstore-test`).

Now we actually need to apply this chart in Integration. So it would help if we actually deploy this via an ArgoCD application.