### PR TITLE
[PNP-10105] Add 460->410 handling in all environments

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -250,7 +250,6 @@ http {
     charset utf-8;
 
     {{- if eq $.Values.govukEnvironment "integration" }}
-      error_page 460 =410 /410.html;
       {{- range(list 400 401 403 404 405 406 422 429 500 502 503 504) }}
         error_page {{ . }} /{{ . }}.html;
       {{- end }}
@@ -259,6 +258,8 @@ http {
         error_page {{ . }} /{{ . }}.html;
       {{- end }}
     {{- end }}
+
+    error_page 460 =410 /410.html;
 
     {{- range(list 400 401 403 404 405 406 410 422 429 500 502 503 504) }}
 


### PR DESCRIPTION
- Move the 460->410 intercept out of the integration only branch.
- This will allow all environments to intercept 460 status codes and rewrite them as 410s with the static html.
- Note that at this stage we are _not_ removing 410 interception in prod/staging, only allowing 460 handling. This means we can keep current behaviour until new versions of router and email-alert-frontend that return 460 are deployed.

https://gov-uk.atlassian.net/browse/PNP-10105