### PR TITLE
Enable Assets Nginx ALB Tweaks in Production.

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -185,7 +185,7 @@ govukApplications:
             paths:
               - path: /
       assetManagerNFS: &assets-nfs assets.production.govuk-internal.digital
-      nginxAlbOptimisation: false
+      nginxAlbOptimisation: true
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf


### PR DESCRIPTION
## What?
This toggles the new "ALB Optimisation" feature flag to `true` in Production now that we're confident that the changes are valid. With this flipped to "true", we can keen an eye out for any errors and see if these changes have a positive trend on our LCU and Processed Bytes.