### PR TITLE
ExternalSecret for Specialist Publisher MySQL creds [WHIT-3578]

### DIFF
--- a/charts/external-secrets/templates/specialist-publisher/specialist-publisher-mysql.yaml
+++ b/charts/external-secrets/templates/specialist-publisher/specialist-publisher-mysql.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: specialist-publisher-mysql
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >
+      Credentials for Specialist Publisher to connect to MYSQL.
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    deletionPolicy: {{ .Values.externalSecrets.deletionPolicy }}
+    name: specialist-publisher-mysql
+    template:
+      data:
+        DATABASE_URL: '{{ $.Files.Get "externalsecrets-templates/mysql-conn-string.tpl" | trim }}/specialist_publisher_production'
+  dataFrom:
+    - extract:
+        key: govuk/specialist-publisher/mysql
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
Define Kubernetes ExternalSecret for mapping the secret between AWS Secrets Manager and Kubernetes.

Follows on from https://github.com/alphagov/govuk-infrastructure/pull/4704

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578