### PR TITLE
Dynamically parameterise RDS snapshot names

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -56,6 +56,31 @@ rdsParquetExports:
     s3Bucket: "govuk-integration-database-backups"
     iamRoleArn: "arn:aws:iam::210287912431:role/rds-parquet-exporter-export-task-govuk"
     kmsKeyId: "arn:aws:kms:eu-west-1:210287912431:key/cb8ad532-b89a-4303-92c1-3f7ef4cda4fc"
+  dbTables:
+    publisher-integration-postgres:
+      - publisher_production.public.editions
+      - publisher_production.public.actions
+    publishing-api-integration-postgres:
+      - publishing_api_production.public.actions
+      - publishing_api_production.public.change_notes
+      - publishing_api_production.public.documents
+      - publishing_api_production.public.editions
+      - publishing_api_production.public.events
+      - publishing_api_production.public.expanded_links
+      - publishing_api_production.public.link_changes
+      - publishing_api_production.public.link_sets
+      - publishing_api_production.public.links
+      - publishing_api_production.public.path_reservations
+      - publishing_api_production.public.unpublishings
+    support-api-integration-postgres:
+      - support_contacts_production.public.anonymous_contacts
+      - support_contacts_production.public.archived_service_feedbacks
+    whitehall-integration-mysql:
+      - whitehall_production.assets
+      - whitehall_production.attachment_data
+      - whitehall_production.attachments
+      - whitehall_production.documents
+      - whitehall_production.editions
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 govukApplications:
   - name: account-api

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -56,6 +56,31 @@ rdsParquetExports:
     s3Bucket: "govuk-staging-database-backups"
     iamRoleArn: "arn:aws:iam::696911096973:role/rds-parquet-exporter-export-task-govuk"
     kmsKeyId: "arn:aws:kms:eu-west-1:696911096973:key/15bdd743-ecd7-4059-86ff-b8b6a72054c4"
+  dbTables:
+    publisher-staging-postgres:
+      - publisher_production.public.editions
+      - publisher_production.public.actions
+    publishing-api-staging-postgres:
+      - publishing_api_production.public.actions
+      - publishing_api_production.public.change_notes
+      - publishing_api_production.public.documents
+      - publishing_api_production.public.editions
+      - publishing_api_production.public.events
+      - publishing_api_production.public.expanded_links
+      - publishing_api_production.public.link_changes
+      - publishing_api_production.public.link_sets
+      - publishing_api_production.public.links
+      - publishing_api_production.public.path_reservations
+      - publishing_api_production.public.unpublishings
+    support-api-staging-postgres:
+      - support_contacts_production.public.anonymous_contacts
+      - support_contacts_production.public.archived_service_feedbacks
+    whitehall-staging-mysql:
+      - whitehall_production.assets
+      - whitehall_production.attachment_data
+      - whitehall_production.attachments
+      - whitehall_production.documents
+      - whitehall_production.editions
 # Apps for Argo CD to deploy, along with any app-specific Helm values.
 govukApplications:
   - name: account-api

--- a/charts/rds-parquet-exporter/values.yaml
+++ b/charts/rds-parquet-exporter/values.yaml
@@ -28,10 +28,10 @@ aws:
   kmsKeyId: "arn:aws:kms:eu-west-1:696911096973:key/15bdd743-ecd7-4059-86ff-b8b6a72054c4"
 
 dbTables:
-  publisher-integration-postgres:
+  publisher-staging-postgres:
     - publisher_production.public.editions
     - publisher_production.public.actions
-  publishing-api-integration-postgres:
+  publishing-api-staging-postgres:
     - publishing_api_production.public.actions
     - publishing_api_production.public.change_notes
     - publishing_api_production.public.documents
@@ -43,10 +43,10 @@ dbTables:
     - publishing_api_production.public.links
     - publishing_api_production.public.path_reservations
     - publishing_api_production.public.unpublishings
-  support-api-integration-postgres:
+  support-api-staging-postgres:
     - support_contacts_production.public.anonymous_contacts
     - support_contacts_production.public.archived_service_feedbacks
-  whitehall-integration-mysql:
+  whitehall-staging-mysql:
     - whitehall_production.assets
     - whitehall_production.attachment_data
     - whitehall_production.attachments


### PR DESCRIPTION
### Summary
Fix: Dynamically parameterises RDS snapshot names for the integration and staging environments

### Files Modified
* `app-config/values-integration.yaml` (integration-specific snapshot config)
* `app-config/values-staging.yaml` (staging-specific snapshot config)
* `rds-parquet-exporter/values.yaml` (base template configuration)

### Verification
* Verified that snapshot names interpolate correctly according to the target environment values.