### PR TITLE
Update `GOVUK_NOTIFY_API_KEY` env var for Fact Check Manager integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1609,8 +1609,8 @@ govukApplications:
         - name: GOVUK_NOTIFY_API_KEY
           valueFrom:
             secretKeyRef:
-              name: fact-check-manager-notify-team
-              key: notify-team
+              name: fact-check-manager-notify
+              key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEST_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
### Changes
Update `GOVUK_NOTIFY_API_KEY` env var for Fact Check Manager integration to `fact-check-manager-notify` external secret. This follows the convention set by other apps using Notify.