### PR TITLE
Lint app-config chart alongwith all other helm charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,31 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: render-charts
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+          show-progress: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c   # v8.0.1
         with:
           name: rendered-charts
-          path: .
+          path: rendered-charts
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310   # v5.0.1
 
       - name: helm lint
         run: |
-          EXITCODE=0
-          for env in values/*; do
-            [ -d "$env" ] || continue
-            for chart in "$env"/*; do
-              [ -d "$chart" ] || continue
-              chart_name=$(basename "$chart")
-              for app in "$chart"/*; do
-                echo "helm lint for app $app with chart $chart_name"
-                if ! output=$(helm lint --quiet -f "$app" "raw-charts/$chart_name"); then
-                  echo "$output"
-                  EXITCODE=1
-                fi
-              done
-            done
-          done
-          exit "$EXITCODE"
+          make lint-helm RENDERED_HELM_CHART_PATH=rendered-charts
 
   kubeconform:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+SHELL=bash
 .PHONY: check-yamllint lint check help enable-deployment-integration disable-deployment-integration enable-deployment-staging disable-deployment-staging enable-deployment-production disable-deployment-production
 
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+lint: lint-yaml
 
 check-yamllint: ## Check if yamllint is installed
 	@if command -v yamllint >/dev/null 2>&1; then \
@@ -13,9 +16,36 @@ check-yamllint: ## Check if yamllint is installed
 		exit 1; \
 	fi
 
-lint: check-yamllint ## Run yamllint on all YAML files
+
+lint-yaml: check-yamllint ## Run yamllint on all YAML files
 	@echo "Running yamllint..."
 	yamllint -f github .
+
+RENDERED_HELM_CHART_PATH := output
+lint-helm:
+	@EXITCODE=0; \
+	shopt -s nullglob; \
+	cd "$(RENDERED_HELM_CHART_PATH)"; \
+	for values_file in values/*/*/*.yaml; do \
+		echo "$${values_file}" | while IFS="/" read -r _ env chart app; do \
+		  	echo "helm lint for $$app with chart $$chart"; \
+			helm lint --quiet -f "$${values_file}" "raw-charts/$$chart/"; \
+			if [[ $$? != 0 ]]; then \
+				EXITCODE=1; \
+			fi; \
+		done; \
+	done; \
+	\
+	for values_file in raw-charts/app-config/values-*.yaml; do \
+  		echo "helm lint for app-config with $$values_file"; \
+  		helm lint --quiet -f "$$values_file" raw-charts/app-config/; \
+		if [[ $$? != 0 ]]; then \
+			EXITCODE=1; \
+		fi; \
+  	done; \
+  	exit "$$EXITCODE";
+
+
 
 check: lint ## Alias for lint target
 


### PR DESCRIPTION
## What
We had an issue where the `app-config` chart was failing because of some bad templating code, but it wasn't detected because that chart wasn't being linted. We now lint it.

Brings the helm linting code into Make to make it easier to run the linter locally, and simplifies the script while the opportunity presented itself.

## How to review

I haven't rebase this branch atop `main` yet on purpose! The place in `main` it branches off from doesn't have the fix for the templating error, which allows us to see that this change will error in the right ways.

Once a reviewer has seen that to be the case, I will rebase the branch and they can test it again.