### PR TITLE
URL-encode database username/password when constructing URL

### DIFF
--- a/charts/external-secrets/externalsecrets-templates/mysql-conn-string.tpl
+++ b/charts/external-secrets/externalsecrets-templates/mysql-conn-string.tpl
@@ -1,1 +1,1 @@
-mysql2://{{ .username | toString }}:{{ .password | toString }}@{{ .host | toString }}
+mysql2://{{ .username | urlquery }}:{{ .password | urlquery }}@{{ .host | toString }}

--- a/charts/external-secrets/externalsecrets-templates/psql-conn-string.tpl
+++ b/charts/external-secrets/externalsecrets-templates/psql-conn-string.tpl
@@ -1,1 +1,1 @@
-postgresql://{{ .username | toString }}:{{ .password | toString }}@{{ .host | toString }}
+postgresql://{{ .username | urlquery }}:{{ .password | urlquery }}@{{ .host | toString }}


### PR DESCRIPTION
One of the database passwords I created recently has a '?' char in it, which has a special meaning in URL construction, breaking the db connection URL. URL-encoding the username and password that is interpolated should solve the issue.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578