### PR TITLE
[PP-7805] Disable SVG batch scanning in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -221,8 +221,6 @@ govukApplications:
       nginxConfigMap:
         create: false
         name: asset-manager-nginx-conf
-      svgBatchScan:
-        enabled: true
       extraEnv:
         - name: ASSET_MANAGER_CLAMSCAN_PATH
           value: /usr/local/bin/clamdscan


### PR DESCRIPTION
We were running this in integration to learn about performance and see what kinds of issues get flagged. We've learnt all we need to for now, so we're turning it off