### PR TITLE
[MAIN-7504] Add db-backup jobs for fact-check-manager

### DIFF
--- a/charts/db-backup/values.yaml
+++ b/charts/db-backup/values.yaml
@@ -155,6 +155,12 @@ cronjobs:
       operations:
         - op: backup
 
+    fact-check-manager-postgres:
+      schedule: "26 23 * * *"
+      db: fact-check-manager_production
+      operations:
+        - op: backup
+
     places-manager-postgres:
       schedule: "18 23 * * *"
       db: imminence_production
@@ -359,6 +365,14 @@ cronjobs:
       extraEnv:
         - name: DB_OWNER
           value: email-alert-api
+
+    fact-check-manager-postgres:
+      schedule: "26 1 * * 1-5"
+      db: fact-check-manager_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-production-database-backups
+        - op: backup
 
     places-manager-postgres:
       schedule: "18 1 * * 1-5"
@@ -621,6 +635,14 @@ cronjobs:
       extraEnv:
         - name: DB_OWNER
           value: email-alert-api
+
+    fact-check-manager-postgres:
+      schedule: "26 3 * * 1"
+      db: fact-check-manager_production
+      operations:
+        - op: restore
+          bucket: s3://govuk-staging-database-backups
+        - op: backup
 
     places-manager-postgres:
       schedule: "18 3 * * 1"


### PR DESCRIPTION
[MAIN-7504](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-7504)

### Changes
Add db-backup jobs (backup and restore) for fact-check-manager databases

- Backs up the production database nightly at 23:26
- Restores into staging at 01:26 on weekdays, followed by a backup
- Restores into integration at 03:26 on Mondays, followed by a backup

[MAIN-7504]: https://gov-uk.atlassian.net/browse/MAIN-7504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ