### PR TITLE
Update ckan-postgres backup configuration

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -534,7 +534,6 @@ cronjobs:
         - op: backup
 
     ckan-postgres:
-      suspend: true
       schedule: "43 3 * * 1"
       db: ckan_production
       operations:


### PR DESCRIPTION
Removed the suspend option for ckan-postgres backup to enable restore and backup on Integration

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?search=aws&selectedIssue=DGUK-686