### PR TITLE
Update report evaluation jobs

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3170,15 +3170,14 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
-        - name: report-evaluations-may
-          task: "report:evaluations[2026-05, succeeded running]"
-          schedule: "0 0 1 1 * " # midnight on Jan 1st - placeholder to be run manually.
-        - name: report-evaluations-june
-          task: "report:evaluations[2026-06, succeeded running]"
-          schedule: "0 0 1 1 * "
-        - name: report-evaluations-july
-          task: "report:evaluations[2026-07, succeeded running]"
-          schedule: "0 0 1 1 * "
+        - name: report-evaluations-this-month
+          task: "report:evaluations_this_month[failed]"
+          schedule: "0 0 31 2 *" # to be run manually
+          suspend: true
+        - name: report-evaluations-last-month
+          task: "report:evaluations_last_month[failed]"
+          schedule: "0 0 31 2 *" # to be run manually
+          suspend: true
       extraEnv:
         - name: GOOGLE_CLOUD_CREDENTIALS
           valueFrom:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3074,12 +3074,12 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
-        - name: report-evaluations-aug
-          task: "report:evaluations[2026-08, failed]"
+        - name: report-evaluations-this-month
+          task: "report:evaluations_this_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true
-        - name: report-evaluations-july
-          task: "report:evaluations[2026-07, failed]"
+        - name: report-evaluations-last-month
+          task: "report:evaluations_last_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true
       extraEnv:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3054,15 +3054,14 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
-        - name: report-evaluations-may
-          task: "report:evaluations[2026-05, succeeded running]"
-          schedule: "0 0 1 1 * " # midnight on Jan 1st - placeholder to be run manually.
-        - name: report-evaluations-june
-          task: "report:evaluations[2026-06, succeeded running]"
-          schedule: "0 0 1 1 * "
-        - name: report-evaluations-july
-          task: "report:evaluations[2026-07, succeeded running]"
-          schedule: "0 0 1 1 * "
+        - name: report-evaluations-this-month
+          task: "report:evaluations_this_month[failed]"
+          schedule: "0 0 31 2 *" # to be run manually
+          suspend: true
+        - name: report-evaluations-last-month
+          task: "report:evaluations_last_month[failed]"
+          schedule: "0 0 31 2 *" # to be run manually
+          suspend: true
       extraEnv:
         - name: GOOGLE_CLOUD_CREDENTIALS
           valueFrom:


### PR DESCRIPTION
Uses [new rake tasks](https://github.com/alphagov/search-api-v2-beta-features/pull/166) that report evaluations for this month and last month instead of fixed months, so that we don't have to update the list of cronTasks every month.

Also aligns the cronTasks across integration, staging and production, so that we're consistently on a suspended schedule and reporting the same (failed) states across environments.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2262