### PR TITLE
Add Elasticdump job for staging/production blue/green Elasticsearch data sync

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2877,6 +2877,10 @@ govukApplications:
             cpu: 500m
             memory: 2Gi
       cronTasks:
+        - name: elasticdump
+          task: "elasticdump"
+          schedule: "0 0 31 2 *" # never
+          suspend: true # Only run this task manually
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
           schedule: "50 2 * * *"
@@ -2935,6 +2939,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-rabbitmq
               key: RABBITMQ_URL
+        - name: ELASTICDUMP_PARAMETERS
+          valueFrom:
+            secretKeyRef:
+              name: search-api-elasticdump
+              key: parameters
         - name: TENSORFLOW_SAGEMAKER_ENDPOINT
           value: govuk-production-search-ltr-endpoint
   - name: search-api-v2

--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2849,6 +2849,10 @@ govukApplications:
       redis:
         enabled: true
       cronTasks:
+        - name: elasticdump
+          task: "elasticdump"
+          schedule: "0 0 31 2 *" # never
+          suspend: true # Only run this task manually
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
           schedule: "50 2 * * *"
@@ -2923,6 +2927,11 @@ govukApplications:
             secretKeyRef:
               name: search-api-rabbitmq
               key: RABBITMQ_URL
+        - name: ELASTICDUMP_PARAMETERS
+          valueFrom:
+            secretKeyRef:
+              name: search-api-elasticdump
+              key: parameters
         - name: TENSORFLOW_SAGEMAKER_ENDPOINT
           value: govuk-staging-search-ltr-endpoint
   - name: search-api-v2


### PR DESCRIPTION
Adds a manually triggered cronjob in staging and production to run the Elasticdump rake task so we can copy data between the blue and green Elasticsearch/OpenSearch clusters.

The job is configured to never run automatically.

See also: https://github.com/alphagov/govuk-helm-charts/pull/4366 for prior art in integration

Jira: https://gov-uk.atlassian.net/browse/SCH-2331
