### PR TITLE
Deploy the job request operator as a Helm chart

### DIFF
--- a/charts/app-config/helm-versions/integration
+++ b/charts/app-config/helm-versions/integration
@@ -1,3 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.59.0"
 https://stakater.github.io/stakater-charts reloader: "2.2.16"
+oci://ghcr.io/alphagov/govuk/charts/govuk-job-request-operator govuk-job-request-operator: "v0.0.14"

--- a/charts/app-config/helm-versions/production
+++ b/charts/app-config/helm-versions/production
@@ -1,3 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.59.0"
 https://stakater.github.io/stakater-charts reloader: "2.2.16"
+oci://ghcr.io/alphagov/govuk/charts/govuk-job-request-operator govuk-job-request-operator: "v0.0.14"

--- a/charts/app-config/helm-versions/staging
+++ b/charts/app-config/helm-versions/staging
@@ -1,3 +1,4 @@
 # $repo_url $chart_name: "$chart_version"
 https://kubernetes.github.io/autoscaler cluster-autoscaler: "9.59.0"
 https://stakater.github.io/stakater-charts reloader: "2.2.16"
+oci://ghcr.io/alphagov/govuk/charts/govuk-job-request-operator govuk-job-request-operator: "v0.0.14"

--- a/charts/app-config/templates/job-request-operator.yaml
+++ b/charts/app-config/templates/job-request-operator.yaml
@@ -1,0 +1,37 @@
+{{- $helmReleaseInfo := include "app-config.helm-release"
+        ( merge (deepCopy .) (dict "repoURL" "oci://ghcr.io/alphagov/govuk/charts/govuk-job-request-operator" "chart" "govuk-job-request-operator") )
+}}
+{{- $imageTag := get ($helmReleaseInfo|fromYaml) "targetRevision" }}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: job-request-operator
+  namespace: {{ $.Values.argoNamespace | default $.Release.Namespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    slackChannel: "#govuk-platform-engineering-support"
+    repoName: "alphagov/govuk-job-request-operator/releases"
+    imageTag: "{{ $imageTag }}"
+    notifications.argoproj.io/subscribe.on-deployed.argo_events: ""
+    notifications.argoproj.io/subscribe.deployment.grafana: "deployment|{{ .name }}"
+    postSyncWorkflowEnabled: "{{ .postSyncWorkflowEnabled | default "true" }}"
+spec:
+  project: govuk-operators
+  source:
+    {{- $helmReleaseInfo | nindent 4 }}
+    path: .
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: job-request-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true

--- a/renovate.json
+++ b/renovate.json
@@ -87,7 +87,17 @@
             ],
             "datasourceTemplate": "helm",
             "matchStrings": [
-                "(?<registryUrl>.+) (?<depName>.+): \"(?<currentValue>[0-9\\.]+)\""
+                "(?<registryUrl>https://.+) (?<depName>.+): \"(?<currentValue>[0-9\\.]+)\""
+            ]
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/.*\\/helm-versions\\/.*/"
+            ],
+            "datasourceTemplate": "docker",
+            "matchStrings": [
+                "(?<registryUrl>oci://.+) (?<depName>.+): \"(?<currentValue>v?[0-9\\.]+)\""
             ]
         }
     ]


### PR DESCRIPTION
## What

Deploys the job request operator using the helm chart it builds and publishes. This is a little different from other things we've done before, because the chart is published as an OCI image to a registry, instead of being hosted on a Helm chart repository.

## How to review

n.b. check that `cluster-services` has been run in all environments before test and merging; there were some additional PRs that added some supporting pieces around the edges of this

1. Deploy the branch to integration
2. Check the operator is deployed
3. Check it works