### PR TITLE
Remove HighVertexP90Latency alert

### DIFF
--- a/charts/monitoring-config/rules/search_api_v2.yaml
+++ b/charts/monitoring-config/rules/search_api_v2.yaml
@@ -2,14 +2,6 @@ groups:
   - name: SearchApiV2AcuteMetrics
     interval: 1m
     rules:
-      - record: search_api_v2:vertex_search_response_times_p90:rate5m
-        expr: |
-          histogram_quantile(0.9, sum by(le) (
-            rate(
-              search_api_v2_vertex_search_request_duration_bucket[5m]
-            )
-          )
-          )
       - record: search_api_v2:search_requests:rate5m
         expr: |
           sum by (status) (
@@ -46,20 +38,6 @@ groups:
             /
             sum (search_api_v2:autocomplete_requests:rate5m) > 0
           ) or vector(1)
-      - alert: HighVertexP90Latency
-        expr: search_api_v2:vertex_search_response_times_p90:rate5m > 2
-        for: 5m
-        labels:
-          severity: critical
-          destination: slack-search-team
-        annotations:
-          summary: "High Vertex Search Latency (90th percentile)"
-          grafana_path: >-
-            d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
-          runbook_url: >-
-            https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
-          description: >-
-            Google Vertex search request duration has exceeded 2 seconds for more than 5 minutes.
       - alert: SearchDegradedAcute
         expr: search_api_v2:search_successful_requests:ratio_rate5m < 0.99
         for: 10m

--- a/charts/monitoring-config/rules/search_api_v2_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_v2_tests.yaml
@@ -4,25 +4,6 @@ rule_files:
   - search_api_v2.yaml
 
 tests:
-  # Tests for search_api_v2:vertex_search_response_times_p90:rate5m
-  - interval: 1m
-    input_series:
-      # Bucket 0.5: 0 requests
-      - series: 'search_api_v2_vertex_search_request_duration_bucket{le="0.5"}'
-        values: '0x10'
-      # Bucket 1.0: 90% of total requests (18 req/min * 5 min = 90 total requests.)
-      - series: 'search_api_v2_vertex_search_request_duration_bucket{le="1"}'
-        values: '0+18x10'
-      # Bucket +Inf: 100% of total requests (20 req/min * 5 min = 100 total requests.)
-      - series: 'search_api_v2_vertex_search_request_duration_bucket{le="+Inf"}'
-        values: '0+20x10'
-    promql_expr_test:
-      - expr: search_api_v2:vertex_search_response_times_p90:rate5m
-        eval_time: 5m
-        exp_samples:
-          - value: 1
-            labels: 'search_api_v2:vertex_search_response_times_p90:rate5m'
-
   # Tests for search_api_v2:search_requests:rate5m
   - interval: 1m
     input_series:
@@ -112,30 +93,6 @@ tests:
         exp_samples:
           - labels: 'search_api_v2:autocomplete_successful_requests:ratio_rate5m{}'
             value: 0.85
-
-  # Tests for HighVertexP90Latency alert
-  - interval: 1m
-    input_series:
-      - series: 'search_api_v2:vertex_search_response_times_p90:rate5m'
-        values: '2.5x10'
-    alert_rule_test:
-      - eval_time: 4m
-        alertname: HighVertexP90Latency
-        exp_alerts: []
-      - eval_time: 5m
-        alertname: HighVertexP90Latency
-        exp_alerts:
-          - exp_labels:
-              alertname: HighVertexP90Latency
-              severity: critical
-              destination: slack-search-team
-            exp_annotations:
-              summary: "High Vertex Search Latency (90th percentile)"
-              grafana_path: >-
-                d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser
-              runbook_url: >-
-                https://docs.publishing.service.gov.uk/manual/search-alerts-and-monitoring.html#alertmanager
-              description: "Google Vertex search request duration has exceeded 2 seconds for more than 5 minutes."
 
   # Tests for SearchDegradedAcute alert
   - interval: 1m


### PR DESCRIPTION
Now that we have a 2-second timeout for search requests [1], there is no need for this alert because it will never be triggered.

[1] https://github.com/alphagov/search-api-v2/blob/main/app/services/discovery_engine/clients.rb#L17