### PR TITLE
Schedule generate-sitemap later on staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2877,7 +2877,7 @@ govukApplications:
       cronTasks:
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
-          schedule: "50 2 * * *"
+          schedule: "10 3 * * *"
         - name: load-page-traffic
           command: "./bin/load_page_traffic.sh"
           schedule: "0 22 * * *"


### PR DESCRIPTION
Currently this job coincides with the job to restore staging from the production snapshot, making the generate-sitemap job fail as it can't find the cluster. Moving it back to after the snapshot job has finished, so that there is no clash. 

Note that this is probably a temporary move while we dig properly into how to schedule all of the cron tasks touching elasticsearch more effectively.