### PR TITLE
Switch the search-api over from the green to blue cluster in staging

### DIFF
--- a/charts/app-config/values-staging.yaml
+++ b/charts/app-config/values-staging.yaml
@@ -2910,7 +2910,7 @@ govukApplications:
         - name: AWS_S3_SITEMAPS_BUCKET_NAME
           value: govuk-staging-sitemaps
         - name: ELASTICSEARCH_URI
-          value: https://vpc-green-elasticsearch6-domain-42a562y7oibo5y7raa6rhkcb5m.eu-west-1.es.amazonaws.com
+          value: https://vpc-search-domain-blue-2r6mvgunhmodzz3v5wvkufe73u.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
           value: info
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
We upgraded the blue cluster to Opensearch 3.7 and provisioned it.

We can now switch the Search API over to the Blue cluster in staging