### PR TITLE
feat: add CKAN anonymisation script for integration restore (DGUK-688)

### DIFF
--- a/charts/db-backup/scripts/ckan.sql
+++ b/charts/db-backup/scripts/ckan.sql
@@ -19,19 +19,17 @@
 -- Excludes active sysadmin accounts with a @dsit.gov.uk email — these are
 -- real admin accounts that must remain functional after restore.
 
-UPDATE public."user"
+UPDATE public.user
 SET
-  name     = 'user_' || id,
+  name = 'user_' || id,
   fullname = CASE
-               WHEN fullname IS NOT NULL THEN repeat('*', length(fullname))
-               ELSE NULL
-             END,
-  email    = 'user_' || id || '@example.com',
-  apikey   = CASE
-               WHEN apikey IS NOT NULL THEN repeat('*', length(apikey))
-               ELSE NULL
-             END
-WHERE NOT (sysadmin = true AND state = 'active' AND email ILIKE '%@dsit.gov.uk');
+    WHEN fullname IS NOT NULL THEN repeat('*', length(fullname))
+  END,
+  email = 'user_' || id || '@example.com',
+  apikey = CASE
+    WHEN apikey IS NOT NULL THEN repeat('*', length(apikey))
+  END
+WHERE NOT (sysadmin = TRUE AND state = 'active' AND email ILIKE '%@dsit.gov.uk');
 
 -- ---------------------------------------------------------------------------
 -- package
@@ -42,22 +40,18 @@ WHERE NOT (sysadmin = true AND state = 'active' AND email ILIKE '%@dsit.gov.uk')
 
 UPDATE public.package
 SET
-  author           = CASE
-                       WHEN author IS NOT NULL THEN repeat('*', greatest(length(author), 1))
-                       ELSE NULL
-                     END,
-  author_email     = CASE
-                       WHEN author_email IS NOT NULL THEN 'masked@example.com'
-                       ELSE NULL
-                     END,
-  maintainer       = CASE
-                       WHEN maintainer IS NOT NULL THEN repeat('*', greatest(length(maintainer), 1))
-                       ELSE NULL
-                     END,
+  author = CASE
+    WHEN author IS NOT NULL THEN repeat('*', greatest(length(author), 1))
+  END,
+  author_email = CASE
+    WHEN author_email IS NOT NULL THEN 'masked@example.com'
+  END,
+  maintainer = CASE
+    WHEN maintainer IS NOT NULL THEN repeat('*', greatest(length(maintainer), 1))
+  END,
   maintainer_email = CASE
-                       WHEN maintainer_email IS NOT NULL THEN 'masked@example.com'
-                       ELSE NULL
-                     END;
+    WHEN maintainer_email IS NOT NULL THEN 'masked@example.com'
+  END;
 
 -- ---------------------------------------------------------------------------
 -- package_extra
@@ -80,10 +74,10 @@ WHERE key IN (
 );
 
 UPDATE public.package_extra
-SET value = CASE
-              WHEN value IS NOT NULL THEN repeat('*', greatest(length(value), 1))
-              ELSE NULL
-            END
+SET
+  value = CASE
+    WHEN value IS NOT NULL THEN repeat('*', greatest(length(value), 1))
+  END
 WHERE key IN (
   'publisher_name',
   'license_name',

--- a/charts/db-backup/scripts/ckan.sql
+++ b/charts/db-backup/scripts/ckan.sql
@@ -15,6 +15,9 @@
 -- name:     user_{id}              — replaces username slug (often email-derived)
 -- fullname: repeat '*' to match original length
 -- apikey:   repeat '*' to match original length
+--
+-- Excludes active sysadmin accounts with a @dsit.gov.uk email — these are
+-- real admin accounts that must remain functional after restore.
 
 UPDATE public."user"
 SET
@@ -27,7 +30,8 @@ SET
   apikey   = CASE
                WHEN apikey IS NOT NULL THEN repeat('*', length(apikey))
                ELSE NULL
-             END;
+             END
+WHERE NOT (sysadmin = true AND state = 'active' AND email ILIKE '%@dsit.gov.uk');
 
 -- ---------------------------------------------------------------------------
 -- package

--- a/charts/db-backup/scripts/ckan.sql
+++ b/charts/db-backup/scripts/ckan.sql
@@ -1,0 +1,96 @@
+-- ckan.sql
+-- Anonymises PII in the CKAN integration database.
+-- Masks rather than deletes rows so relational structure is preserved.
+-- Runs as part of the db-backup transform step after restore from staging.
+--
+-- Tables covered:
+--   user          (name, fullname, email, apikey)
+--   package       (author, author_email, maintainer, maintainer_email)
+--   package_extra (value for PII-bearing keys)
+
+-- ---------------------------------------------------------------------------
+-- user
+-- ---------------------------------------------------------------------------
+-- email:    user_{id}@example.com  — unique per user, traceable via UUID
+-- name:     user_{id}              — replaces username slug (often email-derived)
+-- fullname: repeat '*' to match original length
+-- apikey:   repeat '*' to match original length
+
+UPDATE public."user"
+SET
+  name     = 'user_' || id,
+  fullname = CASE
+               WHEN fullname IS NOT NULL THEN repeat('*', length(fullname))
+               ELSE NULL
+             END,
+  email    = 'user_' || id || '@example.com',
+  apikey   = CASE
+               WHEN apikey IS NOT NULL THEN repeat('*', length(apikey))
+               ELSE NULL
+             END;
+
+-- ---------------------------------------------------------------------------
+-- package
+-- ---------------------------------------------------------------------------
+-- author/maintainer names:  repeat '*' to match original length
+-- author/maintainer emails: fixed masked value (not user-account emails,
+--                           so UUID tracing is not needed)
+
+UPDATE public.package
+SET
+  author           = CASE
+                       WHEN author IS NOT NULL THEN repeat('*', greatest(length(author), 1))
+                       ELSE NULL
+                     END,
+  author_email     = CASE
+                       WHEN author_email IS NOT NULL THEN 'masked@example.com'
+                       ELSE NULL
+                     END,
+  maintainer       = CASE
+                       WHEN maintainer IS NOT NULL THEN repeat('*', greatest(length(maintainer), 1))
+                       ELSE NULL
+                     END,
+  maintainer_email = CASE
+                       WHEN maintainer_email IS NOT NULL THEN 'masked@example.com'
+                       ELSE NULL
+                     END;
+
+-- ---------------------------------------------------------------------------
+-- package_extra
+-- ---------------------------------------------------------------------------
+-- Mask values for all keys that may contain contact or personal data.
+-- Email keys  → fixed masked email address
+-- Name keys   → repeat '*' to match original length
+-- Phone keys  → '***'
+
+UPDATE public.package_extra
+SET value = 'masked@example.com'
+WHERE key IN (
+  'dcat_publisher_email',
+  'contact-email',
+  'email_notify_maintainer',
+  'email_notify_author',
+  'contact_email',
+  'publisher_email',
+  'foi-email'
+);
+
+UPDATE public.package_extra
+SET value = CASE
+              WHEN value IS NOT NULL THEN repeat('*', greatest(length(value), 1))
+              ELSE NULL
+            END
+WHERE key IN (
+  'publisher_name',
+  'license_name',
+  'dcat_publisher_name',
+  'contact-name',
+  'foi-name'
+);
+
+UPDATE public.package_extra
+SET value = '***'
+WHERE key IN (
+  'contact-phone',
+  'foi-phone'
+);

--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -539,6 +539,8 @@ cronjobs:
       operations:
         - op: restore
           bucket: s3://govuk-staging-database-backups
+        - op: transform
+          script: ckan.sql
         - op: backup
 
     collections-publisher-mysql:


### PR DESCRIPTION
I have now added ckan.sql which will masks PII after restoring staging data to integration it includes user: name → user_{id}, fullname → ***, email → user_{id}@example.com, apikey → *** package: author/maintainer names → ***, emails → masked@example.com and package_extra: masks values for 14 PII-bearing keys (emails, names, phones)

the transform step into the integration ckan-postgres cronjob in values.yaml.