### PR TITLE
Move restore from prod back by 5 minutes

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -39,7 +39,7 @@ cronjobs:
 
   staging:
     green-es6-cp-prod:  # This would be too long as green-elasticsearch6-domain-cp-prod
-      schedule: "30 2 * * *"
+      schedule: "35 2 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO

--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -73,7 +73,7 @@ cronjobs:
 
   integration:
     green-es6-cp-stag:  # This would be too long as green-elasticsearch6-domain-cp-stag
-      schedule: "17 4 * * 1"
+      schedule: "35 4 * * 1"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO


### PR DESCRIPTION
Currently this is coinciding with a regular uptick in traffic that happens between 15 & 35 minutes past the hour each hour, meaning that we've seen an increase in the number of errors since the job was rescheduled on 30th July from 3am to 2:30am:
<img width="903" height="125" alt="Screenshot 2026-08-06 at 13 40 31" src="https://github.com/user-attachments/assets/db22a9c9-3b61-4837-97b4-b431856eebfc" />

It also coincides with the cluster health dropping to `yellow` status:
<img width="516" height="306" alt="Screenshot 2026-08-06 at 13 59 56" src="https://github.com/user-attachments/assets/18bc63e8-b26c-4500-9301-a73b5397afc5" />

Moving the job back by 5 minutes to 2:35am so that it starts after the rush. The next uptick in traffic on staging happens at 2:45am, so it'd be good for this to finish before that:

<img width="887" height="239" alt="Screenshot 2026-08-06 at 13 34 56" src="https://github.com/user-attachments/assets/d3148ad7-e685-4c65-85b9-a5171a7fb79e" />

Also making a similar change to the timing of the restore backup from staging job running on integration, as there's a similar spike in traffic between 15 & 35 minutes past the hour each hour:

<img width="771" height="204" alt="Screenshot 2026-08-06 at 13 57 11" src="https://github.com/user-attachments/assets/2d1fe734-d808-4ff0-93be-7730497f46cf" />

This also coincides with the integration ES cluster having `yellow` status, though not every day on integration. E.g. 3rd August 2026:
<img width="512" height="303" alt="Screenshot 2026-08-06 at 14 04 09" src="https://github.com/user-attachments/assets/7a8cf761-5e79-4e67-9587-3fc64add9898" />

Moving this job to 4:35am to avoid the current spike.