### PR TITLE
[PP-7925] Raise nginx proxy_read_timeout for support apps

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3599,6 +3599,7 @@ govukApplications:
       arch: arm64
       podTerminationGracePeriodSecs: 50
       containerPreStopSleepSecs: 40
+      nginxProxyReadTimeout: 30s
       appResources:
         limits:
           cpu: 1
@@ -3675,6 +3676,7 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
+      nginxProxyReadTimeout: 30s
       appResources:
         limits:
           cpu: 1

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3435,6 +3435,7 @@ govukApplications:
       arch: arm64
       podTerminationGracePeriodSecs: 50
       containerPreStopSleepSecs: 40
+      nginxProxyReadTimeout: 30s
       appResources:
         limits:
           cpu: 1
@@ -3508,6 +3509,7 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
+      nginxProxyReadTimeout: 30s
       appResources:
         limits:
           cpu: 1

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3401,6 +3401,7 @@ govukApplications:
       arch: arm64
       podTerminationGracePeriodSecs: 50
       containerPreStopSleepSecs: 40
+      nginxProxyReadTimeout: 30s
       appResources:
         limits:
           cpu: 1
@@ -3472,6 +3473,7 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
+      nginxProxyReadTimeout: 30s
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
nginx times out any request whose upstream does not start sending a response within `proxy_read_timeout`. In this repo that value comes from `nginxProxyReadTimeout` [1], which defaults to 15s in `generic-govuk-app` [2]. Some apps override it to 30, 60, or 300 seconds, but Support and Support API were both left on the 15s default

For Support this capped requests well below the app's own limit: despite the 30s `GdsApi` timeout it sets [3], nginx returned a 504 after 15s

Support API needs the same override for a less obvious reason. `proxy_read_timeout` applies at each hop, and the slow work behind the anonymous feedback explorer is the SQL, which runs in Support API behind its own nginx. Raising the timeout only in Support would leave Support API's nginx as the binding 15s limit sitting directly on top of the slow query, so the 504 would persist. Both hops must be raised for the 30s ceiling to apply along the whole path

This overrides `nginxProxyReadTimeout` to 30s for Support and Support API in all three environments, matching the `GdsApi` timeout

Before:

```
  browser
    │
    ▼
  support nginx          proxy_read_timeout = 15s
    │
    ▼
  support Puma
    │       GdsApi HTTP timeout = 30s
    ▼
  support-api nginx      proxy_read_timeout = 15s   ← 504 here
    │
    ▼
  support-api Puma
    │
    ▼
  SQL (feedback query, often runs > 15s)

  The slow SQL sits behind support-api's nginx, which returns a 504
  at 15s before the 30s GdsApi timeout is ever reached
  Effective ceiling: 15s
```

After:

```
  browser
    │
    ▼
  support nginx          proxy_read_timeout = 30s
    │
    ▼
  support Puma
    │       GdsApi HTTP timeout = 30s
    ▼
  support-api nginx      proxy_read_timeout = 30s
    │
    ▼
  support-api Puma
    │
    ▼
  SQL (feedback query)

  All three limits now agree at 30s, so a request gets the full 30s
  Effective ceiling: 30s
```

[1]: https://github.com/alphagov/govuk-helm-charts/blob/bd2b4a4d78c47892811ee526c7cd745cf0db95b7/charts/generic-govuk-app/templates/nginx-configmap.yaml#L93
[2]: https://github.com/alphagov/govuk-helm-charts/blob/bd2b4a4d78c47892811ee526c7cd745cf0db95b7/charts/generic-govuk-app/values.yaml#L95
[3]: https://github.com/alphagov/support/blob/f135338e64831898023aaf3e53dd6bdefb082d16/config/initializers/gds_api.rb#L3