### PR TITLE
Add /search/opensearch.xml as static path served by nginx

### DIFF
--- a/charts/app-config/opensearch.xml
+++ b/charts/app-config/opensearch.xml
@@ -1,0 +1,7 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>GOV.UK</ShortName>
+    <Description>Search GOV.UK - The best place to find government services and information.</Description>
+    <Url type="text/html" template="https://www.gov.uk/search/all?keywords={searchTerms}"/>
+</OpenSearchDescription>

--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -177,6 +177,11 @@ http {
       root /usr/share/nginx/html;
     }
 
+    location = /search/opensearch.xml {
+      add_header cache-control "max-age=1800,public";
+      root /usr/share/nginx/html;
+    }
+
     # Endpoint for liveness and readiness checks of the nginx container.
     location = /readyz {
       return 200 'ok\n';

--- a/charts/app-config/templates/router-nginx-configmap.yaml
+++ b/charts/app-config/templates/router-nginx-configmap.yaml
@@ -24,6 +24,8 @@ data:
     {{- $.Files.Get "humans.txt" | nindent 4 }}
   nginx.conf: |-
     {{- include "app-config.router-nginx-config" ( mergeOverwrite . ( dict "Stack" "live" ) ) | nindent 4 }}
+  opensearch.xml: |-
+    {{- $.Files.Get "opensearch.xml" | nindent 4 }}
   robots.txt: |-
     {{- if eq .Values.govukEnvironment "production" }}
       {{- $.Files.Get "www-production-robots.txt" | nindent 4 }}

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2692,6 +2692,9 @@ govukApplications:
           mountPath: /usr/share/nginx/html/humans.txt
           subPath: humans.txt
         - name: live-router-nginx-conf
+          mountPath: /usr/share/nginx/html/opensearch.xml
+          subPath: opensearch.xml
+        - name: live-router-nginx-conf
           mountPath: /usr/share/nginx/html/robots.txt
           subPath: robots.txt
         - name: router-nginx-htpasswd

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2579,6 +2579,9 @@ govukApplications:
           mountPath: /usr/share/nginx/html/humans.txt
           subPath: humans.txt
         - name: live-router-nginx-conf
+          mountPath: /usr/share/nginx/html/opensearch.xml
+          subPath: opensearch.xml
+        - name: live-router-nginx-conf
           mountPath: /usr/share/nginx/html/robots.txt
           subPath: robots.txt
         - name: router-nginx-htpasswd

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2552,6 +2552,9 @@ govukApplications:
           mountPath: /usr/share/nginx/html/humans.txt
           subPath: humans.txt
         - name: live-router-nginx-conf
+          mountPath: /usr/share/nginx/html/opensearch.xml
+          subPath: opensearch.xml
+        - name: live-router-nginx-conf
           mountPath: /usr/share/nginx/html/robots.txt
           subPath: robots.txt
         - name: router-nginx-htpasswd


### PR DESCRIPTION
- This was served by finder-frontend, but it hasn't changed, so is a good candidate for being served directly from nginx, with a cache of 30 minutes.