### PR TITLE
[PP-7931] Remove publishing-api-read-replica deployment in integration

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2506,53 +2506,6 @@ govukApplications:
             secretKeyRef:
               name: publishing-api-bigquery
               key: client-secret
-  - name: publishing-api-read-replica
-    repoName: publishing-api
-    postSyncWorkflowEnabled: "false"
-    helmValues:
-      arch: arm64
-      appResources:
-        limits:
-          cpu: 2
-          memory: 1.5Gi
-        requests:
-          cpu: 10m
-          memory: 512Mi
-      nginxClientMaxBodySize: 2M
-      uploadAssets:
-        enabled: false
-      dbMigrationEnabled: false
-      rails:
-        createKeyBaseSecret: false
-      sentry:
-        createSecret: false
-      extraEnv:
-        - name: GDS_SSO_OAUTH_ID
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-publishing-api
-              key: oauth_id
-        - name: GDS_SSO_OAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: signon-app-publishing-api
-              key: oauth_secret
-        - name: GOVUK_CONTENT_SCHEMAS_PATH
-          value: /app/content_schemas
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: publishing-api-postgres
-              key: DATABASE_URL
-        - name: REPLICA_DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: publishing-api-postgres
-              key: REPLICA_DATABASE_URL
-        - name: RAILS_ENV
-          value: production_replica
-        - name: DISABLE_QUEUE_PUBLISHER
-          value: "true"
   - name: release
     helmValues:
       arch: arm64


### PR DESCRIPTION
We're removing the publishing-api-read-replica in integration to reduce cost as it's not currently being used.

Depends on: 

https://github.com/alphagov/govuk-helm-charts/pull/4426