### PR TITLE
Load values files for Kyverno Policies Chart

### DIFF
--- a/charts/app-config/templates/kyverno-policies.yaml
+++ b/charts/app-config/templates/kyverno-policies.yaml
@@ -11,6 +11,11 @@ spec:
   source:
     repoURL: git@github.com/alphagov/govuk-helm-charts
     path: charts/kyverno-policies
+    helm:
+      valueFiles:
+      - values.yaml
+      - values-{{ .Values.govukEnvironment }}.yaml
+      ignoreMissingValueFiles: true
   destination:
     server: https://kubernetes.default.svc
     namespace: sigstore-test
@@ -19,6 +24,7 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
+    - CreateNamespace=true
     - ApplyOutOfSyncOnly=true
     - ServerSideApply=true
 {{ end }}


### PR DESCRIPTION
## What?
We could see the kyverno-policies application loaded into Argo in Integration (good), but it had nothing in it (bad).

Turns out, `.Values.sigstorePolicy.enabled` was evaluating to `false` because the values-integration file wasn't being loaded. This should fix that.