### PR TITLE
Enable rails migration on integration for Specialist Publisher

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3375,6 +3375,7 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 384Mi
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:


### PR DESCRIPTION
I need to run the rails migration to test the switch to MySQL. I can't do this from within the pod itself (with `k exec`) as the assumed user doesn't have permissions to write to `/app/db/schema.rb`.

Merging this and then redeploying the branch of Specialist Publisher should enable me to test it in the short term (and I can always revert this change if we then want to deploy `main` again).

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578