### PR TITLE
Reschedule search-endex-env-sync jobs for elasticsearch staging

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -39,7 +39,7 @@ cronjobs:
 
   staging:
     green-es6-cp-prod:  # This would be too long as green-elasticsearch6-domain-cp-prod
-      schedule: "35 2 * * *"
+      schedule: "50 2 * * *"
       args: [restore_latest]
       extraEnv:
         - name: SNAPSHOT_REPO
@@ -47,7 +47,7 @@ cronjobs:
         - name: SUBDOMAIN
           value: elasticsearch6
     green-es6-snapshot:  # This would be too long as green-elasticsearch6-domain-snapshot
-      schedule: "07 3 * * *"
+      schedule: "37 3 * * *"
       args: [create_and_clean_up]
       extraEnv:
         - name: SUBDOMAIN


### PR DESCRIPTION
Move restore from prod & staging snapshot back

The number of shard failures has been higher since the restore job was rescheduled on 30th July. Moving it back by a further 15 minutes to hopefully reduce interaction with other traffic to the cluster.

<img width="871" height="236" alt="Screenshot 2026-08-10 at 10 53 53" src="https://github.com/user-attachments/assets/9b825de1-7545-4e6a-8e82-373e37ed3a61" />
