### PR TITLE
Temporary crontask for search-api-v2-beta-features

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3116,6 +3116,15 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
+        - name: report-evaluations-may
+          task: "report:evaluations[2026-05, pending failed]"
+          schedule: "0 0 1 1 * " # midnight on Jan 1st - placeholder to be run manually.
+        - name: report-evaluations-june
+          task: "report:evaluations[2026-06, pending failed]"
+          schedule: "0 0 1 1 * "
+        - name: report-evaluations-july
+          task: "report:evaluations[2026-07, pending failed]"
+          schedule: "0 0 1 1 * "
       extraEnv:
         - name: GOOGLE_CLOUD_CREDENTIALS
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3037,6 +3037,15 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
+        - name: report-evaluations-may
+          task: "report:evaluations[2026-05, pending failed]"
+          schedule: "0 0 1 1 * " # midnight on Jan 1st - placeholder to be run manually.
+        - name: report-evaluations-june
+          task: "report:evaluations[2026-06, pending failed]"
+          schedule: "0 0 1 1 * "
+        - name: report-evaluations-july
+          task: "report:evaluations[2026-07, pending failed]"
+          schedule: "0 0 1 1 * "
       extraEnv:
         - name: GOOGLE_CLOUD_CREDENTIALS
           valueFrom:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2992,6 +2992,15 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
+        - name: report-evaluations-may
+          task: "report:evaluations[2026-05, pending failed]"
+          schedule: "0 0 1 1 * "  # midnight on Jan 1st - placeholder to be run manually.
+        - name: report-evaluations-june
+          task: "report:evaluations[2026-06, pending failed]"
+          schedule: "0 0 1 1 * "
+        - name: report-evaluations-july
+          task: "report:evaluations[2026-07, pending failed]"
+          schedule: "0 0 1 1 * "
       extraEnv:
         - name: GOOGLE_CLOUD_CREDENTIALS
           valueFrom:


### PR DESCRIPTION
We have a pressing need to run a rake task on search-api-beta-features. This is a work around to enable us to do that via argo, as we can't currently shell into the application

https://github.com/alphagov/govuk-helm-charts/blob/bde6e1ac05a24e4912259907548e245f383ac3b7/charts/app-config/values-production.yaml#L3006