### PR TITLE
Fix role_attribute_path grafana ini config option for ephemeral clusters

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/_ephemeral-config.tpl
+++ b/charts/kube-prometheus-stack-bootstrap/templates/_ephemeral-config.tpl
@@ -64,7 +64,7 @@
       "enabled": true
       "api_url": "https://dex.{{ $domainSuffix }}/userinfo"
       "auth_url": "https://dex.{{ $domainSuffix }}/auth"
-      "role_attribute_path": "'Admin'"
+      "role_attribute_path": "\"'Admin'\"" # This needs to end up double quoted in the ini file, so we need triple quoting here :cry:
       "token_url": "https://dex.{{ $domainSuffix }}/token"
       "scopes": "openid profile email groups"
     "date_formats":


### PR DESCRIPTION
In an eph cluster when you log into grafana as the ephemeral user you are not admin, this is because in the generated ini file becomes:

```
  role_attribute_path = 'Admin'
```

unfortunately the Ini parser sees `'Admin'` as a whole string, and so parses the value to be `Admin` which means it tries to look up in the id token for a field called Admin, which doesn't exist, to get the ini parser to parse out the JMESPath string of Admin we need to double quote it (so the ini parser resolves it to `'Admin'`.

To make this more painful it's being set in a [yaml file](https://noyaml.com/) where it is double quoted, but the yaml parser is removing the outer level of quoting, so we need it to be triple quoted 😢 to end up in the ini file double quoted, to be parsed by the ini parser as a quoted string