### PR TITLE
[PP-7776] Remove publishing-api-read-replica deployment in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2468,54 +2468,6 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-bigquery
               key: client-secret
-  - name: publishing-api-read-replica
-    repoName: publishing-api
-    postSyncWorkflowEnabled: "false"
-    helmValues:
-      arch: arm64
-      appResources:
-        limits:
-          cpu: 2
-          memory: 1.5Gi
-        requests:
-          cpu: 20m
-          memory: 768Mi
-      nginxClientMaxBodySize: 2M
-      dbMigrationEnabled: false
-      uploadAssets:
-        enabled: false
-      rails:
-        createKeyBaseSecret: false
-      sentry:
-        createSecret: false
-      extraEnv:
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-publishing-api
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-publishing-api
-              key: oauth_secret
-        - name: GOVUK_CONTENT_SCHEMAS_PATH
-          value: /app/content_schemas
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: publishing-api-postgres
-              key: DATABASE_URL
-        - name: REPLICA_DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: publishing-api-postgres
-              key: REPLICA_DATABASE_URL
-        - name: RAILS_ENV
-          value: production_replica
-        - name: DISABLE_QUEUE_PUBLISHER
-          value: "true"
-      cronTasks: []
   - name: release
     helmValues:
       arch: arm64

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -351,8 +351,6 @@ govukApplications:
           value: "0"
         - name: GRAPHQL_RATE_WORLD_INDEX
           value: "0"
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
       cronTasks: []
   - name: draft-collections
     repoName: collections
@@ -1225,8 +1223,6 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.staging.govuk-internal.digital
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
       cronTasks: []
   - name: draft-feedback
     repoName: feedback
@@ -1473,8 +1469,6 @@ govukApplications:
               key: api_key
         - name: WEB_CONCURRENCY
           value: '4'
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
       nginxConfigMap:
         extraServerConf: |
           location ~ /government/uploads/(?<item_path>.+) {

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -343,14 +343,6 @@ govukApplications:
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
-        - name: GRAPHQL_RATE_MINISTERS_INDEX
-          value: "0"
-        - name: GRAPHQL_RATE_ROLE
-          value: "0"
-        - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0"
-        - name: GRAPHQL_RATE_WORLD_INDEX
-          value: "0"
       cronTasks: []
   - name: draft-collections
     repoName: collections
@@ -1408,60 +1400,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
-        - name: GRAPHQL_RATE_ANSWER
-          value: "0"
-        - name: GRAPHQL_RATE_CALENDAR
-          value: "0"
-        - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0"
-        - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0"
-        - name: GRAPHQL_RATE_CORPORATE_INFORMATION_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_DOCUMENT_COLLECTION
-          value: "0"
-        - name: GRAPHQL_RATE_FATALITY_NOTICE
-          value: "0"
-        - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0"
-        - name: GRAPHQL_RATE_GUIDE
-          value: "0"
-        - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0"
-        - name: GRAPHQL_RATE_LANDING_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_LOCAL_TRANSACTION
-          value: "0"
-        - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0"
-        - name: GRAPHQL_RATE_PLACE
-          value: "0"
-        - name: GRAPHQL_RATE_PUBLICATION
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0"
-        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
-          value: "0"
-        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
-          value: "0"
-        - name: GRAPHQL_RATE_SPEECH
-          value: "0"
-        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
-          value: "0"
-        - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_TRANSACTION
-          value: "0"
         - name: OS_MAPS_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We’re removing Publishing API read replica in staging (and shortly in production) to reduce cost as we’re not actively using it at the moment.

Depends on (and includes commits):
- https://github.com/alphagov/govuk-helm-charts/pull/4310