### PR TITLE
Fact Check Manager Notify Secrets

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -1521,6 +1521,12 @@ govukApplications:
             secretKeyRef:
               name: signon-app-fact-check-manager
               key: oauth_secret
+        - name: GOVUK_NOTIFY_NEW_FACT_CHECK_REQUEST_TEMPLATE_ID
+          value: 5fd98fb2-6145-400a-8fe6-17c0d05965a8
+        - name: GOVUK_NOTIFY_RESPONSE_ACCEPTED_TEMPLATE_ID
+          value: 1d5486d4-841d-4ca5-b2f3-f806191c4ce8
+        - name: GOVUK_NOTIFY_RESPONSE_REJECTED_TEMPLATE_ID
+          value: 11abc603-5662-4921-ba5c-b21277f640dd
         - name: PUBLISHER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -1536,6 +1536,11 @@ govukApplications:
               key: DATABASE_URL
         - name: GOVUK_CSP_REPORT_ONLY
           value: "true"
+        - name: GOVUK_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fact-check-manager-notify
+              key: GOVUK_NOTIFY_API_KEY
         - name: JWT_AUTH_SECRET
           valueFrom:
             secretKeyRef:
@@ -1551,6 +1556,12 @@ govukApplications:
             secretKeyRef:
               name: signon-app-fact-check-manager
               key: oauth_secret
+        - name: GOVUK_NOTIFY_NEW_FACT_CHECK_REQUEST_TEMPLATE_ID
+          value: 673dc314-b0b4-4900-9e9a-2c9386a87781
+        - name: GOVUK_NOTIFY_RESPONSE_ACCEPTED_TEMPLATE_ID
+          value: f0c23f77-704c-4b0c-9d72-648fdbc7ee6c
+        - name: GOVUK_NOTIFY_RESPONSE_REJECTED_TEMPLATE_ID
+          value: 9cb24bc3-e239-4f44-9b2e-f122f713fdeb
         - name: PUBLISHER_BEARER_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This PR adds Notify template IDs (Staging & Production) and Notify API Key (Staging team key only, Production live key to follow once that service is live) to the helm chart.

Following the pattern from Integration that the template IDs themselves are not considered sensitive information and are fine to include here in-code, as they grant no particular access to Notify (an API key is still required).