### PR TITLE
Add rekor.url property to keyless attestor.

### DIFF
--- a/charts/kyverno-policies/templates/policy.yaml
+++ b/charts/kyverno-policies/templates/policy.yaml
@@ -34,4 +34,6 @@ spec:
               # Typical: https://github.com/ORG/REPO/.github/workflows/WORKFLOW.yml@refs/heads/BRANCH
               subject: {{ required "A valid OIDC subject is required for Sigstore" .Values.sigstorePolicy.subject | quote }}
               issuer: "https://token.actions.githubusercontent.com"
+              rekor:
+                url: "https://rekor.sigstore.dev"
 {{- end }}


### PR DESCRIPTION
## What?
I managed to expose an error that revealed an empty (required) property we weren't setting that was causing the ArgoCD deployment to fail. For now we'll use the public sigstore repo unless we later decide we want to use our own.