### PR TITLE
Enable rails db:migrate on Specialist Publisher [WHIT-3578]

### DIFF
--- a/charts/app-config/values-integration.yaml
+++ b/charts/app-config/values-integration.yaml
@@ -3375,6 +3375,7 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 384Mi
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:

--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -3423,6 +3423,7 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 450Mi
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -3391,6 +3391,7 @@ govukApplications:
         requests:
           cpu: 10m
           memory: 450Mi
+      dbMigrationEnabled: true
       nginxClientMaxBodySize: *max-upload-size
       nginxProxyReadTimeout: 30s
       workers:


### PR DESCRIPTION
Specialist Publisher's DB is being switched from Mongo (DocumentDB) to MySQL / ActiveRecord. We need rails migrations in place so that the new Users table can be set up automatically when we merge and deploy https://github.com/alphagov/specialist-publisher/pull/3828

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578