### PR TITLE
Use Kubernetes secret in Specialist Publisher ENV var [WHIT-3578]

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3453,6 +3453,11 @@ govukApplications:
           value: *publishing-bootstrap-gtm-auth
         - name: GOOGLE_TAG_MANAGER_PREVIEW # Non-prod only
           value: *publishing-bootstrap-gtm-preview
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: specialist-publisher-mysql
+              key: DATABASE_URL
   - name: support
     helmValues:
       arch: arm64

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3497,6 +3497,11 @@ govukApplications:
           value: *publishing-notify-template
         - name: GOOGLE_TAG_MANAGER_ID
           value: *publishing-bootstrap-gtm-id
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: specialist-publisher-mysql
+              key: DATABASE_URL
       cronTasks: []
   - name: support
     helmValues:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3463,6 +3463,11 @@ govukApplications:
               key: GOVUK_NOTIFY_API_KEY
         - name: GOVUK_NOTIFY_TEMPLATE_ID
           value: *publishing-notify-template
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: specialist-publisher-mysql
+              key: DATABASE_URL
       cronTasks: []
   - name: support
     helmValues:


### PR DESCRIPTION
Use the Kubernetes secret defined in https://github.com/alphagov/govuk-helm-charts/pull/4438 so that Specialist Publisher can set up a connection to its new MySQL database.

Follows on from https://github.com/alphagov/govuk-infrastructure/pull/4704

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578