### PR TITLE
Warning level alert if the elasticsearch cluster status unknown

### DIFF
--- a/charts/monitoring-config/rules/search_api_alerts.yaml
+++ b/charts/monitoring-config/rules/search_api_alerts.yaml
@@ -2,6 +2,16 @@ groups:
   - name: SearchApiElasticsearchAlerts
     rules:
       - alert: SearchApiElasticsearchClusterStatus
+        expr: search_api_elasticsearch_status == 3
+        for: 30m
+        labels:
+          severity: warning
+          destination: slack-search-team
+        annotations:
+          summary: Elasticsearch cluster status is UNKNOWN or UNAVAILABLE
+          description: >-
+            The state of the Elasticsearch cluster used by Search API is unknown.
+      - alert: SearchApiElasticsearchClusterStatus
         expr: search_api_elasticsearch_status == 2
         for: 5m
         labels:

--- a/charts/monitoring-config/rules/search_api_alerts_tests.yaml
+++ b/charts/monitoring-config/rules/search_api_alerts_tests.yaml
@@ -19,6 +19,21 @@ tests:
   - interval: 1m
     input_series:
       - series: "search_api_elasticsearch_status"
+        values: "3x40"
+    alert_rule_test:
+      - alertname: SearchApiElasticsearchClusterStatus
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              destination: "slack-search-team"
+            exp_annotations:
+              summary: Elasticsearch cluster status is UNKNOWN or UNAVAILABLE
+              description: >-
+                The state of the Elasticsearch cluster used by Search API is unknown.
+  - interval: 1m
+    input_series:
+      - series: "search_api_elasticsearch_status"
         values: "2x40"
     alert_rule_test:
       - alertname: SearchApiElasticsearchClusterStatus


### PR DESCRIPTION
The Elasticsearch HealthAPI can return a status of UNKNOWN or UNAVAILABLE https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-health-report#operation-health-report-200-body-application-json-status

We need to add a link to up to date documentation to explain debugging steps in the event of this alert firing. Will be added in follow up work (See Jira [#SCH-2014](https://gov-uk.atlassian.net/browse/SCH-2014))

Jira https://gov-uk.atlassian.net/browse/SCH-2013