### PR TITLE
Suspend search quality-monitoring jobs

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2940,6 +2940,7 @@ govukApplications:
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 8-17 * * *" # 9 minutes past the hour every day from 8am-5pm
+          suspend: true # The results from job are not being monitored, and it's in review for being deleted.
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2927,6 +2927,7 @@ govukApplications:
         - name: quality-monitoring-assert-invariants
           task: "quality_monitoring:assert_invariants"
           schedule: "09 9 * * *" # 09:09am daily
+          suspend: true # The results from job are not being monitored, and it's in review for being deleted.
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"


### PR DESCRIPTION
The results from these jobs are not currently being reviewed, so it's a waste of resources to run them. The Search Team is currently using Google Cloud Discovery Engine's in built Evaluations service to evaluate search quality. The legacy workflow provided by the quality monitoring job should be retired once we are confident that the new evaluations are accurate and resilient enough.

See: https://gov-uk.atlassian.net/browse/SCH-490

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2009