### PR TITLE
[PP-7782] Set ClamAV `maxFileSize` as an environment variable for Asset Manager

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -238,6 +238,8 @@ govukApplications:
             secretKeyRef:
               name: authenticating-proxy-jwt-auth-secret
               key: JWT_AUTH_SECRET
+        - name: MAX_FILE_SIZE_MB
+          value: "{{ .Values.clamav.maxFileSizeMB }}"
         - name: MONGODB_URI
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -206,6 +206,8 @@ govukApplications:
             secretKeyRef:
               name: authenticating-proxy-jwt-auth-secret
               key: JWT_AUTH_SECRET
+        - name: MAX_FILE_SIZE_MB
+          value: "{{ .Values.clamav.maxFileSizeMB }}"
         - name: MONGODB_URI
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -239,6 +239,8 @@ govukApplications:
             secretKeyRef:
               name: authenticating-proxy-jwt-auth-secret
               key: JWT_AUTH_SECRET
+        - name: MAX_FILE_SIZE_MB
+          value: "{{ .Values.clamav.maxFileSizeMB }}"
         - name: MONGODB_URI
           valueFrom:
             secretKeyRef:

--- a/charts/asset-manager/templates/clamav-configmap.yaml
+++ b/charts/asset-manager/templates/clamav-configmap.yaml
@@ -25,12 +25,12 @@ data:
     # Whitehall and Specialist Publisher allow up to 500 MB uploads. Keep in
     # sync with StreamMaxLen, because clamdscan streams when connecting via TCP
     # (as opposed to UNIX socket).
-    MaxFileSize 750M
+    MaxFileSize {{ .Values.clamav.maxFileSizeMB }}M
     MaxScanSize 5000M
     MaxScanTime 0
     MaxThreads 20
     SelfCheck 900
-    StreamMaxLength 750M
+    StreamMaxLength {{ .Values.clamav.maxFileSizeMB }}M
     TCPAddr 127.0.0.1
     TCPSocket 3310
   freshclam.conf: |

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -146,3 +146,6 @@ nfs:
   assetStorage: 15Gi
 
 appEnabled: true
+
+clamav:
+  maxFileSizeMB: 750


### PR DESCRIPTION
We would like the Asset Manager application to be able to know ClamAV's file size limit, so it can handle requests containing large assets better.

Therefore moving the file size limit into a variable, which is then made available through an environment variable on the app.