### PR TITLE
Run the Elasticdump script at 11:15 UTC (12:15 BST) on 7 Sept

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2877,8 +2877,8 @@ govukApplications:
       cronTasks:
         - name: elasticdump
           task: "elasticdump"
-          schedule: "0 0 31 2 *" # never
-          suspend: true # Only run this task manually
+          schedule: "15 11 7 9 1" # Monday 7 September 11:15 UTC
+          suspend: false
         - name: generate-sitemap
           task: "sitemap:generate_and_upload"
           schedule: "10 3 * * *"


### PR DESCRIPTION
To sync data between the green and blue cluster