### PR TITLE
[PP-7929] Raise nginx timeout for Support/Support API

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3597,7 +3597,7 @@ govukApplications:
       arch: arm64
       podTerminationGracePeriodSecs: 50
       containerPreStopSleepSecs: 40
-      nginxProxyReadTimeout: 30s
+      nginxProxyReadTimeout: 60s
       appResources:
         limits:
           cpu: 1
@@ -3674,7 +3674,7 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
-      nginxProxyReadTimeout: 30s
+      nginxProxyReadTimeout: 60s
       appResources:
         limits:
           cpu: 1

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3435,7 +3435,7 @@ govukApplications:
       arch: arm64
       podTerminationGracePeriodSecs: 50
       containerPreStopSleepSecs: 40
-      nginxProxyReadTimeout: 30s
+      nginxProxyReadTimeout: 60s
       appResources:
         limits:
           cpu: 1
@@ -3509,7 +3509,7 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
-      nginxProxyReadTimeout: 30s
+      nginxProxyReadTimeout: 60s
       appResources:
         limits:
           cpu: 1

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3401,7 +3401,7 @@ govukApplications:
       arch: arm64
       podTerminationGracePeriodSecs: 50
       containerPreStopSleepSecs: 40
-      nginxProxyReadTimeout: 30s
+      nginxProxyReadTimeout: 60s
       appResources:
         limits:
           cpu: 1
@@ -3473,7 +3473,7 @@ govukApplications:
   - name: support-api
     helmValues:
       arch: arm64
-      nginxProxyReadTimeout: 30s
+      nginxProxyReadTimeout: 60s
       appResources:
         limits:
           cpu: 1


### PR DESCRIPTION
We know that requests for feedback can be slow. Over the last 15 days there were 190 requests that took 10 seconds, 75 over 30 seconds, 49 over 60 seconds, and 23 over 120 seconds. The three worst offenders took just over 30 minutes(!)

We recently fixed the nginx timeout (previously 15s) to be in line with the GdsApi timeout of 30s configured in the app:
ade2e8f4e6f29adefa6eecb8a69823c8a42cde28. It looks like when this was configured in the app, they were in line, so a more recent change must have caused the settings to drift:
https://github.com/alphagov/support/commit/bfdb31403c6d21332a0e61ca3f1646c6c8a5feac

We've decided to raise it further to 60s - which a few other apps already use - so that more requests will resolve before timing out. For those that take longer than a minute, caching should mean that a single refresh is sufficient for the vast majority of requests

The app will be configured to match this change: https://github.com/alphagov/support/pull/2077