### PR TITLE
Add Specialist Publisher to list of external secrets [WHIT-3578]

### DIFF
--- a/charts/external-secrets/values.yaml
+++ b/charts/external-secrets/values.yaml
@@ -10,6 +10,7 @@ provisionDatabaseReadonlySecrets:
     - release
     - search_admin
     - signon
+    - specialist_publisher
     - whitehall
   postgres:
     - account_api


### PR DESCRIPTION
As per https://docs.publishing.service.gov.uk/kubernetes/creating-a-new-database/create-readonly-credentials-for-your-rds-database.html#add-your-database-to-the-list-of-external-secrets-to-be-provisioned

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578