### PR TITLE
Define GOV.UK Notify API key external secret for Fact Check Manager

### DIFF
--- a/charts/external-secrets/templates/fact-check-manager/notify.yaml
+++ b/charts/external-secrets/templates/fact-check-manager/notify.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fact-check-manager-notify
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      The GOV.UK Notify API key belonging to Fact Check Manager.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: fact-check-manager-notify
+  dataFrom:
+    - extract:
+        key: govuk/fact-check-manager/notify
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
### Changes

Define an external secret for GOV.UK Notify API key for Fact Check Manager.