### PR TITLE
Return asset manager redis memory to normal

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -159,13 +159,6 @@ govukApplications:
           memory: 2Gi
       redis:
         enabled: true
-        config:
-          maxmemory: 3500mb
-        resources:
-          limits:
-            memory: 4Gi
-          requests:
-            memory: 4Gi
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
It was increased in #4338 and #4339 to deal with an incident.
