### PR TITLE
Switch the production Green Elasticsearch cluster over to Blue

### DIFF
--- a/charts/app-config/values-production.yaml
+++ b/charts/app-config/values-production.yaml
@@ -2922,7 +2922,7 @@ govukApplications:
         - name: AWS_S3_SITEMAPS_BUCKET_NAME
           value: govuk-production-sitemaps
         - name: ELASTICSEARCH_URI
-          value: https://vpc-green-elasticsearch6-domain-y4xd7c6mh2vucmkgtcit6h222u.eu-west-1.es.amazonaws.com
+          value: https://vpc-search-domain-blue-geugsmga57pxgusy3pdiko77xe.eu-west-1.es.amazonaws.com
         - name: LOG_LEVEL
           value: info
         - name: GDS_SSO_OAUTH_ID


### PR DESCRIPTION
We provisioned the Blue Opensearch cluster and tested it. This PR switches the old Elasticsearch 6.8 'Green' cluster over to the new Opensearch 3.7 'Blue' cluster

https://gov-uk.atlassian.net/browse/SCH-2338