### PR TITLE
Set no minimum age for new versions of the job request operator

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,12 @@
             "additionalBranchPrefix": "{{replace '^.+\\/' '' packageFile}}-",
             "commitMessageSuffix": " ({{replace '^.+\\/' '' packageFile}})",
             "minimumReleaseAge": "10 days"
+        },
+        {
+            "matchPackageNames": [
+                "ghcr.io/alphagov/govuk/charts/govuk-job-request-operator"
+            ],
+            "minimumReleaseAge": null
         }
     ],
     "customManagers": [


### PR DESCRIPTION
We trust it because it's our code. We don't need it to wait 10 days.