### PR TITLE
Fix Asset Manager Redis config in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -161,10 +161,11 @@ govukApplications:
         enabled: true
         config:
           maxmemory: 3500mb
-        limits:
-          memory: 4Gi
-        requests:
-          memory: 4Gi
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            memory: 4Gi
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
The limits and requests keys need to be nested in resources