### PR TITLE
[PP-7886] Do not proxy HMRC Manuals API assets to S3

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1872,6 +1872,7 @@ govukApplications:
           cpu: 10m
           memory: 320Mi
       nginxClientMaxBodySize: 2M
+      proxyRailsAssetsToS3: false
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1764,6 +1764,7 @@ govukApplications:
           cpu: 10m
           memory: 320Mi
       nginxClientMaxBodySize: 2M
+      proxyRailsAssetsToS3: false
       ingress:
         enabled: true
         annotations:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1771,6 +1771,7 @@ govukApplications:
           cpu: 10m
           memory: 320Mi
       nginxClientMaxBodySize: 2M
+      proxyRailsAssetsToS3: false
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
We have recently added an API endpoint at `/assets`, however requests are currently being proxied to S3.

Removing this proxy so we can serve the requests from the app.

The app has no assets (it is API only) so this won't affect any existing files.