### PR TITLE
Add feature flag environment variable for HMRC-manuals-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1890,6 +1890,8 @@ govukApplications:
       extraEnv:
         - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
           value: "1"
+        - name: ALLOW_ASSET_MANAGER_REQUESTS
+          value: "1"
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This will be used to facilitate only allowing Hmrc-manuals-api to connect to asset-manager on integration for now.