### PR TITLE
Shorten cron task names

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3170,11 +3170,11 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
-        - name: report-evaluations-this-month
+        - name: report-evals-this-month
           task: "report:evaluations_this_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true
-        - name: report-evaluations-last-month
+        - name: report-evals-last-month
           task: "report:evaluations_last_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3094,11 +3094,11 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
-        - name: report-evaluations-this-month
+        - name: report-evals-this-month
           task: "report:evaluations_this_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true
-        - name: report-evaluations-last-month
+        - name: report-evals-last-month
           task: "report:evaluations_last_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3074,11 +3074,11 @@ govukApplications:
         - name: setup-sample-query-sets
           task: "quality:setup_sample_query_sets"
           schedule: "0 2 1 * *" # 02:00 first day of the month
-        - name: report-evaluations-this-month
+        - name: report-evals-this-month
           task: "report:evaluations_this_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true
-        - name: report-evaluations-last-month
+        - name: report-evals-last-month
           task: "report:evaluations_last_month[failed]"
           schedule: "0 0 31 2 *" # to be run manually
           suspend: true


### PR DESCRIPTION
Argo can't sync if crontask names are more than 52 characters (see screenshot). Existing names were 57 characters, e.g. `search-api-v2-beta-features-report-evaluations-last-month`. Shortening by abbreviating 'evaluations', e.g. `search-api-v2-beta-features-report-evals-last-month`

<img width="1491" height="183" alt="20260821 crontask names too long" src="https://github.com/user-attachments/assets/30db381c-6acf-4737-8ec1-751cdb52ac3e" />
