### PR TITLE
Update values-integration.yaml

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1942,9 +1942,7 @@ govukApplications:
       config:
         mongo:
           dbHosts:
-            - licensify-documentdb-0.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
-            - licensify-documentdb-1.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
-            - licensify-documentdb-2.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
+            - licensify-documentdb-clone-0.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
         adminBaseUrl: https://licensify-admin.integration.publishing.service.gov.uk
         frontendBaseUrl: https://www.integration.publishing.service.gov.uk
         signonBaseUrl: https://signon.integration.publishing.service.gov.uk


### PR DESCRIPTION
Update integration DB settings to test only the newer migrated document DB version from v3 to v5.
This is only for testing only, but we need to test it on a running system, (as local builds are not setup for document db format databases currently as they use mongo instead).