### PR TITLE
Sch 2143 add alert for number of autocomplete suggestions

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -79,6 +79,13 @@ groups:
             /
             sum (search_api_v2:search_requests:rate1h) > 0
           ) or vector(1)
+      - record: search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h
+        expr: |
+          histogram_quantile(1, sum by(le) (
+            increase(
+              search_api_v2_discovery_engine_autocomplete_suggestions_response_bucket[1h]
+            )
+          )) and sum(increase(search_api_v2_discovery_engine_autocomplete_suggestions_response_bucket{le="+Inf"}[1h])) > 500
       - alert: SearchDegradedMid
         expr: search_api_v2:search_successful_requests:ratio_rate1h < 0.999
         for: 2h
@@ -94,6 +101,21 @@ groups:
           description: >-
             1 hour rolling success rate for search requests has dropped below 99.9% for more than 2
             hours.
+      - alert: AutocompleteDegradedMid
+        expr: search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h == 0
+        for: 10m
+        labels:
+          severity: warning
+          destination: slack-search-team
+        annotations:
+          summary: "Search API v2: Degraded autocomplete performance (mid)"
+          grafana_path: >-
+            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+          runbook_url: >-
+            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+          description: >-
+            Maximum number of autocomplete suggestions returned by Google Cloud Discovery Engine over 1 hour
+            has dropped to zero for more than 10 minutes.
 
   - name: SearchApiV2LongMetrics
     interval: 1h

--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -21,30 +21,12 @@ groups:
               }[5m]
             )
           )
-      - record: search_api_v2:autocomplete_requests:rate5m
-        expr: |
-          sum by (status) (
-            rate(
-              http_requests_total{
-                namespace="apps",
-                job="search-api-v2",
-                controller="autocompletes"
-              }[5m]
-            )
-          )
       - record: search_api_v2:search_successful_requests:ratio_rate5m
         expr: |
           (
             sum (search_api_v2:search_requests:rate5m{status="200"})
             /
             sum (search_api_v2:search_requests:rate5m) > 0
-          ) or vector(1)
-      - record: search_api_v2:autocomplete_successful_requests:ratio_rate5m
-        expr: |
-          (
-            sum (search_api_v2:autocomplete_requests:rate5m{status="200"})
-            /
-            sum (search_api_v2:autocomplete_requests:rate5m) > 0
           ) or vector(1)
       - alert: HighVertexP90Latency
         expr: search_api_v2:vertex_search_response_times_p90:rate5m > 2
@@ -75,21 +57,6 @@ groups:
           description: >-
             5 minute rolling success rate for search requests has dropped below 99% for more than 10
             minutes.
-      - alert: AutocompleteDegradedAcute
-        expr: search_api_v2:autocomplete_successful_requests:ratio_rate5m < 0.9
-        for: 10m
-        labels:
-          severity: warning
-          destination: slack-search-team
-        annotations:
-          summary: "Search API v2: Degraded autocomplete performance (acute)"
-          grafana_path: >-
-            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
-          runbook_url: >-
-            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
-          description: >-
-            5 minute rolling success rate for autocomplete requests has dropped below 90% for more
-            than 10 minutes.
 
   - name: SearchApiV2MidMetrics
     interval: 5m

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -169,6 +169,28 @@ tests:
           - labels: 'search_api_v2:search_successful_requests:ratio_rate1h{}'
             value: 0.92
 
+  # Tests for search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h
+  - interval: 5m
+    input_series:
+      # 1st hour of responses all have 5 suggestions, next hour's have 0
+      - series: 'search_api_v2_discovery_engine_autocomplete_suggestions_response_bucket{le="0.0"}'
+        values: '0x11 0+100x13'
+      - series: 'search_api_v2_discovery_engine_autocomplete_suggestions_response_bucket{le="5.0"}'
+        values: '0+100x24'
+      - series: 'search_api_v2_discovery_engine_autocomplete_suggestions_response_bucket{le="+Inf"}'
+        values: '0+100x24'
+    promql_expr_test:
+      - expr: search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h
+        eval_time: 1h55m
+        exp_samples:
+          - value: 5
+            labels: 'search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h'
+      - expr: 'search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h'
+        eval_time: 2h
+        exp_samples:
+          - value: 0
+            labels: 'search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h'
+
   # Tests for SearchDegradedMid
   - interval: 5m
     input_series:
@@ -194,6 +216,31 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "1 hour rolling success rate for search requests has dropped below 99.9% for more than 2 hours."
+
+  # Tests for AutocompleteDegradedMid
+  - interval: 5m
+    input_series:
+      - series: 'search_api_v2:discovery_engine_autocomplete_suggestions_response:p100_increase1h'
+        values: '5x12 0x12'
+    alert_rule_test:
+      - eval_time: 1h10m
+        alertname: AutocompleteDegradedMid
+        exp_alerts: []
+      - eval_time: 1h15m
+        alertname: AutocompleteDegradedMid
+        exp_alerts:
+          - exp_labels:
+              alertname: AutocompleteDegradedMid
+              severity: warning
+              destination: slack-search-team
+            exp_annotations:
+              summary: "Search API v2: Degraded autocomplete performance (mid)"
+              grafana_path: >-
+                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
+              runbook_url: >-
+                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
+              description: "Maximum number of autocomplete suggestions returned by Google Cloud Discovery Engine over 1 hour
+            has dropped to zero for more than 10 minutes."
 
   # Tests for search_api_v2:search_requests:rate24h
   - interval: 1h

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -49,32 +49,6 @@ tests:
           - labels: 'search_api_v2:search_requests:rate5m{status="502"}'
             value: 0.05
 
-  # Tests for search_api_v2:autocomplete_requests:rate5m
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0+120x5'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0+12x5'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="502"}'
-        values: '0+6x5'
-    promql_expr_test:
-      - expr: search_api_v2:autocomplete_requests:rate5m{status="200"}
-        eval_time: 5m
-        exp_samples:
-          - labels: 'search_api_v2:autocomplete_requests:rate5m{status="200"}'
-            value: 2
-      - expr: search_api_v2:autocomplete_requests:rate5m{status="500"}
-        eval_time: 5m
-        exp_samples:
-          - labels: 'search_api_v2:autocomplete_requests:rate5m{status="500"}'
-            value: 0.2
-      - expr: search_api_v2:autocomplete_requests:rate5m{status="502"}
-        eval_time: 5m
-        exp_samples:
-          - labels: 'search_api_v2:autocomplete_requests:rate5m{status="502"}'
-            value: 0.1
-
   # Tests for search_api_v2:search_successful_requests:ratio_rate5m
   - interval: 1m
     input_series:
@@ -93,25 +67,6 @@ tests:
         exp_samples:
           - labels: 'search_api_v2:search_successful_requests:ratio_rate5m{}'
             value: 0.92
-
-  # Tests for search_api_v2:autocomplete_successful_requests:ratio_rate5m
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0x5 0+85x5'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0x5 0+15x5'
-    promql_expr_test:
-      - expr: search_api_v2:autocomplete_successful_requests:ratio_rate5m
-        eval_time: 5m
-        exp_samples:
-          - labels: 'search_api_v2:autocomplete_successful_requests:ratio_rate5m{}'
-            value: 1  # No requests means 100% success rate
-      - expr: search_api_v2:autocomplete_successful_requests:ratio_rate5m
-        eval_time: 10m
-        exp_samples:
-          - labels: 'search_api_v2:autocomplete_successful_requests:ratio_rate5m{}'
-            value: 0.85
 
   # Tests for HighVertexP90Latency alert
   - interval: 1m
@@ -168,38 +123,6 @@ tests:
               runbook_url: >-
                 https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
               description: "5 minute rolling success rate for search requests has dropped below 99% for more than 10 minutes."
-
-  # Tests for AutocompleteDegradedAcute alert
-  - interval: 1m
-    input_series:
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="200"}'
-        values: '0x10 0+90x10 0+89x13'
-      - series: 'http_requests_total{namespace="apps", job="search-api-v2", controller="autocompletes", status="500"}'
-        values: '0x10 0+10x10 0+11x13'
-    alert_rule_test:
-      - eval_time: 11m
-        alertname: AutocompleteDegradedAcute
-        exp_alerts: []
-      - eval_time: 20m
-        alertname: AutocompleteDegradedAcute
-        exp_alerts: []
-      - eval_time: 30m
-        alertname: AutocompleteDegradedAcute
-        exp_alerts: []
-      - eval_time: 33m
-        alertname: AutocompleteDegradedAcute
-        exp_alerts:
-          - exp_labels:
-              alertname: AutocompleteDegradedAcute
-              severity: warning
-              destination: slack-search-team
-            exp_annotations:
-              summary: "Search API v2: Degraded autocomplete performance (acute)"
-              grafana_path: >-
-                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
-              runbook_url: >-
-                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
-              description: "5 minute rolling success rate for autocomplete requests has dropped below 90% for more than 10 minutes."
 
   # Tests for search_api_v2:search_requests:rate1h
   - interval: 5m


### PR DESCRIPTION
- Removes old AutocompleteDegradedAcute alert, which is no longer helpful now that we're handling GCP errors within search-api-v2, so these return a 200 status. (See https://github.com/alphagov/search-api-v2/pull/677)
- Adds new autocomplete alerting that checks the maximum number of autocomplete suggestions we return from a request to Google Cloud Discovery Engine, and raises when this drops to zero.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2143