### PR TITLE
[SCH-2052] Reschedule cron jobs touching elasticsearch cluster to remove overlap

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2964,7 +2964,7 @@ govukApplications:
               memory: 800Mi
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
-          schedule: "35 00 * * *"
+          schedule: "15 00 * * *"
       workers:
         enabled: true
         replicaCount: 3

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2838,7 +2838,7 @@ govukApplications:
           schedule: "0 22 * * *"
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
-          schedule: "35 00 * * *"
+          schedule: "15 00 * * *"
       extraEnv:
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-production-search-relevancy

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2810,7 +2810,7 @@ govukApplications:
           schedule: "0 22 * * *"
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
-          schedule: "35 00 * * *"
+          schedule: "15 00 * * *"
       workers:
         enabled: true
         types:

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -15,7 +15,7 @@ govukEnvironment: staging
 cronjobs:
   production:
     green-es6-snapshot:  # This would be too long as green-elasticsearch6-domain-snapshot
-      schedule: "21 1 * * *"
+      schedule: "51 1 * * *"
       args: [create_and_clean_up]
       extraEnv:
         - name: SUBDOMAIN


### PR DESCRIPTION
There's an overlap on production between the `update-govuk-index-popularity` and `green-es6-snapshot` jobs, which coincides with some disk throughput throttle warnings and insufficient GC warnings. We were also having problems with `green-es6-snapshot` job not always being able to clean up old snapshots.

Amending the schedule so that `update-govuk-index-popularity` job has completed before `green-es6-snapshot` job starts.

See [Jira ticket SCH-2052](https://gov-uk.atlassian.net/browse/SCH-2052)