### PR TITLE
[PP-7805] Include extraEnv in SVG batch scan cron job

### DIFF
--- a/charts/asset-manager/templates/_svg-batch-scan_podspec.yaml
+++ b/charts/asset-manager/templates/_svg-batch-scan_podspec.yaml
@@ -38,6 +38,9 @@ spec:
         - name: REDIS_URL
           value: {{ .Values.redis.redisUrlOverride.workers | default (printf "redis://%s-redis" $fullName) }}
         {{- end }}
+        {{- with .Values.extraEnv }}
+          {{- (tpl (toYaml .) $) | trim | nindent 8 }}
+        {{- end }}
       {{- with .Values.appResources }}
       resources:
         {{- . | toYaml | trim | nindent 8 }}


### PR DESCRIPTION
The Rake task the cron job called is failing with the following error

```
rake aborted!
JWT auth secret is not configured. See config/secrets.yml
```

JWT_AUTH_SECRET is defined in extraEnv in each environment's chart values, so here we fold that in to make it available when running the cron job