### PR TITLE
Stop SHA pinning govuk-infrastructure workflows and actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
         with:
           show-progress: false
-      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@b6e3293ee4405b58975b7e9d0257a8f15470013d # main
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended",
-        "helpers:pinGitHubActionDigests"
+        "helpers:pinGitHubActionDigests",
+        "github>alphagov/govuk-infrastructure:renovate"
     ],
     "platformAutomerge": true,
     "labels": [


### PR DESCRIPTION
Relates to https://github.com/alphagov/govuk-infrastructure/issues/4474

Stop SHA pinning govuk-infra in github actions and workflows.

Make renovate extend the govuk-infra renovate config which will make it not set sha pins on govuk-infrastructure