### PR TITLE
Remove stale ENV vars for HMRC-manuals-api

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1888,8 +1888,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
-          value: "1"
         - name: ALLOW_ASSET_MANAGER_REQUESTS
           value: "1"
         - name: ASSET_MANAGER_BEARER_TOKEN
@@ -1912,8 +1910,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-hmrc-manuals-api-publishing-api
               key: bearer_token
-        - name: PUBLISH_TOPICS
-          value: "1"
         - name: PUMA_TIMEOUT
           value: "300"
   - name: licensify

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1780,8 +1780,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
-          value: "1"
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1802,8 +1800,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-hmrc-manuals-api-publishing-api
               key: bearer_token
-        - name: PUBLISH_TOPICS
-          value: "1"
         - name: PUMA_TIMEOUT
           value: "300"
       cronTasks: []

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1787,8 +1787,6 @@ govukApplications:
       uploadAssets:
         enabled: false
       extraEnv:
-        - name: ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS
-          value: "1"
         - name: ASSET_MANAGER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -1809,8 +1807,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-hmrc-manuals-api-publishing-api
               key: bearer_token
-        - name: PUBLISH_TOPICS
-          value: "1"
         - name: PUMA_TIMEOUT
           value: "300"
       cronTasks: []


### PR DESCRIPTION
`ALLOWED_UNKNOWN_HMRC_MANUAL_SLUGS` was removed in #944

`PUBLISH_TOPICS` was removed in #128