### PR TITLE
Correct Renovate configuration for updating Helm OCI images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -96,8 +96,9 @@
                 "/.*\\/helm-versions\\/.*/"
             ],
             "datasourceTemplate": "docker",
+            "packageNameTemplate": "{{dockerUrl}}",
             "matchStrings": [
-                "(?<registryUrl>oci://.+) (?<depName>.+): \"(?<currentValue>v?[0-9\\.]+)\""
+                "oci://(?<dockerUrl>.+) (?<depName>.+): \"(?<currentValue>v?[0-9\\.]+)\""
             ]
         }
     ]


### PR DESCRIPTION
## What

Renovate's Helm datasource doesn't understand OCI images, but its Docker datasource does. We were previously doing the correct thing for a Docker image, but by including the "oci://" prefix in the registry URL, Renovate was trying to look up "https://oci://registry.url/package".

Instead, the correct approach is to extract the "registry.url/package" component and supply that to the Docker datasource as the package name, so that it can construct "https://registry.url/package" for itself.

## How to review

You can test this yourself using Renovate locally:

```bash
$ docker run -it -v"$(pwd):/repo" -e "RENOVATE_TOKEN=${GITHUB_TOKEN}" -e "GITHUB_COM_TOKEN=${GITHUB_TOKEN}" renovate/renovate:43.288.0 bash

$ cd /repo

# tee so you can read it more easily. There are almost 2000 lines.
$ LOG_LEVEL=debug renovate --platform local | tee output.txt 
```

In the output I saw Renovate's conclusion about what new versions it could get for the job request operator, and it is correct about them.

```json
"deps": [
               {
                 "depName": "govuk-job-request-operator",
                 "packageName": "ghcr.io/alphagov/govuk/charts/govuk-job-request-operator",
                 "currentValue": "v0.1.0",
                 "datasource": "docker",
                 "replaceString": "oci://ghcr.io/alphagov/govuk/charts/govuk-job-request-operator govuk-job-request-operator: \"v0.1.0\"",
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "v0.2.1",
                     "newValue": "v0.2.1",
                     "newMajor": 0,
                     "newMinor": 2,
                     "newPatch": 1,
                     "updateType": "minor",
                     "isBreaking": false,
                     "pendingChecks": true,
                     "branchName": "renovate/integration-govuk-job-request-operator-0.x"
                   }
                 ],
                 "versioning": "docker",
                 "warnings": [],
                 "sourceUrl": "https://github.com/alphagov/govuk-job-request-operator",
                 "registryUrl": "https://ghcr.io",
                 "lookupName": "alphagov/govuk/charts/govuk-job-request-operator",
                 "currentVersion": "v0.1.0",
                 "isSingleVersion": true,
                 "fixedVersion": "v0.1.0"
               }
             ],
```