### PR TITLE
[PP-7941] Add JWT auth secret as env var in HMRC Manuals API

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1909,6 +1909,11 @@ govukApplications:
             secretKeyRef:
               name: signon-app-hmrc-manuals-api
               key: oauth_secret
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1799,6 +1799,11 @@ govukApplications:
             secretKeyRef:
               name: signon-app-hmrc-manuals-api
               key: oauth_secret
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1851,6 +1851,11 @@ govukApplications:
             secretKeyRef:
               name: signon-app-hmrc-manuals-api
               key: oauth_secret
+        - name: JWT_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authenticating-proxy-jwt-auth-secret
+              key: JWT_AUTH_SECRET
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This secret will be used to generate JWTs that allow the preview of assets uploaded through HMRC Manuals API.