### PR TITLE
Revert "Enable rails migration on integration for Specialist Publisher"

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3375,7 +3375,6 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 384Mi
-      dbMigrationEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:


### PR DESCRIPTION
Reverts alphagov/govuk-helm-charts#4441

This has now been successfully tested on integration.