### PR TITLE
[PP-7931] Stop frontend apps using Publishing API read replica in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -381,8 +381,6 @@ govukApplications:
           value: "0"
         - name: GRAPHQL_RATE_WORLD_INDEX
           value: "0"
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
   - name: draft-collections
     repoName: collections
     helmValues:
@@ -410,8 +408,6 @@ govukApplications:
           value: *emergency-banner-redis
         - name: PLEK_HOSTNAME_PREFIX
           value: draft-
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
   - name: collections-publisher
     helmValues:
       arch: arm64
@@ -1240,8 +1236,6 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: MEMCACHE_SERVERS
           value: frontend-memcached-govuk.eks.integration.govuk-internal.digital
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
   - name: draft-feedback
     repoName: feedback
     helmValues:
@@ -1465,8 +1459,6 @@ govukApplications:
           value: "0"
         - name: GRAPHQL_RATE_TRANSACTION
           value: "0"
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
       nginxConfigMap:
         extraServerConf: |
           location ~ /government/uploads/(?<item_path>.+) {
@@ -1542,8 +1534,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
-        - name: PLEK_SERVICE_PUBLISHING_API_URI
-          value: "http://publishing-api-read-replica"
         - name: PUBLISHING_API_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -373,14 +373,6 @@ govukApplications:
               key: bearer_token
         - name: EMERGENCY_BANNER_REDIS_URL
           value: *emergency-banner-redis
-        - name: GRAPHQL_RATE_MINISTERS_INDEX
-          value: "0"
-        - name: GRAPHQL_RATE_ROLE
-          value: "0"
-        - name: GRAPHQL_RATE_TOPICAL_EVENT
-          value: "0"
-        - name: GRAPHQL_RATE_WORLD_INDEX
-          value: "0"
   - name: draft-collections
     repoName: collections
     helmValues:
@@ -1405,60 +1397,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-frontend-email-alert-api
               key: bearer_token
-        - name: GRAPHQL_RATE_ANSWER
-          value: "0"
-        - name: GRAPHQL_RATE_CALENDAR
-          value: "0"
-        - name: GRAPHQL_RATE_CALL_FOR_EVIDENCE
-          value: "0"
-        - name: GRAPHQL_RATE_CASE_STUDY
-          value: "0"
-        - name: GRAPHQL_RATE_CORPORATE_INFORMATION_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_DOCUMENT_COLLECTION
-          value: "0"
-        - name: GRAPHQL_RATE_FATALITY_NOTICE
-          value: "0"
-        - name: GRAPHQL_RATE_FIELDS_OF_OPERATION
-          value: "0"
-        - name: GRAPHQL_RATE_GUIDE
-          value: "0"
-        - name: GRAPHQL_RATE_HELP_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_HOMEPAGE
-          value: "0"
-        - name: GRAPHQL_RATE_LANDING_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_LOCAL_TRANSACTION
-          value: "0"
-        - name: GRAPHQL_RATE_NEWS_ARTICLE
-          value: "0"
-        - name: GRAPHQL_RATE_PLACE
-          value: "0"
-        - name: GRAPHQL_RATE_PUBLICATION
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_GUIDE
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_HOMEPAGE
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_STANDARD
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_SERVICE_TOOLKIT
-          value: "0"
-        - name: GRAPHQL_RATE_SERVICE_MANUAL_TOPIC
-          value: "0"
-        - name: GRAPHQL_RATE_SIMPLE_SMART_ANSWER
-          value: "0"
-        - name: GRAPHQL_RATE_SPECIALIST_DOCUMENT
-          value: "0"
-        - name: GRAPHQL_RATE_SPEECH
-          value: "0"
-        - name: GRAPHQL_RATE_STATISTICAL_DATA_SET
-          value: "0"
-        - name: GRAPHQL_RATE_TOPICAL_EVENT_ABOUT_PAGE
-          value: "0"
-        - name: GRAPHQL_RATE_TRANSACTION
-          value: "0"
       nginxConfigMap:
         extraServerConf: |
           location ~ /government/uploads/(?<item_path>.+) {


### PR DESCRIPTION
We are removing the read replica from integration to reduce cost as it's not being used at the moment. 