### PR TITLE
Add Elasticdump job for blue/green Elasticsearch sync

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2944,6 +2944,10 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: elasticdump
+          task: "elasticdump"
+          schedule: "0 0 31 2 *" # never
+          suspend: true # Only run this task manually
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
           schedule: "50 2 * * *"
@@ -3026,6 +3030,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-rabbitmq
               key: RABBITMQ_URL
+        - name: ELASTICDUMP_PARAMETERS
+          valueFrom:
+            secretKeyRef:
+              name: search-api-elasticdump
+              key: parameters
         - name: TENSORFLOW_SAGEMAKER_ENDPOINT
           value: govuk-integration-search-ltr-endpoint
   - name: search-api-v2

--- a/charts/external-secrets/templates/search-api/elasticdump.yaml
+++ b/charts/external-secrets/templates/search-api/elasticdump.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: search-api-elasticdump
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Parameters used by Elasticdump to copy data across Blue and Green OpenSearch clusters
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: search-api-elasticdump
+  dataFrom:
+    - extract:
+        key: govuk/search-api/elasticdump
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
Add a job to run the elasticdump rake task on search-api for copying data between the blue and green Elastic/Opensearch clusters. This job is set to never run and shouldbe triggered manually.

Add a ELASTICDUMP_PARAMETERS environment variable used to configure the rake task. Its value is stored in secrets.

Jira: https://gov-uk.atlassian.net/browse/SCH-2234
Rake task: https://github.com/alphagov/search-api/pull/3710