### PR TITLE
BAU - Add `svg-batch-scan` asset manager cron job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -220,10 +220,6 @@ govukApplications:
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf
-      cronTasks:
-        - name: svg-batch-scan
-          task: "assets:bulk_scan_svgs[1000]"
-          schedule: "0 * * * *"
       extraEnv:
         - name: ASSET_MANAGER_CLAMSCAN_PATH
           value: /usr/local/bin/clamdscan

--- a/charts/asset-manager/templates/_svgbatch_podspec.yaml
+++ b/charts/asset-manager/templates/_svgbatch_podspec.yaml
@@ -1,0 +1,61 @@
+{{- define "asset-manager.svgbatchscan.podspec" }}
+{{- $fullName := include "asset-manager.fullname" . }}
+metadata:
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/component: svg-batch-scan
+spec:
+  activeDeadlineSeconds: 1800
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: svg-batch-scan
+      image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+      imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+      # Replace with "assets:bulk_scan_svgs[1000]"
+      command: ["freshclam"]
+      args:
+        - "--foreground"
+        - "--stdout"
+      # Set up some memory and CPU resources in the values.yaml file in this directory
+      {{ with .Values.freshclamResources }}
+      resources:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{ end }}
+      volumeMounts:
+        - name: clam-virus-db
+          mountPath: /var/lib/clamav
+        - name: etc-clamav
+          mountPath: {{ .Values.clamMountConfigPath }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+  # You'll need access to the asset-manager volume to do the SVG scan presumably?
+  volumes:
+    - name: clam-virus-db
+      persistentVolumeClaim:
+        claimName: {{ $fullName }}-clamav-db
+    - name: etc-clamav
+      configMap:
+        name: {{ $fullName }}-etc-clamav
+  restartPolicy: Never
+  {{- if eq "arm64" .Values.arch }}
+  tolerations:
+    - key: arch
+      operator: Equal
+      value: {{ .Values.arch }}
+      effect: NoSchedule
+  nodeSelector:
+    kubernetes.io/arch: {{ .Values.arch }}
+  {{- end }}
+{{- end }}

--- a/charts/asset-manager/templates/svg-batch-scan-cronjob.yaml
+++ b/charts/asset-manager/templates/svg-batch-scan-cronjob.yaml
@@ -1,0 +1,27 @@
+{{ if eq .Values.govukEnvironment "integration" }}
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}-svg-batch-scan
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/component: svg-batch-scan
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "asset-manager.labels" . | nindent 8 }}
+        app: {{ $fullName }}-svg-batch-scan
+        app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
+        app.kubernetes.io/component: svg-batch-scan
+    spec:
+      backoffLimit: 1
+      template:
+        {{- include "asset-manager.svgbatchscan.podspec" . | indent 8 }}
+{{ end }}


### PR DESCRIPTION
Description:
- Nothing in the asset-manager chart iterates through `{{- range .Values.cronTasks }}` as `generic-govuk-app` has https://github.com/alphagov/govuk-helm-charts/blob/15509344665e62de17038412b850ac5bcf2a41e7/charts/generic-govuk-app/templates/cron-task.yaml#L2
- Create a new CronJob that runs in integration