### PR TITLE
Correct API groups in govuk-operators ArgoCD project

### DIFF
--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps ArgoCD with initial configuration
-version: 0.5.0
+version: 0.6.0

--- a/charts/argo-bootstrap/templates/argocd/govuk-operators-project.yaml
+++ b/charts/argo-bootstrap/templates/argocd/govuk-operators-project.yaml
@@ -23,9 +23,9 @@ spec:
     - group: ''
       kind: PersistentVolume
 
-    - group: "rbac.authorization.k8s.io:"
+    - group: "rbac.authorization.k8s.io"
       kind: ClusterRole
-    - group: "rbac.authorization.k8s.io:"
+    - group: "rbac.authorization.k8s.io"
       kind: ClusterRoleBinding
 
     - group: "admissionregistration.k8s.io"


### PR DESCRIPTION
The RBAC group had a trailing colon