### PR TITLE
Set `dbMigrationEnabled: true` for fact-check-manager in production

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1474,7 +1474,7 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 512Mi
-      dbMigrationEnabled: false
+      dbMigrationEnabled: true
       workers:
         enabled: true
       workerResources:


### PR DESCRIPTION
The fact-check-manager database is set up now so we can enable database migrations.