### PR TITLE
[PP-7805] Fix Asset Manager SVG batch scan cron job

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -220,10 +220,8 @@ govukApplications:
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf
-      cronTasks:
-        - name: svg-batch-scan
-          task: "assets:bulk_scan_svgs[1000]"
-          schedule: "0 * * * *"
+      svgBatchScan:
+        enabled: true
       extraEnv:
         - name: ASSET_MANAGER_CLAMSCAN_PATH
           value: /usr/local/bin/clamdscan

--- a/charts/asset-manager/templates/_svg-batch-scan_podspec.yaml
+++ b/charts/asset-manager/templates/_svg-batch-scan_podspec.yaml
@@ -1,0 +1,63 @@
+{{- define "asset-manager.svg-batch-scan.podspec" }}
+{{- $fullName := include "asset-manager.fullname" . }}
+metadata:
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/component: svg-batch-scan
+spec:
+  activeDeadlineSeconds: 300
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+    - name: app-tmp
+      emptyDir: {}
+  containers:
+    - name: svg-batch-scan
+      image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+      imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
+      command: ["rake"]
+      args: ["assets:bulk_scan_svgs[1000]"]
+      envFrom:
+        - configMapRef:
+            name: govuk-apps-env
+      env:
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.repoName }}-rails-secret-key-base
+              key: secret-key-base
+        {{- if .Values.redis.enabled }}
+        - name: REDIS_URL
+          value: {{ .Values.redis.redisUrlOverride.workers | default (printf "redis://%s-redis" $fullName) }}
+        {{- end }}
+      {{- with .Values.appResources }}
+      resources:
+        {{- . | toYaml | trim | nindent 8 }}
+      {{- end }}
+      volumeMounts:
+        - name: app-tmp
+          mountPath: /tmp
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+  restartPolicy: Never
+  {{- if eq "arm64" .Values.arch }}
+  tolerations:
+    - key: arch
+      operator: Equal
+      value: {{ .Values.arch }}
+      effect: NoSchedule
+  nodeSelector:
+    kubernetes.io/arch: {{ .Values.arch }}
+  {{- end }}
+{{- end }}

--- a/charts/asset-manager/templates/svg-batch-scan-cronjob.yaml
+++ b/charts/asset-manager/templates/svg-batch-scan-cronjob.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.svgBatchScan.enabled }}
+{{- $fullName := include "asset-manager.fullname" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}-svg-batch-scan
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
+  labels:
+    {{- include "asset-manager.labels" . | nindent 4 }}
+    app: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
+    app.kubernetes.io/component: svg-batch-scan
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "asset-manager.labels" . | nindent 8 }}
+        app: {{ $fullName }}-svg-batch-scan
+        app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
+        app.kubernetes.io/component: svg-batch-scan
+    spec:
+      backoffLimit: 1
+      template:
+        {{- include "asset-manager.svg-batch-scan.podspec" . | indent 8 }}
+{{- end }}

--- a/charts/asset-manager/values.yaml
+++ b/charts/asset-manager/values.yaml
@@ -85,6 +85,9 @@ clamdResources:
     cpu: 500m
     memory: 2000Mi
 
+svgBatchScan:
+  enabled: false
+
 # clamMountConfigPath is the path to which the clamav.conf and freshclam.conf are mounted
 clamMountConfigPath: "/usr/local/etc"
 


### PR DESCRIPTION
This was trying to use functionality defined in the generic-govuk-app chart, but we use a custom one for Asset Manager. This therefore migrates to defining a CronJob within the Asset Manager chart

It's disabled by default, then overridden in integration for now

Closes #4375