### PR TITLE
[PNP-10105] Handle 410/460 differently on integration

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -249,9 +249,17 @@ http {
     # Error pages
     charset utf-8;
 
+    {{- if eq $.Values.govukEnvironment "integration" }}
+      error_page 460 =410 /410.html;
+      {{- range(list 400 401 403 404 405 406 422 429 500 502 503 504) }}
+      error_page {{ . }} /{{ . }}.html;
+    {{- else }}
+      {{- range(list 400 401 403 404 405 406 410 422 429 500 502 503 504) }}
+      error_page {{ . }} /{{ . }}.html;
+    {{- end }}
+
     {{- range(list 400 401 403 404 405 406 410 422 429 500 502 503 504) }}
 
-    error_page {{ . }} /{{ . }}.html;
     location /{{ . }}.html {
       proxy_pass https://govuk-app-assets-{{ $.Values.govukEnvironment }}.s3.eu-west-1.amazonaws.com/error_pages/{{ . }}.html;
       internal;


### PR DESCRIPTION
In order to test a possible solution to the 410 issue (that we can't return custom 410 pages from apps because they get intercepted and turned into static ones, but we can't just _not_ intercept because otherwise router would have to render 410 pages), we make the following changes:

Separate the range that gets passed to `error_page` directives from the range that is used to create the locations (this allows us to keep creating all locations without necessarily handling them all)

Branch on govukEnvironment. Prod/staging get the current behaviour (a full list of return codes is passed to the error_page directive). Integration gets the same list minus 410, but additionally it handles a 460 return code by translating it to a 410 and returning the /410.html location.

https://gov-uk.atlassian.net/browse/PNP-10105