### PR TITLE
Asset Manager Improvements: Integration/Staging

### DIFF
--- a/charts/asset-manager/templates/nginx-configmap.yaml
+++ b/charts/asset-manager/templates/nginx-configmap.yaml
@@ -30,9 +30,40 @@ data:
       server_tokens off;
 
       sendfile        on;
+
+      {{- if or (eq .Values.govukEnvironment "integration") (eq .Values.govukEnvironment "staging") }}
+      tcp_nopush      on;
+      tcp_nodelay     on;
+
+      keepalive_timeout  75;
+      keepalive_requests 10000;
+
+      # Gzip Compression
+      gzip on;
+      gzip_comp_level 5;
+      gzip_min_length  256;
+      gzip_proxied any;
+      gzip_vary on;
+      gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/rss+xml
+        application/atom+xml
+        image/svg+xml;
+
+      resolver kube-dns.kube-system.svc.cluster.local. valid=5s ipv6=off;
+      resolver_timeout 2s;
+      {{- else }}
       keepalive_timeout  65;
 
       resolver kube-dns.kube-system.svc.cluster.local.;
+      {{- end }}
 
       upstream {{ $fullName }} {
         server 127.0.0.1:{{ .Values.appPort }};
@@ -141,6 +172,11 @@ data:
         location ~ /cloud-storage-proxy/(.*) {
           # Prevent requests to this location from outside Nginx
           internal;
+
+          {{- if or (eq .Values.govukEnvironment "integration") (eq .Values.govukEnvironment "staging") }}
+          # Stream S3 payload to ALB w/o going through tmp directory.
+          proxy_buffering off;
+          {{- end }}
 
           # Construct download URL from:
           # $1:       Host + path from regexp match in location


### PR DESCRIPTION
## What?
This applies some changes for asset manager in Integration and Staging only for now, with the aim of:

* Reducing our Bandwidth usage by using mild gzip compression (assets-origin is one of our main offenders for this)
* Setting some generous (but not too generous) keepalive limits to reduce constant cycling of TLS handshakes.
* Setting the TCP nopush and TCP nodelay options to stop Fastly having to wait longer than necessary.
* Let resolver ignore IPv6 and cache kube hosts for up to 5 seconds to reduce the number of lookups (help avoid DNS storms).
* Turn off proxy buffering for anything coming from the cloud storage proxy location - this is wasting cycles writing stuff into /tmp when it doesn't need to.

...ultimately reducing the number of peak LCUs we need to pay for ($$$). And hopefully cutting our Bandwidth needs ($$$$$).

This is currently only being rolled out to Integration and Staging so we can give it all a test before rolling anything into Prod.

## Related

* https://github.com/alphagov/govuk-fastly-secrets/pull/112
* https://github.com/alphagov/govuk-fastly/pull/428