### PR TITLE
Temporarily suspend regular binary evaluations

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3164,6 +3164,7 @@ govukApplications:
         - name: rpt-binary-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
+          suspend: true
         - name: rpt-binary-metric-wknd
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8 * * 6,0" # at 08:00 GMT on saturday and sunday

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3018,6 +3018,7 @@ govukApplications:
         - name: rpt-binary-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
+          suspend: true # temporarily suspend 17/08/2026 to manually rerun failing evaluations
         - name: rpt-binary-metric-wknd
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8 * * 6,0" # at 08:00 GMT on saturday and sunday

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3048,6 +3048,7 @@ govukApplications:
         - name: rpt-binary-metrics
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8-16/2 * * 1-5" # every two hours between 8am and 4pm on weekdays
+          suspend: true
         - name: rpt-binary-metric-wknd
           task: "quality:report_quality_metrics[binary]"
           schedule: "0 8 * * 6,0" # at 08:00 GMT on saturday and sunday


### PR DESCRIPTION
Several evaluations jobs have failed in the last 3 days, and we need to rerun them manually. There can only be one evaluation running at a time per environment, so we're suspending the scheduled evaluations to make space for the manually-run evaluations. Will re-enable later.

I've suspended the regular evaluations on all environments, in case we needed to re-run the evaluations on all environments.