### PR TITLE
[SCH-2037] Restore search ES cluster from environment above before taking snapshot

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -39,7 +39,7 @@ cronjobs:
 
   staging:
     green-es6-cp-prod:  # This would be too long as green-elasticsearch6-domain-cp-prod
-      schedule: "00 3 * * *"
+      schedule: "30 2 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO
@@ -47,7 +47,7 @@ cronjobs:
         - name: SUBDOMAIN
           value: elasticsearch6
     green-es6-snapshot:  # This would be too long as green-elasticsearch6-domain-snapshot
-      schedule: "37 2 * * *"
+      schedule: "07 3 * * *"
       args: [create_and_clean_up]
       extraEnv:
         - name: SUBDOMAIN
@@ -73,7 +73,7 @@ cronjobs:
 
   integration:
     green-es6-cp-stag:  # This would be too long as green-elasticsearch6-domain-cp-stag
-      schedule: "17 6 * * *"
+      schedule: "17 4 * * 1"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO


### PR DESCRIPTION
Amend scheduling of cronjobs for `search-index-env-sync` so that restoring from a snapshot of the environment above happens before a snapshot of the current environment is taken. 

Also move to weekly syncing of search integration cluster, to match the way that data is synced between environments for the rest of GOV.UK.

See [Jira ticket SCH-2037](https://gov-uk.atlassian.net/browse/SCH-2037)