### PR TITLE
chore: 🤖 re-enable publisher environment sync

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -683,7 +683,7 @@ cronjobs:
         - op: backup
 
     publisher-postgres:
-      suspend: true
+      suspend: false
       schedule: "41 3 * * 1"
       db: publisher_production
       operations:

--- a/charts/monitoring-config/rules/integration/database_backups_and_syncs_integration_only_alerts.yaml
+++ b/charts/monitoring-config/rules/integration/database_backups_and_syncs_integration_only_alerts.yaml
@@ -137,7 +137,7 @@ groups:
         expr: >-
           db_backup_job_status_timestamp_seconds{
             state="succeeded",
-            database_instance!~"signon-mysql|publisher-postgres" # Publisher-postgres temporarily disabled while syncs for the environment are paused
+            database_instance!~"signon-mysql"
           } < time() - 648000  # 1 week + 12 hours
         labels:
           severity: warning


### PR DESCRIPTION
A user has requested we re-enable their db backup sync

https://gds.slack.com/archives/C013F737737/p1786713374877439?thread_ts=1784211696.431339&cid=C013F737737