### PR TITLE
[SCH-2052] Retry snapshot creation if gateway times out

### DIFF
--- a/charts/search-index-env-sync/snapshot.sh
+++ b/charts/search-index-env-sync/snapshot.sh
@@ -39,6 +39,7 @@ create () {
   local deadline
   local current_time
   local state
+  local snapshot_retry_count
 
   start_time=$(date +%s)
   readonly start_time
@@ -47,6 +48,15 @@ create () {
   
   set +e
   result=$(mycurl -XPUT "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME?wait_for_completion=true")
+
+  snapshot_retry_count=1
+  while [[ "$result" == *"504 Gateway Time-out"* ]] && [[ "$snapshot_retry_count" -le 3 ]]; do
+    echo "Gateway timed-out, retrying snapshot creation"
+    sleep 5
+    result=$(mycurl -XPUT "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME?wait_for_completion=true")
+    ((snapshot_retry_count++))
+  done
+
   set -e
   state=$(jq -r .snapshot.state <<<"$result")
   echo "$result" | jq


### PR DESCRIPTION
Snapshot creation has been failing sporadically with 504 Gateway Time-out. I've added up to three retries to see if that resolves the problem.

See [Argo logs](https://argo.eks.production.govuk.digital/applications/cluster-services/search-index-env-sync?view=tree&resource=&orphaned=false&node=batch%2FJob%2Fapps%2Fsearch-index-env-sync-green-es6-snapshot-29760591%2F0&tab=logs) or screenshot from them showing error:
<img width="1412" height="679" alt="20260803 gateway timeout on snapshot creation" src="https://github.com/user-attachments/assets/b15b2b20-33de-4fd9-9d2a-ae89b2ecc295" />

Relates to [Jira ticket SCH-2052](https://github.com/alphagov/govuk-helm-charts/pull/4383)
