### PR TITLE
Suspend cronjobs syncing data to Green cluster on integration

### DIFF
--- a/charts/search-index-env-sync/values.yaml
+++ b/charts/search-index-env-sync/values.yaml
@@ -80,12 +80,14 @@ cronjobs:
           value: govuk-staging
         - name: SUBDOMAIN
           value: elasticsearch6
+      suspend: true # Only re-enable after the blue clusters have been created
     green-es6-snapshot: # This would be too long as green-elasticsearch6-domain-snapshot
       schedule: "37 5 * * 1"
       args: [create_and_clean_up]
       extraEnv:
         - name: SUBDOMAIN
           value: elasticsearch6
+      suspend: true # Only re-enable after the blue clusters have been created
     chat-engine-cp-prod:
       schedule: "12 4 * * *"
       args: [restore_latest]


### PR DESCRIPTION
The Green Elasticsearch cluster on Integration is going to be removed, so these cronjobs will fail if they are not suspended.

The Blue cluster is not compatible with the Green cluster, so we cannot use snapshots to sync data between them. These cronjobs can only be reinstated after all clusters have been upgraded in staging and production.
