### PR TITLE
Remove GOVUK_PROMETHEUS_EXPORTER env var from all charts

### DIFF
--- a/charts/app-config/templates/env-configmap.yaml
+++ b/charts/app-config/templates/env-configmap.yaml
@@ -17,8 +17,6 @@ data:
   GOVUK_ASSET_ROOT: https://{{ .Values.assetsDomain }}
   GOVUK_CSP_REPORT_URI: {{ .Values.cspReportURI | quote }}
   GOVUK_ENVIRONMENT: {{ .Values.govukEnvironment }}
-  # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-  GOVUK_PROMETHEUS_EXPORTER: "true"
   GOVUK_PERSONALISATION_FEEDBACK_URI: https://signin.account.gov.uk/support
   {{- if eq .Values.govukEnvironment "production" }}
   GOVUK_PERSONALISATION_MANAGE_URI: "https://account.gov.uk?link=manage-account"

--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -1181,9 +1181,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-service-email-alert-api
               key: bearer_token
-        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-        - name: GOVUK_PROMETHEUS_EXPORTER
-          value: force
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:
@@ -3025,9 +3022,6 @@ govukApplications:
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"
-        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-        - name: GOVUK_PROMETHEUS_EXPORTER
-          value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_THREADS

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1159,9 +1159,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-service-email-alert-api
               key: bearer_token
-        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-        - name: GOVUK_PROMETHEUS_EXPORTER
-          value: force
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:
@@ -3014,9 +3011,6 @@ govukApplications:
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"
-        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-        - name: GOVUK_PROMETHEUS_EXPORTER
-          value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_THREADS

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1189,9 +1189,6 @@ govukApplications:
             secretKeyRef:
               name: signon-token-email-alert-service-email-alert-api
               key: bearer_token
-        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-        - name: GOVUK_PROMETHEUS_EXPORTER
-          value: force
         - name: RABBITMQ_URL
           valueFrom:
             secretKeyRef:
@@ -3001,9 +2998,6 @@ govukApplications:
       extraEnv:
         - name: ENABLE_AUTOCOMPLETE
           value: "true"
-        # TODO: remove GOVUK_PROMETHEUS_EXPORTER once govuk_app_config >=9.10 is everywhere.
-        - name: GOVUK_PROMETHEUS_EXPORTER
-          value: force
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME
           value: search_api_v2_published_documents
         - name: PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_THREADS


### PR DESCRIPTION
Relates to https://github.com/alphagov/govuk-infrastructure/issues/2308

All apps now use govuk_app_config > 9.10.0 and the GOVUK_PROMETHEUS_EXPORTER env var no longer does anything.

Remove it from all our charts since it's no longer required or useful.