### PR TITLE
Restrict cronjob to weekdays and disable integration ArgoCD job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -48,7 +48,7 @@ _alb-ingress-group-backend: &alb-ingress-group-backend
 emergency-banner-redis:
   - &emergency-banner-redis redis://whitehall-admin-redis:6379/1
 rdsParquetExports:
-  enabled: true
+  enabled: false
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: "arn:aws:iam::210287912431:role/rds-parquet-exporter-job-starter-govuk"

--- a/charts/rds-parquet-exporter/templates/cronjob.yaml
+++ b/charts/rds-parquet-exporter/templates/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "rds-parquet-exporter.labels" . | nindent 4 }}
 spec:
-  schedule: "45 3 * * *"
+  schedule: "45 3 * * 1-5"
   suspend: false
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 5


### PR DESCRIPTION
- Changed cron schedule to '45 3 * * 1-5' to prevent weekend runs.

- Disabled the ArgoCD job for the integration environment to pause deployments.