### PR TITLE
Update GOV.UK Chat notification channel

### DIFF
--- a/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
+++ b/charts/kube-prometheus-stack-bootstrap/templates/alertmanagerconfig.yaml
@@ -162,7 +162,7 @@ spec:
         {{- include "slack.expiringtokenstext" . | nindent 8 }}
   - name: 'slack-chat-notifications'
     slackConfigs:
-    - channel: '#dev-notifications-ai-govuk'
+    - channel: '#ai-govuk-chat-devs'
       {{- include "slack.template" . | nindent 6 }}
       text: |-
         {{- include "slack.text" . | nindent 8 }}


### PR DESCRIPTION
We're now using a combined channel for notifications and dev discussion.