### PR TITLE
Increase asset-manager redis memory in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -159,6 +159,8 @@ govukApplications:
           memory: 2Gi
       redis:
         enabled: true
+        config:
+          maxmemory: 3500mb
         limits:
           memory: 4Gi
         requests:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -159,6 +159,10 @@ govukApplications:
           memory: 2Gi
       redis:
         enabled: true
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
To unclog queues that have ground to a halt