### PR TITLE
[PNP-10105] Remove 410 intercept in prod/staging

### DIFF
--- a/charts/app-config/templates/router-nginx-config.tpl
+++ b/charts/app-config/templates/router-nginx-config.tpl
@@ -249,14 +249,8 @@ http {
     # Error pages
     charset utf-8;
 
-    {{- if eq $.Values.govukEnvironment "integration" }}
-      {{- range(list 400 401 403 404 405 406 422 429 500 502 503 504) }}
-        error_page {{ . }} /{{ . }}.html;
-      {{- end }}
-    {{- else }}
-      {{- range(list 400 401 403 404 405 406 410 422 429 500 502 503 504) }}
-        error_page {{ . }} /{{ . }}.html;
-      {{- end }}
+    {{- range(list 400 401 403 404 405 406 422 429 500 502 503 504) }}
+      error_page {{ . }} /{{ . }}.html;
     {{- end }}
 
     error_page 460 =410 /410.html;


### PR DESCRIPTION
This has previously been removed in integration, but we couldn't remove it in production until router and email-alert-frontend were returning 460s. Now we clear the way for custom 410s. If frontend returns a 410, it will be passed through unchanged (allowing custom HTML), and router/email-alert-frontend will return bare 460s (which are already being intercepted in all environments and altered to a 410 and decorated with pre-rendered HTML from S3)

Once this is deployed, frontend PR https://github.com/alphagov/frontend/pull/5697 can be merged (returning 410 for custom gone routes rather than 200).

https://gov-uk.atlassian.net/browse/PNP-10105