### PR TITLE
Schedule update-govuk-index-popularity jobs earlier.

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -2841,7 +2841,7 @@ govukApplications:
               memory: 800Mi
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
-          schedule: "15 00 * * *"
+          schedule: "30 23 * * *"
       workers:
         enabled: true
         replicaCount: 3

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2898,7 +2898,7 @@ govukApplications:
           schedule: "0 22 * * *"
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
-          schedule: "15 00 * * *"
+          schedule: "30 23 * * *"
       extraEnv:
         - name: AWS_S3_RELEVANCY_BUCKET_NAME
           value: govuk-production-search-relevancy

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2870,7 +2870,7 @@ govukApplications:
           schedule: "0 22 * * *"
         - name: update-govuk-index-popularity
           task: "search:update_popularity"
-          schedule: "15 00 * * *"
+          schedule: "30 23 * * *"
       workers:
         enabled: true
         types:


### PR DESCRIPTION
Currently the popularity job is still running on staging when the restore from snapshot job starts at 2:50am UTC, resulting in [errors as the cluster is not available for the popularity update](https://govuk.sentry.io/issues/7679837015/?referrer=slack&notification_uuid=24bf6979-53af-47b7-817b-7a7b0cc9a9cb&alert_rule_id=16480038&alert_type=issue). Moving the popularity jobs earlier across all envs to leave more time to fit in other cronjobs that touch the elasticsearch instances.

See [spreadsheet of all cron jobs that touch the elasticsearch instances](https://beisgov-my.sharepoint.com/:x:/r/personal/lucy_stringer2_dsit_gov_uk/Documents/Documents/Team%20-%20Search/Search%20env%20sync%20timings.xlsx?d=w59e7bb88a5604c31b1423f4d8c941173&csf=1&web=1&e=UifpEw) for list of all cronjobs and workings re changes.