### PR TITLE
Add 5 minute cache to humans.txt

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -174,6 +174,7 @@ http {
     }
 
     location = /humans.txt {
+      add_header cache-control "max-age=600,public";
       root /usr/share/nginx/html;
     }
 


### PR DESCRIPTION
Humans.txt does need to change reasonably quickly when we update it for a leaver, but it can safely stay in caches for a short while.