### PR TITLE
fix: resolve missing service account in rds-parquet-exporter cronjob

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -48,7 +48,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis:6379/1
 rdsParquetExports:
-  enabled: false
+  enabled: true
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: "arn:aws:iam::210287912431:role/rds-parquet-exporter-job-starter-govuk"

--- a/charts/rds-parquet-exporter/templates/_helpers.tpl
+++ b/charts/rds-parquet-exporter/templates/_helpers.tpl
@@ -33,3 +33,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "rds-parquet-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/* 
+Create the name of the service account to use.
+If serviceAccount is disabled, fallback to "default".
+If enabled and a custom name is provided, use that custom name.
+Otherwise, default to the helm-generated full name.
+*/}}
+{{- define "rds-parquet-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rds-parquet-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/rds-parquet-exporter/templates/cronjob.yaml
+++ b/charts/rds-parquet-exporter/templates/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
       backoffLimit: 0
       template:
         spec:
-          serviceAccountName: {{ default (include "rds-parquet-exporter.fullname" .) .Values.serviceAccount.name }}
+          serviceAccountName: {{ include "rds-parquet-exporter.serviceAccountName" . }}
           restartPolicy: Never
           # Pod-level Security Context
           securityContext:

--- a/charts/rds-parquet-exporter/templates/serviceaccount.yaml
+++ b/charts/rds-parquet-exporter/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "rds-parquet-exporter.fullname" .) .Values.serviceAccount.name }}
+  name: {{ include "rds-parquet-exporter.serviceAccountName" . }}
   labels:
     {{- include "rds-parquet-exporter.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/rds-parquet-exporter/values.yaml
+++ b/charts/rds-parquet-exporter/values.yaml
@@ -8,8 +8,8 @@ image:
 installJqAtRuntime: false
 
 serviceAccount:
-  create: false
-  name: ""
+  create: true
+  name: "rds-parquet-exporter"
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::696911096973:role/rds-parquet-exporter-job-starter-govuk"
 


### PR DESCRIPTION
### Summary
Resolves a deployment failure in ArgoCD where the `rds-parquet-exporter` CronJob failed with a `FailedCreate` status due to a missing ServiceAccount look-up error.

### The Problem
The release name (`rds-parquet-exports`) and chart name (`rds-parquet-exporter`) caused Helm to dynamically concatenate and look for `rds-parquet-exports-rds-parquet-exporter`. Because the ServiceAccount was not being explicitly deployed with a matching name, Kubernetes blocked the Pod.

### What this PR does
1. **Created a naming helper:** Added `rds-parquet-exporter.serviceAccountName` in `_helpers.tpl` to handle clean fallback and naming.
2. **Standardized templates:** Updated `cronjob.yaml` and `serviceaccount.yaml` to use this helper so the names are guaranteed to match.
3. **Explicit configuration:** Configured a static, clean custom name (`rds-parquet-exporter`) and EKS IRSA annotations in `values.yaml`.
4. **Environment promotion:** Enabled the Integration environment flag to allow for testing and validation in the Integration cluster before promoting the changes to Staging in the future.

### Verification
* Verified that the ServiceAccount name dynamically matches what is requested in the CronJob Pod spec.
* Prevents dynamic release-name appending, which keeps AWS IAM Role Trust Policies clean and easy to manage.