### PR TITLE
[PP-7805] Queue more SVG scans more often

### DIFF
--- a/charts/asset-manager/templates/_svg-batch-scan_podspec.yaml
+++ b/charts/asset-manager/templates/_svg-batch-scan_podspec.yaml
@@ -24,7 +24,7 @@ spec:
       image: "{{ required "A valid .Values.appImage.repository entry required!" .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
       imagePullPolicy: {{ .Values.appImage.pullPolicy | default "Always" }}
       command: ["rake"]
-      args: ["assets:bulk_scan_svgs[1000]"]
+      args: ["assets:bulk_scan_svgs[2000]"]
       envFrom:
         - configMapRef:
             name: govuk-apps-env

--- a/charts/asset-manager/templates/svg-batch-scan-cronjob.yaml
+++ b/charts/asset-manager/templates/svg-batch-scan-cronjob.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: {{ $fullName }}-svg-batch-scan
     app.kubernetes.io/component: svg-batch-scan
 spec:
-  schedule: "0 * * * *"
+  schedule: "*/5 * * * *"
   jobTemplate:
     metadata:
       labels:


### PR DESCRIPTION
This amends the cron job for the SVG-scan enqueueing Rake task in Asset Manager so that we enqueue up to 2000 jobs every five minutes. The Rake task will not enqueue any jobs if the queue is not empty

These figures are loosely based on the observation that it takes less than two minutes to work through 1000 jobs. We think regularly enqueueing a smaller batch is preferable to enqueueing many jobs hourly since we've previously found that Redis memory spikes when getting to the end of large batches