### PR TITLE
charts/rds-parquet-exporter path corrected in yaml

### DIFF
--- a/charts/app-config/templates/rds-parquet-exports.yaml
+++ b/charts/app-config/templates/rds-parquet-exports.yaml
@@ -10,7 +10,7 @@ spec:
   project: govuk
   source:
     repoURL: git@github.com/alphagov/govuk-helm-charts
-    path: charts/rds-parquet-exports
+    path: charts/rds-parquet-exporter
     targetRevision: HEAD
     helm:
       # Serialise our environment-specific parameters 


### PR DESCRIPTION
Fixes an Argo CD deployment failure caused by a typo in the chart path.

**Changes:**
In `charts/app-config/templates/rds-parquet-exports.yaml`, corrected the path:

* **Incorrect:** `charts/rds-parquet-exports`

* **Correct:** `charts/rds-parquet-exporter`
<img width="471" height="122" alt="image" src="https://github.com/user-attachments/assets/39a30b74-72fc-4c86-b09c-e0fac22f89bb" />



**Chart Path:**
<img width="536" height="63" alt="image" src="https://github.com/user-attachments/assets/aa0a9ebe-b00e-4718-9a14-8fa37a3b8b39" />




