### PR TITLE
Suspend publisher env sync to integration, and the alert for it

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -683,6 +683,7 @@ cronjobs:
         - op: backup
 
     publisher-postgres:
+      suspend: true
       schedule: "41 3 * * 1"
       db: publisher_production
       operations:

--- a/charts/monitoring-config/rules/integration/database_backups_and_syncs_integration_only_alerts.yaml
+++ b/charts/monitoring-config/rules/integration/database_backups_and_syncs_integration_only_alerts.yaml
@@ -137,7 +137,7 @@ groups:
         expr: >-
           db_backup_job_status_timestamp_seconds{
             state="succeeded",
-            database_instance=~"signon-mysql"
+            database_instance!~"signon-mysql|publisher-postgres" # Publisher-postgres temporarily disabled while syncs for the environment are paused
           } < time() - 648000  # 1 week + 12 hours
         labels:
           severity: warning

--- a/charts/monitoring-config/rules/integration/database_backups_and_syncs_integration_only_alerts_tests.yaml
+++ b/charts/monitoring-config/rules/integration/database_backups_and_syncs_integration_only_alerts_tests.yaml
@@ -397,11 +397,11 @@ tests:
       - series: >-
           db_backup_job_status_timestamp_seconds{
           database_engine="mysql",
-          database_instance="signon-mysql",
-          database_db_name="signon_production",
+          database_instance="whitehall-mysql",
+          database_db_name="whitehall_production",
           operation="backup",
           state="succeeded",
-          instance="db-backup-signon-mysql-98765432-c2b1a"
+          instance="db-backup-whitehall-mysql-98765432-c2b1a"
           }
         # See https://github.com/alphagov/govuk-helm-charts/blob/main/charts/monitoring-config/rules/staging/database_backups_and_syncs_staging_only_alerts_tests.yaml#L1
         # for a detailed breakdown of how this expansion notation works
@@ -409,11 +409,11 @@ tests:
       - series: >-
           db_backup_job_status_timestamp_seconds{
           database_engine="mysql",
-          database_instance="signon-mysql",
-          database_db_name="signon_production",
+          database_instance="whitehall-mysql",
+          database_db_name="whitehall_production",
           operation="backup",
           state="succeeded",
-          instance="db-backup-signon-mysql-12345678-a1b2c"
+          instance="db-backup-whitehall-mysql-12345678-a1b2c"
           }
         # See https://github.com/alphagov/govuk-helm-charts/blob/main/charts/monitoring-config/rules/staging/database_backups_and_syncs_staging_only_alerts_tests.yaml#L1
         # for a detailed breakdown of how this expansion notation works
@@ -427,20 +427,20 @@ tests:
               severity: warning
               destination: slack-platform-engineering-database-syncs
               database_engine: mysql
-              database_instance: signon-mysql
-              database_db_name: signon_production
-              instance: db-backup-signon-mysql-12345678-a1b2c
+              database_instance: whitehall-mysql
+              database_db_name: whitehall_production
+              instance: db-backup-whitehall-mysql-12345678-a1b2c
               operation: backup
               state: succeeded
             exp_annotations:
-              summary: Database backup for signon-mysql.signon_production did not succeed in the last week
+              summary: Database backup for whitehall-mysql.whitehall_production did not succeed in the last week
               runbook_url: https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html#alerts
               description: >-
-                The signon_production database in the signon-mysql instance did not successfully perform a backup in the last
+                The whitehall_production database in the whitehall-mysql instance did not successfully perform a backup in the last
                 1 week and 12 hours.
 
                 You can see a snapshot of the overall status on the Grafana Dashboard:
                 https://grafana.eks.test.govuk.digital/d/jfc4fnp/database-backups-and-syncs
 
                 You can see the logs for this job in this Logit search for the pod name:
-                <https://kibana.logit.io/s/12345678-abcd-1234-abcd-123456789abc/app/data-explorer/discover#?_a=(discover:(columns:!(message),isDirty:!t,sort:!(!('@timestamp',asc))),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.pod.name,negate:!f,params:(query:db-backup-signon-mysql-12345678-a1b2c),type:phrase),query:(match_phrase:(kubernetes.pod.name:db-backup-signon-mysql-12345678-a1b2c)))),query:(language:kuery,query:''))|db-backup-signon-mysql-12345678-a1b2c>
+                <https://kibana.logit.io/s/12345678-abcd-1234-abcd-123456789abc/app/data-explorer/discover#?_a=(discover:(columns:!(message),isDirty:!t,sort:!(!('@timestamp',asc))),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.pod.name,negate:!f,params:(query:db-backup-whitehall-mysql-12345678-a1b2c),type:phrase),query:(match_phrase:(kubernetes.pod.name:db-backup-whitehall-mysql-12345678-a1b2c)))),query:(language:kuery,query:''))|db-backup-whitehall-mysql-12345678-a1b2c>


### PR DESCRIPTION
Suspend publisher integration db sync
Exclude publisher from sync too long ago alerts
Fix the weekly alert for integration which was only looking at signon, instead of excluding signon 🫨 and change its test to use whitehall