### PR TITLE
Update values-integration.yaml for Integration to rollout the 3 DB instances as expected instead of just 1

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1947,6 +1947,8 @@ govukApplications:
         mongo:
           dbHosts:
             - licensify-documentdb-clone-0.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
+            - licensify-documentdb-clone-1.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
+            - licensify-documentdb-clone-2.ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com
         adminBaseUrl: https://licensify-admin.integration.publishing.service.gov.uk
         frontendBaseUrl: https://www.integration.publishing.service.gov.uk
         signonBaseUrl: https://signon.integration.publishing.service.gov.uk


### PR DESCRIPTION
This change updates the helm chart such that the integration environment now matches what was originally expected and had.

The original configuration for the other 2 databases was not provided at the time. It since has been provided and as such this change, integrates the other databases to bring it in line as per what is expected and what was provided originally prior to DB version bump.