### PR TITLE
[PP-7805] Add asset-manager cron task for SVG batch scanning

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -186,6 +186,10 @@ govukApplications:
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf
+      cronTasks:
+        - name: svg-batch-scan
+          task: "assets:bulk_scan_svgs[1000]"
+          schedule: "0 * * * *"
       extraEnv:
         - name: ASSET_MANAGER_CLAMSCAN_PATH
           value: /usr/local/bin/clamdscan


### PR DESCRIPTION
Schedule an hourly batch of 1000 existing, already-uploaded assets to be scanned for SVG vulnerabilities, by a [Rake task](https://github.com/alphagov/asset-manager/pull/1991).

Once all assets have been scanned, the job will silently do nothing until we unschedule it.