### PR TITLE
Update access_limited redaction queries and add access_limiting_individuals redaction [WHIT-3730]

### DIFF
--- a/charts/db-backup/scripts/whitehall.sql
+++ b/charts/db-backup/scripts/whitehall.sql
@@ -118,3 +118,7 @@ INNER JOIN editions ON attachments.attachable_id = editions.id
 SET govspeak_contents.body = @lipsum_body
 WHERE
   attachments.attachable_type = 'EDITION' AND editions.access_limiting != 'none';
+
+-- Redact email addresses in access_limiting_individuals.
+UPDATE access_limiting_individuals
+SET email = CONCAT('access-limited-email-', id, '@example.com');

--- a/charts/db-backup/scripts/whitehall.sql
+++ b/charts/db-backup/scripts/whitehall.sql
@@ -52,13 +52,13 @@ WHERE
     FROM
       editions
     WHERE
-      access_limited = 1
+      access_limiting != 'none'
   );
 
 -- Redact slugs for access-limited drafts.
 UPDATE editions
 SET slug = CONCAT(@lipsum_slug, document_id), slug_from_title = CONCAT(@lipsum_slug, document_id)
-WHERE access_limited = 1;
+WHERE access_limiting != 'none';
 
 -- Redact email addresses and comments in fact checks.
 UPDATE fact_check_requests
@@ -76,7 +76,7 @@ WHERE
     FROM
       editions
     WHERE
-      access_limited = 1
+      access_limiting != 'none'
   );
 
 -- Redact HTML attachment data for access-limited drafts.
@@ -89,7 +89,7 @@ WHERE
     FROM
       editions
     WHERE
-      access_limited = 1
+      access_limiting != 'none'
   );
 
 -- Redact file names for attachments on access-limited drafts.
@@ -107,7 +107,7 @@ WHERE
         FROM
           editions
         WHERE
-          editions.access_limited = 1
+          editions.access_limiting != 'none'
       )
   );
 
@@ -117,4 +117,4 @@ INNER JOIN attachments ON govspeak_contents.html_attachment_id = attachments.id
 INNER JOIN editions ON attachments.attachable_id = editions.id
 SET govspeak_contents.body = @lipsum_body
 WHERE
-  attachments.attachable_type = 'EDITION' AND editions.access_limited = 1;
+  attachments.attachable_type = 'EDITION' AND editions.access_limiting != 'none';


### PR DESCRIPTION
## What
I've made 2 changes to the Whitehall DB backup redaction script as part of removing the legacy `access_limited` boolean column from the Whitehall `editions` table ([WHIT-3551](https://gov-uk.atlassian.net/browse/WHIT-3551)).

### 1. Update access_limited redaction queries
All 6 queries that filtered on `access_limited = 1` have been updated to use `access_limiting != 'none'` (the new enum column). This ensures redaction continues to work correctly once the legacy boolean column is dropped.

### 2. Redact emails in access_limiting_individuals
The `access_limiting_individuals` table stores publisher email addresses (PII) for individually access-limited editions. This is a new table with no previous redaction coverage. All rows are redacted unconditionally since every row in this table is PII by definition.


## Why
Before the `access_limited` column can be safely removed from Whitehall, we avoid having the redaction script depend on it. The`access_limiting_individuals` emails must also be redacted to comply with the [GOV.UK PII handling policy](https://docs.publishing.service.gov.uk/manual/architecture-deep-dive.html#environments).


[JIRA
](https://gov-uk.atlassian.net/browse/WHIT-3730)

[WHIT-3551]: https://gov-uk.atlassian.net/browse/WHIT-3551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ